### PR TITLE
feat(portfolio-planner): add AVA test infrastructure with initial tests

### DIFF
--- a/packages/portfolio-planner/package.json
+++ b/packages/portfolio-planner/package.json
@@ -15,7 +15,7 @@
     "prepack": "yarn run -T tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint": "npm run lint:types",
-    "test": "exit 0",
+    "test": "ava",
     "test:vite": "vitest",
     "lint:types": "yarn run -T tsc"
   },
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/node": "^22.10.2",
     "@types/ws": "^8",
+    "ava": "^5.3.0",
     "nodemon": "^3.1.10",
     "ts-blank-space": "^0.6.1",
     "typescript": "^5.7.2"

--- a/packages/portfolio-planner/src/engine.ts
+++ b/packages/portfolio-planner/src/engine.ts
@@ -27,8 +27,10 @@ const PathSeparator = '.';
 /**
  * TODO: Promote elsewhere, maybe @agoric/internal?
  * cf. golang/cosmos/x/vstorage/types/path_keys.go
+ * 
+ * NOTE: Exported for testing purposes only
  */
-const encodedKeyToPath = (key: string) => {
+export const encodedKeyToPath = (key: string) => {
   const split = key.split(EncodedKeySeparator);
   split.length > 1 || Fail`invalid encoded key ${q(key)}`;
   const encodedPath = split.slice(1).join(EncodedKeySeparator);

--- a/packages/portfolio-planner/test/unitTests/engine.test.js
+++ b/packages/portfolio-planner/test/unitTests/engine.test.js
@@ -1,0 +1,45 @@
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+// Load TypeScript compiler for .ts imports
+import 'ts-blank-space/register';
+
+// Import the actual function we want to test directly from engine.ts
+const { encodedKeyToPath } = await import('../../src/engine.ts');
+
+// Test constants and utility values  
+const EncodedKeySeparator = '\x00';
+
+test('encodedKeyToPath converts encoded keys to dot-separated paths', t => {
+  const encodedKey = `prefix${EncodedKeySeparator}published${EncodedKeySeparator}ymax0${EncodedKeySeparator}portfolios`;
+  const expectedPath = 'published.ymax0.portfolios';
+  
+  const result = encodedKeyToPath(encodedKey);
+  
+  t.is(result, expectedPath);
+});
+
+test('encodedKeyToPath handles simple encoded keys', t => {
+  const encodedKey = `prefix${EncodedKeySeparator}simple${EncodedKeySeparator}path`;
+  const expectedPath = 'simple.path';
+  
+  const result = encodedKeyToPath(encodedKey);
+  
+  t.is(result, expectedPath);
+});
+
+test('encodedKeyToPath throws on invalid keys without separator', t => {
+  const invalidKey = 'no-separator-key';
+  
+  t.throws(() => encodedKeyToPath(invalidKey), {
+    message: /invalid encoded key/,
+  });
+});
+
+test('encodedKeyToPath handles single path component', t => {
+  const encodedKey = `prefix${EncodedKeySeparator}single`;
+  const expectedPath = 'single';
+  
+  const result = encodedKeyToPath(encodedKey);
+  
+  t.is(result, expectedPath);
+});


### PR DESCRIPTION
- Update package.json: ava dependency and test script (exit 0 -> ava)
- Export encodedKeyToPath from engine.ts for testing (marked for testing only)
- Configure TypeScript imports in tests using ts-blank-space/register

Tests: 4 passing, covering success paths and error handling
- Encoded key to dot-separated path conversion
- Simple path handling
- Error handling for invalid keys
- Single path component edge case
