### PR TITLE
some JSDoc updates for Zoe

### DIFF
--- a/packages/zoe/src/contractFacet/types-ambient.d.ts
+++ b/packages/zoe/src/contractFacet/types-ambient.d.ts
@@ -207,10 +207,7 @@ type ZcfSeatKit = {
   zcfSeat: ZCFSeat;
   userSeat: ERef<UserSeat>;
 };
-type HandleOffer<OR extends unknown, OA> = (
-  seat: ZCFSeat,
-  offerArgs?: OA,
-) => OR;
+type HandleOffer<OR extends unknown, OA> = (seat: ZCFSeat, offerArgs: OA) => OR;
 type OfferHandler<OR extends unknown = unknown, OA = never> =
   | HandleOffer<OR, OA>
   | {

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -59,6 +59,8 @@
  * @property {import('@agoric/swingset-vat').ShutdownWithFailure} fail called with the reason
  * for calling fail on this seat, where reason is normally an instanceof Error.
  * @property {() => Subscriber<AmountKeywordRecord>} getExitSubscriber
+ * @property {(result: HandleOfferResult) => void} resolveExitAndResult
+ * @property {(payments: PaymentPKeywordRecord) => Promise<void>} finalPayouts
  */
 
 /**

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -228,7 +228,7 @@ export const makeZoeSeatAdminFactory = baggage => {
           );
 
           state.exiting = true;
-          E.when(
+          void E.when(
             doExit(
               facets.zoeSeatAdmin,
               state.currentAllocation,

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -204,6 +204,7 @@ export const makeZoeSeatAdminFactory = baggage => {
           !hasExited1 || assert(!hasExited1, msg);
         },
       },
+      /** @type {ZoeSeatAdmin} */
       zoeSeatAdmin: {
         replaceAllocation(replacementAllocation) {
           const { state, facets } = this;
@@ -355,6 +356,7 @@ export const makeZoeSeatAdminFactory = baggage => {
       };
     },
     {
+      /** @type {UserSeat} */
       userSeat: {
         async getProposal() {
           return this.state.userSeatAccess.getProposal();


### PR DESCRIPTION
refs: #4291

## Description

A little progress on #4291 to see the effort required. It was mostly copy-paste. JSDoc, at least in VS Code rendering, doesn't support Markdown tables so I changed one to a bullet list.

There is much more to do for 4291 but I think this is worth landing. It also annotates the types on the implementation so that hover brings along the JSDoc.

### Security Considerations

n/a
### Scaling Considerations

n/a

### Documentation Considerations

Eventually build the API parts of docs site from the API source code.

### Testing Considerations

n/a

### Upgrade Considerations

n/a
