### PR TITLE
fix: add `--no-bail` to `yarn lerna run test:c8`

### DIFF
--- a/scripts/ci/generate-test-coverage-report.sh
+++ b/scripts/ci/generate-test-coverage-report.sh
@@ -11,7 +11,7 @@ mkdir -p "$NODE_V8_COVERAGE"
 export C8_OPTIONS="--clean=false"
 
 # XXX uses lerna when `yarn workspaces run` should work, but in v1 it always bails on missing script
-yarn lerna run test:c8
+yarn lerna run test:c8 --no-bail
 
 # report over all src and tools files, not just the ones that were loaded during tests
 yarn c8 report --all --include 'packages/*/{src,tools}' --reporter=html-spa --reports-dir=coverage/html


### PR DESCRIPTION
incidental

## Description

[agoric-sdk-coverage.netlify.app](https://agoric-sdk-coverage.netlify.app/) currently understates coverage. Looking at a [recent after-merge CI run](https://github.com/Agoric/agoric-sdk/actions/runs/14826569253/job/41620546275#step:4:1529), a test suite timed out in the middle of collection and prematurely terminated `yarn lerna run test:c8`. This caused many packages to be excluded from coverage calculations.

This change adds the `--no-bail` flag to the lerna command so `test:c8` is run in all packages, regardless if one fails. This ensures we get a complete coverage report that includes all packages, even when there are test failures or timeouts in some packages.

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
Tested locally

### Upgrade Considerations
None