### PR TITLE
Minor notifier improvements

### DIFF
--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -75,7 +75,7 @@ export const makeNotifierKit = (...args) => {
         // If hasState() and either it is final() or it is
         // not the state of updateCount, return the current state.
         assert(currentResponse !== undefined);
-        return currentResponse;
+        return Promise.resolve(currentResponse);
       }
       // otherwise return a promise for the next state.
       if (!optNextPromiseKit) {

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -14,7 +14,7 @@ import './types.js';
 
 /**
  * @template T
- * @param {BaseNotifier<T>} baseNotifierP
+ * @param {ERef<BaseNotifier<T>>} baseNotifierP
  * @returns {AsyncIterable<T> & SharableNotifier}
  */
 export const makeNotifier = baseNotifierP => {
@@ -54,7 +54,7 @@ export const makeNotifier = baseNotifierP => {
  */
 export const makeNotifierKit = (...args) => {
   /** @type {PromiseRecord<UpdateRecord<T>>|undefined} */
-  let nextPromiseKit = makePromiseKit();
+  let optNextPromiseKit;
   /** @type {UpdateCount} */
   let currentUpdateCount = 1; // avoid falsy numbers
   /** @type {UpdateRecord<T>|undefined} */
@@ -75,11 +75,13 @@ export const makeNotifierKit = (...args) => {
         // If hasState() and either it is final() or it is
         // not the state of updateCount, return the current state.
         assert(currentResponse !== undefined);
-        return Promise.resolve(currentResponse);
+        return currentResponse;
       }
       // otherwise return a promise for the next state.
-      assert(nextPromiseKit);
-      return nextPromiseKit.promise;
+      if (!optNextPromiseKit) {
+        optNextPromiseKit = makePromiseKit();
+      }
+      return optNextPromiseKit.promise;
     },
   });
 
@@ -96,15 +98,16 @@ export const makeNotifierKit = (...args) => {
       }
 
       // become hasState() && !final()
-      assert(nextPromiseKit && currentUpdateCount);
+      assert(currentUpdateCount);
       currentUpdateCount += 1;
       currentResponse = harden({
         value: state,
         updateCount: currentUpdateCount,
       });
-      assert(currentResponse);
-      nextPromiseKit.resolve(currentResponse);
-      nextPromiseKit = makePromiseKit();
+      if (optNextPromiseKit) {
+        optNextPromiseKit.resolve(currentResponse);
+        optNextPromiseKit = undefined;
+      }
     },
 
     finish(finalState) {
@@ -113,15 +116,15 @@ export const makeNotifierKit = (...args) => {
       }
 
       // become hasState() && final()
-      assert(nextPromiseKit);
       currentUpdateCount = undefined;
       currentResponse = harden({
         value: finalState,
         updateCount: currentUpdateCount,
       });
-      assert(currentResponse);
-      nextPromiseKit.resolve(currentResponse);
-      nextPromiseKit = undefined;
+      if (optNextPromiseKit) {
+        optNextPromiseKit.resolve(currentResponse);
+        optNextPromiseKit = undefined;
+      }
     },
 
     fail(reason) {
@@ -130,12 +133,14 @@ export const makeNotifierKit = (...args) => {
       }
 
       // become !hasState() && final()
-      assert(nextPromiseKit);
       currentUpdateCount = undefined;
       currentResponse = undefined;
+      if (!optNextPromiseKit) {
+        optNextPromiseKit = makePromiseKit();
+      }
       // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-      nextPromiseKit.promise.catch(_ => {});
-      nextPromiseKit.reject(reason);
+      optNextPromiseKit.promise.catch(_ => {});
+      optNextPromiseKit.reject(reason);
     },
   });
 

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -48,7 +48,7 @@
  * update count, return the current record.
  * Otherwise, after the next state change, the promise will resolve to the
  * then-current value of the record.
- * @returns {Promise<UpdateRecord<T>>} resolves to the corresponding
+ * @returns {ERef<UpdateRecord<T>>} resolves to the corresponding
  * update
  */
 

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -48,7 +48,7 @@
  * update count, return the current record.
  * Otherwise, after the next state change, the promise will resolve to the
  * then-current value of the record.
- * @returns {ERef<UpdateRecord<T>>} resolves to the corresponding
+ * @returns {Promise<UpdateRecord<T>>} resolves to the corresponding
  * update
  */
 

--- a/packages/notifier/test/test-notifier-examples.js
+++ b/packages/notifier/test/test-notifier-examples.js
@@ -35,6 +35,7 @@ test('notifier for-await-of cannot eat promise', async t => {
   const { updater, notifier } = makeNotifierKit();
   paula(updater);
   const subP = Promise.resolve(notifier);
+  // @ts-ignore We are testing a case which violates the static types
   const log = await alice(subP);
 
   // This TypeError is thrown by JavaScript when a for-await-in loop


### PR DESCRIPTION
Main one is that the internal promiseKit is created lazily. This should reduce a lot of pointless allocations.