### PR TITLE
'make' namespace for kinds

### DIFF
--- a/packages/fast-usdc/src/fast-usdc.contract.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.js
@@ -22,6 +22,7 @@ import { prepareTransactionFeedKit } from './exos/transaction-feed.js';
 import * as flows from './fast-usdc.flows.js';
 import { FastUSDCTermsShape, FeeConfigShape } from './type-guards.js';
 import { defineInertInvitation } from './utils/zoe.js';
+import { organizeMakers } from './utils/make-helpers.js';
 
 const trace = makeTracer('FastUsdc');
 
@@ -139,7 +140,9 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
     'test of forcing evidence',
   );
 
-  const { makeLocalAccount, makeNobleAccount } = orchestrateAll(flows, {});
+  const { make: { LocalAccount, NobleAccount } } = organizeMakers(
+    orchestrateAll(flows, {})
+  );
 
   const creatorFacet = zone.exo('Fast USDC Creator', undefined, {
     /** @type {(operatorId: string) => Promise<Invitation<OperatorKit>>} */
@@ -228,13 +231,13 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
     );
   }
 
-  const nobleAccountV = zone.makeOnce('NobleAccount', () => makeNobleAccount());
+  const nobleAccountV = zone.makeOnce('NobleAccount', () => NobleAccount());
 
   const feedKit = zone.makeOnce('Feed Kit', () => makeFeedKit());
 
-  const poolAccountV = zone.makeOnce('PoolAccount', () => makeLocalAccount());
+  const poolAccountV = zone.makeOnce('PoolAccount', () => LocalAccount());
   const settleAccountV = zone.makeOnce('SettleAccount', () =>
-    makeLocalAccount(),
+    LocalAccount(),
   );
   // when() is OK here since this clearly resolves promptly.
   /** @type {[HostInterface<OrchestrationAccount<{chainId: 'agoric-3';}>>, HostInterface<OrchestrationAccount<{chainId: 'agoric-3';}>>]} */

--- a/packages/fast-usdc/src/fast-usdc.contract.js
+++ b/packages/fast-usdc/src/fast-usdc.contract.js
@@ -140,9 +140,9 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
     'test of forcing evidence',
   );
 
-  const { make: { LocalAccount, NobleAccount } } = organizeMakers(
-    orchestrateAll(flows, {})
-  );
+  const {
+    make: { LocalAccount, NobleAccount },
+  } = organizeMakers(orchestrateAll(flows, {}));
 
   const creatorFacet = zone.exo('Fast USDC Creator', undefined, {
     /** @type {(operatorId: string) => Promise<Invitation<OperatorKit>>} */
@@ -236,9 +236,7 @@ export const contract = async (zcf, privateArgs, zone, tools) => {
   const feedKit = zone.makeOnce('Feed Kit', () => makeFeedKit());
 
   const poolAccountV = zone.makeOnce('PoolAccount', () => LocalAccount());
-  const settleAccountV = zone.makeOnce('SettleAccount', () =>
-    LocalAccount(),
-  );
+  const settleAccountV = zone.makeOnce('SettleAccount', () => LocalAccount());
   // when() is OK here since this clearly resolves promptly.
   /** @type {[HostInterface<OrchestrationAccount<{chainId: 'agoric-3';}>>, HostInterface<OrchestrationAccount<{chainId: 'agoric-3';}>>]} */
   const [poolAccount, settlementAccount] = await vowTools.when(

--- a/packages/fast-usdc/src/utils/make-helpers.js
+++ b/packages/fast-usdc/src/utils/make-helpers.js
@@ -1,0 +1,17 @@
+/**
+ * Takes an object of make* functions and returns an object with a single 'make' property
+ * containing those functions renamed without the 'make' prefix.
+ *
+ * @param {Record<string, Function>} makers - Object containing make* functions
+ * @returns {{ make: Record<string, Function> }} Transformed object
+ */
+export const organizeMakers = makers => {
+  const make = {};
+  for (const [key, fn] of Object.entries(makers)) {
+    if (key.startsWith('make')) {
+      const newKey = key.slice(4); // Remove 'make'
+      make[newKey] = fn;
+    }
+  }
+  return harden({ make });
+};

--- a/packages/fast-usdc/src/utils/make-helpers.js
+++ b/packages/fast-usdc/src/utils/make-helpers.js
@@ -9,10 +9,12 @@
 export const organizeMakers = makers => {
   const make = {};
   for (const [key, fn] of Object.entries(makers)) {
-    if (key.startsWith('make')) {
-      const newKey = key.slice(4); // Remove 'make'
-      make[newKey] = fn;
+    if (!key.startsWith('make')) {
+      throw new Error(`Unexpected key ${key}`);
     }
+    const newKey = key.slice(4); // Remove 'make'
+    make[newKey] = fn;
   }
+  // @ts-expect-error cast
   return harden({ make });
 };

--- a/packages/fast-usdc/src/utils/make-helpers.js
+++ b/packages/fast-usdc/src/utils/make-helpers.js
@@ -2,8 +2,9 @@
  * Takes an object of make* functions and returns an object with a single 'make' property
  * containing those functions renamed without the 'make' prefix.
  *
- * @param {Record<string, Function>} makers - Object containing make* functions
- * @returns {{ make: Record<string, Function> }} Transformed object
+ * @template {Record<`make${string}`, Function>} T
+ * @param {T} makers - Object containing make* functions
+ * @returns {{ make: { [K in keyof T as K extends `make${infer R}` ? R : never]: T[K] } }} Transformed object
  */
 export const organizeMakers = makers => {
   const make = {};


### PR DESCRIPTION
variant of https://github.com/Agoric/agoric-sdk/pull/10663

## Description
Defines a convention (with a helper) for a `make` object that has kind constructors.

+ easier to verify that all kinds are defined in the synchronous prelude
+ distinguishes methods that make things from kind constructors

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
