### PR TITLE
TypeScript 5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "type-coverage": "^2.27.1",
     "typedoc": "^0.26.7",
     "typedoc-plugin-markdown": "^4.2.1",
-    "typescript": "~5.8.2",
+    "typescript": "5.9.0-beta",
     "typescript-eslint": "^8.31.0"
   },
   "resolutions": {

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -78,6 +78,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 93.08
+    "atLeast": 93.03
   }
 }

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -78,6 +78,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 93.1
+    "atLeast": 93.08
   }
 }

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -318,16 +318,18 @@ export const AmountMath = {
    * amount, it usually means including all of the elements from both left and
    * right.
    *
-   * @template {Amount} A
-   * @param {A} leftAmount
-   * @param {A} rightAmount
-   * @param {Brand} [brand]
-   * @returns {A}
+   * @type {{
+   *   <A extends CopyBag, B extends CopyBag>(
+   *     leftAmount: CopyBagAmount<A>,
+   *     rightAmount: CopyBagAmount<B>,
+   *     brand?: Brand,
+   *   ): CopyBagAmount<A | B>;
+   *   <A extends Amount>(leftAmount: A, rightAmount: A, brand?: Brand): A;
+   * }}
    */
   add: (leftAmount, rightAmount, brand = undefined) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
     const value = h.doAdd(...coerceLR(h, leftAmount, rightAmount));
-    // @ts-expect-error different subtype
     return harden({ brand: leftAmount.brand, value });
   },
   /**

--- a/packages/ERTP/test/unitTests/mathHelpers/copySetMathHelpers.test.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/copySetMathHelpers.test.js
@@ -210,7 +210,6 @@ test('copySet with strings add', t => {
     () =>
       m.add(
         harden({ brand: mockBrand, value: makeCopySet(['a', 'a']) }),
-        // @ts-expect-error deliberate invalid arguments for testing
         harden({ brand: mockBrand, value: makeCopySet(['b']) }),
       ),
     { message: /value has duplicate(| key)s: "a"/ },
@@ -220,7 +219,6 @@ test('copySet with strings add', t => {
     () =>
       m.add(
         harden({ brand: mockBrand, value: makeCopySet(['a']) }),
-        // @ts-expect-error deliberate invalid arguments for testing
         harden({ brand: mockBrand, value: makeCopySet(['b', 'b']) }),
       ),
     { message: /value has duplicate(| key)s: "b"/ },

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -102,6 +102,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 76.47
+    "atLeast": 76.59
   }
 }

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -99,6 +99,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 79.15
+    "atLeast": 79.11
   }
 }

--- a/packages/async-flow/package.json
+++ b/packages/async-flow/package.json
@@ -60,6 +60,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 77.11
+    "atLeast": 77.1
   }
 }

--- a/packages/base-zone/package.json
+++ b/packages/base-zone/package.json
@@ -57,6 +57,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 91.4
+    "atLeast": 93.22
   }
 }

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -99,6 +99,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 90.98
+    "atLeast": 91.33
   }
 }

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -80,6 +80,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 90.62
+    "atLeast": 89.94
   }
 }

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -182,7 +182,7 @@
     "rimraf": "^5.0.0",
     "terser": "^5.39.0",
     "tsd": "^0.31.1",
-    "typescript": "~5.8.2"
+    "typescript": "5.9.0-beta"
   },
   "dependencies": {
     "@endo/base64": "^1.0.9",

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -82,6 +82,6 @@
     "timeout": "20m"
   },
   "typeCoverage": {
-    "atLeast": 86.88
+    "atLeast": 86.53
   }
 }

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -73,6 +73,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 83.92
+    "atLeast": 83.27
   }
 }

--- a/packages/fast-usdc/src/cli/transfer.js
+++ b/packages/fast-usdc/src/cli/transfer.js
@@ -21,15 +21,27 @@ import { queryUSDCBalance } from './util/bank.js';
 /** @import { SigningStargateClient } from '@cosmjs/stargate' */
 /** @import { JsonRpcProvider as ethProvider } from 'ethers' */
 
