### PR TITLE
ci: bump golangci-lint-action to v8

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,7 +31,7 @@ jobs:
         # https://github.com/golangci/golangci-lint/issues/3862#issuecomment-1572973588
       - run: echo "GOROOT=$(go env GOROOT)" >> $GITHUB_ENV
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           args: --timeout=3m


### PR DESCRIPTION
Bumps golangci-lint-action to v8 for future-proofing against runner updates. Workflows compile the same. Reference: https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0