### PR TITLE
Fix jsdoc missing identifier warning

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -1,14 +1,17 @@
 // @ts-check
 
 /**
- * @typedef {string | string[]} Petname A petname can either be a plain string
+ * @typedef {string | string[]} Petname
+ * A petname can either be a plain string
  * or a path for which the first element is a petname for the origin, and the
- * rest of the elements are a snapshot of the names that were first given by that
- * origin.  We are migrating away from using plain strings, for consistency.
+ * rest of the elements are a snapshot of the names that were first given by
+ * that origin.  We are migrating away from using plain strings, for
+ * consistency.
  */
 
 /**
- * @typedef {Object} WalletUser the presence exposed as `local.wallet` (or
+ * @typedef {Object} WalletUser
+ * The presence exposed as `local.wallet` (or
  * `home.wallet`).  The idea is to provide someplace from which all the rest of
  * the API can be obtained.
  *
@@ -16,58 +19,66 @@
  * the evolving WalletAdminFacet (in internal-types.js).  See
  * https://github.com/Agoric/agoric-sdk/issues/2042 for details.
  *
- * @property {() => Promise<WalletBridge>} getBridge return the wallet bridge
+ * @property {() => Promise<WalletBridge>} getBridge
+ * Return the wallet bridge
  * that bypasses Dapp-authorization.  This should only be used within the REPL
  * or deployment scripts that want to use the WalletBridge API without the
  * effort of calling `getScopedBridge`.
  *
- * @property {(suggestedDappPetname: Petname, dappOrigin: string) =>
- * Promise<WalletBridge>} getScopedBridge return a wallet bridge corresponding
+ * @property {(suggestedDappPetname: Petname,
+ *             dappOrigin: string
+ * ) => Promise<WalletBridge>} getScopedBridge
+ * Return a wallet bridge corresponding
  * to an origin that must be approved in the wallet UI.  This is available for
  * completeness in order to provide the underlying API that's available over the
  * standard wallet-bridge.html.
  *
- * @property {(payment: ERef<Payment>) => Promise<void>} addPayment add a
- * payment of any brand to the wallet for deposit to the user-specified purse
- * (either an autodeposit or manually approved).
+ * @property {(payment: ERef<Payment>) => Promise<void>} addPayment
+ * Add a payment of any brand to the wallet for deposit to the user-specified
+ * purse (either an autodeposit or manually approved).
  *
  * @property {(brandBoardId: string) => Promise<string>} getDepositFacetId
- * return the board ID to use to receive payments of the specified brand (used
+ * Return the board ID to use to receive payments of the specified brand (used
  * by existing deploy scripts).
- * @property {() => Array<[Petname, Issuer]>} getIssuers get all the issuers
- * (used by existing deploy scripts).
- * @property {(petname: Petname) => Issuer} getIssuer get an issuer by petname
- * (used by existing deploy scripts).
- * @property {() => Array<[Petname, Purse]>} getPurses get all the purses (used
- * by existing deploy scripts).
- * @property {(petname: Petname) => Purse} getPurse get a purse by petname (used
- * by existing deploy scripts).
+ * @property {() => Array<[Petname, Issuer]>} getIssuers
+ * Get all the issuers (used by existing deploy scripts).
+ * @property {(petname: Petname) => Issuer} getIssuer
+ * Get an issuer by petname (used by existing deploy scripts).
+ * @property {() => Array<[Petname, Purse]>} getPurses
+ * Get all the purses (used by existing deploy scripts).
+ * @property {(petname: Petname) => Purse} getPurse
+ * Get a purse by petname (used by existing deploy scripts).
  */
 
 /**
- * @typedef {Object} WalletBridge The methods that can be used by an untrusted
+ * @typedef {Object} WalletBridge
+ * The methods that can be used by an untrusted
  * Dapp without breaching the wallet's integrity.  These methods are also
  * exposed via the iframe/WebSocket bridge that a Dapp UI can use to access the
  * wallet.
  *
  * @property {(offer: OfferState) => Promise<string>} addOffer
  * @property {(brandBoardId: string) => Promise<string>} getDepositFacetId
- * return the board ID to use to receive payments of the specified brand.
+ * Return the board ID to use to receive payments of the specified brand.
  * @property {() => Promise<Notifier<Array<PursesJSONState>>>} getPursesNotifier
  * Follow changes to the purses.
- * @property {() => Promise<Notifier<Array<[Petname, BrandRecord]>>>} getIssuersNotifier
+ * @property {(
+ * ) => Promise<Notifier<Array<[Petname, BrandRecord]>>>} getIssuersNotifier
  * Follow changes to the issuers
  * @property {() => Promise<Notifier<Array<OfferState>>>} getOffersNotifier
  * Follow changes to the offers.
- * @property {(petname: Petname, issuerBoardId: string) => Promise<void>}
- * suggestIssuer Introduce an ERTP issuer to the wallet, with a suggested
- * petname.
- * @property {(petname: Petname, installationBoardId: string) => Promise<void>}
- * suggestInstallation Introduce a Zoe contract installation to the wallet, with
- * suggested petname.
- * @property {(petname: Petname, instanceBoardId: string) => Promise<void>}
- * suggestInstance Introduce a Zoe contract instance to the wallet, with
- * suggested petname.
+ * @property {(petname: Petname,
+ *             issuerBoardId: string
+ * ) => Promise<void>} suggestIssuer
+ * Introduce an ERTP issuer to the wallet, with a suggested petname.
+ * @property {(petname: Petname,
+ *             installationBoardId: string
+ * ) => Promise<void>} suggestInstallation
+ * Introduce a Zoe contract installation to the wallet, with suggested petname.
+ * @property {(petname: Petname,
+ *             instanceBoardId: string
+ * ) => Promise<void>} suggestInstance
+ * Introduce a Zoe contract instance to the wallet, with suggested petname.
  * @property {(rawId: string) => Promise<Notifier<any>>} getUINotifier
  * Get the UI notifier from the offerResult for a particular offer,
  * identified by id. This notifier should only contain information that
@@ -80,19 +91,21 @@
  * Get the curated Agoric public naming hub
  * @property {(...path: Array<unknown>) => Promise<unknown>} getNamesByAddress
  * Get the Agoric address mapped to its public naming hub
- * @property {(brands: Array<Brand>) => Promise<Array<Petname>>}
- * getBrandPetnames
+ * @property {(brands: Array<Brand>
+ * ) => Promise<Array<Petname>>} getBrandPetnames
  * Get the petnames for the brands that are passed in
  */
 
 /**
  * @typedef {Object} RecordMetadata
- * @property {number} sequence a monotonically increasing number to allow
- * total ordering between records.
- * @property {number} [creationStamp] the approximate time at which the record
+ * @property {number} sequence
+ * A monotonically increasing number to allow total ordering between records.
+ * @property {number} [creationStamp]
+ * The approximate time at which the record
  * was created in milliseconds since the epoch; `undefined` if there is no
  * timer source
- * @property {number} [updatedStamp] the approximate time at which the record
+ * @property {number} [updatedStamp]
+ * The approximate time at which the record
  * was last updated in milliseconds since the epoch; `undefined` if there is
  * no timer source
  */
