### PR TITLE
feat(walletManager): enable `agoric.chainWallet` deployment power

### DIFF
--- a/packages/dapp-svelte-wallet/api/package.json
+++ b/packages/dapp-svelte-wallet/api/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@agoric/dapp-svelte-wallet-api",
-  "private": true,
+  "name": "@agoric/wallet-backend",
   "version": "0.10.5",
-  "description": "Wallet web server handler",
+  "description": "Wallet backend",
   "type": "module",
   "scripts": {
-    "build": "exit 0",
+    "build": "yarn build:bundles",
+    "build:bundles": "node scripts/build-bundles.js",
     "test": "ava",
     "test:xs": "exit 0",
     "lint": "yarn lint:types && yarn lint:eslint",

--- a/packages/dapp-svelte-wallet/api/scripts/build-bundles.js
+++ b/packages/dapp-svelte-wallet/api/scripts/build-bundles.js
@@ -1,0 +1,46 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import 'ses';
+import fs from 'fs';
+import path from 'path';
+import process from 'process';
+import bundleSource from '@agoric/bundle-source';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
+
+const srcDir = `${dirname}/../src`;
+const bundlesDir = `${dirname}/../bundles`;
+
+async function writeSourceBundle(contractFilename, outputPath) {
+  const bundlePath = new URL(
+    await importMetaResolve(contractFilename, import.meta.url),
+  ).pathname;
+  await bundleSource(bundlePath).then(bundle => {
+    // TODO: fix
+    // @ts-ignore mkdirSync believes it only accepts 2 arguments.
+    fs.mkdirSync(bundlesDir, { recursive: true }, err => {
+      if (err) throw err;
+    });
+    fs.writeFileSync(outputPath, `export default ${JSON.stringify(bundle)};`);
+  });
+}
+
+async function main() {
+  const contractOutputs = [
+    [`${srcDir}/wallet.js`, `${bundlesDir}/bundle-wallet.js`],
+  ];
+  for (const [contractFilename, outputPath] of contractOutputs) {
+    // eslint-disable-next-line no-await-in-loop
+    await writeSourceBundle(contractFilename, outputPath);
+  }
+}
+
+main().then(
+  _ => process.exit(0),
+  err => {
+    console.log('error creating contract bundles:');
+    console.log(err);
+    process.exit(1);
+  },
+);

--- a/packages/vats/decentral-config.json
+++ b/packages/vats/decentral-config.json
@@ -34,6 +34,9 @@
     "sharing": {
       "sourceSpec": "./src/vat-sharing.js"
     },
+    "walletManager": {
+      "sourceSpec": "./src/vat-walletManager.js"
+    },
     "zoe": {
       "sourceSpec": "./src/vat-zoe.js",
       "parameters": {

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -39,6 +39,7 @@
     "@agoric/store": "^0.6.6",
     "@agoric/swingset-vat": "^0.23.0",
     "@agoric/treasury": "^0.6.5",
+    "@agoric/wallet-backend": "^0.10.5",
     "@agoric/zoe": "^0.20.0"
   },
   "devDependencies": {

--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -105,6 +105,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       chainTimerService,
       { zoeService: zoe, feeMintAccess, feeCollectionPurse },
       { priceAuthority, adminFacet: priceAuthorityAdmin },
+      walletManager,
     ] = await Promise.all([
       E(bankVat).makeBankManager(bankBridgeManager),
       E(vats.sharing).getSharingService(),
@@ -115,6 +116,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         vats.zoe,
       ).buildZoe(vatAdminSvc, feeIssuerConfig, zoeFeesConfig, meteringConfig)),
       E(vats.priceAuthority).makePriceAuthority(),
+      E(vats.walletManager).buildWalletManager(vatAdminSvc),
     ]);
 
     const zoeWUnlimitedPurse = E(zoe).bindDefaultFeePurse(feeCollectionPurse);
@@ -539,26 +541,6 @@ export function buildRootObject(vatPowers, vatParameters) {
           ibcport.push(port);
         }
 
