### PR TITLE
convert more packages to use AVA

### DIFF
--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "test": "tape -r esm 'test/**/test*.js' | tap-spec",
+    "test": "ava",
     "lint-fix": "yarn lint --fix",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && eslint '**/*.js'",
@@ -36,10 +36,8 @@
   },
   "devDependencies": {
     "@agoric/install-ses": "^0.2.0",
-    "esm": "^3.2.25",
-    "tap-spec": "^5.0.0",
-    "tape": "^4.11.0",
-    "tape-promise": "^4.0.0"
+    "ava": "^3.11.1",
+    "esm": "^3.2.25"
   },
   "files": [
     "src/",
@@ -93,5 +91,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "require": [
+      "esm"
+    ],
+    "timeout": "2m"
   }
 }

--- a/packages/notifier/test/test-notifier-adaptor.js
+++ b/packages/notifier/test/test-notifier-adaptor.js
@@ -1,7 +1,7 @@
 // @ts-check
 import '@agoric/install-ses';
 import { E } from '@agoric/eventual-send';
-import test from 'tape-promise/tape';
+import test from 'ava';
 import {
   makeAsyncIterableFromNotifier,
   makeNotifierFromAsyncIterable,
@@ -46,14 +46,12 @@ const testEnding = (t, p, fails) => {
   return E.when(
     p,
     result => {
-      t.equal(fails, false);
-      t.equal(result, refResult);
-      return t.end();
+      t.is(fails, false);
+      t.is(result, refResult);
     },
     reason => {
-      t.equal(fails, true);
-      t.equal(reason, refReason);
-      return t.end();
+      t.is(fails, true);
+      t.is(reason, refReason);
     },
   );
 };
@@ -75,16 +73,16 @@ const testManualConsumer = (t, iterable, lossy) => {
       ({ value, done }) => {
         i = skip(i, value, lossy);
         if (done) {
-          t.equal(i, payloads.length);
+          t.is(i, payloads.length);
           return value;
         }
-        t.assert(i < payloads.length);
+        t.truthy(i < payloads.length);
         // Need precise equality
-        t.assert(Object.is(value, payloads[i]));
+        t.truthy(Object.is(value, payloads[i]));
         return testLoop(i + 1);
       },
       reason => {
-        t.assert(i <= payloads.length);
+        t.truthy(i <= payloads.length);
         throw reason;
       },
     );
@@ -97,13 +95,13 @@ const testAutoConsumer = async (t, iterable, lossy) => {
   try {
     for await (const value of iterable) {
       i = skip(i, value, lossy);
-      t.assert(i < payloads.length);
+      t.truthy(i < payloads.length);
       // Need precise equality
-      t.assert(Object.is(value, payloads[i]));
+      t.truthy(Object.is(value, payloads[i]));
       i += 1;
     }
   } finally {
-    t.assert(i <= payloads.length);
+    t.truthy(i <= payloads.length);
   }
   // The for-await-of loop cannot observe the final value of the iterator
   // so this consumer cannot test what that was. Just return what testEnding
@@ -116,20 +114,18 @@ const makeTestUpdater = (t, lossy, fails) => {
   return harden({
     updateState(newState) {
       i = skip(i, newState, lossy);
-      t.assert(i < payloads.length);
+      t.truthy(i < payloads.length);
       // Need precise equality
-      t.assert(Object.is(newState, payloads[i]));
+      t.truthy(Object.is(newState, payloads[i]));
       i += 1;
     },
     finish(finalState) {
-      t.equal(fails, false);
-      t.equal(finalState, refResult);
-      return t.end();
+      t.is(fails, false);
+      t.is(finalState, refResult);
     },
     fail(reason) {
-      t.equal(fails, true);
-      t.equal(reason, refReason);
-      return t.end();
+      t.is(fails, true);
+      t.is(reason, refReason);
     },
   });
 };

--- a/packages/notifier/test/test-notifier.js
+++ b/packages/notifier/test/test-notifier.js
@@ -1,7 +1,7 @@
 // @ts-check
 import '@agoric/install-ses';
 
-import test from 'tape-promise/tape';
+import test from 'ava';
 import { makeNotifierKit } from '../src/index';
 
 import '../src/types';
@@ -14,9 +14,8 @@ test('notifier - initial state', async t => {
   const updateDeNovo = await notifier.getUpdateSince();
   const updateFromNonExistent = await notifier.getUpdateSince();
 
-  t.equals(updateDeNovo.value, 1, 'state is one');
-  t.deepEquals(updateDeNovo, updateFromNonExistent, 'no param same as unknown');
-  t.end();
+  t.is(updateDeNovo.value, 1, 'state is one');
+  t.deepEqual(updateDeNovo, updateFromNonExistent, 'no param same as unknown');
 });
 
 test('notifier - single update', async t => {
@@ -26,15 +25,15 @@ test('notifier - single update', async t => {
   updater.updateState(1);
 
   const updateDeNovo = await notifier.getUpdateSince();
-  t.equals(updateDeNovo.value, 1, 'initial state is one');
+  t.is(updateDeNovo.value, 1, 'initial state is one');
 
   const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateCount);
   const all = Promise.all([updateInWaiting]).then(([update]) => {
-    t.equals(update.value, 3, 'updated state is eventually three');
+    t.is(update.value, 3, 'updated state is eventually three');
   });
 
   const update2 = await notifier.getUpdateSince();
-  t.equals(update2.value, 1);
+  t.is(update2.value, 1);
   updater.updateState(3);
   await all;
 });
@@ -45,15 +44,15 @@ test('notifier - initial update', async t => {
   const { notifier, updater } = makeNotifierKit(1);
 
   const updateDeNovo = await notifier.getUpdateSince();
-  t.equals(updateDeNovo.value, 1, 'initial state is one');
+  t.is(updateDeNovo.value, 1, 'initial state is one');
 
   const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateCount);
   const all = Promise.all([updateInWaiting]).then(([update]) => {
-    t.equals(update.value, 3, 'updated state is eventually three');
+    t.is(update.value, 3, 'updated state is eventually three');
   });
 
   const update2 = await notifier.getUpdateSince();
-  t.equals(update2.value, 1);
+  t.is(update2.value, 1);
   updater.updateState(3);
   await all;
 });
@@ -65,19 +64,19 @@ test('notifier - update after state change', async t => {
   const updateDeNovo = await notifier.getUpdateSince();
 
   const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateCount);
-  t.equals(updateDeNovo.value, 1, 'first state check (1)');
+  t.is(updateDeNovo.value, 1, 'first state check (1)');
   const all = Promise.all([updateInWaiting]).then(([update1]) => {
-    t.equals(update1.value, 3, '4th check (delayed) 3');
+    t.is(update1.value, 3, '4th check (delayed) 3');
     const thirdStatePromise = notifier.getUpdateSince(update1.updateCount);
     Promise.all([thirdStatePromise]).then(([update2]) => {
-      t.equals(update2.value, 5, '5th check (delayed) 5');
+      t.is(update2.value, 5, '5th check (delayed) 5');
     });
   });
 
-  t.equals((await notifier.getUpdateSince()).value, 1, '2nd check (1)');
+  t.is((await notifier.getUpdateSince()).value, 1, '2nd check (1)');
   updater.updateState(3);
 
-  t.equals((await notifier.getUpdateSince()).value, 3, '3rd check (3)');
+  t.is((await notifier.getUpdateSince()).value, 3, '3rd check (3)');
   updater.updateState(5);
   await all;
 });
@@ -89,19 +88,19 @@ test('notifier - final state', async t => {
 
   const updateDeNovo = await notifier.getUpdateSince();
   const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateCount);
-  t.equals(updateDeNovo.value, 1, 'initial state is one');
+  t.is(updateDeNovo.value, 1, 'initial state is one');
   const all = Promise.all([updateInWaiting]).then(([update]) => {
-    t.equals(update.value, 'final', 'state is "final"');
-    t.notOk(update.updateCount, 'no handle after close');
+    t.is(update.value, 'final', 'state is "final"');
+    t.falsy(update.updateCount, 'no handle after close');
     const postFinalUpdate = notifier.getUpdateSince(update.updateCount);
     Promise.all([postFinalUpdate]).then(([after]) => {
-      t.equals(after.value, 'final', 'stable');
-      t.notOk(after.updateCount, 'no handle after close');
+      t.is(after.value, 'final', 'stable');
+      t.falsy(after.updateCount, 'no handle after close');
     });
   });
 
   const invalidHandle = await notifier.getUpdateSince();
-  t.equals(invalidHandle.value, 1, 'still one');
+  t.is(invalidHandle.value, 1, 'still one');
   updater.finish('final');
   await all;
 });

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -33,10 +33,8 @@
     "@agoric/eventual-send": "^0.9.3"
   },
   "devDependencies": {
-    "esm": "^3.2.25",
-    "tap-spec": "^5.0.0",
-    "tape": "^4.11.0",
-    "tape-promise": "^4.0.0"
+    "ava": "^3.11.1",
+    "esm": "^3.2.25"
   },
   "files": [
     "src/",
@@ -86,5 +84,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "require": [
+      "esm"
+    ],
+    "timeout": "2m"
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -33,10 +33,8 @@
     "@agoric/assert": "^0.0.8"
   },
   "devDependencies": {
-    "esm": "^3.2.25",
-    "tap-spec": "^5.0.0",
-    "tape": "^4.11.0",
-    "tape-promise": "^4.0.0"
+    "ava": "^3.11.1",
+    "esm": "^3.2.25"
   },
   "files": [
     "src/",
@@ -86,5 +84,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "require": [
+      "esm"
+    ],
+    "timeout": "2m"
   }
 }

