### PR TITLE
feat: implement staking state query to support voting

### DIFF
--- a/golang/cosmos/x/lien/keeper/keeper.go
+++ b/golang/cosmos/x/lien/keeper/keeper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	vestexported "github.com/cosmos/cosmos-sdk/x/auth/vesting/exported"
+	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 type Keeper interface {
@@ -16,6 +17,9 @@ type Keeper interface {
 	SetLien(ctx sdk.Context, addr sdk.AccAddress, lien types.Lien)
 	IterateLiens(ctx sdk.Context, cb func(addr sdk.AccAddress, lien types.Lien) bool)
 	GetAccountState(ctx sdk.Context, addr sdk.AccAddress) AccountState
+	BondDenom(ctx sdk.Context) string
+	GetDelegatorDelegations(ctx sdk.Context, delegator sdk.AccAddress, maxRetrieve uint16) []stakingTypes.Delegation
+	GetValidator(ctx sdk.Context, valAddr sdk.ValAddress) (stakingTypes.Validator, bool)
 }
 
 // keeperImpl implements the lien keeper.
@@ -179,4 +183,22 @@ func (lk keeperImpl) getLocked(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
 		return vestingAccount.GetVestingCoins(ctx.BlockTime())
 	}
 	return sdk.NewCoins()
+}
+
+// The following methods simply proxy the eponymous staking keeper queries.
+
+// BondDenom returns the denom used for staking.
+func (lk keeperImpl) BondDenom(ctx sdk.Context) string {
+	return lk.stakingKeeper.BondDenom(ctx)
+}
+
+// GetDelegatorDelegations returns the delegator's delegations.
+// Returns up to the specified number of delegations.
+func (lk keeperImpl) GetDelegatorDelegations(ctx sdk.Context, delegator sdk.AccAddress, maxRetrieve uint16) []stakingTypes.Delegation {
+	return lk.stakingKeeper.GetDelegatorDelegations(ctx, delegator, maxRetrieve)
+}
+
+// GetValidator returns the named validator, if found.
+func (lk keeperImpl) GetValidator(ctx sdk.Context, valAddr sdk.ValAddress) (stakingTypes.Validator, bool) {
+	return lk.stakingKeeper.GetValidator(ctx, valAddr)
 }

--- a/golang/cosmos/x/lien/lien_test.go
+++ b/golang/cosmos/x/lien/lien_test.go
@@ -9,14 +9,32 @@ import (
 	"github.com/Agoric/agoric-sdk/golang/cosmos/x/lien/keeper"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/x/lien/types"
 
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 )
 