@@ -100,13 +113,18 @@
 /**
  * @typedef {Object} PursesJSONState
  * @property {Brand} brand
- * @property {string} brandBoardId  the board ID for this purse's brand
- * @property {string=} depositBoardId the board ID for the deposit-only facet of
- * this purse
- * @property {Petname} brandPetname the petname for this purse's brand
- * @property {Petname} pursePetname the petname for this purse
- * @property {any} displayInfo the brand's displayInfo
- * @property {any} value the purse's current balance
+ * @property {string} brandBoardId
+ * The board ID for this purse's brand
+ * @property {string=} depositBoardId
+ * The board ID for the deposit-only facet of this purse
+ * @property {Petname} brandPetname
+ * The petname for this purse's brand
+ * @property {Petname} pursePetname
+ * The petname for this purse
+ * @property {any} displayInfo
+ * The brand's displayInfo
+ * @property {any} value
+ * The purse's current balance
  * @property {any} currentAmountSlots
  * @property {any} currentAmount
  */
@@ -144,6 +162,8 @@
  * @property {(brand: Brand) => IssuerRecord} getByBrand
  * @property {(issuer: Issuer) => boolean} hasByIssuer
  * @property {(issuer: Issuer) => IssuerRecord} getByIssuer
- * @property {(issuerP: ERef<Issuer>, addMeta?: (x: any) => any) => Promise<IssuerRecord>} initIssuer
+ * @property {(issuerP: ERef<Issuer>,
+ *             addMeta?: (x: any) => any
+ * ) => Promise<IssuerRecord>} initIssuer
  * @property {(issuerRecord: IssuerRecord) => void } initIssuerByRecord
  */

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -337,13 +337,14 @@ export function buildRootObject(_vatPowers) {
   function getBridgeURLHandler() {
     return Far('bridgeURLHandler', {
       /**
-       * @typedef {Object} WalletOtherSide the callbacks from a CapTP wallet
-       * client.
-       * @property {(dappOrigin: string, suggestedDappPetname: Petname) => void}
-       * needDappApproval let the other side know that this dapp is still
-       * unapproved
-       * @property {(dappOrigin: string) => void} dappApproved let the other
-       * side know that the dapp has been approved
+       * @typedef {Object} WalletOtherSide
+       * The callbacks from a CapTP wallet client.
+       * @property {(dappOrigin: string,
+       *             suggestedDappPetname: Petname
+       * ) => void} needDappApproval
+       * Let the other side know that this dapp is still unapproved
+       * @property {(dappOrigin: string) => void} dappApproved
+       * Let the other side know that the dapp has been approved
        */
 
       /**

--- a/packages/zoe/src/contracts/priceAggregatorTypes.js
+++ b/packages/zoe/src/contracts/priceAggregatorTypes.js
@@ -1,7 +1,9 @@
 /**
  * @typedef {Object} OracleAdmin
- * @property {() => Promise<void>} delete Remove the oracle from the aggregator
- * @property {(result: any) => Promise<void>} pushResult rather than waiting for
+ * @property {() => Promise<void>} delete
+ * Remove the oracle from the aggregator
+ * @property {(result: any) => Promise<void>} pushResult
+ * Rather than waiting for
  * the polling query, push a result directly from this oracle
  */
 
@@ -30,11 +32,12 @@
  */
 
 /**
- * @typedef {Object} OraclePublicFacet the public methods accessible from the
- * contract instance
- * @property {(query: any) => ERef<Invitation>} makeQueryInvitation create an
- * invitation for an oracle query
- * @property {(query: any) => ERef<any>} query make an unpaid query
+ * @typedef {Object} OraclePublicFacet
+ * The public methods accessible from the contract instance
+ * @property {(query: any) => ERef<Invitation>} makeQueryInvitation
+ * Create an invitation for an oracle query
+ * @property {(query: any) => ERef<any>} query
+ * Make an unpaid query
  */
 
 /**
@@ -44,14 +47,14 @@
  */
 
 /**
- * @typedef {Object} OracleCreatorFacet the private methods accessible from the
- * contract instance
- * @property {() => AmountKeywordRecord} getCurrentFees get the current
- * fee amounts
- * @property {OracleCreatorFacetMakeWithdrawInvitation}
- * makeWithdrawInvitation create an invitation to withdraw fees
+ * @typedef {Object} OracleCreatorFacet
+ * The private methods accessible from the contract instance
+ * @property {() => AmountKeywordRecord} getCurrentFees
+ * Get the current fee amounts
+ * @property {OracleCreatorFacetMakeWithdrawInvitation} makeWithdrawInvitation
+ * Create an invitation to withdraw fees
  * @property {() => Promise<Invitation>} makeShutdownInvitation
- *   Make an invitation to withdraw all fees and shutdown
+ * Make an invitation to withdraw all fees and shutdown
  */
 
 /**
@@ -61,7 +64,8 @@
 
 /**
  * @typedef {Object} OracleInitializationFacet
- * @property {(privateParams: OraclePrivateParameters) => OracleCreatorFacet} initialize
+ * @property {(privateParams: OraclePrivateParameters
+ * ) => OracleCreatorFacet} initialize
  */
 
 /**
@@ -87,8 +91,12 @@
 /**
  * @typedef {Object} OracleHandler
  * @property {(query: any, fee: Amount) => Promise<OracleReply>} onQuery
- * callback to reply to a query
- * @property {(query: any, reason: any) => void} onError notice an error
- * @property {(query: any, reply: any, requiredFee: Amount | undefined) => void}
- * onReply notice a successful reply
+ * Callback to reply to a query
+ * @property {(query: any, reason: any) => void} onError
+ * Notice an error
+ * @property {(query: any,
+ *             reply: any,
+ *             requiredFee: Amount | undefined
+ * ) => void} onReply
+ * Notice a successful reply
  */

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -35,8 +35,8 @@
  * @property {GetInstallationForInstance} getInstallationForInstance
  * @property {GetInstance} getInstance
  * @property {GetInstallation} getInstallation
- * @property {GetInvitationDetails} getInvitationDetails - return an
- * object with the instance, installation, description, invitation
+ * @property {GetInvitationDetails} getInvitationDetails
+ * Return an object with the instance, installation, description, invitation
  * handle, and any custom properties specific to the contract.
  * @property {GetFeeIssuer} getFeeIssuer
  * @property {MakeFeePurse} makeFeePurse
@@ -181,7 +181,8 @@
  * @param {ERef<Installation>} installation
  * @param {IssuerKeywordRecord=} issuerKeywordRecord
  * @param {Object=} terms
- * @param {Object=} privateArgs - an optional configuration object
+ * @param {Object=} privateArgs
+ * An optional configuration object
  * that can be used to pass in arguments that should not be in the
  * public terms
  * @param {ERef<FeePurse>=} feePurse
@@ -337,7 +338,8 @@
  */
 
 /**
- * @typedef {Record<string, any>} SourceBundle Opaque type for a JSONable source bundle
+ * @typedef {Record<string, any>} SourceBundle
+ * Opaque type for a JSONable source bundle
  */
 
 /**
@@ -408,12 +410,14 @@
 
 /**
  * @typedef {Object} MeteringConfig
- * @property {Computrons} initial - the amount of computrons a meter
- * starts with
- * @property {Computrons} incrementBy - when a meter is refilled, this
- * amount will be added
- * @property {Computrons} threshold - Zoe will be notified when the meter
- * drops below this amount
- * @property {{ feeNumerator: bigint, computronDenominator: bigint }}
- * price - the price of computrons in RUN
+ * @property {Computrons} initial
+ * The amount of computrons a meter starts with
+ * @property {Computrons} incrementBy
+ * When a meter is refilled, this amount will be added
+ * @property {Computrons} threshold
+ * Zoe will be notified when the meter drops below this amount
+ * @property {{ feeNumerator: bigint,
+ *              computronDenominator: bigint
+ * }} price
+ * The price of computrons in RUN
  */

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -1,23 +1,30 @@
 /**
  * @typedef {Object} PriceQuote
- * @property {Amount} quoteAmount Amount whose value is a PriceQuoteValue
- * @property {ERef<Payment> | null} quotePayment The `quoteAmount` wrapped as a payment
+ * @property {Amount} quoteAmount
+ * Amount whose value is a PriceQuoteValue
+ * @property {ERef<Payment> | null} quotePayment
+ * The `quoteAmount` wrapped as a payment
  */
 
 /**
- * @typedef {[PriceDescription]} PriceQuoteValue A single-valued set of
- * PriceDescriptions.  This is the `value` in PriceQuote.quoteAmount (`{ brand,
- * value: PriceQuoteValue }`).
+ * @typedef {[PriceDescription]} PriceQuoteValue
+ * A single-valued set of PriceDescriptions.  This is the `value` in
+ * PriceQuote.quoteAmount (`{ brand, value: PriceQuoteValue }`).
  */
 
 /**
- * @typedef {Object} PriceDescription A description of a single quote
- * @property {Amount} amountIn The amount supplied to a trade
- * @property {Amount} amountOut The quoted result of trading `amountIn`
- * @property {TimerService} timer The service that gave the `timestamp`
- * @property {Timestamp} timestamp A timestamp according to `timer` for the
- * quote
- * @property {any=} conditions Additional conditions for the quote
+ * @typedef {Object} PriceDescription
+ * A description of a single quote
+ * @property {Amount} amountIn
+ * The amount supplied to a trade
+ * @property {Amount} amountOut
+ * The quoted result of trading `amountIn`
+ * @property {TimerService} timer
+ * The service that gave the `timestamp`
+ * @property {Timestamp} timestamp
+ * A timestamp according to `timer` for the quote
+ * @property {any=} conditions
+ * Additional conditions for the quote
  */
 
 /**
@@ -50,60 +57,83 @@
  */
 
 /**
- * @typedef {Object} PriceAuthority An object that mints PriceQuotes and handles
+ * @typedef {Object} PriceAuthority
+ * An object that mints PriceQuotes and handles
  * triggers and notifiers for changes in the price
  *
  * @property {(brandIn: Brand, brandOut: Brand) => ERef<Issuer>} getQuoteIssuer
  * Get the ERTP issuer of PriceQuotes for a given brandIn/brandOut pair
  *
- * @property {(brandIn: Brand, brandOut: Brand) => ERef<TimerService>}
- * getTimerService get the timer used in PriceQuotes for a given
- * brandIn/brandOut pair
+ * @property {(brandIn: Brand,
+ *             brandOut: Brand
+ * ) => ERef<TimerService>} getTimerService
+ * Get the timer used in PriceQuotes for a given brandIn/brandOut pair
  *
- * @property {(amountIn: Amount, brandOut: Brand) => ERef<Notifier<PriceQuote>>}
- * makeQuoteNotifier Be notified of the latest PriceQuotes for a given
+ * @property {(amountIn: Amount,
+ *             brandOut: Brand
+ *            ) => ERef<Notifier<PriceQuote>>} makeQuoteNotifier
+ * Be notified of the latest PriceQuotes for a given
  * `amountIn`.  The rate at which these are issued may be very different between
  * `priceAuthorities`.
  *
- * @property {(deadline: Timestamp, amountIn: Amount, brandOut: Brand) =>
- * Promise<PriceQuote>} quoteAtTime Resolves after `deadline` passes on the
+ * @property {(deadline: Timestamp,
+ *             amountIn: Amount,
+ *             brandOut: Brand
+ * ) => Promise<PriceQuote>} quoteAtTime
+ * Resolves after `deadline` passes on the
  * priceAuthority's timerService with the price quote of `amountIn` at that time
  *
- * @property {(amountIn: Amount, brandOut: Brand) => Promise<PriceQuote>}
- * quoteGiven get a quote corresponding to the specified amountIn
+ * @property {(amountIn: Amount,
+ *             brandOut: Brand
+ * ) => Promise<PriceQuote>} quoteGiven
+ * Get a quote corresponding to the specified amountIn
  *
- * @property {(brandIn: Brand, amountOut: Amount) => Promise<PriceQuote>}
- * quoteWanted get a quote corresponding to the specified amountOut
+ * @property {(brandIn: Brand,
+ *             amountOut: Amount) => Promise<PriceQuote>} quoteWanted
+ * Get a quote corresponding to the specified amountOut
  *
- * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
- * quoteWhenGT Resolve when a price quote of `amountIn` exceeds `amountOutLimit`
+ * @property {(amountIn: Amount,
+ *             amountOutLimit: Amount
+ * ) => Promise<PriceQuote>} quoteWhenGT
+ * Resolve when a price quote of `amountIn` exceeds `amountOutLimit`
  *
- * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
- * quoteWhenGTE Resolve when a price quote of `amountIn` reaches or exceeds
+ * @property {(amountIn: Amount,
+ *             amountOutLimit: Amount
+ * ) => Promise<PriceQuote>} quoteWhenGTE
+ * Resolve when a price quote of `amountIn` reaches or exceeds `amountOutLimit`
+ *
+ * @property {(amountIn: Amount,
+ *             amountOutLimit: Amount
+ * ) => Promise<PriceQuote>} quoteWhenLTE
+ * Resolve when a price quote of `amountIn` reaches or drops below
  * `amountOutLimit`
  *
- * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
- * quoteWhenLTE Resolve when a price quote of `amountIn` reaches or drops below
+ * @property {(amountIn: Amount,
+ *             amountOutLimit: Amount
+ * ) => Promise<PriceQuote>} quoteWhenLT
+ * Resolve when the price quote of `amountIn` drops below `amountOutLimit`
+ *
+ * @property {(amountIn: Amount,
+ *             amountOutLimit: Amount
+ * ) => ERef<MutableQuote>} mutableQuoteWhenGT
+ * Resolve when a price quote of `amountIn` exceeds `amountOutLimit`
+ *
+ * @property {(amountIn: Amount,
+ *             amountOutLimit: Amount
+ * ) => ERef<MutableQuote>} mutableQuoteWhenGTE
+ * Resolve when a price quote of `amountIn` reaches or exceeds
  * `amountOutLimit`
  *
- * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
- * quoteWhenLT Resolve when the price quote of `amountIn` drops below
+ * @property {(amountIn: Amount,
+ *             amountOutLimit: Amount
+ * ) => ERef<MutableQuote>} mutableQuoteWhenLTE
+ * Resolve when a price quote of `amountIn` reaches or drops below
  * `amountOutLimit`
  *
- * @property {(amountIn: Amount, amountOutLimit: Amount) => ERef<MutableQuote>}
- * mutableQuoteWhenGT Resolve when a price quote of `amountIn` exceeds `amountOutLimit`
- *
- * @property {(amountIn: Amount, amountOutLimit: Amount) => ERef<MutableQuote>}
- * mutableQuoteWhenGTE Resolve when a price quote of `amountIn` reaches or exceeds
- * `amountOutLimit`
- *
- * @property {(amountIn: Amount, amountOutLimit: Amount) => ERef<MutableQuote>}
- * mutableQuoteWhenLTE Resolve when a price quote of `amountIn` reaches or drops below
- * `amountOutLimit`
- *
- * @property {(amountIn: Amount, amountOutLimit: Amount) => ERef<MutableQuote>}
- * mutableQuoteWhenLT Resolve when the price quote of `amountIn` drops below
- * `amountOutLimit`
+ * @property {(amountIn: Amount,
+ *             amountOutLimit: Amount
+ * ) => ERef<MutableQuote>} mutableQuoteWhenLT
+ * Resolve when the price quote of `amountIn` drops below `amountOutLimit`
  */
 
 /**


### PR DESCRIPTION
On our github PRs, like https://github.com/Agoric/agoric-sdk/pull/3949/files for example, I'm seeing warnings like

![image](https://user-images.githubusercontent.com/273868/136715547-d7c2d0a7-4f4d-4b1b-a7f9-8b3e981a808e.png)

This is due to the peculiar whitespace rules of typescript-in-jsdoc-comments . I do *not* know what these rules are. What I do know are the habits I've developed for avoiding these pitfalls, while staying within 80 columns and making these declarations more readable. So I decided to try out this style on the three jsdoc typing files that were causing these warnings.

There are no changes in this PR other than whitespace, capitalization, and similarly trivial non-semantic punctuation changes.