--- a/packages/tame-metering/package.json
+++ b/packages/tame-metering/package.json
@@ -4,16 +4,16 @@
   "description": "tame-metering",
   "main": "src/index.js",
   "scripts": {
-    "test": "tap --no-coverage 'test/**/test*.js'",
+    "test": "ava",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
     "lint-check": "eslint '**/*.{js,jsx}'",
     "build": "exit 0"
   },
   "dependencies": {
-    "esm": "^3.2.5",
-    "tap": "^14.10.5",
-    "tape": "^4.9.2",
-    "tape-promise": "^4.0.0"
+    "esm": "^3.2.5"
+  },
+  "devDependencies": {
+    "ava": "^3.11.1"
   },
   "keywords": [],
   "files": [
@@ -32,5 +32,14 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "require": [
+      "esm"
+    ],
+    "timeout": "2m"
   }
 }

--- a/packages/tame-metering/test/test-istamed.js
+++ b/packages/tame-metering/test/test-istamed.js
@@ -1,11 +1,10 @@
-import test from 'tape-promise/tape';
+import test from 'ava';
 import { isTamed, tameMetering } from '../src/index';
 
 test('isTamed', t => {
-  t.equal(isTamed(), false, 'isTamed() is false in a new untamed realm');
+  t.is(isTamed(), false, 'isTamed() is false in a new untamed realm');
   tameMetering();
-  t.equal(isTamed(), true, 'isTamed() becomes true after tameMetering()');
+  t.is(isTamed(), true, 'isTamed() becomes true after tameMetering()');
   tameMetering(); // idempotent
-  t.equal(isTamed(), true, 'isTamed() remains true after duplicate call');
-  t.end();
+  t.is(isTamed(), true, 'isTamed() remains true after duplicate call');
 });

