### PR TITLE
feat(multichain): Add Noble Swap Pool Creation in Multichain for Ymax

### DIFF
--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -133,6 +133,10 @@ jobs:
         run: make register-bank-assets
         working-directory: ./agoric-sdk/multichain-testing
 
+      - name: Create Noble Swap Pool (If needed)
+        run: make create-noble-swap-pool
+        working-directory: ./agoric-sdk/multichain-testing
+
       - name: Run @agoric/multichain-testing E2E Tests
         run: ${{ inputs.test_command }}
         working-directory: ./agoric-sdk/multichain-testing

--- a/multichain-testing/Makefile
+++ b/multichain-testing/Makefile
@@ -112,6 +112,16 @@ provision-smart-wallet:
 tail-slog:
 	kubectl exec -i agoriclocal-genesis-0 -c validator -- tail -f slog.slog
 
+
+
+###############################################################################
+###                          Noble Setup                                   ###
+###############################################################################
+
+.PHONY: create-noble-swap-pool
+create-noble-swap-pool:
+	scripts/create-noble-swap-pool.ts
+
 ###############################################################################
 ###                           Start All                                     ###
 ###############################################################################
@@ -121,7 +131,7 @@ wait-for-pods:
 	$(STARSHIP) wait-for-pods
 
 .PHONY: start
-start: sstart fund-provision-pool register-bank-assets
+start: sstart fund-provision-pool register-bank-assets create-noble-swap-pool
 
 .PHONY: sstart
 sstart:

--- a/multichain-testing/config.ymax.yaml
+++ b/multichain-testing/config.ymax.yaml
@@ -49,7 +49,7 @@ chains:
     scripts:
       updateGenesis:
         # We can modify this script as per need for ymax
-        file: scripts/noble-v9.0.4-update-genesis.sh
+        file: scripts/noble-v10-update-genesis.sh
     faucet:
       enabled: true
       type: starship

--- a/multichain-testing/scripts/create-noble-swap-pool.ts
+++ b/multichain-testing/scripts/create-noble-swap-pool.ts
@@ -9,8 +9,10 @@ import { makeHttpClient } from '../tools/makeHttpClient.js';
 const REGISTRY_API_URL = 'http://localhost:8081';
 const POD_NAME = 'noblelocal-genesis-0';
 const CONTAINER = 'validator';
+// TODO: Make it 10 once https://github.com/Agoric/agoric-sdk/pull/11510 is merged
 const REQUIRED_ATLEAST_MAJOR = 9;
 const NOBLE_CHAIN_ID = 'noblelocal';
