### PR TITLE
allow .ts for package exports

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -16,7 +16,7 @@ import { initSwingStore } from '@agoric/swing-store';
 import { mustMatch, M } from '@endo/patterns';
 import { checkBundle } from '@endo/check-bundle/lite.js';
 import { deepCopyJsonable } from '@agoric/internal/src/js-utils.js';
-import { makeLimitedConsole } from '@agoric/internal/src/ses-utils.js';
+import { makeLimitedConsole } from '@agoric/internal/src/ses-utils.ts';
 import engineGC from '@agoric/internal/src/lib-nodejs/engine-gc.js';
 import { startSubprocessWorker } from '@agoric/internal/src/lib-nodejs/spawnSubprocessWorker.js';
 import { waitUntilQuiescent } from '@agoric/internal/src/lib-nodejs/waitUntilQuiescent.js';

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -1,6 +1,6 @@
 import { q } from '@endo/errors';
 import { objectMap } from '@agoric/internal';
-import { makeLimitedConsole } from '@agoric/internal/src/ses-utils.js';
+import { makeLimitedConsole } from '@agoric/internal/src/ses-utils.ts';
 
 /** @import {Callable} from '@agoric/internal'; */
 /** @import {LimitedConsole} from '@agoric/internal/src/js-utils.js'; */

--- a/packages/fast-usdc/package.json
+++ b/packages/fast-usdc/package.json
@@ -29,7 +29,7 @@
     "@fast-check/ava": "^2.0.1",
     "ava": "^5.3.0",
     "c8": "^10.1.2",
