### PR TITLE
9136 require returns

### DIFF
--- a/packages/cosmic-swingset/src/params.js
+++ b/packages/cosmic-swingset/src/params.js
@@ -12,7 +12,10 @@ export const stringToNat = s => {
   return nat;
 };
 
-/** @param {{key: string, size: number}[]} queueSizeEntries */
+/**
+ * @param {{key: string, size: number}[]} queueSizeEntries
+ * @returns {Record<string, number>}
+ */
 export const parseQueueSizes = queueSizeEntries =>
   Object.fromEntries(
     queueSizeEntries.map(({ key, size }) => {
@@ -22,7 +25,10 @@ export const parseQueueSizes = queueSizeEntries =>
     }),
   );
 
-/** @param {Record<string, number>} queueSizes */
+/**
+ * @param {Record<string, number>} queueSizes
+ * @returns {{key: string, size: number}[]}
+ */
 export const encodeQueueSizes = queueSizes =>
   Object.entries(queueSizes).map(([key, size]) => {
     isNat(size) || Fail`Size ${size} is not a positive integer`;
@@ -32,6 +38,9 @@ export const encodeQueueSizes = queueSizes =>
 /**
  * Map the SwingSet parameters to a deterministic data structure.
  * @param {import('@agoric/cosmic-proto/dist/codegen/agoric/swingset/swingset.js').ParamsSDKType} params
+ * @returns {{
+ *   beansPerUnit: Record<string, bigint>, feeUnitPrice: {denom: string, amount: bigint}[], queueMax: Record<string, number>
+ * }}
  */
 export const parseParams = params => {
   const {

--- a/packages/eslint-config/eslint-config.cjs
+++ b/packages/eslint-config/eslint-config.cjs
@@ -60,7 +60,10 @@ module.exports = {
     'jsdoc/require-jsdoc': 'off',
     'jsdoc/require-property-description': 'off',
     'jsdoc/require-param-description': 'off',
-    'jsdoc/require-returns': 'off',
+    'jsdoc/require-returns': [
+      'error',
+      { exemptedBy: ['type'], publicOnly: true },
+    ],
     'jsdoc/require-returns-check': 'off', // TS checks
     'jsdoc/require-returns-description': 'off',
     'jsdoc/require-yields': 'off',
@@ -89,6 +92,8 @@ module.exports = {
     {
       files: ['**/*.ts'],
       rules: {
+        // .ts can specify return type in syntax
+        'jsdoc/require-returns': 'off',
         // Handled better by tsc
         'import/no-unresolved': 'off',
         'no-unused-vars': 'off',

--- a/packages/telemetry/src/otel-trace.js
+++ b/packages/telemetry/src/otel-trace.js
@@ -18,6 +18,7 @@ export const SPAN_EXPORT_DELAY_MS = 1_000;
 /**
  * @param {object} opts
  * @param {Record<string, string>} opts.env
+ * @returns {BasicTracerProvider | undefined}
  */
 export const makeOtelTracingProvider = opts => {
   const { env = process.env } = opts || {};


### PR DESCRIPTION
refs: #9136

## Description

Spike on,
- #9136 

We might want to exempt contracts. We could do that by ignoring `.contract.js` files (and using that extension for contracts). Another option is to have a tag like `@contract` and add it to the rule's ignore list. Either way, we'll lose the documentation of the start function in the `.d.ts`. A counter to that is that documentation of the contract should be at the module level in `@file`.

For Exo, I don't know whether we'd want to exempt because they're more likely to need the JSDoc comments. We could specify the return type by getting it from the interface definitions. But that would require something like https://github.com/Agoric/agoric-sdk/issues/6160

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
