### PR TITLE
Wallet corrections

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/actions.js
+++ b/packages/dapp-svelte-wallet/api/src/actions.js
@@ -1,0 +1,135 @@
+// @ts-check
+
+import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
+import { E } from '@agoric/eventual-send';
+
+export const makePaymentActions = ({
+  getBrandRecord,
+  getPurseByPetname,
+  getRecord,
+  updateRecord,
+  getAutoDepositPurse,
+  getIssuerBoardId,
+}) => {
+  const depositedPK = makePromiseKit();
+
+  return Far('payment actions', {
+    deposit: async (purseOrPetname = undefined) => {
+      const oldPaymentRecord = getRecord();
+      const { brand, payment } = oldPaymentRecord;
+      assert(payment);
+
+      /** @type {Purse} */
+      let purse;
+      if (purseOrPetname === undefined) {
+        const autoDepositPurse = getAutoDepositPurse(brand);
+        if (!autoDepositPurse) {
+          // No automatic purse right now.
+          return depositedPK.promise;
+        }
+        // Plop into the current autodeposit purse.
+        purse = getAutoDepositPurse(brand);
+      } else if (
+        Array.isArray(purseOrPetname) ||
+        typeof purseOrPetname === 'string'
+      ) {
+        purse = getPurseByPetname(purseOrPetname);
+      } else {
+        purse = purseOrPetname;
+      }
+      const brandRecord = getBrandRecord(brand);
+      updateRecord({ ...oldPaymentRecord, status: 'pending' }, brandRecord);
+      // Now try depositing.
+      E(purse)
+        .deposit(payment)
+        .then(
+          depositedAmount => {
+            updateRecord(
+              {
+                ...getRecord(),
+                // Remove the payment so it can be GCed.
+                payment: undefined,
+                status: 'deposited',
+                depositedAmount,
+              },
+              brandRecord,
+            );
+            depositedPK.resolve(depositedAmount);
+          },
+          e => {
+            console.error(
+              'Error depositing payment in',
+              purseOrPetname || 'default purse',
+              e,
+            );
+            if (purseOrPetname === undefined) {
+              // Error in auto-deposit purse, just fail.  They can try
+              // again.
+              updateRecord({
+                ...getRecord(),
+                status: undefined,
+              });
+              depositedPK.reject(e);
+            } else {
+              // Error in designated deposit, so retry automatically without
+              // a designated purse.
+              depositedPK.resolve(getRecord().actions.deposit(undefined));
+            }
+          },
+        );
+      return depositedPK.promise;
+    },
+    refresh: async () => {
+      const oldPaymentRecord = getRecord();
+      const { brand, issuer, payment } = oldPaymentRecord;
+      const brandRecord = getBrandRecord(brand);
+      if (!brandRecord) {
+        return false;
+      }
+
+      if (!issuer) {
+        updateRecord(
+          {
+            ...oldPaymentRecord,
+            issuerBoardId: getIssuerBoardId(brandRecord.issuer),
+          },
+          brandRecord,
+        );
+        return true;
+      }
+
+      if (!payment) {
+        return false;
+      }
+
+      const isLive = await E(issuer).isLive(payment);
+      if (isLive) {
+        return false;
+      }
+
+      updateRecord({
+        ...oldPaymentRecord,
+        // Remove the payment itself so it can be GCed.
+        payment: undefined,
+        status: 'expired',
+      });
+      return true;
+    },
+    getAmountOf: async () => {
+      const oldPaymentRecord = getRecord();
+      const { issuer, payment } = oldPaymentRecord;
+      assert(issuer);
+      assert(payment);
+
+      // Fetch the current amount of the payment.
+      const lastAmount = await E(issuer).getAmountOf(payment);
+
+      updateRecord({
+        ...oldPaymentRecord,
+        lastAmount,
+      });
+      return true;
+    },
+  });
+};

