### PR TITLE
ci: retry multichain-testing e2e tests

### DIFF
--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -114,6 +114,7 @@ jobs:
         with:
           # Retry arbitrarily; this isn't the test itself so don't wire up the flake detection.
           max_attempts: 3
+          timeout_minutes: 5
           command: cd ./agoric-sdk/multichain-testing && make fund-provision-pool register-bank-assets
 
       - name: Run @agoric/multichain-testing E2E Tests

--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -103,23 +103,25 @@ jobs:
           namespace: ${{ env.NAMESPACE }}
           repo: https://hyperweb-io.github.io/starship
 
-      - name: Fund Provision Pool
+      - name: Await pods
         run: |
           kubectl config set-context --current --namespace=${NAMESPACE}
           kubectl get pods
-          make fund-provision-pool
         working-directory: ./agoric-sdk/multichain-testing
 
-      - name: Register Interchain Bank Assets
-        run: make register-bank-assets
-        working-directory: ./agoric-sdk/multichain-testing
+      - name: Setup Agoric chain state
+        uses: nick-fields/retry@v3
+        with:
+          # Retry arbitrarily; this isn't the test itself so don't wire up the flake detection.
+          max_attempts: 3
+          command: cd ./agoric-sdk/multichain-testing && make fund-provision-pool register-bank-assets
 
       - name: Run @agoric/multichain-testing E2E Tests
         id: run-tests
         # These integration tests can be flaky so retry automatically
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 10
+          timeout_minutes: 15
           max_attempts: 2 # only retry once
           retry_on: error # let command timeout fail the job
           command: cd ./agoric-sdk/multichain-testing && ${{ inputs.test_command }}
@@ -128,12 +130,12 @@ jobs:
 
       - name: Notify of flakey test
         # If tests passed but required more than 1 attempt, then the test was flaky, so report it via Slack.
-        if: ${{ steps.run-tests.outputs.exit_code == '0' && steps.run-tests.outputs.total_attempts > '1' }}
+        if: ${{ steps.run-tests.outputs.exit_code == 0 && steps.run-tests.outputs.total_attempts > 1 }}
         uses: slackapi/slack-github-action@v2
         with:
           payload: |
             {
-              "text": "🎯 Flakey test detected in job ${{ github.job }} in workflow ${{ github.workflow }} of ${{ github.repository }}",
+              "text": "🎯 Flakey test detected in job ${{ github.job }} in workflow ${{ github.workflow }} of ${{ github.repository }}\nDetails at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/1",
               "username": "GitHub"
             }
         env:

--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -115,10 +115,30 @@ jobs:
         working-directory: ./agoric-sdk/multichain-testing
 
       - name: Run @agoric/multichain-testing E2E Tests
-        run: ${{ inputs.test_command }}
-        working-directory: ./agoric-sdk/multichain-testing
+        id: run-tests
+        # These integration tests can be flaky so retry automatically
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 2 # only retry once
+          retry_on: error # let command timeout fail the job
+          command: cd ./agoric-sdk/multichain-testing && ${{ inputs.test_command }}
         env:
           FILE: ${{ inputs.config }}
+
+      - name: Notify of flakey test
+        # If tests passed but required more than 1 attempt, then the test was flaky, so report it via Slack.
+        if: ${{ steps.run-tests.outputs.exit_code == '0' && steps.run-tests.outputs.total_attempts > '1' }}
+        uses: slackapi/slack-github-action@v2
+        with:
+          payload: |
+            {
+              "text": "🎯 Flakey test detected in job ${{ github.job }} in workflow ${{ github.workflow }} of ${{ github.repository }}",
+              "username": "GitHub"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       - name: Capture slog.slog
         if: always()


### PR DESCRIPTION
closes: #9934

## Description
Adds a retry to the E2E tests and also a step that notifies through Slack if a flake is detected.

### Testing Considerations

I plan to run this several times before merging. I expect a flake will happen in at least one of them. 