### PR TITLE
remove ses-ava

### DIFF
--- a/a3p-integration/proposals/z:acceptance/yarn.lock
+++ b/a3p-integration/proposals/z:acceptance/yarn.lock
@@ -320,7 +320,6 @@ __metadata:
     "@endo/pass-style": "npm:^1.5.0"
     "@endo/patterns": "npm:^1.5.0"
     "@endo/promise-kit": "npm:^1.1.10"
-    "@endo/ses-ava": "npm:^1.2.10"
     "@endo/stream": "npm:^1.2.10"
     "@endo/zip": "npm:^1.0.9"
     ansi-styles: "npm:^6.2.1"
@@ -983,19 +982,6 @@ __metadata:
   dependencies:
     ses: "npm:^1.12.0"
   checksum: 10c0/39d2d8073484c81a2fc02ce7d40402152953b2f4e33ae4f6429c92c06f766afab9e2af68adb393a8507997e572a0f826436844cb2b61f2f227d48340d0c4bfb2
-  languageName: node
-  linkType: hard
-
-"@endo/ses-ava@npm:^1.2.10":
-  version: 1.2.10
-  resolution: "@endo/ses-ava@npm:1.2.10"
-  dependencies:
-    "@endo/env-options": "npm:^1.1.8"
-    "@endo/init": "npm:^1.1.9"
-    ses: "npm:^1.12.0"
-  peerDependencies:
-    ava: ^5.3.0 || ^6.1.2
-  checksum: 10c0/27e31489db71fb966c7cc78b61912ff764ff20965eb78d6cae7fdb979cafc820176aad03133a10002fe13b4969b74c9b262889c545d2a81537e713cd6196a850
   languageName: node
   linkType: hard
 

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -51,7 +51,6 @@
     "@endo/pass-style": "^1.5.0",
     "@endo/patterns": "^1.5.0",
     "@endo/promise-kit": "^1.1.10",
-    "@endo/ses-ava": "^1.2.10",
     "@endo/stream": "^1.2.10",
     "@endo/zip": "^1.0.9",
     "ansi-styles": "^6.2.1",

--- a/packages/SwingSet/tools/dvo-test-harness.js
+++ b/packages/SwingSet/tools/dvo-test-harness.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/order
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 import { assert } from '@endo/errors';
 import { makeMarshal } from '@endo/marshal';

--- a/packages/SwingSet/tools/prepare-strict-test-env-ava.js
+++ b/packages/SwingSet/tools/prepare-strict-test-env-ava.js
@@ -1,17 +1,15 @@
 /**
- * Like prepare-strict-test-env but also sets up ses-ava and provides
- * the ses-ava `test` function to be used as if it is the ava
- * `test` function.
+ * Like prepare-strict-test-env but also exports the AVA `test` function
+ * for compatibility with earlier uses of @endo/ses-ava.
  */
 
 import '@agoric/swingset-liveslots/tools/prepare-strict-test-env.js';
 
-import { wrapTest } from '@endo/ses-ava';
-import rawTest from 'ava';
+import test from 'ava';
 
 export * from '@agoric/swingset-liveslots/tools/prepare-strict-test-env.js';
 
-export const test = wrapTest(rawTest);
+export { test };
 
 // Does not import from a module because we're testing the global env
 /* global globalThis */

--- a/packages/SwingSet/tools/prepare-test-env-ava.js
+++ b/packages/SwingSet/tools/prepare-test-env-ava.js
@@ -1,17 +1,15 @@
 /**
- * Like prepare-test-env but also sets up ses-ava and provides
- * the ses-ava `test` function to be used as if it is the ava
- * `test` function.
+ * Like prepare-test-env but also exports the AVA `test` function
+ * for compatibility with earlier uses of @endo/ses-ava.
  */
 
 import '@endo/init/pre-bundle-source.js';
 
 import '@agoric/swingset-liveslots/tools/prepare-test-env.js';
 
