### PR TITLE
test: updated test cases from test-vaultFactory.js

### DIFF
--- a/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/inter-protocol/test/vaultFactory/test-vaultFactory.js
@@ -439,7 +439,8 @@ test('first', async t => {
     undefined,
     500n,
   );
-  const { vaultFactory, lender, aethVaultManager } = services.vaultFactory;
+  const { vaultFactory, lender, aethVaultManager, aethCollateralManager } =
+    services.vaultFactory;
   trace(t, 'services', { services, vaultFactory, lender });
 
   // Create a loan for 470 Minted with 1100 aeth collateral
@@ -447,7 +448,7 @@ test('first', async t => {
   const loanAmount = run.make(470n);
   /** @type {UserSeat<VaultKit>} */
   const vaultSeat = await E(zoe).offer(
-    await E(lender).makeVaultInvitation(),
+    E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: collateralAmount },
       want: { Minted: loanAmount },
@@ -563,7 +564,7 @@ test('price drop', async t => {
   trace(t, 'setup');
 
   const {
-    vaultFactory: { vaultFactory, lender },
+    vaultFactory: { vaultFactory, lender, aethCollateralManager },
     priceAuthority,
     reserveKit: { reserveCreatorFacet },
   } = services;
@@ -573,7 +574,7 @@ test('price drop', async t => {
   const loanAmount = run.make(270n);
   /** @type {UserSeat<VaultKit>} */
   const vaultSeat = await E(zoe).offer(
-    await E(lender).makeVaultInvitation(),
+    E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: collateralAmount },
       want: { Minted: loanAmount },
@@ -716,7 +717,7 @@ test('price falls precipitously', async t => {
   );
   // we start with time=0, price=2200
 
-  const { vaultFactory, lender } = services.vaultFactory;
+  const { vaultFactory, lender, aethCollateralManager } = services.vaultFactory;
 
   const { reserveCreatorFacet } = services.reserveKit;
   // Create a loan for 370 Minted with 400 aeth collateral
@@ -724,7 +725,7 @@ test('price falls precipitously', async t => {
   const loanAmount = run.make(370n);
   /** @type {UserSeat<VaultKit>} */
   const userSeat = await E(zoe).offer(
-    E(lender).makeVaultInvitation(),
+    E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: collateralAmount },
       want: { Minted: loanAmount },
@@ -890,14 +891,14 @@ test('interest on multiple vaults', async t => {
     SECONDS_PER_DAY,
     500n,
   );
-  const { vaultFactory, lender } = services.vaultFactory;
+  const { vaultFactory, lender, aethCollateralManager } = services.vaultFactory;
 
   // Create a loan for Alice for 4700 Minted with 1100 aeth collateral
   const collateralAmount = aeth.make(1100n);
   const aliceLoanAmount = run.make(4700n);
   /** @type {UserSeat<VaultKit>} */
   const aliceLoanSeat = await E(zoe).offer(
-    E(lender).makeVaultInvitation(),
+    E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: collateralAmount },
       want: { Minted: aliceLoanAmount },
@@ -936,7 +937,7 @@ test('interest on multiple vaults', async t => {
   const bobLoanAmount = run.make(3200n);
   /** @type {UserSeat<VaultKit>} */
   const bobLoanSeat = await E(zoe).offer(
-    E(lender).makeVaultInvitation(),
+    E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: bobCollateralAmount },
       want: { Minted: bobLoanAmount },
@@ -1018,7 +1019,7 @@ test('interest on multiple vaults', async t => {
   // try opening a vault that can't cover fees
   /** @type {UserSeat<VaultKit>} */
   const caroleLoanSeat = await E(zoe).offer(
-    E(lender).makeVaultInvitation(),
+    E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: aeth.make(200n) },
       want: { Minted: run.make(0n) }, // no debt
@@ -1036,7 +1037,7 @@ test('interest on multiple vaults', async t => {
   const wantedRun = 1_000n;
   /** @type {UserSeat<VaultKit>} */
   const danLoanSeat = await E(zoe).offer(
-    E(lender).makeVaultInvitation(),
+    E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: aeth.make(2_000n) },
       want: { Minted: run.make(wantedRun) },
@@ -1075,7 +1076,8 @@ test('adjust balances', async t => {
     undefined,
     500n,
   );
-  const { lender } = services.vaultFactory;
+  const { lender, aethCollateralManager } = services.vaultFactory;
+  console.log('inside test :::: LENDER', { lender, ELender: E(lender) });
 
   // initial loan /////////////////////////////////////
 
@@ -1084,7 +1086,7 @@ test('adjust balances', async t => {
   const aliceLoanAmount = run.make(5000n);
   /** @type {UserSeat<VaultKit>} */
   const aliceLoanSeat = await E(zoe).offer(
-    E(lender).makeVaultInvitation(),
+    E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: collateralAmount },
       want: { Minted: aliceLoanAmount },
@@ -1599,7 +1601,7 @@ test('overdeposit', async t => {
     undefined,
     500n,
   );
-  const { vaultFactory, lender } = services.vaultFactory;
+  const { vaultFactory, lender, aethCollateralManager } = services.vaultFactory;
 
   // Alice's loan /////////////////////////////////////
 
@@ -1608,7 +1610,7 @@ test('overdeposit', async t => {
   const aliceLoanAmount = run.make(5000n);
   /** @type {UserSeat<VaultKit>} */
   const aliceLoanSeat = await E(zoe).offer(
-    E(lender).makeVaultInvitation(),
+    E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: collateralAmount },
       want: { Minted: aliceLoanAmount },
@@ -1650,7 +1652,7 @@ test('overdeposit', async t => {
   const bobLoanAmount = run.make(1000n);
   /** @type {UserSeat<VaultKit>} */
   const bobLoanSeat = await E(zoe).offer(
-    E(lender).makeVaultInvitation(),
+    E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: bobCollateralAmount },
       want: { Minted: bobLoanAmount },
@@ -1749,7 +1751,7 @@ test('mutable liquidity triggers and interest', async t => {
   );
 
   const {
-    vaultFactory: { lender },
+    vaultFactory: { lender, aethCollateralManager },
     priceAuthority,
     reserveKit: { reserveCreatorFacet },
   } = services;
@@ -1770,7 +1772,7 @@ test('mutable liquidity triggers and interest', async t => {
   const aliceLoanAmount = run.make(5000n);
   /** @type {UserSeat<VaultKit>} */
   const aliceLoanSeat = await E(zoe).offer(
-    E(lender).makeVaultInvitation(),
+    E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: aliceCollateralAmount },
       want: { Minted: aliceLoanAmount },
@@ -1818,7 +1820,7 @@ test('mutable liquidity triggers and interest', async t => {
   const bobLoanAmount = run.make(512n);
   /** @type {UserSeat<VaultKit>} */
   const bobLoanSeat = await E(zoe).offer(
-    E(lender).makeVaultInvitation(),
+    E(aethCollateralManager).makeVaultInvitation(),
     harden({
       give: { Collateral: bobCollateralAmount },
       want: { Minted: bobLoanAmount },


### PR DESCRIPTION
test: updated some of the test cases from test-vaultFactory to use the correct API

refs: #6811 

## Description

WIP PR for updating vault code to use the correct invitations. If this is desired, then I believe the plan of action would be to continue through the tests to make sure they are no longer using the deprecated `makeVaultInviation`.

### Security Considerations
Not AFAIK, but I could be overlooking something.

### Documentation Considerations

### Testing Considerations
I don't believe any additional test cases are needed. Just need to make sure all existing tests are passing once the code is updated.