--- a/packages/tame-metering/test/test-sanity.js
+++ b/packages/tame-metering/test/test-sanity.js
@@ -1,9 +1,8 @@
 import '../src/install-global-metering';
-import test from 'tape-promise/tape';
+import test from 'ava';
 
 test('symbol properties', t => {
-  t.assert(RegExp[Symbol.species], 'RegExp[Symbol.species] is kept');
-  t.end();
+  t.truthy(RegExp[Symbol.species], 'RegExp[Symbol.species] is kept');
 });
 
 function foo(_bar) {
@@ -12,6 +11,5 @@ function foo(_bar) {
 }
 
 test('direct eval', t => {
-  t.equals(foo(123), 123, 'direct eval succeeds');
-  t.end();
+  t.is(foo(123), 123, 'direct eval succeeds');
 });

--- a/packages/transform-eventual-send/package.json
+++ b/packages/transform-eventual-send/package.json
@@ -4,7 +4,7 @@
   "description": "transform-eventual-send",
   "main": "src/index.js",
   "scripts": {
-    "test": "tape -r esm 'test/**/*.js'",
+    "test": "ava",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'",
     "build": "exit 0"
@@ -13,10 +13,8 @@
     "@agoric/acorn-eventual-send": "^2.0.6",
     "@agoric/babel-parser": "^7.6.4",
     "@babel/generator": "^7.5.0",
-    "esm": "^3.2.5",
-    "tap-spec": "^5.0.0",
-    "tape": "^4.9.2",
-    "tape-promise": "^4.0.0"
+    "ava": "^3.11.1",
+    "esm": "^3.2.5"
   },
   "keywords": [],
   "files": [
@@ -35,5 +33,14 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "require": [
+      "esm"
+    ],
+    "timeout": "2m"
   }
 }

