### PR TITLE
chore(deps): bump anylogger to 1.0

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -57,7 +57,7 @@
     "@endo/stream": "^1.2.13",
     "@endo/zip": "^1.0.11",
     "ansi-styles": "^6.2.1",
-    "anylogger": "^0.21.0",
+    "anylogger": "^1.0.11",
     "better-sqlite3": "^10.1.0",
     "import-meta-resolve": "^4.1.0",
     "microtime": "^3.1.0",

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -71,7 +71,7 @@
     "@endo/promise-kit": "^1.1.13",
     "@endo/zip": "^1.0.11",
     "@iarna/toml": "^2.2.3",
-    "anylogger": "^0.21.0",
+    "anylogger": "^1.0.11",
     "chalk": "^5.2.0",
     "commander": "^12.1.0",
     "deterministic-json": "^1.0.5",

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -45,7 +45,7 @@
     "@iarna/toml": "^2.2.3",
     "@opentelemetry/api": "~1.9.0",
     "@opentelemetry/sdk-metrics": "~1.30.1",
-    "anylogger": "^0.21.0",
+    "anylogger": "^1.0.11",
     "deterministic-json": "^1.0.5",
     "import-meta-resolve": "^4.1.0",
     "ses": "^1.14.0",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -34,7 +34,7 @@
     "@endo/patterns": "^1.7.0",
     "@endo/promise-kit": "^1.1.13",
     "@endo/stream": "^1.2.13",
-    "anylogger": "^0.21.0",
+    "anylogger": "^1.0.11",
     "jessie.js": "^0.3.4"
   },
   "devDependencies": {

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -44,7 +44,7 @@
     "@endo/init": "^1.1.12",
     "@endo/marshal": "^1.8.0",
     "@endo/promise-kit": "^1.1.13",
-    "anylogger": "^0.21.0",
+    "anylogger": "^1.0.11",
     "deterministic-json": "^1.0.5",
     "express": "^5.0.1",
     "http-proxy-middleware": "^2.0.6",

--- a/packages/swingset-runner/test/demo.test.js
+++ b/packages/swingset-runner/test/demo.test.js
@@ -23,14 +23,18 @@ function rimraf(dirPath) {
   }
 }
 
