### PR TITLE
Adapt timers to async iterables by cooling

### DIFF
--- a/packages/SwingSet/src/vats/timed-iteration.js
+++ b/packages/SwingSet/src/vats/timed-iteration.js
@@ -1,0 +1,82 @@
+// @ts-check
+
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+
+// TODO There's nothing SwingSet specific in this file. It should probably
+// live in @agoric/notifier. But we'd also need to move the
+// type definitions of `Timestamp` and `RelativeTime` there.
+// We should also somehow extend the abstraction so the iterator
+// can be terminated, i.e., finished or failed.
+
+/**
+ * @param {(delay: RelativeTime) => Promise<Timestamp>} delayFn
+ * @param {() => Timestamp} getCurrentTime
+ * @param {Timestamp} baseTime
+ * @param {RelativeTime} interval
+ * @returns {AsyncIterator<Timestamp>}
+ */
+export const makeTimedIterator = (
+  delayFn,
+  getCurrentTime,
+  baseTime,
+  interval,
+) => {
+  // The latest stamp we have produced a notifier update for.
+  let latestNotifiedStamp = baseTime;
+
+  const iterator = Far('Timed async iterator', {
+    next: async () => {
+      // Whenever we have an observer for a new state, we need to handle two
+      // different cases:
+      // 1. If there would have been a prior wakeup since the last
+      //    notification, report it immediately.
+      // 2. Otherwise, set a wakeup when the next one would be scheduled.
+
+      const now = getCurrentTime();
+
+      // Calculate where we are relative to our base time.
+      const currentOffset = now > baseTime ? now - baseTime : 0n;
+      const intervalRemaining = interval - (currentOffset % interval);
+
+      // Find the previous wakeup relative to our last one.
+      const nextWakeup = baseTime + currentOffset + intervalRemaining;
+      const priorWakeup = nextWakeup - interval;
+
+      if (priorWakeup > latestNotifiedStamp) {
+        // At least one interval has passed since the prior one we notified
+        // for, so we can do an immediate update.
+        latestNotifiedStamp = priorWakeup;
+        return harden({ done: false, value: priorWakeup });
+      } else {
+        // The last notification we know about is in the future, so notify
+        // later because the client is waiting on a promise.
+        latestNotifiedStamp = nextWakeup;
+        return E.when(delayFn(nextWakeup - now), wakeTime =>
+          harden({ done: false, value: wakeTime }),
+        );
+      }
+    },
+  });
+  return iterator;
+};
+
+/**
+ * @param {(delay: RelativeTime) => Promise<Timestamp>} delayFn
+ * @param {() => Timestamp} getCurrentTime
+ * @param {Timestamp} baseTime
+ * @param {RelativeTime} interval
+ * @returns {AsyncIterable<Timestamp>}
+ */
+export const makeTimedIterable = (
+  delayFn,
+  getCurrentTime,
+  baseTime,
+  interval,
+) => {
+  const iterable = Far('Timed async iterable', {
+    [Symbol.asyncIterator]: () =>
+      makeTimedIterator(delayFn, getCurrentTime, baseTime, interval),
+  });
+  return iterable;
+};

--- a/packages/SwingSet/src/vats/types.js
+++ b/packages/SwingSet/src/vats/types.js
@@ -1,14 +1,27 @@
+// @ts-check
+
 /**
- * @typedef {Object} TimerService Gives the ability to get the current time,
+ * @typedef {Object} TimerService
+ * Gives the ability to get the current time,
  * schedule a single wake() call, create a repeater that will allow scheduling
  * of events at regular intervals, or remove scheduled calls.
- * @property {() => Timestamp} getCurrentTimestamp Retrieve the latest timestamp
- * @property {(baseTime: Timestamp, waker: ERef<TimerWaker>) => Timestamp} setWakeup Return
- * value is the time at which the call is scheduled to take place
- * @property {(waker: ERef<TimerWaker>) => Array<Timestamp>} removeWakeup Remove the waker
+ *
+ * @property {() => Timestamp} getCurrentTimestamp
+ * Retrieve the latest timestamp
+ *
+ * @property {(baseTime: Timestamp,
+ *             waker: ERef<TimerWaker>
+ * ) => Timestamp} setWakeup
+ * Return value is the time at which the call is scheduled to take place
+ *
+ * @property {(waker: ERef<TimerWaker>) => Array<Timestamp>} removeWakeup
+ * Remove the waker
  * from all its scheduled wakeups, whether produced by `timer.setWakeup(h)` or
  * `repeater.schedule(h)`.
- * @property {(delay: RelativeTime, interval: RelativeTime) => TimerRepeater} makeRepeater
+ *
+ * @property {(delay: RelativeTime,
+ *             interval: RelativeTime
+ * ) => TimerRepeater} makeRepeater
  * Create and return a repeater that will schedule `wake()` calls
  * repeatedly at times that are a multiple of interval following delay.
  * Interval is the difference between successive times at which wake will be
@@ -16,34 +29,47 @@
  * called after the next multiple of interval from the base. Since times can be
  * coarse-grained, the actual call may occur later, but this won't change when
  * the next event will be called.
- * @property {(delay: RelativeTime, interval: RelativeTime) => Notifier<Timestamp>} makeNotifier
+ *
+ * @property {(delay: RelativeTime,
+ *             interval: RelativeTime
+ * ) => Notifier<Timestamp>} makeNotifier
  * Create and return a Notifier that will deliver updates repeatedly at times
  * that are a multiple of interval following delay.
+ *
  * @property {(delay: RelativeTime) => Promise<Timestamp>} delay
- * Create and return a promise that will resolve after the relative time has passed.
+ * Create and return a promise that will resolve after the relative time has
+ * passed.
  */
 
 /**
- * @typedef {bigint} Timestamp An absolute individual stamp returned by a
+ * @typedef {bigint} Timestamp
+ * An absolute individual stamp returned by a
  * TimerService.  Note that different timer services may have different
  * interpretations of actual Timestamp values.
- * @typedef {bigint} RelativeTime Difference between two Timestamps.  Note that
+ *
+ * @typedef {bigint} RelativeTime
+ * Difference between two Timestamps.  Note that
  * different timer services may have different interpretations of actual
  * RelativeTime values.
  */
 
 /**
  * @typedef {Object} TimerWaker
+ *
  * @property {(timestamp: Timestamp) => void} wake The timestamp passed to
  * `wake()` is the time that the call was scheduled to occur.
  */
 
 /**
  * @typedef {Object} TimerRepeater
- * @property {(waker: ERef<TimerWaker>) => Timestamp} schedule Returns the time scheduled for
+ *
+ * @property {(waker: ERef<TimerWaker>) => Timestamp} schedule
+ * Returns the time scheduled for
  * the first call to `E(waker).wake()`.  The waker will continue to be scheduled
  * every interval until the repeater is disabled.
- * @property {() => void} disable Disable this repeater, so `schedule(w)` can't
+ *
+ * @property {() => void} disable
+ * Disable this repeater, so `schedule(w)` can't
  * be called, and wakers already scheduled with this repeater won't be
  * rescheduled again after `E(waker).wake()` is next called on them.
  */

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -2,13 +2,11 @@
 // eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
