### PR TITLE
chore(xsnap): fix/hush lint complaints

### DIFF
--- a/packages/xsnap/api.js
+++ b/packages/xsnap/api.js
@@ -1,6 +1,8 @@
 /* eslint-disable max-classes-per-file */
 
-/** The version identifier for our meter type.
+/**
+ * The version identifier for our meter type.
+ *
  * TODO Bump this whenever there's a change to metering semantics.
  * Also, update golden master test/test-xs-perf.js to reflect new meter
  * version.

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -217,12 +217,14 @@ export async function replayXSnap(
       const seq = parseInt(digits, 10);
       console.log(folder, seq, kind);
       if (running && !['command', 'reply'].includes(kind)) {
+        // eslint-disable-next-line @jessie.js/no-nested-await
         await running;
         running = undefined;
       }
       const file = rd.file(step);
       switch (kind) {
         case 'isReady':
+          // eslint-disable-next-line @jessie.js/no-nested-await
           await it.isReady();
           break;
         case 'evaluate':
@@ -243,6 +245,7 @@ export async function replayXSnap(
             return;
           } else {
             try {
+              // eslint-disable-next-line @jessie.js/no-nested-await
               await it.snapshot(file.getText());
             } catch (err) {
               console.warn(err, 'while taking snapshot:', err);

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -205,7 +205,9 @@ export function xsnap(options) {
           )}`,
         );
       } else if (message[0] === QUERY) {
+        // eslint-disable-next-line @jessie.js/no-nested-await
         const commandResult = await handleCommand(message.subarray(1));
+        // eslint-disable-next-line @jessie.js/no-nested-await
         await messagesToXsnap.next([QUERY_RESPONSE_BUF, commandResult]);
       } else {
         // unrecognized responses also kill the process


### PR DESCRIPTION
The no-nested-await suppressions are all inside `for await` loops (despite being inside `if` clauses as well). I think this meets our requirements, but the linter does not know that yet.