+/**
+ * @param {File} configFile
+ * @param {string} amount
+ * @param {string} EUD
+ * @param {typeof globalThis.console} [out]
+ * @param {typeof globalThis.fetch} [fetch]
+ * @param {VStorage} [vstorage]
+ * @param {{signer: SigningStargateClient, address: string}} [nobleSigner]
+ * @param {ethProvider} [ethProvider]
+ * @param {typeof process.env} [env]
+ * @param {typeof globalThis.setTimeout} [setTimeout]
+ */
 export const transfer = async (
-  /** @type {File} */ configFile,
-  /** @type {string} */ amount,
-  /** @type {string} */ EUD,
+  configFile,
+  amount,
+  EUD,
   out = console,
   fetch = globalThis.fetch,
-  /** @type {VStorage | undefined} */ vstorage,
-  /** @type {{signer: SigningStargateClient, address: string} | undefined} */ nobleSigner,
-  /** @type {ethProvider | undefined} */ ethProvider,
+  vstorage,
+  nobleSigner,
+  ethProvider,
   env = process.env,
   setTimeout = globalThis.setTimeout,
 ) => {

--- a/packages/fast-usdc/test/util/file.test.ts
+++ b/packages/fast-usdc/test/util/file.test.ts
@@ -55,6 +55,8 @@ const makeMkdirMock = () => {
 
 test('returns the path', t => {
   const path = 'config/dir/.fast-usdc/config.json';
+  // @ts-expect-error missing arguments
+  // but we are only testing the path here
   const file = makeFile(path);
 
   t.is(file.path, path);

--- a/packages/inter-protocol/package.json
+++ b/packages/inter-protocol/package.json
@@ -83,6 +83,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 95.72
+    "atLeast": 95.65
   }
 }

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -62,6 +62,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 92.98
+    "atLeast": 92.99
   }
 }

--- a/packages/internal/src/js-utils.js
+++ b/packages/internal/src/js-utils.js
@@ -69,7 +69,7 @@ export const deepCopyJsonable = value => JSON.parse(JSON.stringify(value));
  * @param {O[K]} value
  * @param {K | undefined} name
  * @param {O | undefined} container
