### PR TITLE
define issue templates for each Issue Type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,10 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
+# legacy classification using labels
 labels: 'bug'
+# new native Issue Type https://github.com/orgs/community/discussions/148715
+type: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,8 +2,6 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-# legacy classification using labels
-labels: 'bug'
 # new native Issue Type https://github.com/orgs/community/discussions/148715
 type: 'bug'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -2,8 +2,6 @@
 name: Feature
 about: A request, idea, or new functionality
 title: ''
-# legacy classification using labels
-labels: 'enhancement'
 # new native Issue Type https://github.com/orgs/community/discussions/148715
 type: 'feature'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,8 +1,11 @@
 ---
-name: Work Item
-about: A unit of work that (maybe) needs to be done
+name: Feature
+about: A request, idea, or new functionality
 title: ''
+# legacy classification using labels
 labels: 'enhancement'
+# new native Issue Type https://github.com/orgs/community/discussions/148715
+type: 'feature'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,17 @@
+---
+name: Task
+about: A specific piece of work
+title: ''
+# new native Issue Type https://github.com/orgs/community/discussions/148715
+type: 'task'
+assignees: ''
+
+---
+
+<!-- For sub-tasks of larger issues or for one-off tasks. If your issue can affect chain behavior, file a `feature` or `bug_report` instead. -->
+
+# What
+
+## Why
+
+## How

--- a/.github/ISSUE_TEMPLATE/work_item.md
+++ b/.github/ISSUE_TEMPLATE/work_item.md
@@ -11,10 +11,18 @@ assignees: ''
 
 ## Description of the Design
 
-## Security Considerations
+<!-- Remember to discuss these aspects when relevant:
 
-## Scaling Considerations
+### Security
 
-## Test Plan
+### Scaling
 
-## Upgrade Considerations
+### Testing
+
+### Upgrade
+-->
+
+<!-- To capture any important details for planning and prioritization:
+
+## Priortization
+-->


### PR DESCRIPTION
incidental

## Description

[GitHub has been improving their Issues functionality](https://github.blog/changelog/2025-01-13-evolving-github-issues-public-preview/). They now have [Issue Types](https://github.com/orgs/community/discussions/148715).

This adopts them in our templates. Our `work_item` template conflated Features and Tasks so this splits them into two templates. The existing structure seemed best suited for "feature" so this adds a new simpler structure for "task".

### Security Considerations
n/a

### Scaling Considerations
n/a


### Documentation Considerations
Somewhat self-documenting. Once approved by eng leads we'll need to communicate with the team before enacting (by merge).

### Testing Considerations
Would be nice if we could see it in action but not possible until merge. Easy to tweak though.

### Upgrade Considerations
n/a

(I wonder if we should have another PR template for stuff like this that obviously has no upgrade impact.)