--- a/packages/transform-eventual-send/test/test-transformer.js
+++ b/packages/transform-eventual-send/test/test-transformer.js
@@ -1,4 +1,4 @@
-import { test } from 'tape';
+import test from 'ava';
 import * as babelParser from '@agoric/babel-parser';
 import babelGenerate from '@babel/generator';
 import { makeTransform } from '../src';
@@ -7,43 +7,39 @@ test('transformer', t => {
   const source = `let p = bob~.foo(arg1, arg2);`;
   const transformer = makeTransform(babelParser, babelGenerate);
   const output = transformer(source);
-  t.equal(
-    output,
-    `let p = HandledPromise.applyMethod(bob, "foo", [arg1, arg2]);`,
-  );
-  t.equal(
+  t.is(output, `let p = HandledPromise.applyMethod(bob, "foo", [arg1, arg2]);`);
+  t.is(
     transformer(output),
     `let p = HandledPromise.applyMethod(bob, "foo", [arg1, arg2]);`,
   );
-  t.equal(transformer('123;456'), '123;456;');
-  t.equal(transformer('123;'), '123;');
-  t.equal(transformer('123'), '123;');
-  t.equal(
+  t.is(transformer('123;456'), '123;456;');
+  t.is(transformer('123;'), '123;');
+  t.is(transformer('123'), '123;');
+  t.is(
     transformer(`"abc"~.length`),
     'HandledPromise.get("abc", "length");',
     '.get() works',
   );
-  t.equal(
+  t.is(
     transformer(`({foo(nick) { return "hello " + nick; }})~.foo('person')`),
     `HandledPromise.applyMethod({ foo(nick) {return "hello " + nick;} }, "foo", ['person']);`,
     '.applyMethod() works',
   );
-  t.equal(
+  t.is(
     transformer(`((punct) => "world" + punct)~.('!')`),
     `HandledPromise.applyFunction(punct => "world" + punct, ['!']);`,
     '.applyFunction() works',
   );
-  t.equal(
+  t.is(
     transformer(`["a", "b", "c"]~.[2]`),
     `HandledPromise.get(["a", "b", "c"], 2);`,
     'computed .get works',
   );
-  t.equal(
+  t.is(
     transformer(
       `({foo(greeting) { return greeting + ' world';}})~.foo~.('hello')`,
     ),
     `HandledPromise.applyFunction(HandledPromise.get({ foo(greeting) {return greeting + ' world';} }, "foo"), ['hello']);`,
     'double eventual send works',
   );
-  t.end();
 });

--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -4,7 +4,7 @@
   "description": "transform-metering",
   "main": "src/index.js",
   "scripts": {
-    "test": "tap --no-coverage --jobs=1 'test/**/test*.js'",
+    "test": "ava",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
     "lint-check": "eslint '**/*.{js,jsx}'",
     "build": "exit 0"
@@ -12,12 +12,10 @@
   "devDependencies": {
     "@agoric/install-ses": "^0.2.0",
     "@babel/core": "^7.5.0",
+    "ava": "^3.11.1",
     "esm": "^3.2.5",
     "rollup": "^1.16.6",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "tap": "^14.10.5",
-    "tape": "^4.9.2",
-    "tape-promise": "^4.0.0"
+    "rollup-plugin-node-resolve": "^5.2.0"
   },
   "dependencies": {
     "@agoric/nat": "^2.0.1",
@@ -41,5 +39,14 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "require": [
+      "esm"
+    ],
+    "timeout": "2m"
   }
 }

--- a/packages/transform-metering/test/test-meter.js
+++ b/packages/transform-metering/test/test-meter.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import test from 'tape-promise/tape';
+import test from 'ava';
 
 import { makeMeter } from '../src/index';
 import * as c from '../src/constants';
@@ -7,118 +7,108 @@ import * as c from '../src/constants';
 const testAllExhausted = (t, meter, desc) => {
   t.throws(
     () => meter[c.METER_ALLOCATE](),
-    RangeError,
+    { instanceOf: RangeError },
     `${desc} stays exhausted for allocate`,
   );
   t.throws(
     () => meter[c.METER_COMPUTE](),
-    RangeError,
+    { instanceOf: RangeError },
     `${desc} stays exhausted for compute`,
   );
   t.throws(
     () => meter[c.METER_ENTER](),
-    RangeError,
+    { instanceOf: RangeError },
     `${desc} stays exhausted for enter`,
   );
   t.throws(
     () => meter[c.METER_LEAVE](),
-    RangeError,
+    { instanceOf: RangeError },
     `${desc} stays exhausted for leave`,
   );
 };
 
 test('meter running', async t => {
-  try {
-    const { meter } = makeMeter({ budgetCompute: 10 });
-    meter[c.METER_COMPUTE](9);
-    t.throws(() => meter[c.METER_COMPUTE](), RangeError, 'compute exhausted');
-    testAllExhausted(t, meter, 'compute meter');
+  const { meter } = makeMeter({ budgetCompute: 10 });
+  meter[c.METER_COMPUTE](9);
+  t.throws(
+    () => meter[c.METER_COMPUTE](),
+    { instanceOf: RangeError },
+    'compute exhausted',
+  );
+  testAllExhausted(t, meter, 'compute meter');
 
-    const { meter: meter2 } = makeMeter({ budgetAllocate: 10 });
-    meter2[c.METER_ALLOCATE](new Array(8));
-    t.throws(
-      () => meter2[c.METER_ALLOCATE]([]),
-      RangeError,
-      'array allocate exhausted',
-    );
-    testAllExhausted(t, meter2, 'allocate meter');
+  const { meter: meter2 } = makeMeter({ budgetAllocate: 10 });
+  meter2[c.METER_ALLOCATE](new Array(8));
+  t.throws(
+    () => meter2[c.METER_ALLOCATE]([]),
+    { instanceOf: RangeError },
+    'array allocate exhausted',
+  );
+  testAllExhausted(t, meter2, 'allocate meter');
 
-    const { meter: meter3 } = makeMeter({ budgetStack: 10 });
-    for (let i = 0; i < 9; i += 1) {
-      meter3[c.METER_ENTER]();
-    }
-    for (let i = 0; i < 9; i += 1) {
-      meter3[c.METER_LEAVE]();
-    }
-    for (let i = 0; i < 9; i += 1) {
-      meter3[c.METER_ENTER]();
-    }
-    t.throws(() => meter3[c.METER_ENTER](), RangeError, 'stack exhausted');
-    testAllExhausted(t, meter3, 'stack meter');
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  } finally {
-    t.end();
+  const { meter: meter3 } = makeMeter({ budgetStack: 10 });
+  for (let i = 0; i < 9; i += 1) {
+    meter3[c.METER_ENTER]();
   }
+  for (let i = 0; i < 9; i += 1) {
+    meter3[c.METER_LEAVE]();
+  }
+  for (let i = 0; i < 9; i += 1) {
+    meter3[c.METER_ENTER]();
+  }
+  t.throws(
+    () => meter3[c.METER_ENTER](),
+    { instanceOf: RangeError },
+    'stack exhausted',
+  );
+  testAllExhausted(t, meter3, 'stack meter');
 });
 
-test('meter running', async t => {
-  try {
-    t.throws(
-      () => makeMeter({ budgetAllocate: true, budgetCombined: null }),
-      TypeError,
-      'missing combined allocate',
-    );
+test('makeMeter', async t => {
+  t.throws(
+    () => makeMeter({ budgetAllocate: true, budgetCombined: null }),
+    { instanceOf: TypeError },
+    'missing combined allocate',
+  );
 
-    t.throws(
-      () => makeMeter({ budgetCompute: true, budgetCombined: null }),
-      TypeError,
-      'missing combined compute',
-    );
+  t.throws(
+    () => makeMeter({ budgetCompute: true, budgetCombined: null }),
+    { instanceOf: TypeError },
+    'missing combined compute',
+  );
 
-    t.throws(
-      () => makeMeter({ budgetStack: true, budgetCombined: null }),
-      TypeError,
-      'missing combined stack',
-    );
+  t.throws(
+    () => makeMeter({ budgetStack: true, budgetCombined: null }),
+    { instanceOf: TypeError },
+    'missing combined stack',
+  );
 
-    // Try a combined meter.
-    const { meter } = makeMeter({
-      budgetAllocate: true,
-      budgetCompute: true,
-      budgetStack: true,
-      budgetCombined: 10,
-    });
-    t.throws(
-      () => {
-        meter[c.METER_ALLOCATE]([2, 3, 4]);
-        meter[c.METER_COMPUTE](4);
-        meter[c.METER_ENTER]();
-        meter[c.METER_COMPUTE]();
-        meter[c.METER_ENTER]();
-      },
-      /RangeError/,
-      'combined meter exhausted',
-    );
-    testAllExhausted(t, meter, 'combined meter');
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  } finally {
-    t.end();
-  }
+  // Try a combined meter.
+  const { meter } = makeMeter({
+    budgetAllocate: true,
+    budgetCompute: true,
+    budgetStack: true,
+    budgetCombined: 10,
+  });
+  t.throws(
+    () => {
+      meter[c.METER_ALLOCATE]([2, 3, 4]);
+      meter[c.METER_COMPUTE](4);
+      meter[c.METER_ENTER]();
+      meter[c.METER_COMPUTE]();
+      meter[c.METER_ENTER]();
+    },
+    { instanceOf: RangeError },
+    'combined meter exhausted',
+  );
+  testAllExhausted(t, meter, 'combined meter');
 });
 
 test('getBalance', async t => {
-  try {
-    const { meter, refillFacet } = makeMeter({ budgetCompute: 10 });
-    t.equal(refillFacet.getComputeBalance(), 10);
-    meter[c.METER_COMPUTE](3);
-    t.equal(refillFacet.getComputeBalance(), 7);
-    t.equal(refillFacet.getAllocateBalance(), c.DEFAULT_COMBINED_METER);
-    t.equal(refillFacet.getCombinedBalance(), c.DEFAULT_COMBINED_METER);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  } finally {
-    t.end();
-  }
+  const { meter, refillFacet } = makeMeter({ budgetCompute: 10 });
+  t.is(refillFacet.getComputeBalance(), 10);
+  meter[c.METER_COMPUTE](3);
+  t.is(refillFacet.getComputeBalance(), 7);
+  t.is(refillFacet.getAllocateBalance(), c.DEFAULT_COMBINED_METER);
+  t.is(refillFacet.getCombinedBalance(), c.DEFAULT_COMBINED_METER);
 });

--- a/packages/transform-metering/test/test-tame.js
+++ b/packages/transform-metering/test/test-tame.js
@@ -2,57 +2,48 @@
 import replaceGlobalMeter from '@agoric/tame-metering/src/install-global-metering';
 
 // eslint-disable-next-line import/order
-import test from 'tape-promise/tape';
+import test from 'ava';
 
 import { makeMeter, makeWithMeter } from '../src/index';
 
 test('meter running', async t => {
-  try {
-    const { meter, refillFacet } = makeMeter({ budgetCombined: 10 });
-    const { withMeter, withoutMeter } = makeWithMeter(
-      replaceGlobalMeter,
-      meter,
-    );
-    const withMeterFn = (thunk, newMeter = meter) => () =>
-      withMeter(thunk, newMeter);
+  const { meter, refillFacet } = makeMeter({ budgetCombined: 10 });
+  const { withMeter, withoutMeter } = makeWithMeter(replaceGlobalMeter, meter);
+  const withMeterFn = (thunk, newMeter = meter) => () =>
+    withMeter(thunk, newMeter);
 
-    t.equal(new [].constructor(40).length, 40, `new [].constructor works`);
+  t.is(new [].constructor(40).length, 40, `new [].constructor works`);
 
-    t.equal(
-      withoutMeter(() => true),
-      true,
-      `withoutMeter works`,
-    );
-    t.equal(
-      withMeter(() => true),
-      true,
-      `withMeter works`,
-    );
+  t.is(
+    withoutMeter(() => true),
+    true,
+    `withoutMeter works`,
+  );
+  t.is(
+    withMeter(() => true),
+    true,
+    `withMeter works`,
+  );
 
-    refillFacet.combined(1000);
-    t.throws(
-      withMeterFn(() => new Array(10000)),
-      RangeError,
-      'new Array exhausted',
-    );
+  refillFacet.combined(1000);
+  t.throws(
+    withMeterFn(() => new Array(10000)),
+    { instanceOf: RangeError },
+    'new Array exhausted',
+  );
 
-    refillFacet.combined(100);
-    t.throws(
-      withMeterFn(() => 'x'.repeat(10000)),
-      RangeError,
-      'long string exhausted',
-    );
+  refillFacet.combined(100);
+  t.throws(
+    withMeterFn(() => 'x'.repeat(10000)),
+    { instanceOf: RangeError },
+    'long string exhausted',
+  );
 
-    const a = new Array(10);
-    refillFacet.combined(10);
-    t.throws(
-      withMeterFn(() => a.map(Object.create)),
-      RangeError,
-      'map to Object create exhausted',
-    );
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  } finally {
-    t.end();
-  }
+  const a = new Array(10);
+  refillFacet.combined(10);
+  t.throws(
+    withMeterFn(() => a.map(Object.create)),
+    { instanceOf: RangeError },
+    'map to Object create exhausted',
+  );
 });

--- a/packages/transform-metering/test/test-transform.js
+++ b/packages/transform-metering/test/test-transform.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import test from 'tape-promise/tape';
+import test from 'ava';
 import * as babelCore from '@babel/core';
 import fs from 'fs';
 
@@ -7,55 +7,49 @@ import { makeMeteringTransformer } from '../src/index';
 import * as c from '../src/constants';
 
 test('meter transform', async t => {
-  try {
-    let getMeter;
-    const meteringTransform = makeMeteringTransformer(babelCore, {
-      overrideMeterId: '$m',
-      overrideRegExpIdPrefix: '$re_',
+  let getMeter;
+  const meteringTransform = makeMeteringTransformer(babelCore, {
+    overrideMeterId: '$m',
+    overrideRegExpIdPrefix: '$re_',
+  });
+  const rewrite = (source, testName) => {
+    let cMeter;
+    getMeter = () => ({
+      [c.METER_COMPUTE]: units => (cMeter = units),
     });
-    const rewrite = (source, testName) => {
-      let cMeter;
-      getMeter = () => ({
-        [c.METER_COMPUTE]: units => (cMeter = units),
-      });
 
-      const ss = meteringTransform.rewrite({
-        src: source,
-        endowments: { getMeter },
-        sourceType: 'script',
-      });
+    const ss = meteringTransform.rewrite({
+      src: source,
+      endowments: { getMeter },
+      sourceType: 'script',
+    });
 
-      t.equals(cMeter, source.length, `compute meter updated ${testName}`);
-      return ss.src;
-    };
+    t.is(cMeter, source.length, `compute meter updated ${testName}`);
+    return ss.src;
+  };
 
-    t.throws(
-      () => rewrite(`$m.l()`, 'blacklisted meterId'),
-      SyntaxError,
-      'meterId cannot appear in source',
+  t.throws(
+    () => rewrite(`$m.l()`, 'blacklisted meterId'),
+    { instanceOf: SyntaxError },
+    'meterId cannot appear in source',
+  );
+
+  const base = `${__dirname}/../testdata`;
+  const tests = await fs.promises.readdir(base);
+  for (const testDir of tests) {
+    const src = await fs.promises.readFile(
+      `${base}/${testDir}/source.js`,
+      'utf8',
     );
-
-    const base = `${__dirname}/../testdata`;
-    const tests = await fs.promises.readdir(base);
-    for (const testDir of tests) {
-      const src = await fs.promises.readFile(
-        `${base}/${testDir}/source.js`,
-        'utf8',
-      );
-      const rewritten = await fs.promises
-        .readFile(`${base}/${testDir}/rewrite.js`, 'utf8')
-        // Fix golden files in case they have DOS or MacOS line endings.
-        .then(s => s.replace(/(\r\n|\r)/g, '\n'))
-        .catch(_ => undefined);
-      const transformed = rewrite(src.trimRight(), testDir);
-      if (rewritten === undefined) {
-        console.log(transformed);
-      }
-      t.equals(transformed, rewritten.trimRight(), `rewrite ${testDir}`);
+    const rewritten = await fs.promises
+      .readFile(`${base}/${testDir}/rewrite.js`, 'utf8')
+      // Fix golden files in case they have DOS or MacOS line endings.
+      .then(s => s.replace(/(\r\n|\r)/g, '\n'))
+      .catch(_ => undefined);
+    const transformed = rewrite(src.trimRight(), testDir);
+    if (rewritten === undefined) {
+      console.log(transformed);
     }
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  } finally {
-    t.end();
+    t.is(transformed, rewritten.trimRight(), `rewrite ${testDir}`);
   }
 });

--- a/packages/weak-store/package.json
+++ b/packages/weak-store/package.json
@@ -29,10 +29,8 @@
     "@agoric/assert": "^0.0.8"
   },
   "devDependencies": {
-    "esm": "^3.2.25",
-    "tap-spec": "^5.0.0",
-    "tape": "^4.11.0",
-    "tape-promise": "^4.0.0"
+    "ava": "^3.11.1",
+    "esm": "^3.2.25"
   },
   "files": [
     "src/",
@@ -82,5 +80,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "require": [
+      "esm"
+    ],
+    "timeout": "2m"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10410,7 +10410,7 @@ tape-promise@^4.0.0:
     is-promise "^2.1.0"
     onetime "^2.0.0"
 
-tape@^4.10.2, tape@^4.11.0, tape@^4.9.2:
+tape@^4.10.2, tape@^4.11.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/tape/-/tape-4.11.0.tgz#63d41accd95e45a23a874473051c57fdbc58edc1"
   integrity sha512-yixvDMX7q7JIs/omJSzSZrqulOV51EC9dK8dM0TzImTIkHWfe2/kFyL5v+d9C+SrCMaICk59ujsqFAVidDqDaA==


### PR DESCRIPTION
convert `notifier`, `store`, `weak-store`, `promise-kit`, `transform-eventual-send`, `tame-metering`, and `transform-metering` to use AVA

refs #1568 
