### PR TITLE
like #11459 but on a different endo-branch

### DIFF
--- a/packages/SwingSet/test/upgrade/upgrade.test.js
+++ b/packages/SwingSet/test/upgrade/upgrade.test.js
@@ -133,6 +133,8 @@ const initKernelForTest = async (t, bundleData, config, options = {}) => {
   };
 };
 
+// Gratuitous change so I can create an otherwise identical PR
+
 const testNullUpgrade = async (t, defaultManagerType) => {
   const config = makeConfigFromPaths('../../tools/bootstrap-relay.js', {
     defaultManagerType,


### PR DESCRIPTION
#endo-branch: markm-speed-up-something

Assumes https://github.com/endojs/endo/pull/2860

Staged on #11459 

closes: #XXXX
refs: #11459 https://github.com/endojs/endo/pull/2860

## Description

Like (and staged on) #11459, but with a different endo branch that I can co-experiment with, while leaving #11459 on the endo master branch as a baseline.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