+const NOBLE_AUTHORITY_ADDRESS = 'noble13am065qmk680w86wya4u9refhnssqwcvgs0sfk';
 
 async function checkNobleChainPresence(nobleChainId: string) {
   let resp;
@@ -140,7 +142,7 @@ async function createPool({
     NOBLE_CHAIN_ID,
     '--generate-only',
     '--from',
-    'noble13am065qmk680w86wya4u9refhnssqwcvgs0sfk',
+    NOBLE_AUTHORITY_ADDRESS,
   ]);
   await execa(
     'kubectl',

--- a/multichain-testing/scripts/create-noble-swap-pool.ts
+++ b/multichain-testing/scripts/create-noble-swap-pool.ts
@@ -9,8 +9,7 @@ import { makeHttpClient } from '../tools/makeHttpClient.js';
 const REGISTRY_API_URL = 'http://localhost:8081';
 const POD_NAME = 'noblelocal-genesis-0';
 const CONTAINER = 'validator';
-// TODO: Make it 10 once https://github.com/Agoric/agoric-sdk/pull/11510 is merged
-const REQUIRED_ATLEAST_MAJOR = 9;
+const REQUIRED_ATLEAST_MAJOR = 10;
 const NOBLE_CHAIN_ID = 'noblelocal';
 const NOBLE_AUTHORITY_ADDRESS = 'noble13am065qmk680w86wya4u9refhnssqwcvgs0sfk';
 

--- a/multichain-testing/scripts/create-noble-swap-pool.ts
+++ b/multichain-testing/scripts/create-noble-swap-pool.ts
@@ -1,0 +1,237 @@
+#!/usr/bin/env -S node --import ts-blank-space/register
+/* eslint-env node */
+import '@endo/init';
+import { execa } from 'execa';
+import { parseArgs } from 'node:util';
+import { makeBlockTool } from '../tools/e2e-tools.js';
+import { makeHttpClient } from '../tools/makeHttpClient.js';
+
+const REGISTRY_API_URL = 'http://localhost:8081';
+const POD_NAME = 'noblelocal-genesis-0';
+const CONTAINER = 'validator';
+const REQUIRED_ATLEAST_MAJOR = 9;
+const NOBLE_CHAIN_ID = 'noblelocal';
+
+async function checkNobleChainPresence(nobleChainId: string) {
+  let resp;
+
+  resp = await fetch(`${REGISTRY_API_URL}/chains/${nobleChainId}`);
+  resp = await resp.json();
+
+  // Incase nobleChainId not present/running, resp.chain_id will be undefined
+  if (resp.chain_id !== nobleChainId) {
+    console.log(
+      `Noble chain with id ${nobleChainId} is not present or running.`,
+    );
+    return false;
+  }
+  const rpcUrl = resp.apis.rpc[0].address;
+  const { waitForBlock } = makeBlockTool({
+    rpc: makeHttpClient(rpcUrl, fetch),
+    delay: ms => new Promise(resolve => setTimeout(resolve, ms)),
+  });
+  await waitForBlock(1);
+  return true;
+}
+
+async function getNobleVersion({
+  pod,
+  container,
+}: {
+  pod: string;
+  container: string;
+}) {
+  const { stdout } = await execa('kubectl', [
+    'exec',
+    '-i',
+    pod,
+    '-c',
+    container,
+    '--',
+    'nobled',
+    'version',
+    '--long',
+    '--output',
+    'json',
+  ]);
+  const info = JSON.parse(stdout);
+  const sdkVer = info.version.replace(/^v/, ''); // Remove leading 'v' if present
+  return sdkVer;
+}
+
+async function getSwapPools({
+  pod,
+  container,
+}: {
+  pod: string;
+  container: string;
+}) {
+  const { stdout } = await execa('kubectl', [
+    'exec',
+    '-i',
+    pod,
+    '-c',
+    container,
+    '--',
+    'nobled',
+    'query',
+    'swap',
+    'pools',
+    '--output',
+    'json',
+  ]);
+  const data = JSON.parse(stdout);
+  return data.pools;
+}
+
+async function pollSwapPools(
+  pod: string,
+  container: string,
+  intervalMs: number = 2000,
+  timeoutMs: number = 30_000, // Wait for 30 seconds atmost
+) {
+  const start = Date.now();
+
+  while (true) {
+    const swapPools = await getSwapPools({ pod, container });
+    if (Array.isArray(swapPools) && swapPools.length > 0) {
+      return swapPools;
+    }
+
+    const elapsed = Date.now() - start;
+    if (elapsed >= timeoutMs) {
+      throw new Error(
+        `Timed out after ${timeoutMs}ms waiting for swapPools for pod=${pod}, container=${container}`,
+      );
+    }
+
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+}
+
+async function createPool({
+  pod,
+  container,
+}: {
+  pod: string;
+  container: string;
+}) {
+  const { stdout: genJson } = await execa('kubectl', [
+    'exec',
+    '-i',
+    pod,
+    '-c',
+    container,
+    '--',
+    'nobled',
+    'tx',
+    'swap',
+    'stableswap',
+    'create-pool',
+    'uusdc',
+    '0',
+    '5',
+    '1',
+    '100',
+    '100',
+    '1000000000000000000uusdc',
+    '1000000000000000000uusdn',
+    '--chain-id',
+    NOBLE_CHAIN_ID,
+    '--generate-only',
+    '--from',
+    'noble13am065qmk680w86wya4u9refhnssqwcvgs0sfk',
+  ]);
+  await execa(
+    'kubectl',
+    [
+      'exec',
+      '-i',
+      pod,
+      '-c',
+      container,
+      '--',
+      'nobled',
+      'tx',
+      'authority',
+      'execute',
+      '-',
+      '--from',
+      'genesis',
+      '--chain-id',
+      NOBLE_CHAIN_ID,
+      '--keyring-backend',
+      'test',
+      '--gas',
+      'auto',
+      '--gas-adjustment',
+      '1.4',
+      '-y',
+    ],
+    {
+      stdio: ['pipe', 'inherit', 'inherit'],
+      input: genJson,
+    },
+  );
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      pod: { type: 'string', short: 'p' },
+      container: { type: 'string', short: 'c' },
+      help: { type: 'boolean', short: 'h' },
+      chainId: { type: 'string', short: 'k' },
+    },
+    allowPositionals: false,
+  });
+
+  if (values.help) {
+    console.log(`
+Usage: create-noble-swap-pool.ts [options]
+
+Options:
+  -p, --pod        Pod name (default: ${POD_NAME})
+  -c, --container  Container name (default: ${CONTAINER})
+  -k --chain-id   Chain ID (default: ${NOBLE_CHAIN_ID})
+`);
+    process.exit(0);
+  }
+
+  const pod = values.pod ?? POD_NAME;
+  const container = values.container ?? CONTAINER;
+  const nobleChainId = values.chainId ?? NOBLE_CHAIN_ID;
+
+  console.log('Doing Pre-Checks for Noble chain...');
+  const hasNobleChain = await checkNobleChainPresence(nobleChainId);
+  if (!hasNobleChain) return;
+
+  const sdkVersion = await getNobleVersion({ pod, container });
+  if (parseInt(sdkVersion) < REQUIRED_ATLEAST_MAJOR) {
+    console.log(
+      `noble sdk version ${sdkVersion} is less than required v${REQUIRED_ATLEAST_MAJOR}`,
+    );
+    return;
+  }
+
+  // Here, we are good to create swap pools
+  let swapPools = await getSwapPools({ pod, container });
+
+  // swapPools will be null if there are no pools
+  if (swapPools) {
+    console.log('Swap Pools Already exists', swapPools);
+    return;
+  }
+
+  console.log('Creating swap pool...');
+  await createPool({ pod, container });
+
+  swapPools = await pollSwapPools(pod, container);
+  console.log('Swap pool created successfuly...', swapPools);
+}
+
+main().catch(err => {
+  console.error('An error occurred while creating the swap pool:');
+  console.error(err);
+  process.exit(1);
+});