-import { wrapTest } from '@endo/ses-ava';
-import rawTest from 'ava';
+import test from 'ava';
 
-export const test = wrapTest(rawTest);
+export { test };
 
 // Does not import from a module because we're testing the global env
 /* global globalThis */

--- a/packages/base-zone/package.json
+++ b/packages/base-zone/package.json
@@ -37,7 +37,6 @@
   },
   "devDependencies": {
     "@endo/init": "^1.1.9",
-    "@endo/ses-ava": "^1.2.10",
     "ava": "^5.3.0"
   },
   "publishConfig": {

--- a/packages/base-zone/test/exos.test.js
+++ b/packages/base-zone/test/exos.test.js
@@ -1,4 +1,4 @@
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 import { makeHeapZone } from '../heap.js';
 import { testFirstZoneIncarnation } from '../tools/testers.js';

--- a/packages/base-zone/test/make-once.test.js
+++ b/packages/base-zone/test/make-once.test.js
@@ -1,4 +1,4 @@
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 import { makeHeapZone } from '../heap.js';
 import { testMakeOnce } from '../tools/testers.js';

--- a/packages/base-zone/test/prepare-attenuator.test.js
+++ b/packages/base-zone/test/prepare-attenuator.test.js
@@ -1,8 +1,7 @@
 // Modeled on test-heap-classes.js
 
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
-// eslint-disable-next-line import/order
 import { M } from '@endo/patterns';
 import { makeHeapZone } from '../src/heap.js';
 import { prepareAttenuatorMaker } from '../src/prepare-attenuator.js';

--- a/packages/base-zone/test/prepare-revocable.test.js
+++ b/packages/base-zone/test/prepare-revocable.test.js
@@ -1,8 +1,7 @@
 // Modeled on test-heap-classes.js
 
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
-// eslint-disable-next-line import/order
 import { M } from '@endo/patterns';
 import { makeHeapZone } from '../src/heap.js';
 import { prepareRevocableMakerKit } from '../src/prepare-revocable.js';

--- a/packages/base-zone/test/prepare-test-env-ava.js
+++ b/packages/base-zone/test/prepare-test-env-ava.js
@@ -1,4 +1,0 @@
-import { wrapTest } from '@endo/ses-ava';
-import rawTest from 'ava';
-
-export const test = wrapTest(rawTest);

--- a/packages/casting/package.json
+++ b/packages/casting/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@agoric/cosmic-proto": "^0.4.0",
-    "@endo/ses-ava": "^1.2.10",
     "ava": "^5.3.0",
     "c8": "^10.1.3",
     "express": "^5.0.1",

--- a/packages/casting/test/mvp.test.js
+++ b/packages/casting/test/mvp.test.js
@@ -3,7 +3,7 @@
 import './lockdown.js';
 
 import { makeMarshal } from '@endo/marshal';
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 import {
   iterateLatest,

--- a/packages/casting/test/netconfig.test.js
+++ b/packages/casting/test/netconfig.test.js
@@ -1,4 +1,4 @@
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 import { assertNetworkConfig } from '../src/netconfig.js';
 
 test('https://main.agoric.net/network-config 2022-10-27', t => {

--- a/packages/casting/test/prepare-test-env-ava.js
+++ b/packages/casting/test/prepare-test-env-ava.js
@@ -1,6 +1,0 @@
-import './lockdown.js';
-import { wrapTest } from '@endo/ses-ava';
-import rawTest from 'ava';
-
-/** @type {typeof rawTest} */
-export const test = wrapTest(rawTest);

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -47,7 +47,6 @@
     "@agoric/swing-store": "^0.9.1",
     "@agoric/swingset-vat": "^0.32.2",
     "@endo/init": "^1.1.9",
-    "@endo/ses-ava": "^1.2.10",
     "ava": "^5.3.0",
     "c8": "^10.1.3"
   },

--- a/packages/notifier/test/makeNotifierFromSubscriber.test.js
+++ b/packages/notifier/test/makeNotifierFromSubscriber.test.js
@@ -1,4 +1,4 @@
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 import {
   makePublishKit,

--- a/packages/notifier/test/notifier-adaptor.test.js
+++ b/packages/notifier/test/notifier-adaptor.test.js
@@ -1,4 +1,4 @@
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 import {
   makeAsyncIterableFromNotifier,

--- a/packages/notifier/test/notifier-examples.test.js
+++ b/packages/notifier/test/notifier-examples.test.js
@@ -1,4 +1,4 @@
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 // eslint-disable-next-line import/order
 import { E } from '@endo/far';

--- a/packages/notifier/test/notifier.test.js
+++ b/packages/notifier/test/notifier.test.js
@@ -1,4 +1,4 @@
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 import { makeNotifierKit } from '../src/index.js';
 
 /**

--- a/packages/notifier/test/prepare-test-env-ava.js
+++ b/packages/notifier/test/prepare-test-env-ava.js
@@ -1,4 +1,0 @@
-import { wrapTest } from '@endo/ses-ava';
-import rawTest from 'ava';
-
-export const test = wrapTest(rawTest);

--- a/packages/notifier/test/stored-subscription.test.js
+++ b/packages/notifier/test/stored-subscription.test.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/order
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 import { E } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';

--- a/packages/notifier/test/subscriber-examples.test.js
+++ b/packages/notifier/test/subscriber-examples.test.js
@@ -1,4 +1,4 @@
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 // eslint-disable-next-line import/order
 import { E } from '@endo/far';

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -63,7 +63,6 @@
     "@cosmjs/proto-signing": "^0.33.0",
     "@endo/bundle-source": "^4.0.0",
     "@endo/import-bundle": "^1.4.0",
-    "@endo/ses-ava": "^1.2.10",
     "ava": "^5.3.1",
     "bech32": "^2.0.0",
     "c8": "^10.1.3",

--- a/packages/orchestration/test/exos/chain-hub-transfer-routes.test.ts
+++ b/packages/orchestration/test/exos/chain-hub-transfer-routes.test.ts
@@ -1,5 +1,5 @@
 import '@agoric/swingset-liveslots/tools/prepare-test-env.js';
-import test from '@endo/ses-ava/prepare-endo.js';
+import test from 'ava';
 
 import { typedJson } from '@agoric/cosmic-proto';
 import { makeNameHubKit } from '@agoric/vats';

--- a/packages/orchestration/test/exos/chain-hub.test.ts
+++ b/packages/orchestration/test/exos/chain-hub.test.ts
@@ -1,5 +1,5 @@
 import '@agoric/swingset-liveslots/tools/prepare-test-env.js';
-import test from '@endo/ses-ava/prepare-endo.js';
+import test from 'ava';
 
 import { makeIssuerKit } from '@agoric/ertp';
 import { makeNameHubKit, type IBCChannelID } from '@agoric/vats';

--- a/packages/orchestration/test/tools/make-test-address.test.ts
+++ b/packages/orchestration/test/tools/make-test-address.test.ts
@@ -1,4 +1,4 @@
-import test from '@endo/ses-ava/prepare-endo.js';
+import test from 'ava';
 import { encodeAddressHook } from '@agoric/cosmic-proto/address-hooks.js';
 import { makeTestAddress } from '../../tools/make-test-address.js';
 

--- a/packages/orchestration/test/utils/address.test.ts
+++ b/packages/orchestration/test/utils/address.test.ts
@@ -1,5 +1,5 @@
 import { validateRemoteIbcAddress } from '@agoric/vats/tools/ibc-utils.js';
-import test from '@endo/ses-ava/prepare-endo.js';
+import test from 'ava';
 import type { Bech32Address } from '../../src/cosmos-api.ts';
 import type { CosmosChainAddress } from '../../src/orchestration-api.ts';
 import {

--- a/packages/orchestration/test/utils/cosmos.test.ts
+++ b/packages/orchestration/test/utils/cosmos.test.ts
@@ -1,4 +1,4 @@
-import test from '@endo/ses-ava/prepare-endo.js';
+import test from 'ava';
 import {
   toDenomAmount,
   toTruncatedDenomAmount,

--- a/packages/orchestration/test/utils/denomHash.test.ts
+++ b/packages/orchestration/test/utils/denomHash.test.ts
@@ -1,4 +1,4 @@
-import test from '@endo/ses-ava/prepare-endo.js';
+import test from 'ava';
 
 import bundleSource from '@endo/bundle-source';
 import { importBundle } from '@endo/import-bundle';

--- a/packages/orchestration/test/utils/packet.test.ts
+++ b/packages/orchestration/test/utils/packet.test.ts
@@ -1,4 +1,4 @@
-import test from '@endo/ses-ava/prepare-endo.js';
+import test from 'ava';
 import { Any } from '@agoric/cosmic-proto/google/protobuf/any.js';
 import {
   QueryBalanceRequest,
@@ -29,7 +29,7 @@ test('makeTxPacket', t => {
     '{"type":1,"data":"ChcKCy9mb28uYmFyLnYxEggKBgoEc2VudBIFaGVsbG8YkE4=","memo":""}',
     'accepts options for TxBody',
   );
-  t.deepEqual(
+  t.is(
     makeTxPacket([
       // @ts-expect-error missing value field
       {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -40,7 +40,6 @@
   },
   "devDependencies": {
     "@endo/init": "^1.1.9",
-    "@endo/ses-ava": "^1.2.10",
     "ava": "^5.3.0"
   },
   "files": [

--- a/packages/store/test/prepare-test-env-ava.js
+++ b/packages/store/test/prepare-test-env-ava.js
@@ -1,5 +1,8 @@
-import { wrapTest } from '@endo/ses-ava';
-import rawTest from 'ava';
+/**
+ * Like prepare-test-env but also exports the AVA `test` function for
+ * compatibility with earlier uses of @endo/ses-ava.
+ */
 
-/** @type {typeof rawTest} */
-export const test = wrapTest(rawTest);
+import test from 'ava';
+
+export { test };

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "@endo/lockdown": "^1.0.15",
-    "@endo/ses-ava": "^1.2.10",
     "ava": "^5.3.0",
     "c8": "^10.1.3",
     "tmp": "^0.2.1"

--- a/packages/telemetry/test/flight-recorder.test.js
+++ b/packages/telemetry/test/flight-recorder.test.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { promisify } from 'node:util';
 import tmp from 'tmp';
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 import {
   makeSimpleCircularBuffer,

--- a/packages/telemetry/test/import.test.js
+++ b/packages/telemetry/test/import.test.js
@@ -1,5 +1,5 @@
 /* global setTimeout */
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 import { getTelemetryProviders } from '../src/index.js';
 

--- a/packages/telemetry/test/prepare-test-env-ava.js
+++ b/packages/telemetry/test/prepare-test-env-ava.js
@@ -1,4 +1,8 @@
-import { wrapTest } from '@endo/ses-ava';
-import rawTest from 'ava';
+/**
+ * Like prepare-test-env but also exports the AVA `test` function for
+ * compatibility with earlier uses of @endo/ses-ava.
+ */
 
-export const test = wrapTest(rawTest);
+import test from 'ava';
+
+export { test };

--- a/packages/vat-data/package.json
+++ b/packages/vat-data/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@endo/init": "^1.1.9",
     "@endo/far": "^1.1.11",
-    "@endo/ses-ava": "^1.2.10",
     "ava": "^5.3.0",
     "tsd": "^0.31.1"
   },

--- a/packages/vat-data/test/amplify-virtual-class-kits.test.js
+++ b/packages/vat-data/test/amplify-virtual-class-kits.test.js
@@ -1,5 +1,5 @@
 // modeled on test-amplify-heap-class-kits.js
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 // eslint-disable-next-line import/order
 import { M } from '@endo/patterns';

--- a/packages/vat-data/test/durable-classes.test.js
+++ b/packages/vat-data/test/durable-classes.test.js
@@ -1,6 +1,6 @@
 // Modeled on test-heap-classes.js
 
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 // eslint-disable-next-line import/order
 import { M } from '@agoric/store';

--- a/packages/vat-data/test/is-instance-virtual-class-kits.test.js
+++ b/packages/vat-data/test/is-instance-virtual-class-kits.test.js
@@ -1,6 +1,6 @@
 // modeled on test-is-instance-heap-class-kits.js
 
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 // eslint-disable-next-line import/order
 import { M } from '@endo/patterns';

--- a/packages/vat-data/test/prepare-test-env-ava.js
+++ b/packages/vat-data/test/prepare-test-env-ava.js
@@ -1,7 +1,9 @@
+/**
+ * Like prepare-test-env but also exports the AVA `test` function for
+ * compatibility with earlier uses of @endo/ses-ava.
+ */
 import './prepare-test-env.js';
 
-import { wrapTest } from '@endo/ses-ava';
-import rawTest from 'ava';
+import test from 'ava';
 
-/** @type {typeof rawTest} */
-export const test = wrapTest(rawTest);
+export { test };

--- a/packages/vat-data/test/prepare.test.js
+++ b/packages/vat-data/test/prepare.test.js
@@ -1,6 +1,6 @@
 // Modeled on test-heap-classes.js
 
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 // eslint-disable-next-line import/order
 import { M } from '@agoric/store';

--- a/packages/vat-data/test/scalar-only-keys.test.js
+++ b/packages/vat-data/test/scalar-only-keys.test.js
@@ -1,6 +1,6 @@
 // From https://github.com/Agoric/agoric-sdk/pull/6903#discussion_r1098067133
 
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 // eslint-disable-next-line import/order
 import { M, makeScalarMapStore } from '@agoric/store';

--- a/packages/vat-data/test/virtual-classes.test.js
+++ b/packages/vat-data/test/virtual-classes.test.js
@@ -1,6 +1,6 @@
 // Modeled on test-heap-classes.js
 
-import { test } from './prepare-test-env-ava.js';
+import test from 'ava';
 
 // eslint-disable-next-line import/order
 import { M } from '@agoric/store';

--- a/packages/xsnap/src/avaHandler.cjs
+++ b/packages/xsnap/src/avaHandler.cjs
@@ -49,8 +49,6 @@ const testRequire = function require(specifier) {
           dirname: s => s.substring(0, s.lastIndexOf('/')),
         },
       };
-    case '@endo/ses-ava':
-      return { wrapTest: test => test };
     case '@endo/init':
     case '@endo/init/debug.js':
     case '@endo/init/pre.js':

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -33,7 +33,6 @@ const asset = (ref, readFile) =>
 const externals = [
   'ava',
   'ses',
-  '@endo/ses-ava',
   '@endo/bundle-source',
   '@endo/init',
   '@endo/init/debug.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1728,15 +1728,6 @@
   dependencies:
     ses "^1.12.0"
 
-"@endo/ses-ava@^1.2.10":
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/@endo/ses-ava/-/ses-ava-1.2.10.tgz#a6c01e23939a56d3b52dc279a80027b89dd96669"
-  integrity sha512-s6M1g3nYSsYnqJVONGinv3wjuXR8LWRxQ/V3NbXCZtBvIwLkfNgy6N8UBQph+Murh70F89nDc+JYhBkcGfVjxQ==
-  dependencies:
-    "@endo/env-options" "^1.1.8"
-    "@endo/init" "^1.1.9"
-    ses "^1.12.0"
-
 "@endo/stream-node@^1.1.10":
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/@endo/stream-node/-/stream-node-1.1.10.tgz#b7a75b7d9216670acba68ed134beb69ae53e6981"


### PR DESCRIPTION
no ticket, spike experiment

## Description

This removes `@endo/ses-ava` from Agoric SDK, relying instead on lockdown configuration to make SES work well with mainstream Ava.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
