### PR TITLE
test: multiple validators to detect divergence

### DIFF
--- a/multichain-testing/config.fusdc.go-relayer.yaml
+++ b/multichain-testing/config.fusdc.go-relayer.yaml
@@ -34,7 +34,7 @@ chains:
       memory: 4Gi
   - id: osmosislocal
     name: osmosis
-    numValidators: 1
+    numValidators: 2
     genesis:
       app_state:
         staking:
@@ -65,7 +65,7 @@ chains:
       memory: 1Gi
   - id: noblelocal
     name: noble
-    numValidators: 1
+    numValidators: 2
     genesis:
       app_state:
         staking:

--- a/multichain-testing/config.fusdc.go-relayer.yaml
+++ b/multichain-testing/config.fusdc.go-relayer.yaml
@@ -5,7 +5,7 @@ chains:
   - id: agoriclocal
     name: agoric
     image: ghcr.io/agoric/agoric-sdk:dev
-    numValidators: 1
+    numValidators: 2 # multiple to detect divergence
     env:
       - name: DEBUG
         value: SwingSet:vat,SwingSet:ls

--- a/multichain-testing/config.fusdc.go-relayer.yaml
+++ b/multichain-testing/config.fusdc.go-relayer.yaml
@@ -5,7 +5,7 @@ chains:
   - id: agoriclocal
     name: agoric
     image: ghcr.io/agoric/agoric-sdk:dev
-    numValidators: 2 # multiple to detect divergence
+    numValidators: 1
     env:
       - name: DEBUG
         value: SwingSet:vat,SwingSet:ls

--- a/multichain-testing/config.fusdc.yaml
+++ b/multichain-testing/config.fusdc.yaml
@@ -34,7 +34,7 @@ chains:
       memory: 4Gi
   - id: osmosislocal
     name: osmosis
-    numValidators: 1
+    numValidators: 2
     genesis:
       app_state:
         staking:
@@ -65,7 +65,7 @@ chains:
       memory: 1Gi
   - id: noblelocal
     name: noble
-    numValidators: 1
+    numValidators: 2
     genesis:
       app_state:
         staking:

--- a/multichain-testing/config.fusdc.yaml
+++ b/multichain-testing/config.fusdc.yaml
@@ -5,7 +5,7 @@ chains:
   - id: agoriclocal
     name: agoric
     image: ghcr.io/agoric/agoric-sdk:dev
-    numValidators: 1
+    numValidators: 2 # multiple to detect divergence
     env:
       - name: DEBUG
         value: SwingSet:vat,SwingSet:ls

--- a/multichain-testing/config.fusdc.yaml
+++ b/multichain-testing/config.fusdc.yaml
@@ -5,7 +5,7 @@ chains:
   - id: agoriclocal
     name: agoric
     image: ghcr.io/agoric/agoric-sdk:dev
-    numValidators: 2 # multiple to detect divergence
+    numValidators: 1
     env:
       - name: DEBUG
         value: SwingSet:vat,SwingSet:ls

--- a/multichain-testing/config.go-relayer.yaml
+++ b/multichain-testing/config.go-relayer.yaml
@@ -34,7 +34,7 @@ chains:
       memory: 4Gi
   - id: osmosislocal
     name: osmosis
-    numValidators: 1
+    numValidators: 2
     genesis:
       app_state:
         staking:

--- a/multichain-testing/config.go-relayer.yaml
+++ b/multichain-testing/config.go-relayer.yaml
@@ -5,7 +5,7 @@ chains:
   - id: agoriclocal
     name: agoric
     image: ghcr.io/agoric/agoric-sdk:dev
-    numValidators: 1
+    numValidators: 2 # multiple to detect divergence
     env:
       - name: DEBUG
         value: SwingSet:vat,SwingSet:ls

--- a/multichain-testing/config.go-relayer.yaml
+++ b/multichain-testing/config.go-relayer.yaml
@@ -5,7 +5,7 @@ chains:
   - id: agoriclocal
     name: agoric
     image: ghcr.io/agoric/agoric-sdk:dev
-    numValidators: 2 # multiple to detect divergence
+    numValidators: 1
     env:
       - name: DEBUG
         value: SwingSet:vat,SwingSet:ls

--- a/multichain-testing/config.yaml
+++ b/multichain-testing/config.yaml
@@ -34,7 +34,7 @@ chains:
       memory: 4Gi
   - id: osmosislocal
     name: osmosis
-    numValidators: 1
+    numValidators: 2
     genesis:
       app_state:
         staking:

--- a/multichain-testing/config.yaml
+++ b/multichain-testing/config.yaml
@@ -5,7 +5,7 @@ chains:
   - id: agoriclocal
     name: agoric
     image: ghcr.io/agoric/agoric-sdk:dev
-    numValidators: 1
+    numValidators: 2 # multiple to detect divergence
     env:
       - name: DEBUG
         value: SwingSet:vat,SwingSet:ls

--- a/multichain-testing/config.yaml
+++ b/multichain-testing/config.yaml
@@ -5,7 +5,7 @@ chains:
   - id: agoriclocal
     name: agoric
     image: ghcr.io/agoric/agoric-sdk:dev
-    numValidators: 2 # multiple to detect divergence
+    numValidators: 1
     env:
       - name: DEBUG
         value: SwingSet:vat,SwingSet:ls


### PR DESCRIPTION
closes: #10896 

## Description
Fast USDC testing relies heavily on multichain-testing. This bumps `numValidators` from 1 to 2 so the test suite can also detect divergence between validators.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
comments

### Testing Considerations
per se

### Upgrade Considerations
none