### PR TITLE
chore(a3p): setup the oracle and push price for ATOM and stATOM at `use` phase of `f:replace-price-feeds`

### DIFF
--- a/a3p-integration/proposals/n:upgrade-next/test-lib/price-feed.js
+++ b/a3p-integration/proposals/n:upgrade-next/test-lib/price-feed.js
@@ -1,0 +1,62 @@
+/* eslint-env node */
+
+import {
+  agoric,
+  getContractInfo,
+  pushPrices,
+  getPriceQuote,
+} from '@agoric/synthetic-chain';
+import { retryUntilCondition } from './sync-tools.js';
+
+export const scale6 = x => BigInt(x * 1_000_000);
+
+/**
+ *
+ * @param {number} price
+ * @param {string} brand
+ * @param {Map<any, any>} oraclesByBrand
+ * @param {number} roundId
+ * @returns {Promise<void>}
+ */
+export const verifyPushedPrice = async (
+  price,
+  brand,
+  oraclesByBrand,
+  roundId,
+) => {
+  const pushPriceRetryOpts = {
+    maxRetries: 5, // arbitrary
+    retryIntervalMs: 5000, // in ms
+  };
+
+  await pushPrices(price, brand, oraclesByBrand, roundId);
+  console.log(`Pushing price ${price} for ${brand}`);
+
+  await retryUntilCondition(
+    () => getPriceQuote(brand),
+    res => res === `+${scale6(price).toString()}`,
+    'price not pushed yet',
+    {
+      log: console.log,
+      setTimeout: global.setTimeout,
+      ...pushPriceRetryOpts,
+    },
+  );
+  console.log(`Price ${price} pushed for ${brand}`);
+};
+
+/**
+ *
+ * @param {string} brand
+ * @returns {Promise<number>}
+ */
+export const getPriceFeedRoundId = async brand => {
+  const latestRoundPath = `published.priceFeed.${brand}-USD_price_feed.latestRound`;
+  const latestRound = await getContractInfo(latestRoundPath, {
+    agoric,
+    prefix: '',
+  });
+
+  console.log('latestRound: ', latestRound);
+  return Number(latestRound.roundId);
+};

