### PR TITLE
use Node's scheduler wait

### DIFF
--- a/a3p-integration/proposals/b:enable-orchestration/test-lib/wallet.js
+++ b/a3p-integration/proposals/b:enable-orchestration/test-lib/wallet.js
@@ -4,7 +4,6 @@
  */
 // TODO DRY in https://github.com/Agoric/agoric-sdk/issues/9109
 // @ts-check
-/* global */
 
 import { E, Far } from '@endo/far';
 import { inspect } from 'util';

--- a/a3p-integration/proposals/c:stake-bld/test-lib/wallet.js
+++ b/a3p-integration/proposals/c:stake-bld/test-lib/wallet.js
@@ -4,7 +4,6 @@
  */
 // TODO DRY in https://github.com/Agoric/agoric-sdk/issues/9109
 // @ts-check
-/* global */
 
 import { E, Far } from '@endo/far';
 import { inspect } from 'util';

--- a/multichain-testing/test/stake-ica.test.ts
+++ b/multichain-testing/test/stake-ica.test.ts
@@ -1,9 +1,9 @@
 import anyTest from '@endo/ses-ava/prepare-endo.js';
 import type { TestFn } from 'ava';
+import { scheduler } from 'node:timers/promises';
 import { commonSetup, SetupContextWithWallets } from './support.js';
 import { makeDoOffer } from '../tools/e2e-tools.js';
 import { makeQueryClient } from '../tools/query.js';
-import { sleep } from '../tools/sleep.js';
 
 const test = anyTest as TestFn<SetupContextWithWallets>;
 