--- a/packages/dapp-svelte-wallet/api/src/date-now.js
+++ b/packages/dapp-svelte-wallet/api/src/date-now.js
@@ -1,0 +1,46 @@
+import { E } from '@agoric/eventual-send';
+import { observeNotifier } from '@agoric/notifier';
+import { makePromiseKit } from '@agoric/promise-kit';
+
+export const DEFAULT_TIMER_SERVICE_POLL_INTERVAL = 60_000n;
+export const DEFAULT_TIMER_DEVICE_SCALE = 1;
+
+// Make a function that returns the latest polled time.
+// This only provides as high resolution as the timer device.
+export const makeTimerDeviceDateNow = (
+  D,
+  timerDevice,
+  timerDeviceScale = DEFAULT_TIMER_DEVICE_SCALE,
+) => () => {
+  const stamp = D(timerDevice).getLastPolled();
+  const lastPolledStamp = parseInt(`${stamp}`, 10) * timerDeviceScale;
+  return lastPolledStamp;
+};
+
+// Make a function that returns the latest polled time.  This only provides as
+// high resolution as the timer service poll interval.
+export const makeTimerServiceDateNow = (
+  timerService,
+  timerPollInterval = DEFAULT_TIMER_SERVICE_POLL_INTERVAL,
+) => {
+  let lastPolledStamp = NaN;
+  const dateNow = () => lastPolledStamp;
+
+  /** @type {PromiseRecord<typeof dateNow>} */
+  const dateNowPK = makePromiseKit();
+
+  // Subscribe to a notifier that will poll the local timer service
+  // regularly.
+  const timerNotifier = E(timerService).makeNotifier(0n, timerPollInterval);
+
+  // Begin observing the notifier.
+  observeNotifier(timerNotifier, {
+    updateState(stamp) {
+      lastPolledStamp = parseInt(`${stamp}`, 10);
+      dateNowPK.resolve(dateNow);
+    },
+  }).catch(e => dateNowPK.reject(e));
+
+  // Return the dateNow function after the notifier fires at least once.
+  return dateNowPK.promise;
+};

--- a/packages/dapp-svelte-wallet/api/src/internal-types.js
+++ b/packages/dapp-svelte-wallet/api/src/internal-types.js
@@ -67,9 +67,9 @@
  * @typedef {Object} PaymentRecord
  * @property {RecordMetadata} meta
  * @property {Issuer} [issuer]
- * @property {Payment} payment
+ * @property {Payment} [payment]
  * @property {Brand} brand
