### PR TITLE
chore(swingset): @types/tmp belongs in devDependencies

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -25,7 +25,9 @@
   },
   "devDependencies": {
     "@endo/ses-ava": "^0.2.8",
-    "ava": "^3.12.1"
+    "@types/tmp": "^0.2.0",
+    "ava": "^3.12.1",
+    "tmp": "^0.2.1"
   },
   "dependencies": {
     "@agoric/assert": "^0.3.13",

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -43,14 +43,12 @@
     "@agoric/swing-store": "^0.6.1",
     "@agoric/xsnap": "^0.9.1",
     "@endo/base64": "^0.2.8",
-    "@types/tmp": "^0.2.0",
     "anylogger": "^0.21.0",
     "import-meta-resolve": "^1.1.1",
     "node-lmdb": "^0.9.5",
     "re2": "^1.16.0",
     "semver": "^6.3.0",
-    "ses": "^0.14.3",
-    "tmp": "^0.2.1"
+    "ses": "^0.14.3"
   },
   "files": [
     "bin/vat",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3067,6 +3067,11 @@
   dependencies:
     "@sinonjs/fake-timers" "^7.1.0"
 
+"@types/tmp@^0.2.0":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.1.tgz#83ecf4ec22a8c218c71db25f316619fe5b986011"
+  integrity sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg==
+
 "@types/trusted-types@^1.0.1":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3067,11 +3067,6 @@
   dependencies:
     "@sinonjs/fake-timers" "^7.1.0"
 
-"@types/tmp@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
-  integrity sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==
-
 "@types/trusted-types@^1.0.1":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"


### PR DESCRIPTION
snapstore has moved (back) to xsnap

discovered while reviewing the SwingSet dependencies for a security review