@@ -249,7 +249,7 @@ const stakeScenario = test.macro(async (t, scenario: StakeIcaScenario) => {
   t.log('Current Balance:', currentBalances[0]);
 
   console.log('waiting for unbonding period');
-  await sleep(120000);
+  await scheduler.wait(120000);
   const { balances: rewardsWithUndelegations } = await retryUntilCondition(
     () => queryClient.queryBalances(address),
     ({ balances }) => {

--- a/multichain-testing/test/tools/wallet.test.ts
+++ b/multichain-testing/test/tools/wallet.test.ts
@@ -2,7 +2,7 @@ import anyTest from '@endo/ses-ava/prepare-endo.js';
 import type { TestFn } from 'ava';
 import { makeQueryClient } from '../../tools/query.js';
 import { createWallet } from '../../tools/wallet.js';
-import { sleep } from '../../tools/sleep.js';
+import { scheduler } from 'node:timers/promises';
 import { commonSetup } from '../support.js';
 
 const test = anyTest as TestFn<Record<string, never>>;
@@ -30,7 +30,7 @@ const walletScenario = test.macro(async (t, scenario: string) => {
   await creditFromFaucet(addr);
   // XXX needed to avoid race condition between faucet POST and LCD Query
   // see https://github.com/cosmology-tech/starship/issues/417
-  await sleep(1000, t.log);
+  await scheduler.wait(1000);
 
   const { balances: updatedBalances } = await queryClient.queryBalances(addr);
   const expectedDenom = scenario === 'osmosis' ? 'uosmo' : 'uatom';

--- a/multichain-testing/tools/sleep.ts
+++ b/multichain-testing/tools/sleep.ts
@@ -1,10 +1,6 @@
-type Log = (...values: unknown[]) => void;
+import { scheduler } from 'node:timers/promises';
 
-export const sleep = (ms: number, log: Log = () => {}) =>
-  new Promise(resolve => {
-    log(`Sleeping for ${ms}ms...`);
-    setTimeout(resolve, ms);
-  });
+type Log = (...values: unknown[]) => void;
 
 const retryUntilCondition = async <T>(
   operation: () => Promise<T>,
@@ -35,7 +31,7 @@ const retryUntilCondition = async <T>(
     console.log(
       `Retry ${retries}/${maxRetries} - Waiting for ${retryIntervalMs}ms for ${message}...`,
     );
-    await sleep(retryIntervalMs, log);
+    await scheduler.wait(retryIntervalMs);
   }
 
   throw new Error(`${message} condition failed after ${maxRetries} retries.`);

--- a/packages/agoric-cli/src/commands/gov.js
+++ b/packages/agoric-cli/src/commands/gov.js
@@ -1,8 +1,9 @@
 // @ts-check
 /* eslint-disable func-names */
-/* global globalThis, process, setTimeout */
+/* global globalThis, process */
 import { execFileSync as execFileSyncAmbient } from 'child_process';
 import { Command, CommanderError } from 'commander';
+import { scheduler } from 'node:timers/promises';
 import { normalizeAddressWithOptions, pollBlocks } from '../lib/chain.js';
 import { getNetworkConfig, makeRpcUtils } from '../lib/rpc.js';
 import {
@@ -45,7 +46,7 @@ export const makeGovCommand = (_logger, io = {}) => {
     stderr = process.stderr,
     fetch = globalThis.fetch,
     execFileSync = execFileSyncAmbient,
-    delay = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    delay = scheduler.wait,
   } = io;
 
   const cmd = new Command('gov').description('Electoral governance commands');

--- a/packages/agoric-cli/src/commands/oracle.js
+++ b/packages/agoric-cli/src/commands/oracle.js
@@ -1,11 +1,12 @@
 // @ts-check
 /* eslint-disable func-names */
-/* global fetch, setTimeout, process */
+/* global fetch, process */
 import { Fail } from '@endo/errors';
 import { Nat } from '@endo/nat';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { Command } from 'commander';
 import * as cp from 'child_process';
+import { scheduler } from 'node:timers/promises';
 import { inspect } from 'util';
 import { oracleBrandFeedName } from '@agoric/inter-protocol/src/proposals/utils.js';
 import { normalizeAddressWithOptions } from '../lib/chain.js';
@@ -36,7 +37,7 @@ const scaleDecimals = num => BigInt(num * Number(COSMOS_UNIT));
  */
 export const makeOracleCommand = (logger, io = {}) => {
   const {
-    delay = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    delay = scheduler.wait,
     execFileSync = cp.execFileSync,
     env = process.env,
     stdout = process.stdout,

--- a/packages/agoric-cli/tools/getting-started.js
+++ b/packages/agoric-cli/tools/getting-started.js
@@ -1,8 +1,9 @@
-/* global process setTimeout setInterval clearInterval */
+/* global process setInterval clearInterval */
 
 import fs from 'fs';
 import path from 'path';
 import tmp from 'tmp';
+import { scheduler } from 'node:timers/promises';
 import { makePromiseKit } from '@endo/promise-kit';
 import { request } from 'http';
 
@@ -117,7 +118,7 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
 
     // XXX: use abci_info endpoint to get block height
     // sleep to let contract start
-    await new Promise(resolve => setTimeout(resolve, TIMEOUT_SECONDS));
+    await scheduler.wait(TIMEOUT_SECONDS);
 
     // ==============
     // yarn start:contract

--- a/packages/boot/test/bootstrapTests/vow-offer-results.test.ts
+++ b/packages/boot/test/bootstrapTests/vow-offer-results.test.ts
@@ -1,7 +1,7 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import type { TestFn } from 'ava';
-import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import { scheduler } from 'node:timers/promises';
 import {
   makeWalletFactoryContext,
   type WalletFactoryTestContext,
@@ -40,9 +40,7 @@ test('resolves', async t => {
   });
   // Ensure the offer has executed. Without this there's work in the
   // crank when the contract is restarted below.
-  await new Promise(resolve => {
-    setTimeout(resolve, 1000);
-  });
+  await scheduler.wait(1000);
 
   t.log('confirm the value is not in offer results');
   {
@@ -87,9 +85,7 @@ test('resolves', async t => {
 
   t.log('confirm the value is now in offer results');
   // Ensure the getter vow has had time to resolved.
-  await new Promise(resolve => {
-    setTimeout(resolve, 1000);
-  });
+  await scheduler.wait(1000);
   {
     const statusRecord = getter.getLatestUpdateRecord();
     // narrow the type

--- a/packages/casting/src/defaults.js
+++ b/packages/casting/src/defaults.js
@@ -1,4 +1,5 @@
-/* global setTimeout */
+/* global */
+import { scheduler } from 'node:timers/promises';
 import { Far } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
 
@@ -21,7 +22,7 @@ export const DEFAULT_KEEP_POLLING_SECONDS = 5;
  * @param {number} ms
  * @returns {Promise<void>}
  */
-export const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+export const delay = ms => scheduler.wait(ms);
 
 /**
  * @param {number} range

--- a/packages/casting/src/defaults.js
+++ b/packages/casting/src/defaults.js
@@ -1,4 +1,3 @@
-/* global */
 import { scheduler } from 'node:timers/promises';
 import { Far } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';

--- a/packages/cosmic-swingset/test/provision-smartwallet.test.js
+++ b/packages/cosmic-swingset/test/provision-smartwallet.test.js
@@ -1,7 +1,7 @@
-/* global setTimeout */
 import test from 'ava';
 
 // Use ambient authority only in test.before()
+import { scheduler } from 'node:timers/promises';
 import { spawn as ambientSpawn } from 'child_process';
 import * as ambientPath from 'path';
 import * as ambientFs from 'fs';
@@ -35,7 +35,7 @@ test.before(async t => {
   const dirname = ambientPath.dirname(filename);
   const makefileDir = ambientPath.join(dirname, '..');
 
-  const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+  const delay = ms => scheduler.wait(ms);
 
   const io = { spawn: ambientSpawn, cwd: makefileDir };
   const pspawnMake = pspawn('make', io);

--- a/packages/smart-wallet/test/invitation1.test.js
+++ b/packages/smart-wallet/test/invitation1.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global setTimeout */
+import { scheduler } from 'node:timers/promises';
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { createRequire } from 'module';
 import { E, Far } from '@endo/far';
@@ -20,7 +20,7 @@ import { prepareSmartWallet } from '../src/smartWallet.js';
 /** @type {import('ava').TestFn<Awaited<ReturnType<makeTestContext>>>} */
 const test = anyTest;
 
-const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+const delay = ms => scheduler.wait(ms);
 
 const nodeRequire = createRequire(import.meta.url);
 const asset = {

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import url from 'url';
 import { execFile } from 'child_process';
 import { open as tempOpen } from 'temp';
+import { scheduler } from 'node:timers/promises';
 
 import WebSocket from 'ws';
 
@@ -185,7 +186,7 @@ export async function connectToChain(
       }
 
       // It was undefined, so wait, then retry.
-      await new Promise(resolve => setTimeout(resolve, 5000));
+      await scheduler.wait(5000);
       rpcHrefIndex = (rpcHrefIndex + 1) % rpcHrefs.length;
     }
     throw Error(`Unreachable, but the tools don't know that`);

--- a/packages/telemetry/src/ingest-slog-entrypoint.js
+++ b/packages/telemetry/src/ingest-slog-entrypoint.js
@@ -1,5 +1,4 @@
 #! /usr/bin/env node
-/* global setTimeout */
 import '@endo/init';
 
 import fs from 'fs';
@@ -7,6 +6,7 @@ import zlib from 'zlib';
 import readline from 'readline';
 import process from 'process';
 
+import { scheduler } from 'timers/promises';
 import { makeSlogSender } from './make-slog-sender.js';
 
 const LINE_COUNT_TO_FLUSH = 10000;
@@ -110,7 +110,7 @@ async function run() {
     let maybeWait;
     if (linesProcessedThisPeriod >= MAX_LINE_COUNT_PER_PERIOD) {
       const delayMS = PROCESSING_PERIOD - (now - startOfLastPeriod);
-      maybeWait = new Promise(resolve => setTimeout(resolve, delayMS));
+      maybeWait = scheduler.wait(delayMS);
     }
     await maybeWait;
     now = Date.now();

--- a/packages/telemetry/test/import.test.js
+++ b/packages/telemetry/test/import.test.js
@@ -1,10 +1,7 @@
-/* global setTimeout */
+import { setTimeout } from 'node:timers/promises';
 import { test } from './prepare-test-env-ava.js';
 
 import { getTelemetryProviders } from '../src/index.js';
-
-const sleep = timeoutMs =>
-  new Promise(resolve => setTimeout(resolve, timeoutMs));
 
 test('get telemetry providers', async t => {
   const logged = [];
@@ -17,7 +14,7 @@ test('get telemetry providers', async t => {
   t.is(providers.metricsProvider, undefined);
 
   t.deepEqual(logged, []);
-  await sleep(250);
+  await setTimeout(250);
   t.deepEqual(logged, []);
 
   const providers2 = getTelemetryProviders({
@@ -29,7 +26,7 @@ test('get telemetry providers', async t => {
   t.is(typeof providers2.metricsProvider, 'object');
 
   t.deepEqual(logged, []);
-  await sleep(250);
+  await setTimeout(250);
   t.deepEqual(logged, [
     ['Prometheus scrape endpoint: http://0.0.0.0:9393/metrics'],
   ]);

--- a/packages/xsnap/test/xsnap.test.js
+++ b/packages/xsnap/test/xsnap.test.js
@@ -1,7 +1,8 @@
-/* global setTimeout, FinalizationRegistry, setImmediate, process */
+/* global  FinalizationRegistry, setImmediate, process */
 
 import test from 'ava';
 
+import { scheduler } from 'node:timers/promises';
 import { createHash } from 'crypto';
 import * as proc from 'child_process';
 import * as os from 'os';
@@ -381,9 +382,7 @@ test('execute immediately after makeSnapshotStream', async t => {
   t.deepEqual(messages, ['before']);
 });
 
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
+const delay = scheduler.wait;
 
 test('fail to send command to already-closed xsnap worker', async t => {
   const vat = await xsnap({ ...options(io) });
@@ -420,7 +419,7 @@ test('abnormal termination', async t => {
   });
 
   // Allow the evaluate command to flush.
-  await delay(10);
+  await scheduler.wait(10);
   await vat.terminate();
   await hang;
 });

--- a/packages/xsnap/test/xsnap.test.js
+++ b/packages/xsnap/test/xsnap.test.js
@@ -1,8 +1,7 @@
-/* global  FinalizationRegistry, setImmediate, process */
+/* global setTimeout, FinalizationRegistry, setImmediate, process */
 
 import test from 'ava';
 
-import { scheduler } from 'node:timers/promises';
 import { createHash } from 'crypto';
 import * as proc from 'child_process';
 import * as os from 'os';
@@ -382,7 +381,9 @@ test('execute immediately after makeSnapshotStream', async t => {
   t.deepEqual(messages, ['before']);
 });
 
-const delay = scheduler.wait;
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 test('fail to send command to already-closed xsnap worker', async t => {
   const vat = await xsnap({ ...options(io) });
@@ -419,7 +420,7 @@ test('abnormal termination', async t => {
   });
 
   // Allow the evaluate command to flush.
-  await scheduler.wait(10);
+  await delay(10);
   await vat.terminate();
   await hang;
 });


### PR DESCRIPTION
_incidental_

## Description
Since Node 16.14, there's a `Scheduler` api that has a `wait` method: https://nodejs.org/api/timers.html#timerspromisesschedulerwaitdelay-options

This is more ergonomic than the `setTimeout` approach. It matches perfectly the `delay` and `sleep` functions we've sprinkled around, but is aligned with some standardization.

If the "experimental" aspect feels too bleeding edge, we could use the version of `setTimeout` that returns a promise. But I think that's easily confused with the global one.


### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
