### PR TITLE
Add env to disable worker restart

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-  "githubPullRequests.ignoredPullRequestBranches": [
-    "master"
-  ],
-  "prettier.arrowParens": "avoid",
-  "prettier.singleQuote": true,
-  "prettier.trailingComma": "all"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "master"
+  ],
+  "prettier.arrowParens": "avoid",
+  "prettier.singleQuote": true,
+  "prettier.trailingComma": "all"
+}

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -302,6 +302,7 @@ export default async function main(
     const swingsetConfig = harden(initAction.resolvedConfig || {});
     validateSwingsetConfig(swingsetConfig);
     const {
+      maxVatsOnline,
       slogfile,
       vatSnapshotRetention,
       vatTranscriptRetention,
@@ -558,7 +559,7 @@ export default async function main(
       archiveSnapshot,
       archiveTranscript,
       afterCommitCallback,
-      swingsetConfig,
+      maxVatsOnline,
     });
 
     const { blockingSend, shutdown } = s;

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -316,6 +316,10 @@ export default async function main(
       ? vatTranscriptRetention !== 'operational'
       : false;
 
+    const restartWorkerOnSnapshot = processValue.getBoolean({
+      envName: 'XSNAP_RESTART_ON_SNAPSHOT',
+    });
+
     // As a kludge, back-propagate selected configuration into environment variables.
     // eslint-disable-next-line dot-notation
     if (slogfile) env['SLOGFILE'] = slogfile;
@@ -560,6 +564,7 @@ export default async function main(
       archiveTranscript,
       afterCommitCallback,
       maxVatsOnline,
+      restartWorkerOnSnapshot,
     });
 
     const { blockingSend, shutdown } = s;

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -308,6 +308,7 @@ export async function buildSwingset(
  * @property {ReturnType<typeof import('@agoric/swing-store').makeArchiveTranscript>} [archiveTranscript]
  * @property {() => object | Promise<object>} [afterCommitCallback]
  * @property {number} [maxVatsOnline]
+ * @property {boolean} [restartWorkerOnSnapshot]
  */
 
 /**
@@ -338,6 +339,7 @@ export async function launch({
   archiveTranscript,
   afterCommitCallback = async () => ({}),
   maxVatsOnline,
+  restartWorkerOnSnapshot,
 }) {
   console.info('Launching SwingSet kernel');
 
@@ -415,8 +417,10 @@ export async function launch({
   });
 
   console.debug(`buildSwingset`);
+  /** @type {import('@agoric/swingset-vat').VatWarehousePolicy} */
   const warehousePolicy = {
     maxVatsOnline,
+    restartWorkerOnSnapshot,
   };
   const {
     coreProposals: bootstrapCoreProposals,

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -307,10 +307,7 @@ export async function buildSwingset(
  * @property {ReturnType<typeof import('@agoric/swing-store').makeArchiveSnapshot>} [archiveSnapshot]
  * @property {ReturnType<typeof import('@agoric/swing-store').makeArchiveTranscript>} [archiveTranscript]
  * @property {() => object | Promise<object>} [afterCommitCallback]
- * @property {import('./chain-main.js').CosmosSwingsetConfig} swingsetConfig
- *   TODO refactor to clarify relationship vs. import('@agoric/swingset-vat').SwingSetConfig
- *   --- maybe partition into in-consensus "config" vs. consensus-independent "options"?
- *   (which would mostly just require `bundleCachePath` to become a `buildSwingset` input)
+ * @property {number} [maxVatsOnline]
  */
 
 /**
@@ -340,7 +337,7 @@ export async function launch({
   archiveSnapshot,
   archiveTranscript,
   afterCommitCallback = async () => ({}),
-  swingsetConfig,
+  maxVatsOnline,
 }) {
   console.info('Launching SwingSet kernel');
 
@@ -419,7 +416,7 @@ export async function launch({
 
   console.debug(`buildSwingset`);
   const warehousePolicy = {
-    maxVatsOnline: swingsetConfig.maxVatsOnline,
+    maxVatsOnline,
   };
   const {
     coreProposals: bootstrapCoreProposals,

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -129,7 +129,6 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     debugName: GCI,
     metricsProvider,
     slogSender,
-    swingsetConfig: {},
   });
 
   const { blockingSend, savedHeight } = s;

--- a/packages/cosmic-swingset/tools/test-kit.js
+++ b/packages/cosmic-swingset/tools/test-kit.js
@@ -140,7 +140,6 @@ const baseConfig = harden({
  * @param {Replacer<SwingSetConfig>} [options.fixupConfig] a final opportunity
  *   to make any changes
  * @param {import('@agoric/telemetry').SlogSender} [options.slogSender]
- * @param {import('../src/chain-main.js').CosmosSwingsetConfig} [options.swingsetConfig]
  * @param {import('@agoric/swing-store').SwingStore} [options.swingStore]
  *   defaults to a new in-memory store
  * @param {SwingSetConfig['vats']} [options.vats] extra static vat configuration
@@ -170,7 +169,6 @@ export const makeCosmicSwingsetTestKit = async (
     fixupInitMessage,
     fixupConfig,
     slogSender,
-    swingsetConfig = {},
     swingStore,
     vats,
 
@@ -251,7 +249,6 @@ export const makeCosmicSwingsetTestKit = async (
     env,
     debugName,
     slogSender,
-    swingsetConfig,
   });
   const { blockingSend, shutdown: shutdownKernel } = launchResult;
   /** @type {(options?: { kernelOnly?: boolean }) => Promise<void>} */

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -72,6 +72,7 @@ if [ -n "$LOADGEN" ]; then
     "$AG_SETUP_COSMOS_HOME/faucet-helper.sh" add-egress loadgen "$SOLO_ADDR"
   SLOGSENDER=@agoric/telemetry/src/otel-trace.js SOLO_SLOGSENDER="" \
     SLOGSENDER_FAIL_ON_ERROR=1 SLOGSENDER_AGENT=process \
+    XSNAP_RESTART_ON_SNAPSHOT=false \
     AG_CHAIN_COSMOS_HOME=$HOME/.agoric \
     SDK_BUILD=0 MUST_USE_PUBLISH_BUNDLE=1 SDK_SRC=$SDK_SRC OUTPUT_DIR="$RESULTSDIR" ./start.sh \
     --no-stage.save-storage \


### PR DESCRIPTION
incidental

## Description
Add an environment to control the restart of the vat worker when a snapshot is taken. This should have no impact on consensus, but we haven't actually tested this lately, and we used to have problems in the past.

Disable the forced restart in the loadgen CI test to exercise this potential source of divergence.

### Security Considerations
None. A validator using this environment may fall out of consensus.

### Scaling Considerations
Not restarting the worker has an impact on the performance of the worker over time, but given the limited amount of work the CI test does, it should not be noticeable.

### Documentation Considerations
Since this config is fairly experimental, it is not currently documented anywhere. This is in line with similar XSNAP env.

### Testing Considerations
Enabling this in CI

### Upgrade Considerations
Part of chain software, but should not affect consensus.