### PR TITLE
test(upgrade-test): test brand new wallet post upgrade

### DIFF
--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/actions.sh
@@ -7,6 +7,16 @@
 # agoric wallet show --from $GOV1ADDR
 waitForBlock 20
 
+# provision a new user wallet
+
+agd keys add user2 --keyring-backend=test  2>&1 | tee "$HOME/.agoric/user2.out"
+cat "$HOME/.agoric/user2.out" | tail -n1 | tee "$HOME/.agoric/user2.key"
+export USER2ADDR=$($binary keys show user2 -a --keyring-backend="test" 2> /dev/null)
+provisionSmartWallet $USER2ADDR "20000000ubld,100000000${ATOM_DENOM}"
+waitForBlock
+
+test_not_val "$(agd q vstorage data published.wallet.$USER2ADDR -o json | jq -r .value)" "" "ensure user2 provisioned"
+
 echo "Tickling the wallets so they are revived"
 # Until they are revived, the invitations can't be deposited. So the first action can't be to accept an invitation (because it won't be there).
 govaccounts=("$GOV1ADDR" "$GOV2ADDR" "$GOV3ADDR")
@@ -137,6 +147,26 @@ agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-bac
 OFFER=$(mktemp -t agops.XXX)
 agops vaults close --vaultId vault1 --giveMinted 6.06 --from $GOV1ADDR --keyring-backend="test" >|"$OFFER"
 agops perf satisfaction --from "$GOV1ADDR" --executeOffer "$OFFER" --keyring-backend=test
+
+# make sure the same works for user2
+OFFER=$(mktemp -t agops.XXX)
+agops vaults open --wantMinted 7.00 --giveCollateral 11.0 >|"$OFFER"
+agops perf satisfaction --from "$USER2ADDR" --executeOffer "$OFFER" --keyring-backend=test
+
+# put some IST in
+OFFER=$(mktemp -t agops.XXX)
+agops vaults adjust --vaultId vault2 --giveMinted 1.5 --from $USER2ADDR --keyring-backend=test >|"$OFFER"
+agops perf satisfaction --from "$USER2ADDR" --executeOffer "$OFFER" --keyring-backend=test
+
+# add some collateral
+OFFER=$(mktemp -t agops.XXX)
+agops vaults adjust --vaultId vault2 --giveCollateral 2.0 --from $USER2ADDR --keyring-backend="test" >|"$OFFER"
+agops perf satisfaction --from "$USER2ADDR" --executeOffer "$OFFER" --keyring-backend=test
+
+# close out
+OFFER=$(mktemp -t agops.XXX)
+agops vaults close --vaultId vault2 --giveMinted 5.75 --from $USER2ADDR --keyring-backend="test" >|"$OFFER"
+agops perf satisfaction --from "$USER2ADDR" --executeOffer "$OFFER" --keyring-backend=test
 
 # # TODO test bidding
 # # TODO liquidations

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/pre_test.sh
@@ -14,6 +14,9 @@ test_not_val "$(agd q vstorage data published.wallet.$GOV1ADDR -o json | jq -r .
 test_not_val "$(agd q vstorage data published.wallet.$GOV2ADDR -o json | jq -r .value)" "" "ensure gov2 provisioned"
 test_not_val "$(agd q vstorage data published.wallet.$GOV3ADDR -o json | jq -r .value)" "" "ensure gov3 provisioned"
 
+# test user2 not provisioned
+test_val "$(agd q vstorage data published.wallet.$USER2ADDR -o json | jq -r .value)" "" "ensure user2 not provisioned"
+
 # test that we have no vaults
 test_val "$(agd q vstorage data published.vaultFactory.manager0.vaults.vault0 -o json | jq -r .value)" "" "ensure no vaults exist"
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
@@ -3,14 +3,14 @@
 . ./upgrade-test-scripts/env_setup.sh
 
 # provision pool has right balance 