--- a/multichain-testing/scripts/noble-v10-update-genesis.sh
+++ b/multichain-testing/scripts/noble-v10-update-genesis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This file is replica of scripts/noble-update-genesis but with the added genesisState fix for noble-v9.0.4
+# This file is replica of scripts/noble-update-genesis but with the added genesisState fix for noble-v10
 # Diff: https://github.com/Agoric/agoric-sdk/compare/test-noble-v9?expand=1#diff-a104780a601d583f772ed0c6319d049ff8bc7e45703b15a9bbb2491306fd0435
 
 DENOM="${DENOM:=uusdc}"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://github.com/Agoric/agoric-sdk/issues/11513
refs: https://github.com/Agoric/agoric-sdk/issues/11513

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

This PR adds noble swap creation flow in multichain-testing. As script `scripts/create-noble-swap-pool.ts` is added which is invoked in `Makefile` after `make start`. 

**What script does?**

1- First checks for running noble chain in starship infra through registry endpoint (localhost:8081). Exits gracefully if no noble chain running

2- If noble chain running, it  `waits-for-block` and checks for nobled version (should be >= v9). If the version is less than 9, it exits gracefully (as tx swap and pool creation is only helpful in v9 and above).

3- Once above mentioned pre-checks are passed, it checks for swap-pool existence. If the pool exists already, it exits gracefully.

4- If no existing swap-pools, it creates swap-pool and verifies by polling on `nobled query swap pools` as --broadcast option is not there for nobled 9.


So as per the pre-checks, this script will only execute completely for `config.ymax.yaml`. Rest of the confif-* are using
< v9 hence pools won't be created for them.

**How to invoke?**
After setting up starship infra and chains running, we can also run `make create-noble-swap-pool` manually to test locally.

_Github action is also updated and added "Create Noble Swap Pool (If needed)" step which invokes make create-noble-swap-pool_

<img width="1639" alt="Screenshot 2025-06-20 at 8 55 34 PM" src="https://github.com/user-attachments/assets/2daa2e94-f323-4982-9836-230ad5e4dd70" />

<img width="685" alt="Screenshot 2025-06-20 at 8 57 25 PM" src="https://github.com/user-attachments/assets/9c72cec9-35f2-4d8c-a7b8-1b0235a4fff1" />



### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
