### PR TITLE
feat(inter-protocol): `creatorFacet` invitations to withdraw from the reserve

### DIFF
--- a/a3p-integration/proposals/z:acceptance/yarn.lock
+++ b/a3p-integration/proposals/z:acceptance/yarn.lock
@@ -141,6 +141,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@agoric/inter-protocol@portal:../../agoric-sdk/packages/inter-protocol::locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
+    "@agoric/base-zone": "workspace:*"
     "@agoric/ertp": "workspace:*"
     "@agoric/governance": "workspace:*"
     "@agoric/internal": "workspace:*"

--- a/golang/cosmos/app/upgrade.go
+++ b/golang/cosmos/app/upgrade.go
@@ -241,6 +241,29 @@ func makeUnreleasedUpgradeHandler(app *GaiaApp, targetUpgrade string, baseAppLeg
 				),
 			)
 
+			// Reserve contract needs to be upgraded for IST wind-down.
+			reserveUpgradeStep, err := buildProposalStepWithArgs(
+				"@agoric/builders/scripts/vats/upgrade-vats.js",
+				"upgradeZoeContractsProposalBuilder",
+				[]struct {
+					KitLookup  []string `json:"kitLookup"`
+					BundleName string   `json:"bundleName"`
+					Entrypoint string   `json:"entrypoint"`
+				}{
+					{
+						KitLookup:  []string{"reserveKit"},
+						BundleName: "reserve",
+						Entrypoint: "@agoric/inter-protocol/src/reserve/assetReserve.js",
+					},
+				},
+			)
+			if err != nil {
+				return module.VersionMap{}, err
+			}
+			CoreProposalSteps = append(CoreProposalSteps,
+				reserveUpgradeStep,
+			)
+
 			// terminationTargets is a slice of "$boardID:$instanceKitLabel" strings.
 			var terminationTargets []string
 			switch getVariantFromUpgradeName(targetUpgrade) {

--- a/packages/base-zone/src/prepare-revocable.js
+++ b/packages/base-zone/src/prepare-revocable.js
@@ -18,10 +18,18 @@ import { wrapperMethods } from './prepare-attenuator.js';
 
 /**
  * @template [U=any]
+ * @callback MakeRevocableKit
+ * @param {U} underlying
+ * @returns {RevocableKit<U>}
+ */
+
+/**
+ * @template [U=any]
  * @typedef {object} RevocableMakerKit
  * @property {(revocable: U) => boolean} revoke
- * @property {MakeRevocable} makeRevocable
+ * @property {MakeRevocable<U>} makeRevocable
  *   Forwards to the underlying exo object, until revoked
+ * @property {MakeRevocableKit<U>} makeRevocableKit
  */
 
 /**
@@ -150,6 +158,8 @@ export const prepareRevocableMakerKit = (
   return harden({
     revoke,
     makeRevocable,
+    /** @type {MakeRevocableKit} */
+    makeRevocableKit,
   });
 };
 harden(prepareRevocableMakerKit);

--- a/packages/builders/scripts/vats/upgrade-vats.js
+++ b/packages/builders/scripts/vats/upgrade-vats.js
@@ -1,10 +1,10 @@
 /** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
 export const upgradeVatsProposalBuilder = async (
   { publishRef, install },
-  bundleRecord,
+  vatNameToEntrypoint,
 ) => {
-  if (!bundleRecord) {
-    throw Error('Missing bundleRecord');
+  if (!vatNameToEntrypoint) {
+    throw Error('Missing vatNameToEntrypoint');
   }
   return harden({
     sourceSpec: '@agoric/vats/src/proposals/upgrade-vats-generic-proposal.js',
@@ -12,10 +12,36 @@ export const upgradeVatsProposalBuilder = async (
       'getManifestForUpgradingVats',
       {
         bundleRefs: Object.fromEntries(
-          Object.entries(bundleRecord).map(
+          Object.entries(vatNameToEntrypoint).map(
             ([name, entrypoint]) =>
               /** @type {const} */ ([name, publishRef(install(entrypoint))]),
           ),