-    "execa": "9.1.0",
+    "execa": "^9.5.1",
     "ts-blank-space": "^0.4.4"
   },
   "dependencies": {

--- a/packages/fast-usdc/src/cli/bin.js
+++ b/packages/fast-usdc/src/cli/bin.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S TS_BLANK_SPACE_EMIT=false node --import ts-blank-space/register
 import '@endo/init/legacy.js';
 import { initProgram } from './cli.js';
 

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -42,6 +42,14 @@
     "tsd": "^0.31.1"
   },
   "ava": {
+    "extensions": {
+      "js": true,
+      "ts": "module"
+    },
+    "nodeArguments": [
+      "--import=ts-blank-space/register",
+      "--no-warnings"
+    ],
     "require": [
       "@endo/init/debug.js"
     ],

--- a/packages/internal/src/index.js
+++ b/packages/internal/src/index.js
@@ -8,7 +8,7 @@ export * from './errors.js';
 export * from './js-utils.js';
 export { pureDataMarshaller } from './marshal.js';
 export * from './method-tools.js';
-export * from './ses-utils.js';
+export * from './ses-utils.ts';
 export * from './tmpDir.js';
 export * from './typeCheck.js';
 export * from './typeGuards.js';

--- a/packages/internal/src/ses-utils.ts
+++ b/packages/internal/src/ses-utils.ts
@@ -1,5 +1,6 @@
 // @ts-check
 // @jessie-check
+
 /**
  * @file Utility functions that are dependent upon a hardened environment,
  *   either directly or indirectly (e.g. by @endo imports).
@@ -10,18 +11,17 @@ import { objectMetaMap } from '@endo/common/object-meta-map.js';
 import { fromUniqueEntries } from '@endo/common/from-unique-entries.js';
 import { q, Fail, makeError, annotateError, X } from '@endo/errors';
 import { deeplyFulfilled, isObject } from '@endo/marshal';
-import { makePromiseKit } from '@endo/promise-kit';
-import { makeQueue } from '@endo/stream';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+import { makePromiseKit, type PromiseKit } from '@endo/promise-kit';
+import { makeQueue, type AsyncQueue } from '@endo/stream';
 // @ts-ignore TS7016 The 'jessie.js' library may need to update its package.json or typings
 import { asyncGenerate } from 'jessie.js';
+import type { ERef } from '@endo/far';
+import type { Passable, Primitive } from '@endo/pass-style';
 import { logLevels } from './js-utils.js';
 
-/** @import {LimitedConsole} from './js-utils.js'; */
+import type { LimitedConsole } from './js-utils.js';
 
-/** @import {ERef} from '@endo/far'; */
-/** @import {Primitive} from '@endo/pass-style'; */
-/** @import {Permit, Attenuated} from './types.js'; */
+import type { Permit, Attenuated } from './types.js';
 
 export { objectMap, objectMetaMap, fromUniqueEntries };
 
@@ -29,79 +29,73 @@ const { fromEntries, keys, values } = Object;
 
 /** @param {(level: string) => (...args: unknown[]) => void} makeLogger */
 export const makeLimitedConsole = makeLogger => {
-  const limitedConsole = /** @type {any} */ (
-    fromEntries(logLevels.map(level => [level, makeLogger(level)]))
+  const limitedConsole = /** @type {any} */ fromEntries(
+    logLevels.map(level => [level, makeLogger(level)]),
   );
-  return /** @type {LimitedConsole} */ (harden(limitedConsole));
+  return /** @type {LimitedConsole} */ harden(limitedConsole);
 };
 harden(makeLimitedConsole);
 
 /**
- * @template T
- * @typedef {{ [KeyType in keyof T]: T[KeyType] } & {}} Simplify flatten the
+ * flatten the
  *   type output to improve type hints shown in editors
  *   https://github.com/sindresorhus/type-fest/blob/main/source/simplify.d.ts
  */
-
-/**
- * @typedef {(...args: any[]) => any} Callable
- */
-
-/**
- * @template {{}} T
- * @typedef {{
- *   [K in keyof T]: T[K] extends Callable ? T[K] : DeeplyAwaited<T[K]>;
- * }} DeeplyAwaitedObject
- */
-
-/**
- * @template T
- * @typedef {T extends PromiseLike<any>
- *     ? Awaited<T>
- *     : T extends {}
- *       ? Simplify<DeeplyAwaitedObject<T>>
- *       : Awaited<T>} DeeplyAwaited
- */
+export type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};
+export type Callable = (...args: any[]) => any;
+export type DeeplyAwaitedObject<T extends Record<string, unknown>> = {
+  [K in keyof T]: T[K] extends Callable ? T[K] : DeeplyAwaited<T[K]>;
+};
+export type DeeplyAwaited<T> =
+  T extends PromiseLike<any>
+  ? Awaited<T>
+  : T extends Record<string, unknown>
+  ? Simplify<DeeplyAwaitedObject<T>>
+  : Awaited<T>;
 
 /**
  * A more constrained version of {deeplyFulfilled} for type safety until
  * https://github.com/endojs/endo/issues/1257 Useful in starting contracts that
  * need all terms to be fulfilled in order to be durable.
- *
- * @type {<T extends {}>(unfulfilledTerms: T) => Promise<DeeplyAwaited<T>>}
+ * @param obj
  */
-export const deeplyFulfilledObject = async obj => {
+export const deeplyFulfilledObject: <T extends Passable>(
+  unfulfilledTerms: T,
+) => Promise<DeeplyAwaited<T>> = async obj => {
   isObject(obj) || Fail`param must be an object`;
   return deeplyFulfilled(obj);
 };
 
 /**
  * Tolerate absence of AggregateError in e.g. xsnap.
- *
- * @type {(errors: Error[], message?: string, options?: object) => Error}
+ * @param errors
+ * @param message
+ * @param options
  */
-const makeAggregateError =
+const makeAggregateError: (
+  errors: Error[],
+  message?: string,
+  options?: object,
+) => Error =
   typeof AggregateError === 'function'
     ? (errors, message, options) => AggregateError(errors, message, options)
     : (errors, message, options) => {
-        return makeError(message ?? 'multiple errors', undefined, {
-          ...options,
-          errors,
-        });
-      };
+      return makeError(message ?? 'multiple errors', undefined, {
+        ...options,
+        errors,
+      });
+    };
 
-/**
- * @template T
- * @param {readonly (T | PromiseLike<T>)[]} items
- * @returns {Promise<T[]>}
- */
-export const PromiseAllOrErrors = async items => {
+export const PromiseAllOrErrors = async <T>(
+  items: readonly (T | PromiseLike<T>)[],
+): Promise<T[]> => {
   return Promise.allSettled(items).then(results => {
-    const errors = /** @type {PromiseRejectedResult[]} */ (
-      results.filter(({ status }) => status === 'rejected')
-    ).map(result => result.reason);
+    const errors: Error[] = results
+      .filter(({ status }) => status === 'rejected')
+      // @ts-expect-error narrowed by filter
+      .map(result => result.reason);
     if (!errors.length) {
-      return /** @type {PromiseFulfilledResult<T>[]} */ (results).map(
+      return (results as PromiseFulfilledResult<T>[]).map(
         result => result.value,
       );
     } else if (errors.length === 1) {
@@ -112,13 +106,10 @@ export const PromiseAllOrErrors = async items => {
   });
 };
 
-/**
- * @template T
- * @param {() => Promise<T>} trier
- * @param {(error?: unknown) => Promise<unknown>} finalizer
- * @returns {ReturnType<trier>}
- */
-export const aggregateTryFinally = async (trier, finalizer) =>
+export const aggregateTryFinally = async <T>(
+  trier: () => Promise<T>,
+  finalizer: (error?: unknown) => Promise<unknown>,
+): ReturnType<() => Promise<T>> =>
   trier().then(
     async result => finalizer().then(() => result),
     async tryError =>
@@ -133,21 +124,20 @@ export const aggregateTryFinally = async (trier, finalizer) =>
 /**
  * Run a function with the ability to defer last-in-first-out cleanup callbacks.
  *
- * @template T
- * @param {(
- *   addCleanup: (fn: (err?: unknown) => Promise<void>) => void,
- * ) => Promise<T>} fn
- * @returns {ReturnType<fn>}
+ * @param fn
  */
-export const withDeferredCleanup = async fn => {
-  /** @type {((err?: unknown) => unknown)[]} */
-  const cleanupsLIFO = [];
-  /** @type {(cleanup: (err?: unknown) => unknown) => void} */
-  const addCleanup = cleanup => {
+export const withDeferredCleanup = async <T>(
+  fn: (
+    addCleanup: (cfn: (err?: unknown) => Promise<void>) => void,
+  ) => Promise<T>,
+): ReturnType<
+  (addCleanup: (cfn: (err?: unknown) => Promise<void>) => void) => Promise<T>
+> => {
+  const cleanupsLIFO = [] as ((err?: unknown) => unknown)[];
+  const addCleanup: (cleanup: (err?: unknown) => unknown) => void = cleanup => {
     cleanupsLIFO.unshift(cleanup);
   };
-  /** @type {(err?: unknown) => Promise<void>} */
-  const finalizer = async err => {
+  const finalizer: (err?: unknown) => Promise<void> = async err => {
     // Run each cleanup in its own isolated stack.
     const cleanupResults = cleanupsLIFO.map(async cleanup => {
       await null;
@@ -158,22 +148,21 @@ export const withDeferredCleanup = async fn => {
   return aggregateTryFinally(() => fn(addCleanup), finalizer);
 };
 
-/**
- * @template {Record<string, unknown>} T
- * @typedef {{ [P in keyof T]: Exclude<T[P], undefined> }} AllDefined
- */
+export type AllDefined<T extends Record<string, unknown>> = {
+  [P in keyof T]: Exclude<T[P], undefined>;
+};
 
 /**
  * Concise way to check values are available from object literal shorthand.
  * Throws error message to specify the missing values.
  *
- * @template {Record<string, unknown>} T
- * @param {T} obj
- * @returns {asserts obj is AllDefined<T>}
+ * @param obj
  * @throws if any value in the object entries is not defined
  */
-export const assertAllDefined = obj => {
-  const missing = [];
+export const assertAllDefined = <T extends Record<string, unknown>>(
+  obj: T,
+): asserts obj is AllDefined<T> => {
+  const missing = [] as string[];
   for (const [key, val] of Object.entries(obj)) {
     if (val === undefined) {
       missing.push(key);
@@ -187,28 +176,29 @@ export const assertAllDefined = obj => {
 /**
  * Attenuate `specimen` to only properties allowed by `permit`.
  *
- * @template T
- * @template {Permit<T>} P
- * @param {T} specimen
- * @param {P} permit
- * @param {<U, SubP extends Permit<U>>(attenuation: U, permit: SubP) => U} [transform]
+ * @param specimen
+ * @param permit
+ * @param [transform]
  *   used to replace the results of recursive picks (but not blanket permits)
- * @returns {Attenuated<T, P>}
  */
-export const attenuate = (specimen, permit, transform = x => x) => {
+export const attenuate = <T, P extends Permit<T>>(
+  specimen: T,
+  permit: P,
+  transform: <U, SubP extends Permit<U>>(
+    attenuation: U,
+    subpermit: SubP,
+  ) => U = x => x,
+): Attenuated<T, P> => {
   // Fast-path for no attenuation.
   if (permit === true || typeof permit === 'string') {
-    return /** @type {Attenuated<T, P>} */ (specimen);
+    return specimen as Attenuated<T, P>;
   }
 
-  /** @type {string[]} */
-  const path = [];
-  /**
-   * @template SubT
-   * @template {Exclude<Permit<SubT>, Primitive>} SubP
-   * @type {(specimen: SubT, permit: SubP) => Attenuated<SubT, SubP>}
-   */
-  const extract = (subSpecimen, subPermit) => {
+  const path = [] as string[];
+  const extract = <SubT, SubP extends Exclude<Permit<SubT>, Primitive>>(
+    subSpecimen: SubT,
+    subPermit: SubP,
+  ): Attenuated<SubT, SubP> => {
     if (subPermit === null || typeof subPermit !== 'object') {
       throw path.length === 0
         ? Fail`invalid permit: ${q(permit)}`
@@ -227,7 +217,7 @@ export const attenuate = (specimen, permit, transform = x => x) => {
         return [subKey, deepSpecimen];
       }
       path.push(subKey);
-      const extracted = extract(/** @type {any} */ (deepSpecimen), deepPermit);
+      const extracted = extract(deepSpecimen, deepPermit as any);
       const entry = [subKey, extracted];
       path.pop();
       return entry;
@@ -239,22 +229,24 @@ export const attenuate = (specimen, permit, transform = x => x) => {
   return extract(specimen, permit);
 };
 
-/** @type {IteratorResult<undefined, never>} */
-const notDone = harden({ done: false, value: undefined });
+const notDone = harden({ done: false, value: undefined }) as IteratorResult<
+  undefined,
+  never
+>;
 
-/** @type {IteratorResult<never, void>} */
-const alwaysDone = harden({ done: true, value: undefined });
+const alwaysDone = harden({ done: true, value: undefined }) as IteratorResult<
+  never,
+  void
+>;
 
 export const forever = asyncGenerate(() => notDone);
 
 /**
- * @template T
- * @param {() => T} produce The value of `await produce()` is used for its
+ * @param produce The value of `await produce()` is used for its
  *   truthiness vs falsiness. IOW, it is coerced to a boolean so the caller need
  *   not bother doing this themselves.
- * @returns {AsyncIterable<Awaited<T>>}
  */
-export const whileTrue = produce =>
+export const whileTrue = <T>(produce: () => T): AsyncIterable<Awaited<T>> =>
   asyncGenerate(async () => {
     const value = await produce();
     if (!value) {
@@ -267,13 +259,11 @@ export const whileTrue = produce =>
   });
 
 /**
- * @template T
- * @param {() => T} produce The value of `await produce()` is used for its
+ * @param produce The value of `await produce()` is used for its
  *   truthiness vs falsiness. IOW, it is coerced to a boolean so the caller need
  *   not bother doing this themselves.
- * @returns {AsyncIterable<Awaited<T>>}
  */
-export const untilTrue = produce =>
+export const untilTrue = <T>(produce: () => T): AsyncIterable<Awaited<T>> =>
   asyncGenerate(async () => {
     const value = await produce();
     if (value) {
@@ -288,15 +278,12 @@ export const untilTrue = produce =>
     });
   });
 
-/** @type {<X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
-export const zip = (xs, ys) => harden(xs.map((x, i) => [x, ys[+i]]));
+export const zip = <XT, YT>(xs: XT[], ys: YT[]): [XT, YT][] =>
+  harden(xs.map((x, i) => [x, ys[+i]]));
 
-/**
- * @type {<T extends Record<string, ERef<any>>>(
- *   obj: T,
- * ) => Promise<{ [K in keyof T]: Awaited<T[K]> }>}
- */
-export const allValues = async obj => {
+export const allValues = async <T extends Record<string, ERef<any>>>(
+  obj: T,
+): Promise<{ [K in keyof T]: Awaited<T[K]> }> => {
   const resolved = await Promise.all(values(obj));
   // @ts-expect-error cast
   return harden(fromEntries(zip(keys(obj), resolved)));
@@ -307,28 +294,26 @@ export const allValues = async obj => {
  * all consume the source stream in lockstep, and any one returning or throwing
  * early will affect the others.
  *
- * @template [T=unknown]
- * @param {AsyncIterator<T, void, void>} sourceStream
- * @param {number} readerCount
+ * @param sourceStream
+ * @param readerCount
  */
-export const synchronizedTee = (sourceStream, readerCount) => {
-  /** @type {IteratorReturnResult<void> | undefined} */
-  let doneResult;
+export const synchronizedTee = <T = unknown>(
+  sourceStream: AsyncIterator<T, void, void>,
+  readerCount: number,
+): AsyncGenerator<T, void, void>[] => {
+  let doneResult: IteratorReturnResult<void> | undefined;
 
-  /**
-   * @typedef {IteratorResult<
-   *   (value: PromiseLike<IteratorResult<T>>) => void
-   * >} QueuePayload
-   */
-  /** @type {import('@endo/stream').AsyncQueue<QueuePayload>[]} */
-  const queues = [];
+  type QueuePayload = IteratorResult<
+    (value: PromiseLike<IteratorResult<T>>) => void
+  >;
+  const queues = [] as AsyncQueue<QueuePayload>[];
 
-  /** @returns {Promise<void>} */
-  const pullNext = async () => {
+  const pullNext = async (): Promise<void> => {
     const requests = await Promise.allSettled(queues.map(queue => queue.get()));
-    const rejections = [];
-    /** @type {Array<(value: PromiseLike<IteratorResult<T>>) => void>} */
-    const resolvers = [];
+    const rejections = [] as unknown[];
+    const resolvers = [] as Array<
+      (value: PromiseLike<IteratorResult<T>>) => void
+    >;
     let done = false;
     for (const settledResult of requests) {
       if (settledResult.status === 'rejected') {
@@ -338,8 +323,7 @@ export const synchronizedTee = (sourceStream, readerCount) => {
         resolvers.push(settledResult.value.value);
       }
     }
-    /** @type {Promise<IteratorResult<T>>} */
-    let result;
+    let result: Promise<IteratorResult<T>>;
     if (doneResult) {
       result = Promise.resolve(doneResult);
     } else if (rejections.length) {
@@ -374,33 +358,25 @@ export const synchronizedTee = (sourceStream, readerCount) => {
   };
 
   const readers = Array.from({ length: readerCount }).map(() => {
-    /** @type {import('@endo/stream').AsyncQueue<QueuePayload>} */
-    const queue = makeQueue();
+    const queue = makeQueue() as AsyncQueue<QueuePayload>;
     queues.push(queue);
 
-    /** @type {AsyncGenerator<T, void, void>} */
-    const reader = harden({
+    const reader: AsyncGenerator<T, void, void> = harden({
       async next() {
-        /**
-         * @type {import('@endo/promise-kit').PromiseKit<
-         *   IteratorResult<T>
-         * >}
-         */
-        const { promise, resolve } = makePromiseKit();
+        const { promise, resolve } = makePromiseKit() as PromiseKit<
+          IteratorResult<T>
+        >;
         queue.put({ value: resolve, done: false });
         return promise;
       },
       async return() {
-        /**
-         * @type {import('@endo/promise-kit').PromiseKit<
-         *   IteratorResult<T>
-         * >}
-         */
-        const { promise, resolve } = makePromiseKit();
+        const { promise, resolve } = makePromiseKit() as PromiseKit<
+          IteratorResult<T>
+        >;
         queue.put({ value: resolve, done: true });
         return promise;
       },
-      async throw(reason) {
+      async throw(reason: any) {
         const rejection = Promise.reject(reason);
         queue.put(rejection);
         return rejection;

--- a/packages/internal/src/ses-utils.ts
+++ b/packages/internal/src/ses-utils.ts
@@ -159,9 +159,9 @@ export type AllDefined<T extends Record<string, unknown>> = {
  * @param obj
  * @throws if any value in the object entries is not defined
  */
-export const assertAllDefined = <T extends Record<string, unknown>>(
+export function assertAllDefined<T extends Record<string, unknown>>(
   obj: T,
-): asserts obj is AllDefined<T> => {
+): asserts obj is AllDefined<T> {
   const missing = [] as string[];
   for (const [key, val] of Object.entries(obj)) {
     if (val === undefined) {
@@ -171,7 +171,8 @@ export const assertAllDefined = <T extends Record<string, unknown>>(
   if (missing.length > 0) {
     Fail`missing ${q(missing)}`;
   }
-};
+}
+harden(assertAllDefined);
 
 /**
  * Attenuate `specimen` to only properties allowed by `permit`.

--- a/packages/internal/src/types.ts
+++ b/packages/internal/src/types.ts
@@ -2,7 +2,7 @@
 import type { ERef, RemotableBrand } from '@endo/eventual-send';
 import type { Primitive } from '@endo/pass-style';
 import type { Pattern } from '@endo/patterns';
-import type { Callable } from './ses-utils.js';
+import type { Callable } from './ses-utils.ts';
 
 /**
  * A map corresponding with a total function such that `get(key)` is assumed to

--- a/packages/internal/test/types.test-d.ts
+++ b/packages/internal/test/types.test-d.ts
@@ -1,13 +1,13 @@
 import { expectNotType, expectType } from 'tsd';
 import { E, type ERef } from '@endo/far';
-import { attenuate } from '../src/ses-utils.js';
+import { attenuate } from '../src/ses-utils.ts';
 import type { Permit, Remote } from '../src/types.js';
 import type { StorageNode } from '../src/lib-chainStorage.js';
 
 {
   const obj = {
-    m1: () => {},
-    m2: () => {},
+    m1: () => { },
+    m2: () => { },
     data: {
       log: ['string'],
       counter: 0,

--- a/packages/internal/test/utils.test.js
+++ b/packages/internal/test/utils.test.js
@@ -12,7 +12,7 @@ import {
   forever,
   deeplyFulfilledObject,
   synchronizedTee,
-} from '../src/ses-utils.js';
+} from '../src/ses-utils.ts';
 
 /** @import {Permit, Attenuated} from '../src/types.js'; */
 /** @import {Arbitrary} from 'fast-check'; */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,9 @@
     // .ts and rewriting relative paths allow us to include in bundles
     // files that are JS executable (with TS chars blanked) but end in .ts
     "allowImportingTsExtensions": true,
+    // This isn't relevant until `tsconfig.build.json` is used (for
+    // noEmit:false) but it's better to have it here next to
+    // allowImportingTsExtensions to show what will happen upon build.
     "rewriteRelativeImportExtensions": true,
     "noEmit": true
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6246,24 +6246,6 @@ eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-execa@9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-9.1.0.tgz#c42845d2b079642b8e07d9de81db13cdb91e7a9b"
-  integrity sha512-lSgHc4Elo2m6bUDhc3Hl/VxvUDJdQWI40RZ4KMY9bKRc+hgMOT7II/JjbNDhI8VnMtrCb7U/fhpJIkLORZozWw==
-  dependencies:
-    "@sindresorhus/merge-streams" "^4.0.0"
-    cross-spawn "^7.0.3"
-    figures "^6.1.0"
-    get-stream "^9.0.0"
-    human-signals "^7.0.0"
-    is-plain-obj "^4.1.0"
-    is-stream "^4.0.1"
-    npm-run-path "^5.2.0"
-    pretty-ms "^9.0.0"
-    signal-exit "^4.1.0"
-    strip-final-newline "^4.0.0"
-    yoctocolors "^2.0.0"
-
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -6293,6 +6275,24 @@ execa@^7.1.1, execa@^7.2.0:
     onetime "^6.0.0"
     signal-exit "^3.0.7"
     strip-final-newline "^3.0.0"
+
+execa@^9.5.1:
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-9.5.1.tgz#ab9b68073245e1111bba359962a34fcdb28deef2"
+  integrity sha512-QY5PPtSonnGwhhHDNI7+3RvY285c7iuJFFB+lU+oEzMY/gEGJ808owqJsrr8Otd1E/x07po1LkUBmdAc5duPAg==
+  dependencies:
+    "@sindresorhus/merge-streams" "^4.0.0"
+    cross-spawn "^7.0.3"
+    figures "^6.1.0"
+    get-stream "^9.0.0"
+    human-signals "^8.0.0"
+    is-plain-obj "^4.1.0"
+    is-stream "^4.0.1"
+    npm-run-path "^6.0.0"
+    pretty-ms "^9.0.0"
+    signal-exit "^4.1.0"
+    strip-final-newline "^4.0.0"
+    yoctocolors "^2.0.0"
 
 expand-template@^2.0.3:
   version "2.0.3"
@@ -7245,10 +7245,10 @@ human-signals@^4.3.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-4.3.1.tgz#ab7f811e851fca97ffbd2c1fe9a958964de321b2"
   integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
 
-human-signals@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-7.0.0.tgz#93e58e0c19cfec1dded4af10cd4969f5ab75f6c8"
-  integrity sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==
+human-signals@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-8.0.0.tgz#2d3d63481c7c2319f0373428b01ffe30da6df852"
+  integrity sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==
 
 humanize-ms@^1.2.1:
   version "1.2.1"
@@ -7813,7 +7813,14 @@ is-weakmap@^2.0.2:
   resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.2.tgz#bf72615d649dfe5f699079c54b83e47d1ae19cfd"
   integrity sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==
 
-is-weakref@^1.0.2, is-weakref@^1.1.0:
+is-weakref@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
+  dependencies:
+    call-bind "^1.0.2"
+
+is-weakref@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.1.0.tgz#47e3472ae95a63fa9cf25660bcf0c181c39770ef"
   integrity sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==
@@ -9455,12 +9462,20 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npm-run-path@^5.1.0, npm-run-path@^5.2.0:
+npm-run-path@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.3.0.tgz#e23353d0ebb9317f174e93417e4a4d82d0249e9f"
   integrity sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==
   dependencies:
     path-key "^4.0.0"
+
+npm-run-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-6.0.0.tgz#25cfdc4eae04976f3349c0b1afc089052c362537"
+  integrity sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==
+  dependencies:
+    path-key "^4.0.0"
+    unicorn-magic "^0.3.0"
 
 npmlog@^6.0.0, npmlog@^6.0.2:
   version "6.0.2"
@@ -11963,6 +11978,11 @@ unicode-property-aliases-ecmascript@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
+
+unicorn-magic@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.3.0.tgz#4efd45c85a69e0dd576d25532fbfa22aa5c8a104"
+  integrity sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==
 
 unique-filename@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
refs: #5760

## Description
https://github.com/Agoric/agoric-sdk/pull/10480 tries `.ts` for contracts, which are not part of a package's export surface.

This spike explores using `.ts` files for modules that are exported from a package. A complication is that while Typescript 5.7 can automatically convert rewrite `.ts` to `.js` in its build output, we've so far avoided having a build stage during development. So we need a way to have `.ts` locally during development (without building) and for the packages in NPM to have only `.js` files. 

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