+func makeAccAddress() sdk.AccAddress {
+	priv := secp256k1.GenPrivKey()
+	return sdk.AccAddress(priv.PubKey().Address())
+}
+
+func makeValidator() stakingTypes.Validator {
+	valPriv := ed25519.GenPrivKey()
+	valPub := valPriv.PubKey()
+	vaddr := sdk.ValAddress(valPub.Address().Bytes())
+	validator, err := stakingTypes.NewValidator(vaddr, valPub, stakingTypes.Description{})
+	if err != nil {
+		panic(err)
+	}
+	return validator
+}
+
 var (
-	priv1      = secp256k1.GenPrivKey()
-	addr1      = sdk.AccAddress(priv1.PubKey().Address()).String()
-	zero       = sdk.NewInt(0)
+	addr1      = makeAccAddress().String()
+	i          = sdk.NewInt
+	zero       = i(0)
 	zeroCoins  = sdk.NewCoins()
 	c          = sdk.NewInt64Coin
 	emptyState = keeper.AccountState{
@@ -33,7 +51,9 @@ func ubld(amt int64) sdk.Coins {
 }
 
 type mockLienKeeper struct {
-	states map[string]keeper.AccountState
+	states      map[string]keeper.AccountState
+	validators  map[string]stakingTypes.Validator
+	delegations map[string][]stakingTypes.Delegation
 }
 
 var _ Keeper = &mockLienKeeper{}
@@ -62,6 +82,22 @@ func (m *mockLienKeeper) GetAccountState(ctx sdk.Context, addr sdk.AccAddress) k
 		return emptyState
 	}
 	return state
+}
+
+func (m *mockLienKeeper) BondDenom(ctx sdk.Context) string {
+	return "ubld"
+}
+
+func (m *mockLienKeeper) GetValidator(ctx sdk.Context, valAddr sdk.ValAddress) (stakingTypes.Validator, bool) {
+	v, found := m.validators[valAddr.String()]
+	return v, found
+}
+
+func (m *mockLienKeeper) GetDelegatorDelegations(ctx sdk.Context, delegator sdk.AccAddress, maxRetrieve uint16) []stakingTypes.Delegation {
+	if d, found := m.delegations[delegator.String()]; found {
+		return d
+	}
+	return []stakingTypes.Delegation{}
 }
 
 func TestBadType(t *testing.T) {
@@ -116,7 +152,7 @@ func TestGetAccountState(t *testing.T) {
 	acctState.CurrentTime = int64(123456789)
 	want := msgAccountState{
 		CurrentTime: acctState.CurrentTime,
-		Total:       sdk.NewInt(123),
+		Total:       i(123),
 		Bonded:      zero,
 		Unbonding:   zero,
 		Locked:      zero,
@@ -173,7 +209,7 @@ func TestSetLiened_badAddr(t *testing.T) {
 		Type:    "LIEN_SET_LIENED",
 		Address: "foo",
 		Denom:   "ubld",
-		Amount:  sdk.NewInt(123),
+		Amount:  i(123),
 	}
 	jsonMsg, err := json.Marshal(&msg)
 	if err != nil {
@@ -194,7 +230,7 @@ func TestSetLiened_badDenom(t *testing.T) {
 		Type:    "LIEN_SET_LIENED",
 		Address: addr1,
 		Denom:   "x",
-		Amount:  sdk.NewInt(123),
+		Amount:  i(123),
 	}
 	jsonMsg, err := json.Marshal(&msg)
 	if err != nil {
@@ -296,7 +332,7 @@ func TestSetLiened(t *testing.T) {
 				Type:    "LIEN_SET_LIENED",
 				Address: addr1,
 				Denom:   "ubld",
-				Amount:  sdk.NewInt(tt.newLien),
+				Amount:  i(tt.newLien),
 			}
 			jsonMsg, err := json.Marshal(&msg)
 			if err != nil {
@@ -326,6 +362,229 @@ func TestSetLiened(t *testing.T) {
 			}
 			if !reflect.DeepEqual(keeper.states[addr1], wantState) {
 				t.Errorf("bad account state %+v, want %+v", keeper.states[addr1], wantState)
+			}
+		})
+
+	}
+}
+
+func TestGetStaking(t *testing.T) {
+	val1, _ := makeValidator().AddTokensFromDel(i(12300))
+	val2, _ := makeValidator().AddTokensFromDel(i(2345))
+	val3, _ := makeValidator().AddTokensFromDel(i(34567))
+	addr1 := makeAccAddress()
+	addr2 := makeAccAddress()
+	addr3 := makeAccAddress()
+	addr4 := makeAccAddress()
+
+	keeper := mockLienKeeper{
+		validators:  make(map[string]stakingTypes.Validator),
+		delegations: make(map[string][]stakingTypes.Delegation),
+	}
+	keeper.validators[val1.OperatorAddress] = val1
+	keeper.validators[val2.OperatorAddress] = val2
+	keeper.validators[val3.OperatorAddress] = val3
+	keeper.delegations[addr1.String()] = []stakingTypes.Delegation{
+		{
+			DelegatorAddress: addr1.String(),
+			ValidatorAddress: val1.OperatorAddress,
+			Shares:           sdk.NewDec(456),
+		},
+		{
+			DelegatorAddress: addr1.String(),
+			ValidatorAddress: val2.OperatorAddress,
+			Shares:           sdk.NewDec(54),
+		},
+	}
+	keeper.delegations[addr2.String()] = []stakingTypes.Delegation{
+		{
+			DelegatorAddress: addr2.String(),
+			ValidatorAddress: val1.OperatorAddress,
+			Shares:           sdk.NewDec(101),
+		},
+		{
+			DelegatorAddress: addr2.String(),
+			ValidatorAddress: val3.OperatorAddress,
+			Shares:           sdk.NewDec(424),
+		},
+	}
+	keeper.delegations[addr3.String()] = []stakingTypes.Delegation{
+		{
+			DelegatorAddress: addr3.String(),
+			ValidatorAddress: val3.OperatorAddress,
+			Shares:           sdk.NewDec(1025),
+		},
+	}
+	keeper.delegations[addr4.String()] = []stakingTypes.Delegation{}
+
+	ph := NewPortHandler(&keeper)
+	ctx := sdk.Context{}
+	ctlCtx := &vm.ControllerContext{Context: ctx}
+
+	for _, tt := range []struct {
+		name       string
+		validators []string
+		delegators []string
+		wantVals   []sdk.Int
+		wantStates []delegatorState
+	}{
+		{
+			name:       "empty",
+			validators: []string{},
+			delegators: []string{},
+			wantVals:   []sdk.Int{},
+			wantStates: []delegatorState{},
+		},
+		{
+			name:       "one_val",
+			validators: []string{val1.OperatorAddress},
+			delegators: []string{},
+			wantVals:   []sdk.Int{i(12300)},
+			wantStates: []delegatorState{},
+		},
+		{
+			name:       "one_del",
+			validators: []string{},
+			delegators: []string{addr1.String()},
+			wantVals:   []sdk.Int{},
+			wantStates: []delegatorState{
+				{
+					ValidatorIdx: []int{},
+					Values:       []sdk.Int{},
+					Other:        i(510),
+				},
+			},
+		},
+		{
+			name:       "one_each",
+			validators: []string{val1.OperatorAddress},
+			delegators: []string{addr1.String()},
+			wantVals:   []sdk.Int{i(12300)},
+			wantStates: []delegatorState{
+				{
+					ValidatorIdx: []int{0},
+					Values:       []sdk.Int{i(456)},
+					Other:        i(54),
+				},
+			},
+		},
+		{
+			name:       "full",
+			validators: []string{val1.OperatorAddress, val2.OperatorAddress, val3.OperatorAddress},
+			delegators: []string{addr1.String(), addr2.String(), addr3.String(), addr4.String()},
+			wantVals:   []sdk.Int{i(12300), i(2345), i(34567)},
+			wantStates: []delegatorState{
+				{
+					ValidatorIdx: []int{0, 1},
+					Values:       []sdk.Int{i(456), i(54)},
+					Other:        zero,
+				},
+				{
+					ValidatorIdx: []int{0, 2},
+					Values:       []sdk.Int{i(101), i(424)},
+					Other:        zero,
+				},
+				{
+					ValidatorIdx: []int{2},
+					Values:       []sdk.Int{i(1025)},
+					Other:        zero,
+				},
+				{
+					ValidatorIdx: []int{},
+					Values:       []sdk.Int{},
+					Other:        zero,
+				},
+			},
+		},
+		{
+			name:       "dup",
+			validators: []string{val1.OperatorAddress, val1.OperatorAddress},
+			delegators: []string{addr1.String(), addr1.String()},
+			wantVals:   []sdk.Int{i(12300), i(12300)},
+			wantStates: []delegatorState{
+				{
+					ValidatorIdx: []int{1}, // selects last index
+					Values:       []sdk.Int{i(456)},
+					Other:        i(54),
+				},
+				{
+					ValidatorIdx: []int{1}, // selects last index
+					Values:       []sdk.Int{i(456)},
+					Other:        i(54),
+				},
+			},
+		},
+		{
+			name:       "bad_addr",
+			validators: []string{"foo", val1.OperatorAddress},
+			delegators: []string{"bar", addr1.String()},
+			wantVals:   []sdk.Int{i(-1), i(12300)},
+			wantStates: []delegatorState{
+				{
+					ValidatorIdx: []int{},
+					Values:       []sdk.Int{},
+					Other:        i(-1),
+				},
+				{
+					ValidatorIdx: []int{1},
+					Values:       []sdk.Int{i(456)},
+					Other:        i(54),
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := portMessage{
+				Type:       "LIEN_GET_STAKING",
+				Validators: tt.validators,
+				Delegators: tt.delegators,
+			}
+			j, err := json.Marshal(&msg)
+			if err != nil {
+				t.Fatalf("cannot marshal message: %v", err)
+			}
+			reply, err := ph.Receive(ctlCtx, string(j))
+			if err != nil {
+				t.Fatalf("Receive error: %v", err)
+			}
+			result := msgStaking{}
+			err = json.Unmarshal([]byte(reply), &result)
+			if err != nil {
+				t.Fatalf("cannot unmarshal reply %s: %v", reply, err)
+			}
+			if result.Denom != "ubld" {
+				t.Errorf("denom got %s, want ubld", result.Denom)
+			}
+			if len(result.ValidatorValues) != len(tt.wantVals) {
+				t.Errorf("wrong # of vals returned - got %v, want %v", result.ValidatorValues, tt.wantVals)
+			} else {
+				for i, x := range result.ValidatorValues {
+					if !x.Equal(tt.wantVals[i]) {
+						t.Errorf("validator %d got %v, want %v", i, x, tt.wantVals[i])
+					}
+				}
+			}
+			if len(result.DelegatorStates) != len(tt.wantStates) {
+				t.Errorf("wrong # of states returned - got %v, want %v", result.DelegatorStates, tt.wantStates)
+			} else {
+				for s, got := range result.DelegatorStates {
+					want := tt.wantStates[s]
+					if !reflect.DeepEqual(got.ValidatorIdx, want.ValidatorIdx) {
+						t.Errorf("state %d bad validator indexes - got %v, want %v", s, got.ValidatorIdx, want.ValidatorIdx)
+					}
+					if len(got.Values) != len(want.Values) {
+						t.Errorf("state %d wrong # values - got %v, want %v", s, got.Values, want.Values)
+					} else {
+						for v, gotVal := range got.Values {
+							if !gotVal.Equal(want.Values[v]) {
+								t.Errorf("state %d value %d got %v, want %v", s, v, gotVal, want.Values[v])
+							}
+						}
+					}
+					if !got.Other.Equal(want.Other) {
+						t.Errorf("state %d wrong 'other' got %v, want %v", s, got.Other, want.Other)
+					}
+				}
 			}
 		})
 

--- a/golang/cosmos/x/lien/spec/02_messages.md
+++ b/golang/cosmos/x/lien/spec/02_messages.md
@@ -67,7 +67,7 @@ in the request, where the object contains:
     or `"-1"` for a malformed delegator address.
 
 This call obtains a partial snapshot of staking data in a compact
-represetnation. It is intended for use in tallying votes of delegated tokens,
+representation. It is intended for use in tallying votes of delegated tokens,
 with proxying of votes based on delegation. It has nothing to do with liens
 per se, but the lien module has the necessary connectivity to implement it.
 This call may be moved to another module in the future if appropriate.

--- a/golang/cosmos/x/lien/spec/02_messages.md
+++ b/golang/cosmos/x/lien/spec/02_messages.md
@@ -39,15 +39,42 @@ Response:
 
 See [Concepts](01_concepts.md) for the meaning of the amounts.
 
+### LIEN_GET_STAKING
+
+* type: "LIEN_GET_STAKING"
+* validators: array of strings of bech32-encoded operator addresses
+* delegators: array of strings of bech32-encoded account addresses
+
+Response:
+
+* epoch_tag: string encoding the staking epoch.
+If it is the same in two different responses, the results can be
+safely aggregated.
+* denom: string giving the name of the staking token
+* validator_values: array of string encoding nonnegative integer
+giving the tokens delegated to the validator of the same index
+as the request, or `"-1"` for a malformed validator address.
+* delegator_states: array of objects corresponding to the delegators
+in the request, where the object contains:
+    * val_idx: array of nonnegative integers referring to the index of
+    a validator in the request. If the same validator address is
+    given multiple times in the request, the index of the last one is used.
+    * values: array of strings of the same size as `val_idx` encoding
+    nonnegative integers for the amount this delegator has delegated
+    to the referenced validator.
+    * other: string encoding nonnegative integer of the total amount
+    this delegator has delegated to validators not mentioned in the request,
+    or `"-1"` for a malformed delegator address.
+
+This call obtains a partial snapshot of staking data in a compact
+represetnation. It is intended for use in tallying votes of delegated tokens,
+with proxying of votes based on delegation. It has nothing to do with liens
+per se, but the lien module has the necessary connectivity to implement it.
+This call may be moved to another module in the future if appropriate.
+
 ## From Golang to Javascript
 
-### LIEN_SLASHED
-
-* type: "LIEN_SLASHED"
-* addresses: array of bech32-encoded strings, lexicographically sorted
-* currentTime: string timestamp
-
-No reply, eventual delivery.
+None.
 
 ## Design Notes
 

--- a/golang/cosmos/x/lien/spec/02_messages.md
+++ b/golang/cosmos/x/lien/spec/02_messages.md
@@ -51,11 +51,12 @@ Response:
 If it is the same in two different responses, the results can be
 safely aggregated.
 * denom: string giving the name of the staking token
-* validator_values: array of string encoding nonnegative integer
-giving the tokens delegated to the validator of the same index
-as the request, or `"-1"` for a malformed validator address.
-* delegator_states: array of objects corresponding to the delegators
-in the request, where the object contains:
+* validator_values: array of the same length as the request `validators`,
+where each entry is a string encoding nonnegative integer
+giving the tokens delegated to the corresponding validator, or `null`
+if that validator address is malformed.
+* delegator_states: array of the same length as the request `delegators`,
+holding `null` if the address is malformed, otherwise an object containing:
     * val_idx: array of nonnegative integers referring to the index of
     a validator in the request. If the same validator address is
     given multiple times in the request, the index of the last one is used.
@@ -63,8 +64,7 @@ in the request, where the object contains:
     nonnegative integers for the amount this delegator has delegated
     to the referenced validator.
     * other: string encoding nonnegative integer of the total amount
-    this delegator has delegated to validators not mentioned in the request,
-    or `"-1"` for a malformed delegator address.
+    this delegator has delegated to validators not mentioned in the request.
 
 This call obtains a partial snapshot of staking data in a compact
 representation. It is intended for use in tallying votes of delegated tokens,


### PR DESCRIPTION
Remove mention of obsoleted slashing notification.
refs: #3971

## Description

Implement the query for staking state as described in #3971.

### Security Considerations

For large requests and large staking state, the reply message could become uncomfortably large.

Once staking epochs are implemented, we can partition the query across multiple requests.

### Documentation Considerations

Spec updated.

### Testing Considerations

Eventually need end-to-end test with real staking data.