+        ),
+      },
+    ],
+  });
+};
+
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').CoreEvalBuilder} */
+export const upgradeZoeContractsProposalBuilder = async (
+  { publishRef, install },
+  contractKitSpecs,
+) => {
+  if (!contractKitSpecs) {
+    throw Error('Missing contractKitSpecs');
+  }
+  return harden({
+    sourceSpec: '@agoric/vats/src/proposals/upgrade-vats-generic-proposal.js',
+    getManifestCall: [
+      'getManifestForUpgradingZoeContractKits',
+      {
+        contractKitSpecs,
+        /** @type {{ [bundleName: string]: VatSourceRef }} */
+        installationBundleRefs: Object.fromEntries(
+          contractKitSpecs.map(({ bundleName, entrypoint }) => [
+            bundleName,
+            publishRef(install(entrypoint)),
+          ]),
         ),
       },
     ],

--- a/packages/casting/src/defaults.js
+++ b/packages/casting/src/defaults.js
@@ -39,7 +39,7 @@ export const randomBackoff = (range, cap = range) => {
 /**
  * @param {number} [attempt]
  * @param {number} [base]
- * @param {number} [cap=DEFAULT_MAX_BACKOFF]
+ * @param {number} [cap]
  */
 export const exponentialBackoff = (
   attempt = 0,

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
+    "@agoric/base-zone": "workspace:*",
     "@agoric/ertp": "workspace:*",
     "@agoric/governance": "workspace:*",
     "@agoric/internal": "workspace:*",

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -10,6 +10,7 @@ import { prepareAssetReserveKit } from './assetReserveKit.js';
 
 /**
  * @import {EReturn} from '@endo/far';
+ * @import {ContractOf} from '@agoric/zoe/src/zoeService/utils.js';
  * @import {Allocation, ContractMeta, FeeMintAccess, Installation} from '@agoric/zoe';
  */
 
@@ -128,3 +129,5 @@ harden(start);
  * @typedef {EReturn<typeof start>['creatorFacet']} AssetReserveCreatorFacet
  *   the creator facet for the governor
  */
+
+/** @typedef {ContractOf<typeof start>} ReserveContract */

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -10,14 +10,13 @@ import { setupReserve } from '../../src/proposals/econ-behaviors.js';
 import {
   installPuppetGovernance,
   makeMockChainStorageRoot,
-  provideBundle,
 } from '../supports.js';
 import { startEconomicCommittee } from '../../src/proposals/startEconCommittee.js';
 
 /** @import {ZoeManualTimer} from '@agoric/zoe/tools/manualTimer.js'; */
 
-const reserveRoot = './src/reserve/assetReserve.js'; // package relative
-const faucetRoot = './test/vaultFactory/faucet.js';
+import * as reserveContractExports from '../../src/reserve/assetReserve.js'; // package relative
+import * as faucetContractExports from '../vaultFactory/faucet.js';
 
 /** @typedef {ReturnType<typeof setUpZoeForTest>} FarZoeKit */
 
@@ -88,8 +87,9 @@ export const setupReserveServices = async (
   });
 
   const { produce, consume, brand, issuer, installation, instance } = spaces;
-  const reserveBundle = await provideBundle(t, reserveRoot, 'reserve');
-  installation.produce.reserve.resolve(E(zoe).install(reserveBundle));
+  installation.produce.reserve.resolve(
+    farZoeKit.bundleAndInstall(reserveContractExports),
+  );
 
   const istIssuer = await E(zoe).getFeeIssuer();
   const istBrand = await E(istIssuer).getBrand();
@@ -99,8 +99,9 @@ export const setupReserveServices = async (
 
   await setupReserve(spaces);
 
-  const faucetBundle = await provideBundle(t, faucetRoot, 'faucet');
-  const faucetInstallation = E(zoe).install(faucetBundle);
+  const faucetInstallation = await farZoeKit.bundleAndInstall(
+    faucetContractExports,
+  );
   brand.produce.IST.resolve(stableBrand);
   issuer.produce.IST.resolve(stableIssuer);
   const feeMintAccess = await feeMintAccessP;

--- a/packages/orchestration/tools/contract-tests.ts
+++ b/packages/orchestration/tools/contract-tests.ts
@@ -122,15 +122,18 @@ export const setupOrchestrationTest = async ({
 
   await registerKnownChains(agoricNamesAdmin, () => {});
 
+  type TransferMessageInfo = {
+    message: MsgTransfer;
+    sequence: bigint;
+  };
   /**
    * Find the Nth outgoing MsgTransfer and its sequence number from the localchain bridge log.
    * @param index 0-based index from the start, or negative index from the end.
-   * @returns The MsgTransfer message and its sequence number.
+   * @returns {TransferMessageInfo} The MsgTransfer message and its sequence number.
    * @throws If index is out of bounds or sequence is not found in the log result.
    */
   const outgoingTransferAt = (index: number) => {
-    const transferMessagesInfo: { message: MsgTransfer; sequence: bigint }[] =
-      [];
+    const transferMessagesInfo: TransferMessageInfo[] = [];
     const isRelevant = ({ obj, result }) =>
       obj.type === 'VLOCALCHAIN_EXECUTE_TX' &&
       obj.messages &&

--- a/packages/vats/src/proposals/upgrade-vats-generic-proposal.js
+++ b/packages/vats/src/proposals/upgrade-vats-generic-proposal.js
@@ -1,5 +1,9 @@
 import { E } from '@endo/far';
 
+import { makeTracer } from '@agoric/internal';
+
+const trace = makeTracer('UpgradeVats');
+
 /**
  * @param {BootstrapPowers & {
  *   consume: {
@@ -22,16 +26,103 @@ export const upgradeVatsGeneric = async (
   { consume: { vatAdminSvc, vatStore } },
   options,
 ) => {
+  trace('Starting upgrade of vats');
   const { bundleRefs, vatOptions = {} } = options.options;
 
   for await (const [name, ref] of Object.entries(bundleRefs)) {
     assert(ref.bundleID, `bundleID missing for ${name}`);
-    console.log(name, `BUNDLE ID: `, ref.bundleID);
+    trace(name, `BUNDLE ID: `, ref.bundleID);
     const bundleCap = await E(vatAdminSvc).getBundleCap(ref.bundleID);
 
+    trace(name, 'Getting admin node from vatStore');
     const { adminNode } = await E(vatStore).get(name);
+    trace(name, 'Upgrading via adminNode');
     await E(adminNode).upgrade(bundleCap, vatOptions[name] || {});
   }
+
+  trace('Done upgrading vats');
+};
+
+/**
+ * @typedef {{ kitLookup: string[]; bundleName: string; entrypoint?: string }} ContractKitSpec
+ */
+
+/**
+ * @param {PromiseSpaceOf<Record<string, any>>} powers
+ * @param {object} options
+ * @param {{
+ *   contractKitSpecs: ContractKitSpec[];
+ *   installationBundleRefs: { [bundleName: string]: VatSourceRef };
+ * }} options.options
+ */
+export const upgradeZoeContractsGeneric = async ({ consume }, options) => {
+  trace('Starting upgrade of Zoe contract kits');
+
+  const { instancePrivateArgs: instancePrivateArgsP } = consume;
+
+  const { contractKitSpecs, installationBundleRefs } = options.options;
+
+  const kitWithPrivateArgs = async (kitName, contractKitP) => {
+    trace(kitName, 'awaiting contract kit');
+    const contractKit = await contractKitP;
+    if (contractKit.privateArgs) {
+      trace(
+        kitName,
+        'contractKit already has privateArgs',
+        contractKit.privateArgs,
+      );
+      return harden(contractKit);
+    }
+
+    // If the privateArgs are not directly on the contractKit, they may be
+    // on the instancePrivateArgs.
+    trace(kitName, 'getting privateArgs from instancePrivateArgs');
+    const privateArgs = await E(instancePrivateArgsP).get(contractKit.instance);
+    trace(
+      kitName,
+      'adding instancePrivateArgs',
+      privateArgs,
+      'to contract kit',
+    );
+    return harden({ ...contractKit, privateArgs });
+  };
+
+  await null;
+  for (const { kitLookup, bundleName } of contractKitSpecs) {
+    const humanLookup = JSON.stringify(kitLookup);
+    trace(humanLookup, 'Looking for contract kit');
+    let contractKit = consume;
+    for (let i = 0; i < kitLookup.length; i += 1) {
+      contractKit = await contractKit[kitLookup[i]];
+    }
+
+    const { adminFacet, privateArgs } = await kitWithPrivateArgs(
+      humanLookup,
+      contractKit,
+    );
+
+    const contractRef = installationBundleRefs[bundleName];
+    assert(contractRef, `No installation bundle found for ${bundleName}`);
+    assert(
+      contractRef.bundleID,
+      `No bundleID found for ${bundleName} in installationBundleRefs`,
+    );
+
+    trace(humanLookup, 'Upgrading contract kit to', bundleName);
+    const upgradeResult = await E(adminFacet).upgradeContract(
+      contractRef.bundleID,
+      privateArgs,
+    );
+    trace(
+      humanLookup,
+      'Upgraded contract kit to',
+      bundleName,
+      'completed with',
+      upgradeResult,
+    );
+  }
+
+  trace('Done upgrading contract kits.');
 };
 
 export const getManifestForUpgradingVats = (
@@ -49,3 +140,47 @@ export const getManifestForUpgradingVats = (
   },
   options: { bundleRefs, vatOptions },
 });
+
+/**
+ * @param {any} powers
+ * @param {{
+ *   contractKitSpecs: ContractKitSpec[];
+ *   installationBundleRefs: { [bundleName: string]: VatSourceRef };
+ * }} options
+ * @returns
+ */
+export const getManifestForUpgradingZoeContractKits = (
+  { restoreRef },
+  { contractKitSpecs, installationBundleRefs },
+) => {
+  const consumePermits = {
+    instancePrivateArgs: true,
+  };
+  for (const { kitLookup } of contractKitSpecs) {
+    let current = consumePermits;
+    for (let i = 0; i < kitLookup.length - 1; i += 1) {
+      current = current[kitLookup[i]] || (current[kitLookup[i]] = {});
+    }
+    current[kitLookup[kitLookup.length - 1]] ||= true;
+  }
+
+  return {
+    manifest: {
+      [upgradeZoeContractsGeneric.name]: {
+        // Other consume permits should only be added in the definition of
+        // `consumePermits`, at the top of this function.
+        consume: consumePermits,
+      },
+    },
+    installations: Object.fromEntries(
+      Object.entries(installationBundleRefs).map(([bundleName, bundleRef]) => [
+        bundleName,
+        restoreRef(bundleRef),
+      ]),
+    ),
+    options: {
+      contractKitSpecs,
+      installationBundleRefs,
+    },
+  };
+};

--- a/scripts/agd-builder.sh
+++ b/scripts/agd-builder.sh
@@ -202,6 +202,7 @@ $do_not_build || (
       echo "At least $src is newer than node_modules"
       rm -f "$STAMPS/yarn-built"
       lazy_yarn install
+      lazy_yarn postinstall
     }
 
     stamp=$STAMPS/yarn-built

--- a/yarn.lock
+++ b/yarn.lock
@@ -638,6 +638,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@agoric/inter-protocol@workspace:packages/inter-protocol"
   dependencies:
+    "@agoric/base-zone": "workspace:*"
     "@agoric/ertp": "workspace:*"
     "@agoric/governance": "workspace:*"
     "@agoric/internal": "workspace:*"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: Agoric/product-tasks#274

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
This PR provides a way for core-evals to withdraw assets from the reserve.  It does so with the following new invitation-based methods on the `creatorFacet`:

- `makeSingleWithdrawalInvitation()` - returns a one-shot invitation which, when offered, can `want` any assets to withdraw without any `give`
- `makeRepeatableWithdrawalInvitation()` - returns a continuing invitation whose offer result is effectively:

```js
{
  invitationMakers: {
    Withdraw() {
      return makeSingleWithdrawalInvitation();
    }
  }
}
```

- `revokeOutstandingWithdrawalInvitations()` - disable all currently usable invitations made from the above two methods.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
Introduces the power to withdraw from the reserve, though it can only be accessed via the `creatorFacet`, which is closely held by the bootstrap vat.

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
n/a

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
The Reserve contract does not seem to be documented.  This PR does not make that better.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Unit tests are present, and

<details><summary>a chain upgrade successfully runs as follows</summary>

```
2025-06-15T02:52:39.154Z SwingSet: vat: v1: evaluateBundleCap { manifestBundleRef: { bundleID: 'b1-2c128a653ab57e1070e5bf7194a09d28bda89a40593916482ff9ac11d1a461d358f6b235838c2f92b2521373d04a5f4e8676127fde1d3011dcc7be16633197b5' }, manifestGetterName: 'getManifestForUpgradingZoeContractKits', vatAdminSvc: Promise [Promise] {} }
2025-06-15T02:52:39.474Z SwingSet: vat: v1: execute { manifestGetterName: 'getManifestForUpgradingZoeContractKits', bundleExports: [ 'getManifestForUpgradingVats', 'getManifestForUpgradingZoeContractKits', 'upgradeVatsGeneric', 'upgradeZoeContractsGeneric' ] }
2025-06-15T02:52:39.494Z SwingSet: vat: v1: installation reserve: new Promise
2025-06-15T02:52:39.497Z SwingSet: vat: v1: installation reserve settled; remaining: []
2025-06-15T02:52:39.657Z SwingSet: vat: v1: coreProposal: upgradeZoeContractsGeneric
2025-06-15T02:52:39.658Z SwingSet: vat: v1: ----- UpgradeVats.2 2 Starting upgrade of Zoe contract kits
2025-06-15T02:52:39.683Z SwingSet: kernel: attempting to upgrade vat v36 from incarnation 1 to source b1-a56e4e28b0feb9989bec76f1e6525e4e8ae996abafc92b700a9b32b47f01a2a64b22eaa5ed1a30442152eceb2eb3f0f34e3fddc1552ac92ff4a36d68e3a7bb07
2025-06-15T02:52:42.229Z SwingSet: vat: v36: ----- AR.6 2 prepare [ 'feeMintAccess', 'initialPoserInvitation', 'marshaller', 'storageNode' ] [ 'AssetReserveKit_kindHandle', 'Durable Publish Kit_kindHandle', 'Recorder_kindHandle', 'assetReserveKit', 'feeMint', 'governorFacet_kindHandle', 'governorFacet_singleton' ]
2025-06-15T02:52:42.273Z SwingSet: vat: v36: ----- AR.6 3 awaiting feeMint
2025-06-15T02:52:42.277Z SwingSet: vat: v36: ----- ReserveKit.5 2 prepareAssetReserveKit [ 'AssetReserveKit_kindHandle', 'Durable Publish Kit_kindHandle', 'Recorder_kindHandle', 'assetReserveKit', 'feeMint', 'governorFacet_kindHandle', 'governorFacet_singleton' ]
2025-06-15T02:52:42.408Z SwingSet: vat: v36: ----- AR.6 4 awaiting handleParamGovernance
2025-06-15T02:52:42.521Z SwingSet: kernel: vat v36 upgraded from incarnation 1 to 2 with source b1-a56e4e28b0feb9989bec76f1e6525e4e8ae996abafc92b700a9b32b47f01a2a64b22eaa5ed1a30442152eceb2eb3f0f34e3fddc1552ac92ff4a36d68e3a7bb07
2025-06-15T02:52:43.225Z SwingSet: vat: v1: ----- UpgradeVats.2 8 ["reserveKit"] Upgraded contract kit to reserve completed with { incarnationNumber: 2 }
2025-06-15T02:52:43.226Z SwingSet: vat: v1: ----- UpgradeVats.2 9 Done upgrading contract kits.
```

</details>

Later, there will be an `a3p-integration` test to bridge the gap between the unit testing and the upgrade testing.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
Backwards compatible, though some new contract baggage is added to support the invitation revocation feature.