### PR TITLE
ci(after-merge): fix NPM publishing

### DIFF
--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -70,14 +70,9 @@ jobs:
               TAG=other-dev
               ;;
           esac
-          # Prevent `lerna publish` from failing due to uncommitted changes.
-          git stash || true
-          # without concurrency until https://github.com/Agoric/agoric-sdk/issues/8091
-          yarn lerna publish --concurrency 1 --conventional-prerelease --canary --exact \
-            --dist-tag=$TAG --preid=$TAG-$(git rev-parse --short=7 HEAD) \
-            --no-push --no-verify-access --yes
-          # restore any stashed changes for caching
-          git stash pop || true
+          # use Yarn to resolve `workspace:*` versions and its "npm" plugin to publish
+          # https://yarnpkg.com/features/workspaces#publishing-workspaces
+          yarn workspaces foreach --all --topological --no-private npm publish --tolerate-republish --tag $TAG
       - name: notify on failure
         if: failure()
         uses: ./.github/actions/notify-status


### PR DESCRIPTION
refs: #11598

## Description

NPM packages since this PR have had `workspace:*` in their package.json ([example](https://www.npmjs.com/package/@agoric/client-utils/v/0.1.1-dev-bd136ed.0?activeTab=code)):
- https://github.com/Agoric/agoric-sdk/pull/11397

Those can't be installed. This uses Yarn to resolve the versions per https://github.com/Agoric/agoric-sdk/issues/11598#issuecomment-3070750674

### Security Considerations

We might want to enable `--provenance` ([docs](https://yarnpkg.com/configuration/yarnrc#npmPublishProvenance)), which Yarn supports while Lerna didn't, but I think that's out of scope.

### Scaling Considerations
n/a

### Documentation Considerations
aligning with ecosystem, less to document. the new lines reference the documentation.

### Testing Considerations

Up to the reviewers whether to merge this and see if it works or manually run the workflow.

This shouldn't affect the SDK release process, which is why it doesn't close #11598 , but there may be other [pre-release cases to consider](https://github.com/Agoric/agoric-sdk/issues/11598#issuecomment-3070779770).

### Upgrade Considerations
n/a