### PR TITLE
feat(ymax-planner): Establish subscriptions before querying initial state

### DIFF
--- a/packages/ymax-planner/src/engine.ts
+++ b/packages/ymax-planner/src/engine.ts
@@ -366,196 +366,190 @@ export const startEngine = async ({
     portfolioKeyForDepositAddr.set(depositAddress, portfolioKey);
   }).done;
 
-  try {
-    // console.warn('consuming events');
-    for await (const respContainer of eventResponses) {
-      const { query: _query, data: resp, events: respEvents } = respContainer;
-      const { type, value: respData } = resp;
-      if (!respEvents) {
-        console.warn('missing events', type);
-        continue;
+  // console.warn('consuming events');
+  for await (const respContainer of eventResponses) {
+    const { query: _query, data: resp, events: respEvents } = respContainer;
+    const { type, value: respData } = resp;
+    if (!respEvents) {
+      console.warn('missing events', type);
+      continue;
+    }
+
+    // Capture vstorage updates.
+    const eventRecords = Object.entries(respData).flatMap(([key, value]) => {
+      // We care about result_begin_block/result_end_block/etc.
+      if (!key.startsWith('result_')) return [];
+      const events = (value as any)?.events;
+      if (!events) console.warn('missing events', type, key);
+      return events ?? [];
+    }) as CosmosEvent[];
+    const portfolioVstorageEvents = partialMap(eventRecords, eventRecord => {
+      const { type: eventType, attributes: attrRecords } = eventRecord;
+      // Filter for vstorage state_change events.
+      // cf. golang/cosmos/types/events.go
+      if (eventType !== 'state_change') return;
+      const attributes = fromUniqueEntries(
+        attrRecords?.map(({ key, value }) => [key, value]) || [],
+      );
+      if (attributes.store !== 'vstorage') return;
+
+      // Require attributes "key" and "value".
+      if (attributes.key === undefined || attributes.value === undefined) {
+        console.error('vstorage state_change missing "key" and/or "value"');
+        return;
       }
 
-      // Capture vstorage updates.
-      const eventRecords = Object.entries(respData).flatMap(([key, value]) => {
-        // We care about result_begin_block/result_end_block/etc.
-        if (!key.startsWith('result_')) return [];
-        const events = (value as any)?.events;
-        if (!events) console.warn('missing events', type, key);
-        return events ?? [];
-      }) as CosmosEvent[];
-      const portfolioVstorageEvents = partialMap(eventRecords, eventRecord => {
-        const { type: eventType, attributes: attrRecords } = eventRecord;
-        // Filter for vstorage state_change events.
-        // cf. golang/cosmos/types/events.go
-        if (eventType !== 'state_change') return;
-        const attributes = fromUniqueEntries(
-          attrRecords?.map(({ key, value }) => [key, value]) || [],
-        );
-        if (attributes.store !== 'vstorage') return;
+      // Filter for ymax portfolio paths.
+      const path = encodedKeyToPath(attributes.key);
+      if (!vstoragePathStartsWith(path, VSTORAGE_PATH_PREFIX)) return;
 
-        // Require attributes "key" and "value".
-        if (attributes.key === undefined || attributes.value === undefined) {
-          console.error('vstorage state_change missing "key" and/or "value"');
-          return;
-        }
+      return { path, value: attributes.value };
+    });
 
-        // Filter for ymax portfolio paths.
-        const path = encodedKeyToPath(attributes.key);
-        if (!vstoragePathStartsWith(path, VSTORAGE_PATH_PREFIX)) return;
-
-        return { path, value: attributes.value };
-      });
-
-      // Detect new portfolios.
-      for (const { path, value: vstorageValue } of portfolioVstorageEvents) {
-        const streamCell = tryJsonParse(
-          vstorageValue,
-          _err =>
-            Fail`non-JSON value at vstorage path ${q(path)}: ${vstorageValue}`,
-        );
-        mustMatch(harden(streamCell), StreamCellShape);
-        if (path === VSTORAGE_PATH_PREFIX) {
-          for (let i = 0; i < streamCell.values.length; i += 1) {
-            const strValue = streamCell.values[i];
-            const value = tryJsonParse(
-              // @ts-expect-error use `undefined` to force an error for non-string input
-              typeof strValue === 'string' ? strValue : undefined,
-              _err =>
-                Fail`non-JSON StreamCell value for ${q(path)} index ${q(i)}: ${strValue}`,
+    // Detect new portfolios.
+    for (const { path, value: vstorageValue } of portfolioVstorageEvents) {
+      const streamCell = tryJsonParse(
+        vstorageValue,
+        _err =>
+          Fail`non-JSON value at vstorage path ${q(path)}: ${vstorageValue}`,
+      );
+      mustMatch(harden(streamCell), StreamCellShape);
+      if (path === VSTORAGE_PATH_PREFIX) {
+        for (let i = 0; i < streamCell.values.length; i += 1) {
+          const strValue = streamCell.values[i];
+          const value = tryJsonParse(
+            // @ts-expect-error use `undefined` to force an error for non-string input
+            typeof strValue === 'string' ? strValue : undefined,
+            _err =>
+              Fail`non-JSON StreamCell value for ${q(path)} index ${q(i)}: ${strValue}`,
+          );
+          const portfoliosData = vstorageKit.marshaller.fromCapData(
+            value,
+          ) as StatusFor['portfolios'];
+          if (portfoliosData.addPortfolio) {
+            const key = portfoliosData.addPortfolio;
+            console.warn('Detected new portfolio', key);
+            // XXX we should probably read at streamCell.blockHeight.
+            const status = await vstorageKit.readPublished(
+              `${stripPrefix('published.', VSTORAGE_PATH_PREFIX)}.${key}`,
             );
-            const portfoliosData = vstorageKit.marshaller.fromCapData(
-              value,
-            ) as StatusFor['portfolios'];
-            if (portfoliosData.addPortfolio) {
-              const key = portfoliosData.addPortfolio;
-              console.warn('Detected new portfolio', key);
-              // XXX we should probably read at streamCell.blockHeight.
-              const status = await vstorageKit.readPublished(
-                `${stripPrefix('published.', VSTORAGE_PATH_PREFIX)}.${key}`,
-              );
-              mustMatch(status, PortfolioStatusShapeExt, key);
-              const { depositAddress } = status;
-              if (!depositAddress) continue;
-              portfolioKeyForDepositAddr.set(depositAddress, key);
-              console.warn('Added new portfolio', key, depositAddress);
-            }
+            mustMatch(status, PortfolioStatusShapeExt, key);
+            const { depositAddress } = status;
+            if (!depositAddress) continue;
+            portfolioKeyForDepositAddr.set(depositAddress, key);
+            console.warn('Added new portfolio', key, depositAddress);
           }
         }
-        // TODO: Handle portfolio-level path `${VSTORAGE_PATH_PREFIX}.${portfolioKey}` for addition/update of depositAddress.
       }
-
-      // Detect activity against portfolio deposit addresses.
-      const addrsWithActivity: Bech32Address[] = [
-        ...new Set([
-          ...((respEvents['coin_received.receiver'] as Bech32Address[]) || []),
-          ...((respEvents['coin_spent.spender'] as Bech32Address[]) || []),
-          ...((respEvents['transfer.recipient'] as Bech32Address[]) || []),
-          ...((respEvents['transfer.sender'] as Bech32Address[]) || []),
-        ]),
-      ];
-      const depositAddrsWithActivity = new Map(
-        partialMap(addrsWithActivity, addr => {
-          const portfolioKey = portfolioKeyForDepositAddr.get(addr);
-          return portfolioKey ? [addr, portfolioKey] : undefined;
-        }),
-      );
-
-      const addrBalances = new Map() as Map<Bech32Address, Coin[]>;
-      await makeWorkPool(addrsWithActivity, undefined, async addr => {
-        const balancesResp = await cosmosRest.getAccountBalances(
-          'agoric',
-          addr,
-        );
-        addrBalances.set(addr, balancesResp.balances);
-      }).done;
-      console.log(
-        inspect(
-          {
-            addrsWithActivity,
-            addrBalances,
-            depositAddrsWithActivity,
-            portfolioVstorageEvents,
-          },
-          { depth: 10 },
-        ),
-      );
-
-      const vbankAssets = new Map<string, AssetInfo>(
-        depositAddrsWithActivity.size
-          ? await vstorageKit.readPublished('agoricNames.vbankAsset')
-          : undefined,
-      );
-
-      // Respond to deposits.
-      const portfolioOps = await Promise.all(
-        [...depositAddrsWithActivity.entries()].map(
-          async ([addr, portfolioKey]) => {
-            // TODO: maybe snapshot initial balances for deposit amount determination?
-            // For now, require a single denom and assume that the full amount is a new deposit.
-            const balances = addrBalances.get(addr);
-            if (balances?.length !== 1) {
-              console.error(
-                `Unclear which denom to handle for ${addr}`,
-                balances?.map(amount => amount.denom),
-              );
-              return;
-            }
-            const { denom, amount: balanceValue } = balances[0];
-
-            const brand = vbankAssets.get(denom)?.brand as
-              | undefined
-              | Brand<'nat'>;
-            if (!brand) throw Fail`no brand found for denom ${q(denom)}`;
-            const amount = AmountMath.make(brand, Nat(BigInt(balanceValue)));
-
-            const unprefixedPortfolioPath = stripPrefix(
-              'published.',
-              `${VSTORAGE_PATH_PREFIX}.${portfolioKey}`,
-            );
-
-            const steps = await handleDeposit(
-              amount,
-              unprefixedPortfolioPath as any,
-              vstorageKit.readPublished,
-              spectrum,
-              cosmosRest,
-            );
-
-            // TODO: consolidate with portfolioIdOfPath
-            const portfolioId = parseInt(
-              stripPrefix(`portfolio`, portfolioKey),
-              10,
-            );
-
-            return { portfolioId, steps };
-          },
-        ),
-      );
-
-      for (const { portfolioId, steps } of portfolioOps.filter(x => !!x)) {
-        const action: InvokeStoreEntryAction = harden({
-          method: 'invokeEntry',
-          message: {
-            targetName: 'planner',
-            method: 'submit',
-            args: [portfolioId, steps],
-          },
-        });
-
-        console.log('submitting action', action);
-        const result = await submitAction(action, {
-          stargateClient,
-          walletKit,
-          skipPoll: true,
-          address: plannerAddress,
-        });
-        console.log('result', result);
-      }
+      // TODO: Handle portfolio-level path `${VSTORAGE_PATH_PREFIX}.${portfolioKey}` for addition/update of depositAddress.
     }
-  } finally {
-    console.warn('Terminating...');
-    rpc.close();
+
+    // Detect activity against portfolio deposit addresses.
+    const addrsWithActivity: Bech32Address[] = [
+      ...new Set([
+        ...((respEvents['coin_received.receiver'] as Bech32Address[]) || []),
+        ...((respEvents['coin_spent.spender'] as Bech32Address[]) || []),
+        ...((respEvents['transfer.recipient'] as Bech32Address[]) || []),
+        ...((respEvents['transfer.sender'] as Bech32Address[]) || []),
+      ]),
+    ];
+    const depositAddrsWithActivity = new Map(
+      partialMap(addrsWithActivity, addr => {
+        const portfolioKey = portfolioKeyForDepositAddr.get(addr);
+        return portfolioKey ? [addr, portfolioKey] : undefined;
+      }),
+    );
+
+    const addrBalances = new Map() as Map<Bech32Address, Coin[]>;
+    await makeWorkPool(addrsWithActivity, undefined, async addr => {
+      const balancesResp = await cosmosRest.getAccountBalances('agoric', addr);
+      addrBalances.set(addr, balancesResp.balances);
+    }).done;
+    console.log(
+      inspect(
+        {
+          addrsWithActivity,
+          addrBalances,
+          depositAddrsWithActivity,
+          portfolioVstorageEvents,
+        },
+        { depth: 10 },
+      ),
+    );
+
+    const vbankAssets = new Map<string, AssetInfo>(
+      depositAddrsWithActivity.size
+        ? await vstorageKit.readPublished('agoricNames.vbankAsset')
+        : undefined,
+    );
+
+    // Respond to deposits.
+    const portfolioOps = await Promise.all(
+      [...depositAddrsWithActivity.entries()].map(
+        async ([addr, portfolioKey]) => {
+          // TODO: maybe snapshot initial balances for deposit amount determination?
+          // For now, require a single denom and assume that the full amount is a new deposit.
+          const balances = addrBalances.get(addr);
+          if (balances?.length !== 1) {
+            console.error(
+              `Unclear which denom to handle for ${addr}`,
+              balances?.map(amount => amount.denom),
+            );
+            return;
+          }
+          const { denom, amount: balanceValue } = balances[0];
+
+          const brand = vbankAssets.get(denom)?.brand as
+            | undefined
+            | Brand<'nat'>;
+          if (!brand) throw Fail`no brand found for denom ${q(denom)}`;
+          const amount = AmountMath.make(brand, Nat(BigInt(balanceValue)));
+
+          const unprefixedPortfolioPath = stripPrefix(
+            'published.',
+            `${VSTORAGE_PATH_PREFIX}.${portfolioKey}`,
+          );
+
+          const steps = await handleDeposit(
+            amount,
+            unprefixedPortfolioPath as any,
+            vstorageKit.readPublished,
+            spectrum,
+            cosmosRest,
+          );
+
+          // TODO: consolidate with portfolioIdOfPath
+          const portfolioId = parseInt(
+            stripPrefix(`portfolio`, portfolioKey),
+            10,
+          );
+
+          return { portfolioId, steps };
+        },
+      ),
+    );
+
+    for (const { portfolioId, steps } of portfolioOps.filter(x => !!x)) {
+      const action: InvokeStoreEntryAction = harden({
+        method: 'invokeEntry',
+        message: {
+          targetName: 'planner',
+          method: 'submit',
+          args: [portfolioId, steps],
+        },
+      });
+
+      console.log('submitting action', action);
+      const result = await submitAction(action, {
+        stargateClient,
+        walletKit,
+        skipPoll: true,
+        address: plannerAddress,
+      });
+      console.log('result', result);
+    }
   }
+
+  console.warn('Terminating...');
 };
 harden(startEngine);

--- a/packages/ymax-planner/src/engine.ts
+++ b/packages/ymax-planner/src/engine.ts
@@ -429,7 +429,6 @@ export const startEngine = async ({
           if (portfoliosData.addPortfolio) {
             const key = portfoliosData.addPortfolio;
             console.warn('Detected new portfolio', key);
-            // XXX we should probably read at streamCell.blockHeight.
             const status = await vstorageKit.readPublished(
               `${stripPrefix('published.', VSTORAGE_PATH_PREFIX)}.${key}`,
             );


### PR DESCRIPTION
## Description
Update packages/ymax-planner/src/cosmos-rpc.ts CosmosRPCClient `subscribeAll` to provide an initial empty iteration result indicating subscription readiness, and use that to defer the initial state capture in packages/ymax-planner/src/engine.ts.
Also includes miscellaneous cleanup:
* Validate input before making new Promises
* Clarify "query" syntax and semantics, including links to CometBFT documentation

### Security Considerations
None known.

### Scaling Considerations
n/a, ymax-planner subscription count is already limited to 5 and initial state is collected immediately after detecting subscription readiness so there will be minimal buffering of the latter's results.

### Documentation Considerations
n/a

### Testing Considerations
Skipped for now.

### Upgrade Considerations
n/a