### PR TITLE
label instances in tests

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -359,6 +359,9 @@ export async function makeSwingsetController(
             ),
             URL: globalThis.Base64, // Unavailable only on XSnap
             Base64: globalThis.Base64, // Available only on XSnap
+            process: {
+              env,
+            },
           },
         });
         noteStartupPhase(

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -1406,6 +1406,7 @@ export const makeSwingsetTestKit = async <
         configPath || resolvedConfigPath,
         [],
         {
+          DEBUG: 'label-instances',
           SWINGSET_STARTUP_PROFILE: process.env.SWINGSET_STARTUP_PROFILE,
           XSNAP_DEBUG: process.env.XSNAP_DEBUG,
           XSNAP_TEST_RECORD: process.env.XSNAP_TEST_RECORD,

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -166,7 +166,7 @@ const getHostKey = path => `host.${path}`;
  * @param {SwingStoreKernelStorage} kernelStorage
  * @param {ERef<string | SwingSetConfig> | (() => ERef<string | SwingSetConfig>)} getVatConfig
  * @param {unknown} bootstrapArgs JSON-serializable data
- * @param {{}} env
+ * @param {Record<string, string | undefined>} env
  * @param {*} options
  */
 export async function buildSwingset(


### PR DESCRIPTION
__incidental_

## Description
the `DEBUG=label-instances` env option works in unit tests but not in RunUtils tests, because the kernel module endowment doesn't have access.

This provides an `env` so the DEBUG option can be read. Reviewers, how surgical should this be?

It also updates the `makeSwingsetTestKit` to always label instances. It doesn't pass through any other DEBUG options. My thinking is that the test runner should pick the best options for debugging and leave it at that.

### Security Considerations
Endows the kernel with a `process.env`. This should be just a dictionary of strings and presently it is a limited set (not the entire real env). But maybe we should have a special endowment for ENV options with the options reader checks in addition to process.env?

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
TBD

### Upgrade Considerations
none
