### PR TITLE
refactor: compose asContinuingOffer

### DIFF
--- a/packages/async-flow/index.js
+++ b/packages/async-flow/index.js
@@ -1,3 +1,3 @@
 export * from './src/async-flow.js';
 export * from './src/types.js';
-export { makeStateRecord } from './src/endowments.js';
+export { makeSharedStateRecord } from './src/endowments.js';

--- a/packages/async-flow/src/endowments.js
+++ b/packages/async-flow/src/endowments.js
@@ -64,7 +64,7 @@ export const forwardingMethods = rem => {
  * @param {R} dataRecord
  * @returns {R}
  */
-export const makeStateRecord = dataRecord =>
+export const makeSharedStateRecord = dataRecord =>
   harden(
     create(
       objectPrototype,

--- a/packages/orchestration/src/examples/auto-stake-it.contract.js
+++ b/packages/orchestration/src/examples/auto-stake-it.contract.js
@@ -4,7 +4,7 @@ import {
 } from '@agoric/zoe/src/typeGuards.js';
 import { M } from '@endo/patterns';
 import { prepareChainHubAdmin } from '../exos/chain-hub-admin.js';
-import { preparePortfolioHolder } from '../exos/portfolio-holder-kit.js';
+import { preparePortfolioHolderKit } from '../exos/portfolio-holder-kit.js';
 import { withOrchestration } from '../utils/start-helper.js';
 import { prepareStakingTap } from './auto-stake-it-tap-kit.js';
 import * as flows from './auto-stake-it.flows.js';
@@ -52,14 +52,14 @@ const contract = async (
     zone.subZone('stakingTap'),
     vowTools,
   );
-  const makePortfolioHolder = preparePortfolioHolder(
+  const makePortfolioHolderKit = preparePortfolioHolderKit(
     zone.subZone('portfolio'),
     vowTools,
   );
 
   const { makeAccounts } = orchestrateAll(flows, {
     makeStakingTap,
-    makePortfolioHolder,
+    makePortfolioHolderKit,
     chainHub,
   });
 

--- a/packages/orchestration/src/examples/auto-stake-it.flows.js
+++ b/packages/orchestration/src/examples/auto-stake-it.flows.js
@@ -1,11 +1,12 @@
 import { Fail } from '@endo/errors';
+import { asContinuingOffer } from '../exos/portfolio-holder-kit.js';
 
 /**
  * @import {ResolvedPublicTopic} from '@agoric/zoe/src/contractSupport/topics.js';
  * @import {GuestInterface} from '@agoric/async-flow';
  * @import {CosmosValidatorAddress, Orchestrator, CosmosInterchainService, Denom, OrchestrationAccount, StakingAccountActions, OrchestrationFlow} from '@agoric/orchestration';
  * @import {MakeStakingTap} from './auto-stake-it-tap-kit.js';
- * @import {MakePortfolioHolder} from '../exos/portfolio-holder-kit.js';
+ * @import {MakePortfolioHolderKit} from '../exos/portfolio-holder-kit.js';
  * @import {ChainHub} from '../exos/chain-hub.js';
  */
 
@@ -14,7 +15,7 @@ import { Fail } from '@endo/errors';
  * @param {Orchestrator} orch
  * @param {{
  *   makeStakingTap: MakeStakingTap;
- *   makePortfolioHolder: MakePortfolioHolder;
+ *   makePortfolioHolderKit: MakePortfolioHolderKit;
  *   chainHub: GuestInterface<ChainHub>;
  * }} ctx
  * @param {ZCFSeat} seat
@@ -26,7 +27,7 @@ import { Fail } from '@endo/errors';
  */
 export const makeAccounts = async (
   orch,
-  { makeStakingTap, makePortfolioHolder, chainHub },
+  { makeStakingTap, makePortfolioHolderKit, chainHub },
   seat,
   {
     chainName,
@@ -96,9 +97,9 @@ export const makeAccounts = async (
       )
     ),
   );
-  const portfolioHolder = makePortfolioHolder(
+  const portfolioHolderKit = makePortfolioHolderKit(
     accountEntries,
     publicTopicEntries,
   );
-  return portfolioHolder.asContinuingOffer();
+  return asContinuingOffer(portfolioHolderKit);
 };

--- a/packages/orchestration/src/examples/basic-flows.contract.js
+++ b/packages/orchestration/src/examples/basic-flows.contract.js
@@ -4,7 +4,7 @@
  */
 import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
 import { M } from '@endo/patterns';
-import { preparePortfolioHolder } from '../exos/portfolio-holder-kit.js';
+import { preparePortfolioHolderKit } from '../exos/portfolio-holder-kit.js';
 import { withOrchestration } from '../utils/start-helper.js';
 import * as flows from './basic-flows.flows.js';
 
@@ -28,12 +28,12 @@ const contract = async (
   zone,
   { orchestrateAll, vowTools },
 ) => {
-  const makePortfolioHolder = preparePortfolioHolder(
+  const makePortfolioHolderKit = preparePortfolioHolderKit(
     zone.subZone('portfolio'),
     vowTools,
   );
 
-  const orchFns = orchestrateAll(flows, { makePortfolioHolder });
+  const orchFns = orchestrateAll(flows, { makePortfolioHolderKit });
 
   const publicFacet = zone.exo(
     'Basic Flows Public Facet',

--- a/packages/orchestration/src/examples/basic-flows.flows.js
+++ b/packages/orchestration/src/examples/basic-flows.flows.js
@@ -3,13 +3,14 @@
  *   leverage basic functionality of the Orchestration API with async-flow.
  */
 import { M, mustMatch } from '@endo/patterns';
+import { asContinuingOffer } from '../exos/portfolio-holder-kit.js';
 
 /**
  * @import {Zone} from '@agoric/zone';
  * @import {OrchestrationAccount, OrchestrationFlow, Orchestrator} from '@agoric/orchestration';
  * @import {ResolvedPublicTopic} from '@agoric/zoe/src/contractSupport/topics.js';
  * @import {OrchestrationPowers} from '../utils/start-helper.js';
- * @import {MakePortfolioHolder} from '../exos/portfolio-holder-kit.js';
+ * @import {MakePortfolioHolderKit} from '../exos/portfolio-holder-kit.js';
  * @import {OrchestrationTools} from '../utils/start-helper.js';
  */
 
@@ -40,13 +41,13 @@ export const makeOrchAccount = async (orch, _ctx, seat, { chainName }) => {
  * @satisfies {OrchestrationFlow}
  * @param {Orchestrator} orch
  * @param {object} ctx
- * @param {MakePortfolioHolder} ctx.makePortfolioHolder
+ * @param {MakePortfolioHolderKit} ctx.makePortfolioHolderKit
  * @param {ZCFSeat} seat
  * @param {{ chainNames: string[] }} offerArgs
  */
 export const makePortfolioAccount = async (
   orch,
-  { makePortfolioHolder },
+  { makePortfolioHolderKit },
   seat,
   { chainNames },
 ) => {
@@ -70,10 +71,10 @@ export const makePortfolioAccount = async (
       )
     ),
   );
-  const portfolioHolder = makePortfolioHolder(
+  const portfolioHolderKit = makePortfolioHolderKit(
     accountEntries,
     publicTopicEntries,
   );
 
-  return portfolioHolder.asContinuingOffer();
+  return asContinuingOffer(portfolioHolderKit);
 };

--- a/packages/orchestration/src/examples/sendAnywhere.contract.js
+++ b/packages/orchestration/src/examples/sendAnywhere.contract.js
@@ -1,4 +1,4 @@
-import { makeStateRecord } from '@agoric/async-flow';
+import { makeSharedStateRecord } from '@agoric/async-flow';
 import { AmountShape } from '@agoric/ertp';
 import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
 import { M } from '@endo/patterns';
@@ -50,7 +50,7 @@ const contract = async (
   zone,
   { chainHub, orchestrateAll, zoeTools },
 ) => {
-  const contractState = makeStateRecord(
+  const contractState = makeSharedStateRecord(
     /** @type {{ account: OrchestrationAccount<any> | undefined }} */ {
       localAccount: undefined,
     },

--- a/packages/orchestration/test/exos/portfolio-holder-kit.test.ts
+++ b/packages/orchestration/test/exos/portfolio-holder-kit.test.ts
@@ -2,7 +2,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { Far } from '@endo/far';
 import { heapVowE as E } from '@agoric/vow/vat.js';
 import { commonSetup } from '../supports.js';
-import { preparePortfolioHolder } from '../../src/exos/portfolio-holder-kit.js';
+import { preparePortfolioHolderKit } from '../../src/exos/portfolio-holder-kit.js';
 import { prepareMakeTestLOAKit } from './make-test-loa-kit.js';
 import { prepareMakeTestCOAKit } from './make-test-coa-kit.js';
 
@@ -52,7 +52,7 @@ test('portfolio holder kit behaviors', async t => {
   };
   const accountEntries = harden(Object.entries(accounts));
 
-  const makePortfolioHolder = preparePortfolioHolder(
+  const makePortfolioHolderKit = preparePortfolioHolderKit(
     rootZone.subZone('portfolio'),
     vowTools,
   );
@@ -64,8 +64,11 @@ test('portfolio holder kit behaviors', async t => {
       }),
     ),
   );
-  // @ts-expect-error type mismatch between kit and OrchestrationAccountI
-  const holder = makePortfolioHolder(accountEntries, publicTopicEntries);
+  const { holder, invitationMakers } = makePortfolioHolderKit(
+    // @ts-expect-error XXX HostOf or HostInterface
+    accountEntries,
+    publicTopicEntries,
+  );
 
   const cosmosAccount = await E(holder).getAccount('cosmoshub');
   t.is(
@@ -73,8 +76,6 @@ test('portfolio holder kit behaviors', async t => {
     accounts.cosmoshub,
     'same account holder kit provided is returned',
   );
-
-  const { invitationMakers } = await E(holder).asContinuingOffer();
 
   const delegateInv = await E(invitationMakers).MakeInvitation(
     'cosmoshub',


### PR DESCRIPTION
refs: #9786

## Description

Refactor `asContinuingOffer` to a a helper instead of an Exo method, to make it so #9786 can compose the topics and invitation makers.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