- * @param {(value: O[K], name: K, record: O) => O[K] | M} mapper
+ * @param {(value: O[K], name: string, record: O) => O[K] | M} mapper
  * @returns {O[K] | M | { [K2 in keyof O[K]]: O[K][K2] | M }}
  */
 const deepMapObjectInternal = (value, name, container, mapper) => {

--- a/packages/internal/test/utils.test.js
+++ b/packages/internal/test/utils.test.js
@@ -291,7 +291,6 @@ const { value: arbShallow } = fc.letrec(tie => ({
   testProp(
     'attenuate',
     /** @type {any} */ ([arbGoodCase]),
-    // @ts-expect-error TS2345 function signature
     async (t, { specimen, permit, attenuation }) => {
       const actualAttenuation = attenuate(specimen, permit);
       t.deepEqual(actualAttenuation, attenuation);
@@ -332,7 +331,6 @@ const { value: arbShallow } = fc.letrec(tie => ({
     /** @type {any} */ ([
       arbGoodCase.filter(({ specimen }) => hasObjectType(specimen)),
     ]),
-    // @ts-expect-error TS2345 function signature
     async (t, { specimen, permit }) => {
       const tag = Symbol('transformed');
 
@@ -373,7 +371,6 @@ const { value: arbShallow } = fc.letrec(tie => ({
   testProp(
     'attenuate - bad permit',
     /** @type {any} */ ([arbBadPermit]),
-    // @ts-expect-error TS2345 function signature
     async (t, { specimen, permit, problem: _problem }) => {
       // t.log({ specimen, permit, problem });
       t.throws(() => attenuate(specimen, permit), {
@@ -385,7 +382,6 @@ const { value: arbShallow } = fc.letrec(tie => ({
   testProp(
     'attenuate - bad specimen',
     /** @type {any} */ ([arbBadSpecimen]),
-    // @ts-expect-error TS2345 function signature
     async (t, { specimen, permit, problem: _problem }) => {
       // t.log({ specimen, permit, problem });
       t.throws(() => attenuate(specimen, permit), {
@@ -397,7 +393,6 @@ const { value: arbShallow } = fc.letrec(tie => ({
   testProp(
     'attenuate - specimen missing key',
     /** @type {any} */ ([arbSpecimenMissingKey]),
-    // @ts-expect-error TS2345 function signature
     async (t, { specimen, permit, problem: _problem }) => {
       // t.log({ specimen, permit, problem });
       t.throws(() => attenuate(specimen, permit), {

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -103,6 +103,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 97.7
+    "atLeast": 97.46
   }
 }

--- a/packages/pola-io/package.json
+++ b/packages/pola-io/package.json
@@ -38,6 +38,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 80
+    "atLeast": 91.94
   }
 }

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -78,6 +78,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 73.95
+    "atLeast": 73.92
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -61,6 +61,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 89.62
+    "atLeast": 89.63
   }
 }

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -59,6 +59,6 @@
     "timeout": "2m"
   },
   "typeCoverage": {
-    "atLeast": 55.56
+    "atLeast": 56.13
   }
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -67,6 +67,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 88.83
+    "atLeast": 89.28
   }
 }

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -77,6 +77,6 @@
     "workerThreads": false
   },
   "typeCoverage": {
-    "atLeast": 90.49
+    "atLeast": 90.31
   }
 }

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -99,6 +99,6 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 84.69
+    "atLeast": 84.66
   }
 }

--- a/scripts/update-typeCoverage-floor.sh
+++ b/scripts/update-typeCoverage-floor.sh
@@ -11,6 +11,6 @@ for package in packages/*/package.json; do
     # This can raise or lower the amount. "--update-if-higher" will only raise it,
     # but this gives us more flexibility. Reviewers should evaluate whether
     # lowering is warranted.
-    yarn --silent type-coverage --update
+    yarn run --top-level --silent type-coverage --update
   fi
 done

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,7 +455,7 @@ __metadata:
     rimraf: "npm:^5.0.0"
     terser: "npm:^5.39.0"
     tsd: "npm:^0.31.1"
-    typescript: "npm:~5.8.2"
+    typescript: "npm:5.9.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -899,7 +899,7 @@ __metadata:
     type-coverage: "npm:^2.27.1"
     typedoc: "npm:^0.26.7"
     typedoc-plugin-markdown: "npm:^4.2.1"
-    typescript: "npm:~5.8.2"
+    typescript: "npm:5.9.0-beta"
     typescript-eslint: "npm:^8.31.0"
   languageName: unknown
   linkType: soft
@@ -18889,13 +18889,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.1.6 - 5.8.x, typescript@npm:^5.4.5, typescript@npm:~5.8.2":
+"typescript@npm:5.1.6 - 5.8.x, typescript@npm:^5.4.5":
   version: 5.8.3
   resolution: "typescript@npm:5.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
+  languageName: node
+  linkType: hard
+
+"typescript@npm:5.9.0-beta":
+  version: 5.9.0-beta
+  resolution: "typescript@npm:5.9.0-beta"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/f626b54278872569fe3d3b12a5ced752ace64dac57ef901c27b7ffb405ba1beaee6671f5e2e6870fcf0761d4eebcb50de0e09caf891768461a563619743b148e
   languageName: node
   linkType: hard
 
@@ -18929,13 +18939,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.1.6 - 5.8.x#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.8.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.1.6 - 5.8.x#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>":
   version: 5.8.3
   resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A5.9.0-beta#optional!builtin<compat/typescript>":
+  version: 5.9.0-beta
+  resolution: "typescript@patch:typescript@npm%3A5.9.0-beta#optional!builtin<compat/typescript>::version=5.9.0-beta&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/8c8c8eb597bac24ce44b9fde50d47b3cf5b512ff3c77ac210bc251a84f3ee8d14412c6c3e98e39d11040b2f5e94797c7af13d60912aafd52560ddb4ab975b636
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
_evergreen_

## Description
Updates to TypeScript 5.9:
- https://devblogs.microsoft.com/typescript/announcing-typescript-5-9-beta/

Most relevant
- [Support for import defer](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9-beta/#support-for-import-defer) cc @kriskowal 
- [Support for --module node20](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9-beta/#support-for---module-node20)
-- we use `bundler` and in some places `NodeNext` so no change is necessary, but require(ESM) should work now

### Security Considerations
no change

### Scaling Considerations
dev-time only

### Documentation Considerations
some tools that aren't updated for TS 5.9 yet will display a warning

### Testing Considerations
CI and the type coverage script (which this PR also fixes)

### Upgrade Considerations
n/a