### PR TITLE
improve Orch test fidelity

### DIFF
--- a/packages/orchestration/test/exos/agoric-names-tools.test.ts
+++ b/packages/orchestration/test/exos/agoric-names-tools.test.ts
@@ -1,20 +1,19 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { heapVowE as E } from '@agoric/vow/vat.js';
-import { makeHeapZone } from '@agoric/zone';
-import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { makeIssuerKit } from '@agoric/ertp';
 import { AssetInfo } from '@agoric/vats/src/vat-bank.js';
+import { heapVowE as E } from '@agoric/vow/vat.js';
+import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { makeResumableAgoricNamesHack } from '../../src/exos/agoric-names-tools.js';
-import { commonSetup } from '../supports.js';
+import { commonSetup, provideDurableZone } from '../supports.js';
 
 test('agoric names tools', async t => {
+  const zone = provideDurableZone('test');
   const {
     bootstrap: { agoricNames, agoricNamesAdmin, bankManager, vowTools },
     brands: { ist },
-  } = await commonSetup(t);
+  } = await commonSetup(t, zone);
 
-  const zone = makeHeapZone();
   const agNamesTools = makeResumableAgoricNamesHack(zone, {
     agoricNames,
     vowTools,

--- a/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
@@ -6,6 +6,7 @@ import { heapVowE as E } from '@agoric/vow/vat.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { Far } from '@endo/far';
 import { TimeMath } from '@agoric/time';
+import { makeHeapZone } from '@agoric/zone';
 import { prepareLocalOrchestrationAccountKit } from '../../src/exos/local-orchestration-account.js';
 import { ChainAddress } from '../../src/orchestration-api.js';
 import { makeChainHub } from '../../src/exos/chain-hub.js';
@@ -15,12 +16,12 @@ import { UNBOND_PERIOD_SECONDS } from '../ibc-mocks.js';
 import { maxClockSkew } from '../../src/utils/cosmos.js';
 
 test('deposit, withdraw', async t => {
+  const rootZone = makeHeapZone();
   const { bootstrap, brands, utils } = await commonSetup(t);
 
   const { bld: stake } = brands;
 
-  const { timer, localchain, marshaller, rootZone, storage, vowTools } =
-    bootstrap;
+  const { timer, localchain, marshaller, storage, vowTools } = bootstrap;
 
   t.log('chainInfo mocked via `prepareMockChainInfo` until #8879');
 
@@ -88,12 +89,12 @@ test('deposit, withdraw', async t => {
 });
 
 test('delegate, undelegate', async t => {
+  const rootZone = makeHeapZone();
   const { bootstrap, brands, utils } = await commonSetup(t);
 
   const { bld } = brands;
 
-  const { timer, localchain, marshaller, rootZone, storage, vowTools } =
-    bootstrap;
+  const { timer, localchain, marshaller, storage, vowTools } = bootstrap;
 
   t.log('exo setup - prepareLocalChainAccountKit');
   const { makeRecorderKit } = prepareRecorderKitMakers(
@@ -151,12 +152,12 @@ test('delegate, undelegate', async t => {
 });
 
 test('transfer', async t => {
+  const rootZone = makeHeapZone();
   const { bootstrap, brands, utils } = await commonSetup(t);
 
   const { bld: stake } = brands;
 
-  const { timer, localchain, marshaller, rootZone, storage, vowTools } =
-    bootstrap;
+  const { timer, localchain, marshaller, storage, vowTools } = bootstrap;
 
   t.log('exo setup - prepareLocalChainAccountKit');
   const { makeRecorderKit } = prepareRecorderKitMakers(

--- a/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
+++ b/packages/orchestration/test/exos/local-orchestration-account-kit.test.ts
@@ -11,13 +11,13 @@ import { prepareLocalOrchestrationAccountKit } from '../../src/exos/local-orches
 import { ChainAddress } from '../../src/orchestration-api.js';
 import { makeChainHub } from '../../src/exos/chain-hub.js';
 import { NANOSECONDS_PER_SECOND } from '../../src/utils/time.js';
-import { commonSetup } from '../supports.js';
+import { commonSetup, provideDurableZone } from '../supports.js';
 import { UNBOND_PERIOD_SECONDS } from '../ibc-mocks.js';
 import { maxClockSkew } from '../../src/utils/cosmos.js';
 
 test('deposit, withdraw', async t => {
   const rootZone = makeHeapZone();
-  const { bootstrap, brands, utils } = await commonSetup(t);
+  const { bootstrap, brands, utils } = await commonSetup(t, rootZone);
 
   const { bld: stake } = brands;
 
@@ -90,7 +90,7 @@ test('deposit, withdraw', async t => {
 
 test('delegate, undelegate', async t => {
   const rootZone = makeHeapZone();
-  const { bootstrap, brands, utils } = await commonSetup(t);
+  const { bootstrap, brands, utils } = await commonSetup(t, rootZone);
 
   const { bld } = brands;
 
@@ -153,7 +153,7 @@ test('delegate, undelegate', async t => {
 
 test('transfer', async t => {
   const rootZone = makeHeapZone();
-  const { bootstrap, brands, utils } = await commonSetup(t);
+  const { bootstrap, brands, utils } = await commonSetup(t, rootZone);
 
   const { bld: stake } = brands;
 

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -132,8 +132,6 @@ export const commonSetup = async (t: ExecutionContext<any>) => {
       localchain,
       marshaller,
       cosmosInterchainService,
-      // TODO remove; bootstrap doesn't have a zone
-      rootZone: rootZone.subZone('contract'),
       storage,
       vowTools,
       ibcBridge,

--- a/packages/swingset-liveslots/tools/prepare-test-env.js
+++ b/packages/swingset-liveslots/tools/prepare-test-env.js
@@ -9,5 +9,5 @@ import '@agoric/internal/src/install-ses-debug.js';
 
 import { reincarnate } from './setup-vat-data.js';
 
-// Install the VatData globals.
+// Install the fakeVomKit that the VatData global needs.
 reincarnate();

--- a/packages/swingset-liveslots/tools/setup-vat-data.js
+++ b/packages/swingset-liveslots/tools/setup-vat-data.js
@@ -37,10 +37,14 @@ globalThis.VatData = harden({
     fakeVomKit.cm.makeScalarBigWeakSetStore(...args),
 });
 
+/**
+ *
+ * @param {Partial<Exclude<Parameters<typeof makeFakeVirtualStuff>[0], WeakMap | WeakSet> & {fakeVomKit: ReturnType<typeof makeFakeVirtualStuff>}>} options
+ */
 export const reincarnate = (options = {}) => {
   const { fakeStore = new Map(), fakeVomKit: fvk } = options;
 
-  if (options.fakeVomKit) {
+  if (fvk) {
     fvk.vom.flushStateCache();
     fvk.cm.flushSchemaCache();
     fvk.vrm.flushIDCounters();


### PR DESCRIPTION
_incidental_

## Description
Debugging orchestration has been complicated by the (low) fidelity of the testing environment to durability rules. https://github.com/Agoric/agoric-sdk/pull/9539 will help.

This PR makes it easier to even disable `relaxDurabilityRules` in unit tests. It does so in the `agoric-names-tools` test and makes the fake storageNode supports comply with durability rules.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
none