### PR TITLE
chore(swingset): small tweaks to GC

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -949,7 +949,6 @@ function build(
     } else {
       // Remotable
       // console.log(`-- liveslots acting on retireExports ${vref}`);
-      kernelRecognizableRemotables.delete(vref);
       meterControl.assertNotMetered();
       const wr = slotToVal.get(vref);
       if (wr) {
@@ -974,6 +973,7 @@ function build(
           valToSlot.delete(val);
           droppedRegistry.unregister(val);
         }
+        kernelRecognizableRemotables.delete(vref);
         slotToVal.delete(vref);
       }
     }

--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -220,8 +220,9 @@ export function makeVirtualObjectManager(
    *  - any virtual references to it (if so, it will have a refcount > 0)
    *  - being exported (if so, its export flag will be set)
    *
-   * This function is called by code that removes one of these three legs, to see
-   * if the other two legs are now gone also.
+   * This function is called after a leg has been reported missing, and only
+   * if the memory (Representative) leg is currently missing, to see if the
+   * other two legs are now gone also.
    *
    * Deletion consists of removing the vatstore entries that describe its state
    * and track its refcount status.  In addition, when a virtual object is


### PR DESCRIPTION
* rename unretiredKernelRecognizableRemotables to kernelRecognizableRemotables , since they're all unretired
* retireOneExport: delete from kernelRecognizableRemotables even if slotToVal was empty. I don't think this could happen, but they're logically distinct checks.
* rearrange scanForDeadObjects slightly for clarity
* update comment on possibleVirtualObjectDeath
* comment on why we add globals to vatPowers
* don't completely unpack gcTools: one-off uses can dereference directly, to let the unpack fit in a single line

refs #3732
