### PR TITLE
refactor(governance): rename "api" to "method"

### DIFF
--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -129,8 +129,8 @@ capabilities. ContractGovernor starts the governed contract, so it gets the
 powerful creatorFacet. ContractGovernor needs access to the paramManager, but
 shouldn't share it. So the contractGovernor's `creatorFacet` provides access to
 the governed contract's `publicFacet`, `creatorFacet`, `instance`,
-`voteOnApiInvocation`, and `voteOnParamChange`. The contract's owner should
-treat `voteOnApiInvocation` and `voteOnParamChange` as particularly powerful.
+`voteOnInvocation`, and `voteOnParamChange`. The contract's owner should
+treat `voteOnInvocation` and `voteOnParamChange` as particularly powerful.
 
 ### Governing Electorates
 

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -228,7 +228,7 @@ Governed methods and parameters must be included in terms.
         value: invitationAmount,
       },
     },
-    governedApis: ['makeItSo'],
+    governedMethods: ['makeItSo'],
   },
 ```
 

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -189,7 +189,7 @@ yourself using 'addUnknown', let us know!)
 
 `ContractGovernor` has support for contracts that declare that some internal
 APIs should only be invoked under the control of governance. To opt in to this
-support, the contract should include `getGovernedApis` in its creator facet
+support, the contract should include `getGovernedMethods` in its creator facet
 (passed to `wrapCreatorFacet`). That method should return a `Far` object with
 the methods to be called.
 

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -129,8 +129,8 @@ capabilities. ContractGovernor starts the governed contract, so it gets the
 powerful creatorFacet. ContractGovernor needs access to the paramManager, but
 shouldn't share it. So the contractGovernor's `creatorFacet` provides access to
 the governed contract's `publicFacet`, `creatorFacet`, `instance`,
-`voteOnInvocation`, and `voteOnParamChange`. The contract's owner should
-treat `voteOnInvocation` and `voteOnParamChange` as particularly powerful.
+`voteOnMethodInvocation`, and `voteOnParamChange`. The contract's owner should
+treat `voteOnMethodInvocation` and `voteOnParamChange` as particularly powerful.
 
 ### Governing Electorates
 

--- a/packages/governance/docs/contractGovernance.puml
+++ b/packages/governance/docs/contractGovernance.puml
@@ -10,7 +10,7 @@ package "GovernedContract Vat" <<Rectangle>>  {
     }
 
     class GovernedContract {
-        <i>verifiable</i>: Governor, params, governedApis
+        <i>verifiable</i>: Governor, params, governedMethods
         --
         +terms: { electionManager, governedParams }
         +getState()

--- a/packages/governance/docs/contractGovernance.puml
+++ b/packages/governance/docs/contractGovernance.puml
@@ -30,10 +30,10 @@ class "ContractGovernor\n(an ElectionManager)" as ContractGovernor {
     +validateTimer()
     --
     -voteOnParamChange()
-    -voteOnApiInvocation()
+    -voteOnInvocation()
     -getCreatorFacet() - The unrestricted part of the governed contract's creatorFacet
 }
-note left : ContractGovernor starts GovernedContract.\nvoteOnParamChange() and voteOnApiInvocation()\nshould be tightly held. getCreatorFacet()\nis for the contract's creator.
+note left : ContractGovernor starts GovernedContract.\nvoteOnParamChange() and voteOnInvocation()\nshould be tightly held. getCreatorFacet()\nis for the contract's creator.
 
 class Electorate {
     Questions

--- a/packages/governance/docs/contractGovernance.puml
+++ b/packages/governance/docs/contractGovernance.puml
@@ -30,10 +30,10 @@ class "ContractGovernor\n(an ElectionManager)" as ContractGovernor {
     +validateTimer()
     --
     -voteOnParamChange()
-    -voteOnInvocation()
+    -voteOnMethodInvocation()
     -getCreatorFacet() - The unrestricted part of the governed contract's creatorFacet
 }
-note left : ContractGovernor starts GovernedContract.\nvoteOnParamChange() and voteOnInvocation()\nshould be tightly held. getCreatorFacet()\nis for the contract's creator.
+note left : ContractGovernor starts GovernedContract.\nvoteOnParamChange() and voteOnMethodInvocation()\nshould be tightly held. getCreatorFacet()\nis for the contract's creator.
 
 class Electorate {
     Questions

--- a/packages/governance/src/contractGovernance/governApi.js
+++ b/packages/governance/src/contractGovernance/governApi.js
@@ -49,8 +49,8 @@ const setupApiGovernance = async (
   /** @type {WeakSet<Instance>} */
   const voteCounters = new WeakSet();
 
-  /** @type {VoteOnApiInvocation} */
-  const voteOnApiInvocation = async (
+  /** @type {VoteOnInvocation} */
+  const voteOnInvocation = async (
     apiMethodName,
     methodArgs,
     voteCounterInstallation,
@@ -122,7 +122,7 @@ const setupApiGovernance = async (
   };
 
   return Far('paramGovernor', {
-    voteOnApiInvocation,
+    voteOnInvocation,
     createdQuestion: b => voteCounters.has(b),
   });
 };

--- a/packages/governance/src/contractGovernance/governApi.js
+++ b/packages/governance/src/contractGovernance/governApi.js
@@ -49,8 +49,8 @@ const setupApiGovernance = async (
   /** @type {WeakSet<Instance>} */
   const voteCounters = new WeakSet();
 
-  /** @type {VoteOnInvocation} */
-  const voteOnInvocation = async (
+  /** @type {VoteOnMethodInvocation} */
+  const voteOnMethodInvocation = async (
     apiMethodName,
     methodArgs,
     voteCounterInstallation,
@@ -122,7 +122,7 @@ const setupApiGovernance = async (
   };
 
   return Far('paramGovernor', {
-    voteOnInvocation,
+    voteOnMethodInvocation,
     createdQuestion: b => voteCounters.has(b),
   });
 };

--- a/packages/governance/src/contractGovernance/governApi.js
+++ b/packages/governance/src/contractGovernance/governApi.js
@@ -15,7 +15,7 @@ const { details: X } = assert;
 
 /**
  * Make a pair of positions for a question about whether to invoke an API. If
- * the vote passes, the method will be called on the governedApis facet with the
+ * the vote passes, the method will be called on the governedMethods facet with the
  * arguments that were provided.
  *
  * @param {string} apiMethodName
@@ -32,7 +32,7 @@ const makeApiInvocationPositions = (apiMethodName, methodArgs) => {
  *
  * @param {ERef<ZoeService>} zoe
  * @param {Instance} governedInstance
- * @param {ERef<{ [methodName: string]: (...args: any) => unknown }>} governedApis
+ * @param {ERef<{ [methodName: string]: (...args: any) => unknown }>} governedMethods
  * @param {string[]} governedNames names of the governed API methods
  * @param {ERef<TimerService>} timer
  * @param {() => Promise<PoserFacet>} getUpdatedPoserFacet
@@ -41,7 +41,7 @@ const makeApiInvocationPositions = (apiMethodName, methodArgs) => {
 const setupApiGovernance = async (
   zoe,
   governedInstance,
-  governedApis,
+  governedMethods,
   governedNames,
   timer,
   getUpdatedPoserFacet,
@@ -104,7 +104,7 @@ const setupApiGovernance = async (
           );
 
           // E(remote)[name](args) invokes the method named 'name' on remote.
-          return E(governedApis)
+          return E(governedMethods)
             [apiMethodName](...methodArgs)
             .then(() => {
               return positive;

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -188,16 +188,16 @@ const start = async zcf => {
       );
     }
 
-    // if we aren't governing APIs, voteOnApiInvocation shouldn't be called
+    // if we aren't governing APIs, voteOnInvocation shouldn't be called
     return {
-      voteOnApiInvocation: () => {
+      voteOnInvocation: () => {
         throw Error('api governance not configured');
       },
       createdQuestion: () => false,
     };
   };
 
-  const { voteOnApiInvocation, createdQuestion: createdApiQuestion } =
+  const { voteOnInvocation, createdQuestion: createdApiQuestion } =
     await initApiGovernance();
 
   const validateVoteCounter = async voteCounter => {
@@ -231,7 +231,7 @@ const start = async zcf => {
 
   const creatorFacet = Far('governor creatorFacet', {
     voteOnParamChange,
-    voteOnApiInvocation,
+    voteOnInvocation,
     getCreatorFacet: () => limitedCreatorFacet,
     getInstance: () => governedInstance,
     getPublicFacet: () => governedPF,

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -188,16 +188,16 @@ const start = async zcf => {
       );
     }
 
-    // if we aren't governing APIs, voteOnInvocation shouldn't be called
+    // if we aren't governing APIs, voteOnMethodInvocation shouldn't be called
     return {
-      voteOnInvocation: () => {
+      voteOnMethodInvocation: () => {
         throw Error('api governance not configured');
       },
       createdQuestion: () => false,
     };
   };
 
-  const { voteOnInvocation, createdQuestion: createdApiQuestion } =
+  const { voteOnMethodInvocation, createdQuestion: createdApiQuestion } =
     await initApiGovernance();
 
   const validateVoteCounter = async voteCounter => {
@@ -231,7 +231,7 @@ const start = async zcf => {
 
   const creatorFacet = Far('governor creatorFacet', {
     voteOnParamChange,
-    voteOnInvocation,
+    voteOnMethodInvocation,
     getCreatorFacet: () => limitedCreatorFacet,
     getInstance: () => governedInstance,
     getPublicFacet: () => governedPF,

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -174,8 +174,8 @@ const start = async zcf => {
     // @ts-ignore `governedMethods` is present on contracts wiht API invocation.
 
     const [governedMethods, governedNames] = await Promise.all([
-      E(governedCF).getGovernedApis(),
-      E(governedCF).getGovernedApiNames(),
+      E(governedCF).getGovernedMethods(),
+      E(governedCF).getGovernedMethodNames(),
     ]);
     if (governedNames.length) {
       return setupApiGovernance(

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -171,9 +171,9 @@ const start = async zcf => {
   // this conditional was extracted so both sides are equally asynchronous
   /** @type {() => Promise<ApiGovernor>} */
   const initApiGovernance = async () => {
-    // @ts-ignore `governedApis` is present on contracts wiht API invocation.
+    // @ts-ignore `governedMethods` is present on contracts wiht API invocation.
 
-    const [governedApis, governedNames] = await Promise.all([
+    const [governedMethods, governedNames] = await Promise.all([
       E(governedCF).getGovernedApis(),
       E(governedCF).getGovernedApiNames(),
     ]);
@@ -181,7 +181,7 @@ const start = async zcf => {
       return setupApiGovernance(
         zoe,
         governedInstance,
-        governedApis,
+        governedMethods,
         governedNames,
         timer,
         getUpdatedPoserFacet,

--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -87,11 +87,11 @@ const facetHelpers = (zcf, paramManager) => {
       getLimitedCreatorFacet: () => limitedCreatorFacet,
       // The contract provides a facet with the APIs that can be invoked by
       // governance
-      getGovernedApis: () => Far('governedAPIs', governedMethods),
-      // The facet returned by getGovernedApis is Far, so we can't see what
+      getGovernedMethods: () => Far('governedAPIs', governedMethods),
+      // The facet returned by getGovernedMethods is Far, so we can't see what
       // methods it has. There's no clean way to have contracts specify the APIs
       // without also separately providing their names.
-      getGovernedApiNames: () => Object.keys(governedMethods),
+      getGovernedMethodNames: () => Object.keys(governedMethods),
     });
   };
 

--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -71,10 +71,10 @@ const facetHelpers = (zcf, paramManager) => {
   /**
    * @template {{}} CF creator facet
    * @param {ERef<CF>} originalCreatorFacet
-   * @param {Record<string, (...args: any[]) => any>} governedApis
+   * @param {Record<string, (...args: any[]) => any>} governedMethods
    * @returns { ERef<GovernedCreatorFacet<CF>> }
    */
-  const makeGovernorFacet = (originalCreatorFacet, governedApis = {}) => {
+  const makeGovernorFacet = (originalCreatorFacet, governedMethods = {}) => {
     const limitedCreatorFacet = makeLimitedCreatorFacet(originalCreatorFacet);
 
     // exclusively for contractGovernor, which only reveals limitedCreatorFacet
@@ -87,11 +87,11 @@ const facetHelpers = (zcf, paramManager) => {
       getLimitedCreatorFacet: () => limitedCreatorFacet,
       // The contract provides a facet with the APIs that can be invoked by
       // governance
-      getGovernedApis: () => Far('governedAPIs', governedApis),
+      getGovernedApis: () => Far('governedAPIs', governedMethods),
       // The facet returned by getGovernedApis is Far, so we can't see what
       // methods it has. There's no clean way to have contracts specify the APIs
       // without also separately providing their names.
-      getGovernedApiNames: () => Object.keys(governedApis),
+      getGovernedApiNames: () => Object.keys(governedMethods),
     });
   };
 

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -504,7 +504,7 @@
  * @template {object} PF Public facet of governed contract
  * @typedef {Object} GovernedContractFacetAccess
  * @property {VoteOnParamChange} voteOnParamChange
- * @property {VoteOnInvocation} voteOnInvocation
+ * @property {VoteOnMethodInvocation} voteOnMethodInvocation
  * @property {() => Promise<LimitedCreatorFacet<any>>} getCreatorFacet - creator
  *   facet of the governed contract, without the tightly held ability to change
  *   param values.
@@ -582,7 +582,7 @@
  */
 
 /**
- * @callback VoteOnInvocation
+ * @callback VoteOnMethodInvocation
  * @param {string} apiMethodName
  * @param {unknown[]} methodArgs
  * @param {Installation} voteCounterInstallation
@@ -598,7 +598,7 @@
 
 /**
  * @typedef {Object} ApiGovernor
- * @property {VoteOnInvocation} voteOnInvocation
+ * @property {VoteOnMethodInvocation} voteOnMethodInvocation
  * @property {CreatedQuestion} createdQuestion
  */
 

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -504,7 +504,7 @@
  * @template {object} PF Public facet of governed contract
  * @typedef {Object} GovernedContractFacetAccess
  * @property {VoteOnParamChange} voteOnParamChange
- * @property {VoteOnApiInvocation} voteOnApiInvocation
+ * @property {VoteOnInvocation} voteOnInvocation
  * @property {() => Promise<LimitedCreatorFacet<any>>} getCreatorFacet - creator
  *   facet of the governed contract, without the tightly held ability to change
  *   param values.
@@ -582,7 +582,7 @@
  */
 
 /**
- * @callback VoteOnApiInvocation
+ * @callback VoteOnInvocation
  * @param {string} apiMethodName
  * @param {unknown[]} methodArgs
  * @param {Installation} voteCounterInstallation
@@ -598,7 +598,7 @@
 
 /**
  * @typedef {Object} ApiGovernor
- * @property {VoteOnApiInvocation} voteOnApiInvocation
+ * @property {VoteOnInvocation} voteOnInvocation
  * @property {CreatedQuestion} createdQuestion
  */
 

--- a/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
@@ -166,7 +166,7 @@ const setupElectorateChange = async (
 const setupApiCall = async (zoe, log, governor, installations) => {
   const { details, instance, outcomeOfUpdate } = await E(
     governor,
-  ).voteOnApiInvocation(
+  ).voteOnInvocation(
     'governanceApi',
     [], // empty params
     installations.binaryVoteCounter,

--- a/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
@@ -166,7 +166,7 @@ const setupElectorateChange = async (
 const setupApiCall = async (zoe, log, governor, installations) => {
   const { details, instance, outcomeOfUpdate } = await E(
     governor,
-  ).voteOnInvocation(
+  ).voteOnMethodInvocation(
     'governanceApi',
     [], // empty params
     installations.binaryVoteCounter,

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -98,7 +98,7 @@ const setUpGovernedContract = async (zoe, electorateTerms, timer) => {
         value: invitationAmount,
       },
     },
-    governedApis: ['governanceApi'],
+    governedMethods: ['governanceApi'],
   };
   const governorTerms = {
     timer,

--- a/packages/run-protocol/src/reserve/collateralReserve.js
+++ b/packages/run-protocol/src/reserve/collateralReserve.js
@@ -22,7 +22,7 @@ const makeLiquidityKeyword = keyword => `${keyword}Liquidity`;
  *
  * @param {ZCF<GovernanceTerms<{AmmInstance: ParamRecord<'instance'>}> &
  * {
- *   governedApis: ['addLiquidityToAmmPool'],
+ *   governedMethods: ['addLiquidityToAmmPool'],
  * }
  * >} zcf
  * @param {{feeMintAccess: FeeMintAccess, initialPoserInvitation: Payment}} privateArgs

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -284,8 +284,8 @@ export const start = async (zcf, privateArgs) => {
     getParamMgrRetriever,
     getInvitation: electorateParamManager.getInternalParamValue,
     getLimitedCreatorFacet: () => vaultFactory,
-    getGovernedApis: () => harden({}),
-    getGovernedApiNames: () => harden({}),
+    getGovernedMethods: () => harden({}),
+    getGovernedMethodNames: () => harden({}),
   });
 
   return harden({

--- a/packages/run-protocol/test/reserve/test-reserve.js
+++ b/packages/run-protocol/test/reserve/test-reserve.js
@@ -138,7 +138,7 @@ test('governance add Liquidity to the AMM', async t => {
   const params = harden([moola(90_000n), AmountMath.make(runBrand, 80_000n)]);
   const { details: detailsP } = await E(
     governor.governorCreatorFacet,
-  ).voteOnInvocation(
+  ).voteOnMethodInvocation(
     'addLiquidityToAmmPool',
     params,
     await space.installation.consume.binaryVoteCounter,
@@ -215,7 +215,7 @@ test('request more collateral than available', async t => {
   const params = harden([moola(90_000n), AmountMath.make(runBrand, 80_000n)]);
   const { details: detailsP, outcomeOfUpdate } = await E(
     governor.governorCreatorFacet,
-  ).voteOnInvocation(
+  ).voteOnMethodInvocation(
     'addLiquidityToAmmPool',
     params,
     space.installation.consume.binaryVoteCounter,

--- a/packages/run-protocol/test/reserve/test-reserve.js
+++ b/packages/run-protocol/test/reserve/test-reserve.js
@@ -138,7 +138,7 @@ test('governance add Liquidity to the AMM', async t => {
   const params = harden([moola(90_000n), AmountMath.make(runBrand, 80_000n)]);
   const { details: detailsP } = await E(
     governor.governorCreatorFacet,
-  ).voteOnApiInvocation(
+  ).voteOnInvocation(
     'addLiquidityToAmmPool',
     params,
     await space.installation.consume.binaryVoteCounter,
@@ -215,7 +215,7 @@ test('request more collateral than available', async t => {
   const params = harden([moola(90_000n), AmountMath.make(runBrand, 80_000n)]);
   const { details: detailsP, outcomeOfUpdate } = await E(
     governor.governorCreatorFacet,
-  ).voteOnApiInvocation(
+  ).voteOnInvocation(
     'addLiquidityToAmmPool',
     params,
     space.installation.consume.binaryVoteCounter,


### PR DESCRIPTION
Follow up to #4868 

## Description

What are called `governedApis` are a set of methods that contribute to the API of the contract, not each a new API in itself. This renames those to `governedMethods` and the `voteOnApiInvocation` to `voteOnMethodInvocation`.

You can see from commit history I tried the more concise `voteOnInvocation` but it lost the symmetry with `voteOnParamChange` (vote on noun action).


### Security Considerations

--

### Documentation Considerations

Docs updated in global replace. Docs outside this repo not written yet.

### Testing Considerations

--