### PR TITLE
chore: bump yarn patch

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -2,4 +2,4 @@
 # yarn lockfile v1
 
 
-yarn-path ".yarn/releases/yarn-1.22.17.cjs"
+yarn-path ".yarn/releases/yarn-1.22.19.cjs"


### PR DESCRIPTION
## Description

Stops the warning from yarn about a stale version.

No important changes since 1.22.17
 https://github.com/yarnpkg/yarn/releases

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

--