-async function innerTest(t, extraFlags, dbdir) {
+/**
+ * @param {import("ava").ExecutionContext<unknown>} t
+ * @param {{flags: string, dbdir?: string}} input
+ */
+async function innerTest(t, { flags, dbdir }) {
   await new Promise(resolve => {
     const appDir = 'demo/encouragementBot';
     if (dbdir) {
       dbdir = `${appDir}/${dbdir}`;
-      extraFlags += ` --dbdir ${dbdir}`;
+      flags += ` --dbdir ${dbdir}`;
     }
-    const proc = spawn(`node bin/runner ${extraFlags} run ${appDir}`, {
+    const proc = spawn(`node bin/runner ${flags} run ${appDir}`, {
       cwd: path.resolve(dirname, '..'),
       shell: true,
       stdio: ['ignore', 'pipe', 'inherit'],
@@ -43,10 +47,10 @@ async function innerTest(t, extraFlags, dbdir) {
       t.log(output);
       t.is(code, 0, 'exits successfully');
       const uMsg = 'user vat is happy';
-      t.not(output.indexOf(`\n${uMsg}\n`), -1, uMsg);
+      t.true(output.includes(`\n${uMsg}\n`), `'${uMsg}' not in '${output}'`);
       const bMsg = 'bot vat is happy';
-      t.not(output.indexOf(`\n${bMsg}\n`), -1, bMsg);
-      resolve();
+      t.true(output.includes(`\n${bMsg}\n`), `'${bMsg}' not in '${output}'`);
+      resolve(undefined);
       if (dbdir) {
         rimraf(dbdir);
       }
@@ -54,18 +58,21 @@ async function innerTest(t, extraFlags, dbdir) {
   });
 }
 
-test('run encouragmentBot demo with memdb', async t => {
-  await innerTest(t, '--memdb');
+test('run encouragmentBot demo with memdb', innerTest, {
+  flags: '--memdb',
 });
 
-test('run encouragmentBot demo with sqlite', async t => {
-  await innerTest(t, '--sqlite', 'sqlitetest');
+test('run encouragmentBot demo with sqlite', innerTest, {
+  flags: '--sqlite',
+  dbdir: 'sqlitetest',
 });
 
-test('run encouragmentBot demo with default', async t => {
-  await innerTest(t, '', 'defaulttest');
+test('run encouragmentBot demo with default', innerTest, {
+  flags: '',
+  dbdir: 'defaulttest',
 });
 
-test('run encouragmentBot demo with indirectly loaded vats', async t => {
-  await innerTest(t, '--indirect', 'indirecttest');
+test('run encouragmentBot demo with indirectly loaded vats', innerTest, {
+  flags: '--indirect',
+  dbdir: 'indirecttest',
 });

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -39,7 +39,7 @@
     "@opentelemetry/sdk-metrics": "~1.30.1",
     "@opentelemetry/sdk-trace-base": "~1.30.1",
     "@opentelemetry/semantic-conventions": "~1.28.0",
-    "anylogger": "^0.21.0",
+    "anylogger": "^1.0.11",
     "better-sqlite3": "^10.1.0",
     "tmp": "^0.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -559,7 +559,7 @@ __metadata:
     "@iarna/toml": "npm:^2.2.3"
     "@opentelemetry/api": "npm:~1.9.0"
     "@opentelemetry/sdk-metrics": "npm:~1.30.1"
-    anylogger: "npm:^0.21.0"
+    anylogger: "npm:^1.0.11"
     ava: "npm:^5.3.0"
     better-sqlite3: "npm:^10.1.0"
     c8: "npm:^10.1.3"
@@ -809,7 +809,7 @@ __metadata:
     "@endo/ses-ava": "npm:^1.3.2"
     "@endo/stream": "npm:^1.2.13"
     "@fast-check/ava": "npm:^2.0.1"
-    anylogger: "npm:^0.21.0"
+    anylogger: "npm:^1.0.11"
     ava: "npm:^5.3.0"
     jessie.js: "npm:^0.3.4"
     tsd: "npm:^0.33.0"
@@ -1075,7 +1075,7 @@ __metadata:
     "@endo/init": "npm:^1.1.12"
     "@endo/marshal": "npm:^1.8.0"
     "@endo/promise-kit": "npm:^1.1.13"
-    anylogger: "npm:^0.21.0"
+    anylogger: "npm:^1.0.11"
     ava: "npm:^5.3.0"
     c8: "npm:^10.1.3"
     deterministic-json: "npm:^1.0.5"
@@ -1228,7 +1228,7 @@ __metadata:
     "@types/tmp": "npm:^0.2.0"
     "@types/yargs-parser": "npm:^21.0.0"
     ansi-styles: "npm:^6.2.1"
-    anylogger: "npm:^0.21.0"
+    anylogger: "npm:^1.0.11"
     ava: "npm:^5.3.0"
     better-sqlite3: "npm:^10.1.0"
     import-meta-resolve: "npm:^4.1.0"
@@ -1285,7 +1285,7 @@ __metadata:
     "@opentelemetry/sdk-metrics": "npm:~1.30.1"
     "@opentelemetry/sdk-trace-base": "npm:~1.30.1"
     "@opentelemetry/semantic-conventions": "npm:~1.28.0"
-    anylogger: "npm:^0.21.0"
+    anylogger: "npm:^1.0.11"
     ava: "npm:^5.3.0"
     better-sqlite3: "npm:^10.1.0"
     c8: "npm:^10.1.3"
@@ -8559,7 +8559,7 @@ __metadata:
     "@endo/promise-kit": "npm:^1.1.13"
     "@endo/zip": "npm:^1.0.11"
     "@iarna/toml": "npm:^2.2.3"
-    anylogger: "npm:^0.21.0"
+    anylogger: "npm:^1.0.11"
     ava: "npm:^5.3.0"
     c8: "npm:^10.1.2"
     chalk: "npm:^5.2.0"
@@ -8700,10 +8700,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anylogger@npm:^0.21.0":
-  version: 0.21.0
-  resolution: "anylogger@npm:0.21.0"
-  checksum: 10c0/1ca7fcf5bc2b78d1e1d9b8c8cc7ce50b5c6cc67a8da5a28c9c975b7b46fff255a04abab02de38a5139190c9d8b34b3d6c59af6724521b077f7d7dfbad9b47a9c
+"anylogger@npm:^1.0.11":
+  version: 1.0.11
+  resolution: "anylogger@npm:1.0.11"
+  checksum: 10c0/19de7f1607fd898e2ac67068724b9ae248e8f5054866a46579d851782b1ae8e1ff5218f5b5ded1546dbe816091ca3ba1ad0cc78d5084941beaf207bea17ee2c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
no ticket, evergreen

## Description

There doesn't appear to be any API change since 0.21 we have
https://github.com/Download/anylogger/releases


### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

Spot check console log output

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? --> 