### PR TITLE
fix: update broken example link for ENDO_DELIVERY_BREAKPOINTS in docs

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -110,7 +110,7 @@ When the program is run under a debugger, it will breakpoint when the JS
 `debugger;` statement will have no effect. The `debugger;` statement
 is executed *before* the method is entered.
 
-See https://github.com/endojs/endo/blob/master/packages/pass-style/test/prepare-breakpoints.js for an example.
+See https://github.com/endojs/endo/blob/master/packages/vow/src/message-breakpoints.js for an example.
 
 ## ENDO_SEND_BREAKPOINTS
 


### PR DESCRIPTION
Replaced the outdated link to prepare-breakpoints.js with the correct link to message-breakpoints.js in the ENDO_DELIVERY_BREAKPOINTS section of docs/env.md. This ensures users are directed to a valid and relevant example in the Endo repository.