### PR TITLE
dropping the max on the property-based tests led to problems

### DIFF
--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
@@ -13,10 +13,17 @@ const { add, multiply } = natSafeMath;
 const { brand: brandX } = makeIssuerKit('X');
 const { brand: brandY } = makeIssuerKit('Y');
 
-const arbPoolX = fc.bigUint().map(value => m.make(brandX, 100n + value));
-const arbPoolY = fc.bigUint().map(value => m.make(brandY, 100n + value));
-const arbGiveX = fc.bigUint().map(value => m.make(brandX, value));
-const arbGiveY = fc.bigUint().map(value => m.make(brandY, value));
+const oneB = 1_000_000_000n;
+// const dec18 = 1_000_000_000_000_000_000n; // 18 decimals as used in ETH
+
+const arbPoolX = fc
+  .bigUint({ max: oneB })
+  .map(value => m.make(brandX, 100n + value));
+const arbPoolY = fc
+  .bigUint({ max: oneB })
+  .map(value => m.make(brandY, 100n + value));
+const arbGiveX = fc.bigUint({ max: oneB }).map(value => m.make(brandX, value));
+const arbGiveY = fc.bigUint({ max: oneB }).map(value => m.make(brandY, value));
 
 // left and right are within 5% of each other.
 const withinEpsilon = (left, right) =>


### PR DESCRIPTION
refs: #4519

## Description

As a last step before checkin, I dropped the maximums in the property based tests. This led to failures in CI (https://github.com/Agoric/agoric-sdk/runs/5251436118?check_suite_focus=true).

### Security Considerations

We should investigate whether the CI failures represent actual issues. I suspect it's just that the approximation for 'close enough' was insufficient when the numbers being added to the pool got absurdly large.

### Documentation Considerations

No issues.

### Testing Considerations

fixing a test so CI isn't impacted.  We can get this fix in quickly, then we can consider at our leisure whether we need to check more cases.