-        const additionalPowers = {};
-        const powerFlagConfig = [
-          ['agoricNamesAdmin', agoricNamesAdmin],
-          ['bankManager', bankManager],
-          ['pegasusConnections', pegasusConnections],
-          ['priceAuthorityAdmin', priceAuthorityAdmin],
-          ['treasuryCreator', treasuryCreator],
-          ['vattp', () => makeVattpFrom(vats)],
-        ];
-        for (const [flag, value] of powerFlagConfig) {
-          if (
-            powerFlags &&
-            (powerFlags.includes(`agoric.${flag}`) ||
-              powerFlags.includes('agoric.ALL_THE_POWERS'))
-          ) {
-            const power = typeof value === 'function' ? value() : value;
-            additionalPowers[flag] = power;
-          }
-        }
-
         /** @type {{ issuerName: string, purseName: string, issuer: Issuer,
          * brand: Brand, payment: Payment, payToBank: boolean }[]} */
         const userPaymentRecords = [];
@@ -688,6 +670,42 @@ export function buildRootObject(vatPowers, vatParameters) {
             return address;
           },
         });
+
+        const makeChainWallet = () =>
+          E(walletManager).makeWallet({
+            bank,
+            feePurse: userFeePurse,
+            agoricNames,
+            namesByAddress,
+            myAddressNameAdmin,
+            zoe: zoeWUserFeePurse,
+            board,
+            localTimerService: chainTimerService,
+          });
+
+        const additionalPowers = {};
+        const powerFlagConfig = [
+          ['agoricNamesAdmin', agoricNamesAdmin],
+          ['bankManager', bankManager],
+          ['chainWallet', () => makeChainWallet()],
+          ['pegasusConnections', pegasusConnections],
+          ['priceAuthorityAdmin', priceAuthorityAdmin],
+          ['treasuryCreator', treasuryCreator],
+          ['vattp', () => makeVattpFrom(vats)],
+        ];
+        await Promise.all(
+          powerFlagConfig.map(async ([flag, value]) => {
+            if (
+              !powerFlags ||
+              (!powerFlags.includes(`agoric.${flag}`) &&
+                !powerFlags.includes('agoric.ALL_THE_POWERS'))
+            ) {
+              return;
+            }
+            const powerP = typeof value === 'function' ? value() : value;
+            additionalPowers[flag] = await powerP;
+          }),
+        );
 
         const bundle = harden({
           ...additionalPowers,

--- a/packages/vats/src/vat-walletManager.js
+++ b/packages/vats/src/vat-walletManager.js
@@ -1,0 +1,26 @@
+import { Far } from '@agoric/marshal';
+import { E } from '@agoric/eventual-send';
+import walletBundle from '@agoric/wallet-backend/bundles/bundle-wallet.js';
+
+export const buildRootObject = _vatPowers => {
+  return Far('walletManager root', {
+    buildWalletManager: vatAdminSvc =>
+      Far('walletManager', {
+        makeWallet: async terms => {
+          // agoricNames, namesByAddress, myAddressNameAdmin, zoe, board, localTimerService
+          const { bank, feePurse } = terms;
+
+          // FIXME: This is unsustainable.  We need either a single-vat wallet
+          // service that switches meters, or to create a meter-limited
+          // single-wallet vat.
+          const meter = await E(vatAdminSvc).createUnlimitedMeter();
+          const opts = { meter };
+          const { root } = await E(vatAdminSvc).createVat(walletBundle, opts);
+
+          // We have the wallet vat, so we can now start a wallet.
+          await E(root).startup(terms);
+          return E(root).getWallet(bank, feePurse);
+        },
+      }),
+  });
+};


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #2629

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

When the `agoric.chainWallet` deployment power is given (such as on the sim-chain), we create an on-chain wallet for that user.  It shares some purses with the ag-solo wallet (RUN, BLD, zoeFees), but has a different identity.

![image](https://user-images.githubusercontent.com/457244/138396255-7fcea379-731f-4539-ae34-e9134033bd2b.png)

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

For now, the chain wallet has not been optimised, so it may pose a risk to an actual chain.  Fortunately, it is not created except via provisioning powers, which are currently only configurable by the holders of a "provisionpass".  We will need to migrate provisioning powers to on-chain governance, and should decide different policies for chainWallets as they become more useful.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

`home.chainWallet` is an on-chain version of `home.wallet`.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

You can switch between the solo wallet and the chain wallet by running the following in the REPL and reloading the wallet UI after each

```js
home.wallet = agoric.chainWallet; // switch to chain wallet
home.wallet = local.wallet; // switch to ag-solo wallet
```

Watch the purses change in the below recording:

https://user-images.githubusercontent.com/457244/138399335-1baf73a1-de04-429e-9896-05da77cd9c39.mov



