### PR TITLE
Fix missing Fars in pools

### DIFF
--- a/packages/zoe/src/contracts/vpool-xyk-amm/doublePool.js
+++ b/packages/zoe/src/contracts/vpool-xyk-amm/doublePool.js
@@ -2,6 +2,7 @@
 
 import { AmountMath } from '@agoric/ertp';
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 import { makeFeeRatio } from '../constantProduct/calcFees';
 import {
   pricesForStatedInput,
@@ -184,10 +185,10 @@ export const makeDoublePool = (
     return allocateGainsAndLosses(seat, prices);
   };
 
-  return {
+  return Far('double pool', {
     getInputPrice,
     getOutputPrice,
     swapIn,
     swapOut,
-  };
+  });
 };

--- a/packages/zoe/src/contracts/vpool-xyk-amm/singlePool.js
+++ b/packages/zoe/src/contracts/vpool-xyk-amm/singlePool.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { Far } from '@agoric/marshal';
 import { makeFeeRatio } from '../constantProduct/calcFees';
 import {
   pricesForStatedInput,
@@ -82,12 +83,12 @@ export const makeSinglePool = (
   };
 
   /** @type {VPool} */
-  return {
+  return Far('single pool', {
     getInputPrice: (amountIn, amountOut) =>
       publicPrices(getPriceForInput(amountIn, amountOut)),
     getOutputPrice: (amountIn, amountOut) =>
       publicPrices(getPriceForOutput(amountIn, amountOut)),
     swapIn,
     swapOut,
-  };
+  });
 };


### PR DESCRIPTION
Two Far pool objects were not marked `Far`.