-test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ') "19000000"
+test_val $(agd query bank balances agoric1megzytg65cyrgzs6fvzxgrcqvwwl7ugpt62346 -o json | jq -r '.balances | first | .amount ') "18750000"
 
 test_wallet_state "$USER1ADDR" upgraded "user1 wallet is upgraded"
 test_wallet_state "$GOV1ADDR" revived "gov1 wallet is revived"
 test_wallet_state "$GOV2ADDR" revived "gov2 wallet is revived"
 test_wallet_state "$GOV3ADDR" revived "gov3 wallet is revived"
 
-test_val $(agd q vstorage children published.vaultFactory.managers.manager0.vaults -o json | jq -r '.children | length') 2 "we only have two vaults"
+test_val $(agd q vstorage children published.vaultFactory.managers.manager0.vaults -o json | jq -r '.children | length') 3 "we only have three vaults"
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.metrics -o jsonlines | jq -r '.numActiveVaults') 1 "only one vault is active"
 
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.metrics -o jsonlines | jq -r '.totalDebt.value') "6030000" "totalDebt is correct"
@@ -25,3 +25,8 @@ test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.vaultState') "closed" "vault1 is closed"
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.locked.value') "0" "vault1 contains no collateral"
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault1 -o jsonlines | jq -r '.debtSnapshot.debt.value') "0" "vault1 has no debt"
+
+# user2 vault2
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault2 -o jsonlines | jq -r '.vaultState') "closed" "vault2 is closed"
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault2 -o jsonlines | jq -r '.locked.value') "0" "vault2 contains no collateral"
+test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.vaults.vault2 -o jsonlines | jq -r '.debtSnapshot.debt.value') "0" "vault2 has no debt"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-10/test.sh
@@ -10,7 +10,7 @@ test_wallet_state "$GOV1ADDR" revived "gov1 wallet is revived"
 test_wallet_state "$GOV2ADDR" revived "gov2 wallet is revived"
 test_wallet_state "$GOV3ADDR" revived "gov3 wallet is revived"
 
-test_val $(agd q vstorage children published.vaultFactory.managers.manager0.vaults -o json | jq -r '.children | length') 3 "we only have three vaults"
+test_val $(agd q vstorage children published.vaultFactory.managers.manager0.vaults -o json | jq -r '.children | length') 3 "we have three vaults"
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.metrics -o jsonlines | jq -r '.numActiveVaults') 1 "only one vault is active"
 
 test_val $(agoric follow -l -F :published.vaultFactory.managers.manager0.metrics -o jsonlines | jq -r '.totalDebt.value') "6030000" "totalDebt is correct"

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/actions.sh
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-8/actions.sh
@@ -14,18 +14,6 @@ waitForBlock 3
 govaccounts=( "$GOV1ADDR" "$GOV2ADDR" "$GOV3ADDR" )
 govamount="200000000ubld,100000000${USDC_DENOM},100000000${ATOM_DENOM}"
 
-provisionSmartWallet() {
-  i="$1"
-  amount="$2"
-  echo "funding $i"
-  agd tx bank send "validator" "$i" "$amount" -y --keyring-backend=test --chain-id="$CHAINID"
-  waitForBlock
-  echo "provisioning $i"
-  agd tx swingset provision-one my-wallet "$i" SMART_WALLET --keyring-backend=test  --yes --chain-id="$CHAINID" --from="$i"
-  waitForBlock
-  agoric wallet show --from $i
-}
-
 for i in "${govaccounts[@]}"
 do
   provisionSmartWallet "$i" "$govamount"


### PR DESCRIPTION
## Description

Make sure we can provision a brand new wallet after upgrading and do the same operations we test in old wallets we have carried through the upgrades.

### Security Considerations

None, other than this test is meant to uncover any issues with operations on brand new wallets.

### Scaling Considerations


### Documentation Considerations


### Testing Considerations

We are adding a new wallet into the mix.