- * @property {'pending'|'deposited'} [status]
+ * @property {'pending'|'deposited'|'expired'} [status]
  * @property {PaymentActions} actions
  * @property {Amount} [lastAmount]
  * @property {Amount} [depositedAmount]

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -1437,17 +1437,21 @@ test('stamps from localTimerService', async t => {
   await E(wallet).addIssuer('simolean', simoleanIssuer);
   await E(wallet).makeEmptyPurse('simolean', 'Tester', true);
 
+  const { mint: nonameMint, brand: nonameBrand } = makeIssuerKit('noname');
+
   const [pmt1, pmt2, pmt3] = await Promise.all(
     [30n, 50n, 71n].map(async n =>
       E(simoleanMint).mintPayment(AmountMath.make(simoleanBrand, n)),
     ),
   );
+  const pmt4 = E(nonameMint).mintPayment(AmountMath.make(nonameBrand, 103n));
 
   const clockNotifier = E(wallet).getClockNotifier();
   const paymentNotifier = E(wallet).getPaymentsNotifier();
 
   const { updateCount: count0 } = await E(paymentNotifier).getUpdateSince();
   await E(wallet).addPayment(pmt1);
+  E(wallet).addPayment(pmt4);
   const { updateCount: count1 } = await E(paymentNotifier).getUpdateSince(
     count0,
   );
@@ -1466,22 +1470,31 @@ test('stamps from localTimerService', async t => {
   await E(wallet).addPayment(pmt3);
   const { value: payments } = await E(paymentNotifier).getUpdateSince(count1);
 
-  const paymentMeta = payments.map(p => p.meta);
+  const paymentMeta = payments.map(p => ({ ...p.meta, status: p.status }));
   t.deepEqual(paymentMeta, [
     {
       creationStamp: 19199000,
       updatedStamp: 19199000,
       id: 6,
+      status: 'deposited',
     },
     {
-      creationStamp: 19200000,
-      updatedStamp: 19200000,
+      creationStamp: 19199000,
+      updatedStamp: 19199000,
       id: 7,
+      status: undefined,
     },
     {
       creationStamp: 19200000,
       updatedStamp: 19200000,
       id: 8,
+      status: 'deposited',
+    },
+    {
+      creationStamp: 19200000,
+      updatedStamp: 19200000,
+      id: 9,
+      status: 'deposited',
     },
   ]);
 });

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -7,7 +7,6 @@ import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
 
 import { makeZoeKit } from '@agoric/zoe';
 import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
-import makeManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@agoric/eventual-send';
 
 import { assert } from '@agoric/assert';
@@ -1413,18 +1412,21 @@ test('getZoe, getBoard', async t => {
   t.is(await E(wallet).getBoard(), board);
 });
 
-test('stamps from localTimerService', async t => {
+test('stamps from dateNow', async t => {
   const { zoeService } = makeZoeKit(fakeVatAdmin);
   const feePurse = E(zoeService).makeFeePurse();
   const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
   const board = makeBoard();
-  const manualTimer = makeManualTimer(t.log, 19199000n, 1000n);
+
+  const startDateMS = new Date(2020, 0, 1).valueOf();
+  let currentDateMS = startDateMS;
+  const dateNow = () => currentDateMS;
 
   const { admin: wallet, initialized } = makeWallet({
     zoe,
     board,
     myAddressNameAdmin: makeFakeMyAddressNameAdmin(),
-    localTimerService: manualTimer,
+    dateNow,
   });
   await initialized;
 
@@ -1446,9 +1448,9 @@ test('stamps from localTimerService', async t => {
   );
   const pmt4 = E(nonameMint).mintPayment(AmountMath.make(nonameBrand, 103n));
 
-  const clockNotifier = E(wallet).getClockNotifier();
   const paymentNotifier = E(wallet).getPaymentsNotifier();
 
+  const date0 = currentDateMS;
   const { updateCount: count0 } = await E(paymentNotifier).getUpdateSince();
   await E(wallet).addPayment(pmt1);
   E(wallet).addPayment(pmt4);
@@ -1457,14 +1459,9 @@ test('stamps from localTimerService', async t => {
   );
 
   // Wait for tick to take effect.
-  const { updateCount: clock0, value: clockValue0 } = await E(
-    clockNotifier,
-  ).getUpdateSince();
-  t.is(clockValue0, 19199000);
-  await manualTimer.tick();
-
-  const { value: clockValue1 } = await E(clockNotifier).getUpdateSince(clock0);
-  t.is(clockValue1, 19199000 + 1000);
+  currentDateMS += 1234;
+  const date1 = currentDateMS;
+  t.is(dateNow(), startDateMS + 1234);
 
   await E(wallet).addPayment(pmt2);
   await E(wallet).addPayment(pmt3);
@@ -1473,26 +1470,26 @@ test('stamps from localTimerService', async t => {
   const paymentMeta = payments.map(p => ({ ...p.meta, status: p.status }));
   t.deepEqual(paymentMeta, [
     {
-      creationStamp: 19199000,
-      updatedStamp: 19199000,
+      creationStamp: date0,
+      updatedStamp: date0,
       id: 6,
       status: 'deposited',
     },
     {
-      creationStamp: 19199000,
-      updatedStamp: 19199000,
+      creationStamp: date0,
+      updatedStamp: date1,
       id: 7,
       status: undefined,
     },
     {
-      creationStamp: 19200000,
-      updatedStamp: 19200000,
+      creationStamp: date1,
+      updatedStamp: date1,
       id: 8,
       status: 'deposited',
     },
     {
-      creationStamp: 19200000,
-      updatedStamp: 19200000,
+      creationStamp: date1,
+      updatedStamp: date1,
       id: 9,
       status: 'deposited',
     },

--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -29,6 +29,10 @@ const QUOTE_INTERVAL = 5 * 60;
 
 const BASIS_POINTS_DENOM = 10000n;
 
+const CENTRAL_DENOM_NAME = 'urun';
+// On-chain timer device is in seconds, so scale to milliseconds.
+const CHAIN_TIMER_DEVICE_SCALE = 1000;
+
 console.debug(`loading bootstrap.js`);
 
 // Used for coordinating on an index in comms for the provisioning service
@@ -43,7 +47,6 @@ function makeVattpFrom(vats) {
   });
 }
 
-const CENTRAL_DENOM_NAME = 'urun';
 export function buildRootObject(vatPowers, vatParameters) {
   const { D } = vatPowers;
   async function setupCommandDevice(httpVat, cmdDevice, roles) {
@@ -680,7 +683,8 @@ export function buildRootObject(vatPowers, vatParameters) {
             myAddressNameAdmin,
             zoe: zoeWUserFeePurse,
             board,
-            localTimerService: chainTimerService,
+            timerDevice,
+            timerDeviceScale: CHAIN_TIMER_DEVICE_SCALE,
           });
 
         const additionalPowers = {};


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs #3982

## Description

Prevent holding onto deposited or expired payments.

Use a synchronous `dateNow` to construct timestamps for the wallet record metadata.  This can still use a timestamp that's updated by observing an `E(timerService).makeNotifier()`, but it also enables using a `D(timerDevice).getLastPolled()` for truly sync poll-only-when-needed results.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
