### PR TITLE
feat: Thread source map support through all usage of import-bundle

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -12,6 +12,7 @@ import microtime from 'microtime';
 
 import { assert, Fail } from '@agoric/assert';
 import { importBundle } from '@endo/import-bundle';
+import { computeSourceMapLocation } from '@endo/import-bundle/source-map-node.js';
 import { initSwingStore } from '@agoric/swing-store';
 
 import { mustMatch, M } from '@endo/patterns';
@@ -210,6 +211,7 @@ export async function makeSwingsetController(
       URL: globalThis.Base64, // Unavailable only on XSnap
       Base64: globalThis.Base64, // Available only on XSnap
     },
+    computeSourceMapLocation,
   });
   const buildKernel = kernelNS.default;
   writeSlogObject({ type: 'import-kernel-finish' });

--- a/packages/SwingSet/src/kernel/vat-loader/manager-local.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-local.js
@@ -2,6 +2,7 @@
 
 import { assert, Fail } from '@agoric/assert';
 import { importBundle } from '@endo/import-bundle';
+import { computeSourceMapLocation } from '@endo/import-bundle/source-map-node.js';
 import { makeLiveSlots } from '@agoric/swingset-liveslots';
 import { makeManagerKit } from './manager-helper.js';
 import {
@@ -89,6 +90,7 @@ export function makeLocalVatManagerFactory({
         filePrefix: `vat-${vatID}/...`,
         endowments: { ...workerEndowments, ...lsEndowments },
         inescapableGlobalProperties,
+        computeSourceMapLocation,
       });
       return vatNS;
     }

--- a/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
@@ -9,6 +9,7 @@ import { Buffer } from 'buffer';
 
 import { assert, details as X, Fail } from '@agoric/assert';
 import { importBundle } from '@endo/import-bundle';
+import { computeSourceMapLocation } from '@endo/import-bundle/source-map-node.js';
 import { makeMarshal } from '@endo/marshal';
 import {
   makeLiveSlots,
@@ -145,6 +146,7 @@ function handleSetBundle(margs) {
     const vatNS = await importBundle(bundle, {
       endowments: { ...workerEndowments, ...lsEndowments },
       inescapableGlobalProperties,
+      computeSourceMapLocation,
     });
     workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
     return vatNS;

--- a/packages/SwingSet/test/bundling/bootstrap-bundles.js
+++ b/packages/SwingSet/test/bundling/bootstrap-bundles.js
@@ -1,6 +1,7 @@
 import { assert } from '@agoric/assert';
 import { Far, E } from '@endo/far';
 import { importBundle } from '@endo/import-bundle';
+import { computeSourceMapLocation } from '@endo/import-bundle/source-map-node.js';
 
 export function buildRootObject(vatPowers) {
   const { D } = vatPowers;
@@ -14,7 +15,10 @@ export function buildRootObject(vatPowers) {
     const bundle = D(bcap).getBundle();
     assert.typeof(bundle, 'object');
     const endowments = harden({ big: 'big' });
-    const ns = await importBundle(bundle, { endowments });
+    const ns = await importBundle(bundle, {
+      endowments,
+      computeSourceMapLocation,
+    });
     const out = ns.runTheCheck('world');
     // out: [NAME, 'big', 'big', 'world']
     const ok =

--- a/packages/SwingSet/test/zcf-ish-upgrade/pseudo-zcf.js
+++ b/packages/SwingSet/test/zcf-ish-upgrade/pseudo-zcf.js
@@ -4,6 +4,7 @@
 
 import { Far } from '@endo/far';
 import { importBundle } from '@endo/import-bundle';
+import { computeSourceMapLocation } from '@endo/import-bundle/source-map-node.js';
 import { defineDurableKind } from '@agoric/vat-data';
 import { assert } from '@agoric/assert';
 import {
@@ -25,7 +26,10 @@ export const buildRootObject = async (vatPowers, vatParameters, baggage) => {
   const { contractBundleCap } = vatParameters;
   const contractBundle = D(contractBundleCap).getBundle();
   const endowments = { console, assert, VatData };
-  const contractNS = await importBundle(contractBundle, { endowments });
+  const contractNS = await importBundle(contractBundle, {
+    endowments,
+    computeSourceMapLocation,
+  });
   const { setupInstallation, setup: _ } = contractNS;
   if (!setupInstallation) {
     // fall back to old non-upgradable scheme

--- a/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
+++ b/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
@@ -1,6 +1,7 @@
 /* global globalThis WeakRef FinalizationRegistry */
 import { assert, Fail } from '@agoric/assert';
 import { importBundle } from '@endo/import-bundle';
+import { computeSourceMapLocation } from '@endo/import-bundle/source-map-node.js';
 import {
   makeLiveSlots,
   insistVatDeliveryObject,
@@ -272,6 +273,7 @@ function makeWorker(port) {
       const vatNS = await importBundle(bundle, {
         endowments: { ...workerEndowments, ...lsEndowments },
         inescapableGlobalProperties,
+        computeSourceMapLocation,
       });
       bundle = undefined; // overwrite to allow GC to discard big string
       workerLog(`got vatNS:`, Object.keys(vatNS).join(','));

--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -13,6 +13,7 @@ import { prepareRecorderKit } from '@agoric/zoe/src/contractSupport/recorder.js'
 import * as farExports from '@endo/far';
 import { E, Far } from '@endo/far';
 import { importBundle } from '@endo/import-bundle';
+import { computeSourceMapLocation } from '@endo/import-bundle/source-map-node.js';
 import { makePromiseKit } from '@endo/promise-kit';
 import { PowerFlags } from '../walletFlags.js';
 import { BASIC_BOOTSTRAP_PERMITS } from './basic-behaviors.js';
@@ -48,7 +49,10 @@ export const bridgeCoreEval = async allPowers => {
   /** @param {BundleCap} bundleCap */
   const evaluateBundleCap = async bundleCap => {
     const bundle = await D(bundleCap).getBundle();
-    const imported = await importBundle(bundle, { endowments });
+    const imported = await importBundle(bundle, {
+      endowments,
+      sourceMapLocation,
+    });
     return imported;
   };
   harden(evaluateBundleCap);


### PR DESCRIPTION
closes: #8580

## Description

`importBundle` now allows the caller to provide an algorithm for generating a `//#sourceMapURL` for each file in the bundle. This change opts-in to the intended behavior for Node.js using an Endo source map cache generated by `bundleSource`. With this change, local development should become much more transparent.

### Security Considerations

Auditors should not use tools that respect source maps when validating code that might be controlled by an attacker. However, for the purposes of debugging a contract locally, if the developer controls both the bundler and chain, allowing the chain to use the bundler’s sourcemap cache should be safe.

This presupposes that an auditor never allows the attacker to write a source map into their bundle cache.

### Scaling Considerations

The sourceMapURL generator performs no I/O and merely assumes that—if a source map exists— it will be in the endo cache under a name based on its integrity hash.

### Documentation Considerations

The effect of this change should be magical and not require documentation.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

This change does not alter integrity hashes or how they’re checked. The sourceMapURL only appears in the evaluated programs of existing bundles, regardless of whether source maps were generated for those bundles.