### PR TITLE
feat: support any committeeCreatorFacet in startGovernedInstance

### DIFF
--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -177,7 +177,7 @@ harden(produceStartUpgradable);
  *   governedParams: Record<string, unknown>;
  *   timer: ERef<import('@agoric/time').TimerService>;
  *   contractGovernor: ERef<Installation>;
- *   economicCommitteeCreatorFacet: import('@agoric/inter-protocol/src/proposals/econ-behaviors.js').EconomyBootstrapPowers['consume']['economicCommitteeCreatorFacet'];
+ *   committeeCreatorFacet: ERef<CommitteeStartResult['creatorFacet']>;
  * }} govArgs
  * @returns {Promise<GovernanceFacetKit<SF>>}
  */
@@ -190,11 +190,9 @@ const startGovernedInstance = async (
     privateArgs,
     label,
   },
-  { governedParams, timer, contractGovernor, economicCommitteeCreatorFacet },
+  { governedParams, timer, contractGovernor, committeeCreatorFacet },
 ) => {
-  const poserInvitationP = E(
-    economicCommitteeCreatorFacet,
-  ).getPoserInvitation();
+  const poserInvitationP = E(committeeCreatorFacet).getPoserInvitation();
   const [initialPoserInvitation, electorateInvitationAmount] =
     await Promise.all([
       poserInvitationP,
@@ -226,7 +224,6 @@ const startGovernedInstance = async (
     {},
     governorTerms,
     harden({
-      economicCommitteeCreatorFacet,
       governed: {
         ...privateArgs,
         initialPoserInvitation,
@@ -282,7 +279,7 @@ export const produceStartGovernedUpgradable = async ({
    */
   const contractKits = zone.mapStore('GovernedContractKits');
 
-  /** @type {startGovernedUpgradable} */
+  /** @type {StartGovernedUpgradable} */
   const startGovernedUpgradable = async ({
     installation,
     issuerKeywordRecord,
@@ -290,6 +287,7 @@ export const produceStartGovernedUpgradable = async ({
     terms,
     privateArgs,
     label,
+    committeeCreatorFacet = economicCommitteeCreatorFacet, // for backwards compatibility
   }) => {
     const facets = await startGovernedInstance(
       {
@@ -304,7 +302,7 @@ export const produceStartGovernedUpgradable = async ({
         governedParams,
         timer: chainTimerService,
         contractGovernor,
-        economicCommitteeCreatorFacet,
+        committeeCreatorFacet,
       },
     );
     const kit = harden({ ...facets, label });
@@ -312,7 +310,7 @@ export const produceStartGovernedUpgradable = async ({
 
     await E(diagnostics).savePrivateArgs(kit.instance, privateArgs);
     await E(diagnostics).savePrivateArgs(kit.governor, {
-      economicCommitteeCreatorFacet: await economicCommitteeCreatorFacet,
+      committeeCreatorFacet: await committeeCreatorFacet,
     });
 
     return facets;

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -93,6 +93,7 @@ export const startWalletFactory = async (
       econCharterKit,
       startUpgradable,
       startGovernedUpgradable,
+      economicCommitteeCreatorFacet,
     },
     produce: { client, walletFactoryStartResult, provisionPoolStartResult },
     installation: {
@@ -193,6 +194,7 @@ export const startWalletFactory = async (
         value: AmountMath.make(feeBrand, perAccountInitialValue),
       },
     },
+    committeeCreatorFacet: economicCommitteeCreatorFacet,
   });
   provisionPoolStartResult.resolve(ppFacets);
   instanceProduce.provisionPool.resolve(ppFacets.instance);
@@ -270,6 +272,7 @@ export const WALLET_FACTORY_MANIFEST = {
       namesByAddressAdmin: true,
       startUpgradable: true,
       startGovernedUpgradable: true,
+      economicCommitteeCreatorFacet: true,
       econCharterKit: 'psmCharter',
     },
     produce: {

--- a/packages/vats/src/core/types-ambient.d.ts
+++ b/packages/vats/src/core/types-ambient.d.ts
@@ -257,6 +257,11 @@ type WellKnownSpaces = {
   };
 };
 
+type CommitteeStartResult =
+  import('@agoric/zoe/src/zoeService/utils').StartResult<
+    typeof import('@agoric/governance/src/committee.js').start
+  >;
+
 type StartGovernedUpgradableOpts<SF extends GovernableStartFn> = {
   installation: ERef<Installation<SF>>;
   issuerKeywordRecord?: IssuerKeywordRecord;
@@ -270,6 +275,7 @@ type StartGovernedUpgradableOpts<SF extends GovernableStartFn> = {
     'initialPoserInvitation'
   >;
   label: string;
+  committeeCreatorFacet: ERef<CommitteeStartResult['creatorFacet']>;
 };
 
 type StartGovernedUpgradable = <SF extends GovernableStartFn>(
@@ -362,7 +368,12 @@ type ChainBootstrapSpaceT = {
   startUpgradable: StartUpgradable;
   /** kits stored by startUpgradable */
   contractKits: MapStore<Instance, StartedInstanceKitWithLabel>;
-  /** Convience function for starting contracts governed by the Econ Committee */
+  /**
+   * Convienence function for starting contracts governed by a committeee.
+   *
+   * NB: When the committeeCreatorFacet parameter is omitted, it defaults to the
+   * Economic Committee.
+   */
   startGovernedUpgradable: StartGovernedUpgradable;
   /** kits stored by startGovernedUpgradable */
   governedContractKits: MapStore<


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/issues/8330

## Description

Variant of https://github.com/Agoric/agoric-sdk/pull/8589 that updates the existing `startGovernedUpgradable` to take a `committeeCreatorFacet` instead of assuming the EC committee. When the argument is omitted it falls back to the `economicCommitteeCreatorFacet` from promise space.

It does this in `startGovernedUpgradable` which is the API. The params of the internal method `startGovernedInstance` do not need to be backwards compatible.

### Security Considerations

Allows other committees for `startGovernedUpgradable`. This is an improvement in overall security.


### Scaling Considerations

n/a

### Documentation Considerations

Types provide the documentation

### Testing Considerations

Two contracts in SDK use `startGovernedUpgradable`: walletFactory and oracles. They both use the EC committee so to test this change I made one (oracles) rely on the backwards compatibility and one (walletFactory) pass the `committeeCreatorFacet` argument. 

### Upgrade Considerations

This changes bootstrap but not the bootstrap vat in production. That will require a core-eval to reset the existing resolution and then resolve it with this. (Reviewer, should that be part of this PR?)