-import { makePromiseKit } from '@agoric/promise-kit';
 import { assert } from '@agoric/assert';
+import { makePromiseKit } from '@agoric/promise-kit';
+import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
-import {
-  makeAsyncIterableFromNotifier,
-  observeIteration,
-} from './asyncIterableAdaptor.js';
+import { makeAsyncIterableFromNotifier } from './asyncIterableAdaptor.js';
 
 import './types.js';
 
@@ -161,7 +159,79 @@ export const makeNotifierKit = (...args) => {
  * @returns {Notifier<T>}
  */
 export const makeNotifierFromAsyncIterable = asyncIterable => {
-  const { notifier, updater } = makeNotifierKit();
-  observeIteration(asyncIterable, updater);
-  return notifier;
+  const iterator = asyncIterable[Symbol.asyncIterator]();
+
+  /** @type {Promise<UpdateRecord<T>>|undefined} */
+  let optNextPromise;
+  /** @type {UpdateCount} */
+  let currentUpdateCount = 1; // avoid falsy numbers
+  /** @type {UpdateRecord<T>|undefined} */
+  let currentResponse;
+
+  const hasState = () => currentResponse !== undefined;
+
+  const final = () => currentUpdateCount === undefined;
+
+  /**
+   * @template T
+   * @type {BaseNotifier<T>}
+   */
+  const baseNotifier = Far('baseNotifier', {
+    // NaN matches nothing
+    getUpdateSince(updateCount = NaN) {
+      if (
+        hasState() &&
+        (final() ||
+          (currentResponse && currentResponse.updateCount !== updateCount))
+      ) {
+        // If hasState() and either it is final() or it is
+        // not the state of updateCount, return the current state.
+        assert(currentResponse !== undefined);
+        return Promise.resolve(currentResponse);
+      }
+
+      // otherwise return a promise for the next state.
+      if (!optNextPromise) {
+        const nextIterResultP = iterator.next();
+        optNextPromise = E.when(
+          nextIterResultP,
+          ({ done, value }) => {
+            assert(currentUpdateCount);
+            currentUpdateCount = done ? undefined : currentUpdateCount + 1;
+            currentResponse = harden({
+              value,
+              updateCount: currentUpdateCount,
+            });
+            optNextPromise = undefined;
+            return currentResponse;
+          },
+          _reason => {
+            currentUpdateCount = undefined;
+            currentResponse = undefined;
+            // This coercion between incompatible promise types is fine
+            // here, because we know that nextIterResultP is rejected,
+            // and we just need any promise rejected by that reason.
+            return /** @type {Promise<UpdateRecord<T>>} */ (nextIterResultP);
+          },
+        );
+      }
+      return optNextPromise;
+    },
+  });
+
+  return Far('notifier', {
+    ...asyncIterable,
+    ...baseNotifier,
+
+    /**
+     * Use this to distribute a Notifier efficiently over the network,
+     * by obtaining this from the Notifier to be replicated, and applying
+     * `makeNotifier` to it at the new site to get an equivalent local
+     * Notifier at that site.
+     *
+     * @returns {NotifierInternals}
+     */
+    getSharableNotifierInternals: () => baseNotifier,
+  });
 };
+harden(makeNotifierFromAsyncIterable);


### PR DESCRIPTION
Stacked on #3945

Proposed as an alternative to #3854

Hi @michaelfig it turns out there already was a makeNotifierFromAsyncIterable adaptor, which sounds like it was the remaining piece we needed. I believe I wrote it long ago. However, armed with your distinction, I saw that it was hot. I rewrote it to be a coldness-preserving adaptor and then used it to make the timer repair we talked about.