### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/actions/restore-golang/action.yml
+++ b/.github/actions/restore-golang/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: set default environment variables
       run: echo GOPATH="$HOME/go" >> $GITHUB_ENV
       shell: bash
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         path: ${{ inputs.path }}
         clean: 'false'

--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -55,7 +55,7 @@ runs:
 
         echo "NODE_VERSION=$OUTPUT_NODE_VERSION" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         clean: false
         submodules: 'true'
@@ -105,7 +105,7 @@ runs:
     - name: check out Endo if necessary
       id: endo-checkout
       if: steps.endo-branch.outputs.result != 'NOPE'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: endojs/endo
         path: ./replacement-endo

--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         node-version: ['node-new', 'node-old']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - uses: ./.github/actions/restore-node
@@ -37,7 +37,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: 'node-new'
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{github.event_name == 'push' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: 'node-new'
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{github.event_name == 'push'}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: 'node-new'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -18,7 +18,7 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: 'node-new'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
       tag: '${{ steps.docker-tags.outputs.tags }}'
       tags: '${{ steps.docker-tags.outputs.tags }} ${{ needs.snapshot.outputs.tag }}'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: depot/setup-action@v1
         with:
           oidc: true # to set DEPOT_TOKEN for later steps
@@ -168,7 +168,7 @@ jobs:
       # to push the resulting images
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Save SDK_TAG
         run: echo "SDK_TAG=${{ needs.snapshot.outputs.tag }}" >> $GITHUB_ENV
       - name: Prefix tags

--- a/.github/workflows/dump-ci-stats.yml
+++ b/.github/workflows/dump-ci-stats.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         mode: [no-failure]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,7 +76,7 @@ jobs:
         cli: [link-cli/yarn, registry/npm, registry/npx]
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Reconfigure git to use HTTP authentication
@@ -150,7 +150,7 @@ jobs:
 
     runs-on: 'depot-ubuntu-22.04-4'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
           path: ./agoric-sdk
@@ -246,7 +246,7 @@ jobs:
           echo "=== After cleanup:"
           df -h
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: ./agoric-sdk
 
@@ -319,7 +319,7 @@ jobs:
 
       - id: checkout-loadgen
         name: Check out loadgen
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ./${{ env.LOADGEN_REPO_NAME }}
           ref: ${{ steps.get-loadgen-branch.outputs.result }}
@@ -420,7 +420,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Final integration-test-result
         if: always()
         uses: actions/github-script@v7

--- a/.github/workflows/mergify-ready.yml
+++ b/.github/workflows/mergify-ready.yml
@@ -53,7 +53,7 @@ jobs:
       ) &&
       !contains(github.event.pull_request.labels.*.name, 'bypass:linear-history')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - shell: bash
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Check for fixup commits

--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: 'depot-ubuntu-24.04-16'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
           path: ./agoric-sdk

--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - uses: technote-space/get-diff-action@v4
@@ -32,7 +32,7 @@ jobs:
   breakage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - uses: technote-space/get-diff-action@v4
@@ -66,7 +66,7 @@ jobs:
   up-to-date:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - uses: ./.github/actions/restore-golang

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         node-version: ['node-new', 'node-old']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - uses: ./.github/actions/restore-node
@@ -46,7 +46,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install graphviz
         run: sudo apt install -y graphviz
 
@@ -87,7 +87,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: 'node-new'
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: 'node-new'
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: 'node-new'
@@ -168,7 +168,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.engine }}
@@ -266,7 +266,7 @@ jobs:
         run: |
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.engine }}
@@ -399,7 +399,7 @@ jobs:
         run: |
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.engine }}
@@ -438,7 +438,7 @@ jobs:
         run: |
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.engine }}
@@ -477,7 +477,7 @@ jobs:
         run: |
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.engine }}
@@ -517,7 +517,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.engine }}
@@ -559,7 +559,7 @@ jobs:
         run: |
           echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.engine }}
@@ -603,7 +603,7 @@ jobs:
           echo "CI_NODE_INDEX=${{ matrix.node_index }}" >> $GITHUB_ENV
           echo "CI_NODE_TOTAL=${{ matrix.total_nodes }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.engine }}
@@ -647,7 +647,7 @@ jobs:
           echo "CI_NODE_INDEX=${{ matrix.node_index }}" >> $GITHUB_ENV
           echo "CI_NODE_TOTAL=${{ matrix.total_nodes }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.engine }}
@@ -694,7 +694,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs-unit' || 'test:unit' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
         # BEGIN-TEST-BOILERPLATE
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.engine }}
@@ -735,7 +735,7 @@ jobs:
           echo "test=${{ matrix.engine == 'xs' && 'test:xs-worker' || 'test:swingset' }}" >> $GITHUB_OUTPUT
           echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
         # BEGIN-TEST-BOILERPLATE
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-node
         with:
           node-version: ${{ matrix.engine }}

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: ['node-new']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
           path: ./agoric-sdk
@@ -50,7 +50,7 @@ jobs:
             return branch;
 
       - name: Check out dapp
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: Agoric/documentation
           path: dapp

--- a/.github/workflows/test-golang.yml
+++ b/.github/workflows/test-golang.yml
@@ -15,7 +15,7 @@ jobs:
   gotest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/restore-golang
         with:
           go-version: '1.22'

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -11,5 +11,5 @@ jobs:
   run-scripts-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: scripts/test/test.sh


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0