### PR TITLE
fix replace-packages script

### DIFF
--- a/scripts/get-packed-versions.sh
+++ b/scripts/get-packed-versions.sh
@@ -23,6 +23,11 @@ corepack enable
 yarn install 1>&2
 yarn build 1>&2
 
+# use lerna to ensure these run in topological order, whereas npm query
+# sorts in order of the array and lexically for the glob
+# https://github.com/npm/cli/issues/4139#issuecomment-1730186418
+yarn lerna run prepack 1>&2
+# Convention used in Endo
 yarn lerna run build:types 1>&2
 
 npm query .workspace | jq -r '.[].location' | while read -r dir; do

--- a/scripts/registry.sh
+++ b/scripts/registry.sh
@@ -70,6 +70,10 @@ publish() {
     yarn build
     git commit --allow-empty -am "chore: prepare for publishing"
 
+    # use lerna to ensure these run in topological order, whereas npm query
+    # sorts in order of the array and lexically for the glob
+    # https://github.com/npm/cli/issues/4139#issuecomment-1730186418
+    yarn lerna run prepack
     # Convention used in Endo
     yarn lerna run build:types
 

--- a/scripts/replace-packages.sh
+++ b/scripts/replace-packages.sh
@@ -14,6 +14,14 @@ DSTDIR=${2-$PWD/node_modules}
 pushd "$SRCDIR"
 yarn install
 yarn build
+
+# use lerna to ensure these run in topological order, whereas npm query
+# sorts in order of the array and lexically for the glob
+# https://github.com/npm/cli/issues/4139#issuecomment-1730186418
+yarn lerna run prepack
+# Convention used in Endo
+yarn lerna run build:types
+
 npm query .workspace | jq -r '.[].location' | while read -r dir; do
   # Skip private packages.
   test "$(jq .private < "$dir/package.json")" != true || continue
@@ -21,10 +29,10 @@ npm query .workspace | jq -r '.[].location' | while read -r dir; do
   # Create the tarball.
   pushd "$dir"
   name=$(jq -r .name < package.json)
-  stem=$(echo "$name" | sed -e 's!^@!!; s!/!-!g;')
-  rm -f "${stem}"-*.tgz
-  yarn pack
-  tar -xvf "${stem}"-*.tgz
+  rm -f package.tgz
+  npm pack
+  mv ./*.tgz package.tgz
+  tar -xvf package.tgz
 
   # Replace the destination package.
   rm -rf "${DSTDIR:?}/$name"


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/pull/9290

## Description

One of the things to shake out of https://github.com/Agoric/agoric-sdk/pull/9290. `replace-packages.sh` isn't part of any CI and is rarely used at all, but I need it for https://github.com/Agoric/agoric-sdk/pull/8774 to accomodate https://github.com/endojs/endo/pull/2238/commits/bef388ed9c09681116ee5a9ea0fb30e9402b36a9

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