--- a/a3p-integration/proposals/n:upgrade-next/test-lib/sync-tools.js
+++ b/a3p-integration/proposals/n:upgrade-next/test-lib/sync-tools.js
@@ -1,0 +1,72 @@
+/* eslint-env node */
+
+/**
+ * @file These tools mostly duplicate code that will be added in other PRs
+ * and eventually migrated to synthetic-chain. Sorry for the duplication.
+ */
+
+/**
+ * @typedef {object} RetryOptions
+ * @property {number} [maxRetries]
+ * @property {number} [retryIntervalMs]
+ * @property {(...arg0: string[]) => void} log
+ * @property {(object) => void} [setTimeout]
+ * @property {string} [errorMessage=Error]
+ */
+
+const ambientSetTimeout = global.setTimeout;
+
+/**
+ * From https://github.com/Agoric/agoric-sdk/blob/442f07c8f0af03281b52b90e90c27131eef6f331/multichain-testing/tools/sleep.ts#L10
+ *
+ * @param {number} ms
+ * @param {*} sleepOptions
+ */
+const sleep = (ms, { log = () => {}, setTimeout = ambientSetTimeout }) =>
+  new Promise(resolve => {
+    log(`Sleeping for ${ms}ms...`);
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * From https://github.com/Agoric/agoric-sdk/blob/442f07c8f0af03281b52b90e90c27131eef6f331/multichain-testing/tools/sleep.ts#L24
+ *
+ * @param {() => Promise} operation
+ * @param {(result: any) => boolean} condition
+ * @param {string} message
+ * @param {RetryOptions} options
+ */
+export const retryUntilCondition = async (
+  operation,
+  condition,
+  message,
+  { maxRetries = 6, retryIntervalMs = 3500, log, setTimeout },
+) => {
+  console.log({ maxRetries, retryIntervalMs, message });
+  let retries = 0;
+
+  await null;
+  while (retries < maxRetries) {
+    try {
+      const result = await operation();
+      log('RESULT', result);
+      if (condition(result)) {
+        return result;
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        log(`Error: ${error.message}`);
+      } else {
+        log(`Unknown error: ${String(error)}`);
+      }
+    }
+
+    retries += 1;
+    console.log(
+      `Retry ${retries}/${maxRetries} - Waiting for ${retryIntervalMs}ms for ${message}...`,
+    );
+    await sleep(retryIntervalMs, { log, setTimeout });
+  }
+
+  throw Error(`${message} condition failed after ${maxRetries} retries.`);
+};

--- a/a3p-integration/proposals/n:upgrade-next/use.sh
+++ b/a3p-integration/proposals/n:upgrade-next/use.sh
@@ -5,3 +5,6 @@ set -uxeo pipefail
 
 node ./addGov4
 ./acceptInvites.js
+
+./verifyPushedPrice.js 'ATOM' 12.01
+./verifyPushedPrice.js 'stATOM' 12.01

--- a/a3p-integration/proposals/n:upgrade-next/verifyPushedPrice.js
+++ b/a3p-integration/proposals/n:upgrade-next/verifyPushedPrice.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+import {
+  registerOraclesForBrand,
+  generateOracleMap,
+} from '@agoric/synthetic-chain';
+import { argv } from 'node:process';
+import { verifyPushedPrice } from './test-lib/price-feed.js';
+
+const brand = argv[2];
+const price = Number(argv[3]);
+
+const BASE_ID = 'n-upgrade';
+const ROUND_ID = 1;
+
+const oraclesByBrand = generateOracleMap(BASE_ID, [brand]);
+await registerOraclesForBrand(brand, oraclesByBrand);
+console.log(`Registering Oracle for ${brand}`);
+
+await verifyPushedPrice(price, brand, oraclesByBrand, ROUND_ID);
+console.log(`Price pushed for ${brand}`);

--- a/a3p-integration/proposals/z:acceptance/vaults.test.js
+++ b/a3p-integration/proposals/z:acceptance/vaults.test.js
@@ -8,52 +8,14 @@ import {
   adjustVault,
   closeVault,
   getISTBalance,
-  getPriceQuote,
-  pushPrices,
   getContractInfo,
   ATOM_DENOM,
   USER1ADDR,
   waitForBlock,
-  registerOraclesForBrand,
-  generateOracleMap,
 } from '@agoric/synthetic-chain';
 import { getBalances, agopsVaults } from './test-lib/utils.js';
-import { retryUntilCondition } from './test-lib/sync-tools.js';
 
 export const scale6 = x => BigInt(x * 1_000_000);
-
-// There may be a new vaultFactory that doesn't have prices yet, so we publish
-// prices now
-test.before(async t => {
-  const pushPriceRetryOpts = {
-    maxRetries: 5, // arbitrary
-    retryIntervalMs: 5000, // in ms
-  };
-  t.context = {
-    roundId: 1,
-    retryOpts: {
-      pushPriceRetryOpts,
-    },
-  };
-  const oraclesByBrand = generateOracleMap('z-acc', ['ATOM']);
-  await registerOraclesForBrand('ATOM', oraclesByBrand);
-
-  const price = 15.2;
-  // @ts-expect-error   t.context is fine
-  await pushPrices(price, 'ATOM', oraclesByBrand, t.context.roundId);
-
-  await retryUntilCondition(
-    () => getPriceQuote('ATOM'),
-    res => res === `+${scale6(price).toString()}`,
-    'price not pushed yet',
-    {
-      log: t.log,
-      setTimeout: global.setTimeout,
-      // @ts-expect-error t.context is fine
-      ...t.context.pushPriceRetryOpts,
-    },
-  );
-});
 
 test.serial('attempt to open vaults under the minimum amount', async t => {
   const activeVaultsBefore = await agopsVaults(USER1ADDR);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://github.com/Agoric/BytePitchPartnerEng/issues/26
refs: https://github.com/Agoric/BytePitchPartnerEng/issues/22

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

This PR introduces a new script, `verifyPushedPrice`, which is executed during the `use` phase of the `n:upgrade-next` proposal. 
The purpose of this script is to set up the oracle and push an initial price for key brands such as Atom and stAtom. This functionality ensures that a price quote is available for the subsequent proposals and acceptance tests.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

The existing test file, `priceFeedUpdate.test.js`, has been updated to account for the new price feed calls made during the use phase, as well as take advantage of the new helper functions built.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
