### PR TITLE
chore: Add core-eval for terminating the remaining old price_feed vats

### DIFF
--- a/golang/cosmos/app/upgrade.go
+++ b/golang/cosmos/app/upgrade.go
@@ -211,8 +211,8 @@ func makeUnreleasedUpgradeHandler(app *GaiaApp, targetUpgrade string) upgradetyp
 
 			// terminationTargets is a slice of "$boardID:$instanceKitLabel" strings.
 			var terminationTargets []string
-			switch getVariantFromUpgradeName(targetUpgrade) {
-			case "MAINNET":
+			switch ctx.ChainID() {
+			case "agoric-3": // MAINNET
 				terminationTargets = []string{
 					// v29 "zcf-b1-4522b-ATOM-USD_price_feed"
 					"board02963:ATOM-USD_price_feed",

--- a/golang/cosmos/app/upgrade.go
+++ b/golang/cosmos/app/upgrade.go
@@ -209,6 +209,33 @@ func makeUnreleasedUpgradeHandler(app *GaiaApp, targetUpgrade string) upgradetyp
 				return nil, err
 			}
 
+			// terminationTargets is a slice of "$boardID:$instanceKitLabel" strings.
+			var terminationTargets []string
+			switch getVariantFromUpgradeName(targetUpgrade) {
+			case "MAINNET":
+				terminationTargets = []string{
+					// v29 "zcf-b1-4522b-ATOM-USD_price_feed"
+					"board02963:ATOM-USD_price_feed",
+					// v68 "zcf-b1-4522b-stATOM-USD_price_feed"
+					"board012113:stATOM-USD_price_feed",
+					// v98 "zcf-b1-4522b-stOSMO-USD_price_feed"
+					"board002164:stOSMO-USD_price_feed",
+					// v104 "zcf-b1-4522b-stTIA-USD_price_feed"
+					"board043173:stTIA-USD_price_feed",
+				}
+			}
+			if len(terminationTargets) > 0 {
+				terminationStep, err := buildProposalStepWithArgs(
+					"@agoric/vats/src/proposals/terminate-governed-instance.js",
+					// defaultProposalBuilder(powers, targets)
+					"defaultProposalBuilder",
+					terminationTargets,
+				)
+				if err != nil {
+					return module.VersionMap{}, err
+				}
+				CoreProposalSteps = append(CoreProposalSteps, terminationStep)
+			}
 		}
 
 		app.upgradeDetails = &upgradeDetails{


### PR DESCRIPTION
...and their governors

Ref #9483
Fixes #11775

## Description

"$boardID:$instanceKitLabel" strings:
* v29: "board02963:ATOM-USD_price_feed"
* v68: "board012113:stATOM-USD_price_feed"
* v98: "board002164:stOSMO-USD_price_feed"
* v104: "board043173:stTIA-USD_price_feed"

<details><summary>Discovery of "$boardID:$instanceKitLabel" strings</summary>

```console
$ ./packages/cosmic-swingset/tools/inquisitor.mjs mainnet-pre-u21.sqlite
Loading slog sender modules: @agoric/telemetry/src/flight-recorder.js
Launching SwingSet kernel
buildSwingset
[bridge] received { args: [ 'highPriorityQueue.tail' ], method: 'get' }
[bridge] received { args: [ 'highPriorityQueue.head' ], method: 'get' }
[bridge] received { args: [ 'actionQueue.tail' ], method: 'get' }
[bridge] received { args: [ 'actionQueue.head' ], method: 'get' }
Launched SwingSet kernel
endowments: kvStore swingStore getLastBlockInfo pushQueueRecord pushCoreEval runNextBlock EV controller krefOf kser kslot kunser mutations runCoreEval stable
endowments.stable: db getRefs kvGet kvGetJSON kvGlob scanVatStore vatsByID vatsByName
> cmp = (a, b) => a < b ? -1 : a > b ? 1 : 0;
[Function: cmp]
> partialMapVats = fn => [...stable.vatsByID.values()].flatMap(vat => [fn(vat)].filter(x => x));
[Function: partialMapVats]
> console.table(
    partialMapVats(({ vatID, name }) => name.endsWith('price_feed') && { vatID, name })
    .sort((a, b) => cmp(+a.vatID.slice(1), +b.vatID.slice(1)))
  )
┌─────────┬────────┬────────────────────────────────────────┐
│ (index) │ vatID  │ name                                   │
├─────────┼────────┼────────────────────────────────────────┤
│ 0       │ 'v29'  │ 'zcf-b1-4522b-ATOM-USD_price_feed'     │
│ 1       │ 'v68'  │ 'zcf-b1-4522b-stATOM-USD_price_feed'   │
│ 2       │ 'v98'  │ 'zcf-b1-4522b-stOSMO-USD_price_feed'   │
│ 3       │ 'v104' │ 'zcf-b1-4522b-stTIA-USD_price_feed'    │
│ 4       │ 'v111' │ 'zcf-b1-4522b-stkATOM-USD_price_feed'  │
│ 5       │ 'v192' │ 'zcf-b1-991f5f-ATOM-USD_price_feed'    │
│ 6       │ 'v194' │ 'zcf-b1-991f5f-stATOM-USD_price_feed'  │
│ 7       │ 'v196' │ 'zcf-b1-991f5f-stOSMO-USD_price_feed'  │
│ 8       │ 'v198' │ 'zcf-b1-991f5f-stTIA-USD_price_feed'   │
│ 9       │ 'v200' │ 'zcf-b1-991f5f-stkATOM-USD_price_feed' │
│ 10      │ 'v218' │ 'zcf-b1-eca5eb-dATOM-USD_price_feed'   │
└─────────┴────────┴────────────────────────────────────────┘
undefined
> // price_feed vats come in generations, and vatIDs suggest 4522b → 991f5f → eca5eb
undefined
> // v111 was terminated just after this snapshot, but let's inspect importers for the others.
undefined
> getImporters = exporterVatID => {
    const exports = new Set(stable.kvGlob(`${exporterVatID}.c.*+*`, 'ko*').map(kv => kv.value));
    return partialMapVats(({ vatID }) => {
      if (vatID === exporterVatID) return;
      const imports = stable.kvGlob(`${vatID}.c.*`, 'ko*', true);
      for (const { value } of imports) {
        if (exports.has(value)) return vatID;
      }
    });
  };
[Function: getImporters]
> importerData = partialMapVats(
    ({ vatID, name }) => name.endsWith('price_feed') && vatID !== 'v111' && { vatID, name }
  )
  .sort((a, b) => cmp(+a.vatID.slice(1), +b.vatID.slice(1)))
  .map(({ vatID, name }) => ({
    vatID,
    name,
    importers: new Map(
      getImporters(vatID).map(importer => [importer, stable.vatsByID.get(importer).name])
    ),
  }))
[
  {
    vatID: 'v29',
    name: 'zcf-b1-4522b-ATOM-USD_price_feed',
    importers: Map(6) {
      'v1' => 'bootstrap',
      'v7' => 'board',
      'v9' => 'zoe',
      'v26' => 'zcf-b1-9f877-ATOM-USD_price_feed-governor',
      'v43' => 'zcf-b1-94e20-walletFactory',
      'v46' => 'zcf-b1-0b217-scaledPriceAuthority-ATOM'
    }
  },
  {
    vatID: 'v68',
    name: 'zcf-b1-4522b-stATOM-USD_price_feed',
    importers: Map(6) {
      'v1' => 'bootstrap',
      'v7' => 'board',
      'v9' => 'zoe',
      'v43' => 'zcf-b1-94e20-walletFactory',
      'v67' => 'zcf-b1-9f877-stATOM-USD_price_feed-governor',
      'v69' => 'zcf-b1-0b217-scaledPriceAuthority-stATOM'
    }
  },
  {
    vatID: 'v98',
    name: 'zcf-b1-4522b-stOSMO-USD_price_feed',
    importers: Map(6) {
      'v1' => 'bootstrap',
      'v7' => 'board',
      'v9' => 'zoe',
      'v43' => 'zcf-b1-94e20-walletFactory',
      'v97' => 'zcf-b1-9f877-stOSMO-USD_price_feed-governor',
      'v99' => 'zcf-b1-0b217-scaledPriceAuthority-stOSMO'
    }
  },
  {
    vatID: 'v104',
    name: 'zcf-b1-4522b-stTIA-USD_price_feed',
    importers: Map(6) {
      'v1' => 'bootstrap',
      'v7' => 'board',
      'v9' => 'zoe',
      'v43' => 'zcf-b1-94e20-walletFactory',
      'v103' => 'zcf-b1-9f877-stTIA-USD_price_feed-governor',
      'v105' => 'zcf-b1-0b217-scaledPriceAuthority-stTIA'
    }
  },
  {
    vatID: 'v192',
    name: 'zcf-b1-991f5f-ATOM-USD_price_feed',
    importers: Map(7) {
      'v1' => 'bootstrap',
      'v7' => 'board',
      'v8' => 'priceAuthority',
      'v9' => 'zoe',
      'v43' => 'zcf-b1-94e20-walletFactory',
      'v191' => 'zcf-b1-9f877-ATOM-USD_price_feed-governor',
      'v201' => 'zcf-b1-affe49-scaledPriceAuthority-ATOM'
    }
  },
  {
    vatID: 'v194',
    name: 'zcf-b1-991f5f-stATOM-USD_price_feed',
    importers: Map(7) {
      'v1' => 'bootstrap',
      'v7' => 'board',
      'v8' => 'priceAuthority',
      'v9' => 'zoe',
      'v43' => 'zcf-b1-94e20-walletFactory',
      'v193' => 'zcf-b1-9f877-stATOM-USD_price_feed-governor',
      'v202' => 'zcf-b1-affe49-scaledPriceAuthority-stATOM'
    }
  },
  {
    vatID: 'v196',
    name: 'zcf-b1-991f5f-stOSMO-USD_price_feed',
    importers: Map(7) {
      'v1' => 'bootstrap',
      'v7' => 'board',
      'v8' => 'priceAuthority',
      'v9' => 'zoe',
      'v43' => 'zcf-b1-94e20-walletFactory',
      'v195' => 'zcf-b1-9f877-stOSMO-USD_price_feed-governor',
      'v203' => 'zcf-b1-affe49-scaledPriceAuthority-stOSMO'
    }
  },
  {
    vatID: 'v198',
    name: 'zcf-b1-991f5f-stTIA-USD_price_feed',
    importers: Map(7) {
      'v1' => 'bootstrap',
      'v7' => 'board',
      'v8' => 'priceAuthority',
      'v9' => 'zoe',
      'v43' => 'zcf-b1-94e20-walletFactory',
      'v197' => 'zcf-b1-9f877-stTIA-USD_price_feed-governor',
      'v204' => 'zcf-b1-affe49-scaledPriceAuthority-stTIA'
    }
  },
  {
    vatID: 'v200',
    name: 'zcf-b1-991f5f-stkATOM-USD_price_feed',
    importers: Map(7) {
      'v1' => 'bootstrap',
      'v7' => 'board',
      'v8' => 'priceAuthority',
      'v9' => 'zoe',
      'v43' => 'zcf-b1-94e20-walletFactory',
      'v199' => 'zcf-b1-9f877-stkATOM-USD_price_feed-governor',
      'v205' => 'zcf-b1-affe49-scaledPriceAuthority-stkATOM'
    }
  },
  {
    vatID: 'v218',
    name: 'zcf-b1-eca5eb-dATOM-USD_price_feed',
    importers: Map(7) {
      'v1' => 'bootstrap',
      'v7' => 'board',
      'v8' => 'priceAuthority',
      'v9' => 'zoe',
      'v43' => 'zcf-b1-94e20-walletFactory',
      'v216' => 'zcf-b1-f8e26-scaledPriceAuthority-dATOM',
      'v217' => 'zcf-b1-9f877-dATOM-USD_price_feed-governor'
    }
  }
]
> commonImporters =
    [...importerData[0].importers.keys()]
    .filter(k => importerData.every(obj => obj.importers.has(k)))
[ 'v1', 'v7', 'v9', 'v43' ]
> uniqueImporterData = importerData.map(({ vatID, name, importers }) => ({
    vatID,
    name,
    uniqueImporters: new Map(
      [...importers.entries()]
      .filter(([importer]) => !commonImporters.includes(importer))
    ),
  }))
[
  {
    vatID: 'v29',
    name: 'zcf-b1-4522b-ATOM-USD_price_feed',
    uniqueImporters: Map(2) {
      'v26' => 'zcf-b1-9f877-ATOM-USD_price_feed-governor',
      'v46' => 'zcf-b1-0b217-scaledPriceAuthority-ATOM'
    }
  },
  {
    vatID: 'v68',
    name: 'zcf-b1-4522b-stATOM-USD_price_feed',
    uniqueImporters: Map(2) {
      'v67' => 'zcf-b1-9f877-stATOM-USD_price_feed-governor',
      'v69' => 'zcf-b1-0b217-scaledPriceAuthority-stATOM'
    }
  },
  {
    vatID: 'v98',
    name: 'zcf-b1-4522b-stOSMO-USD_price_feed',
    uniqueImporters: Map(2) {
      'v97' => 'zcf-b1-9f877-stOSMO-USD_price_feed-governor',
      'v99' => 'zcf-b1-0b217-scaledPriceAuthority-stOSMO'
    }
  },
  {
    vatID: 'v104',
    name: 'zcf-b1-4522b-stTIA-USD_price_feed',
    uniqueImporters: Map(2) {
      'v103' => 'zcf-b1-9f877-stTIA-USD_price_feed-governor',
      'v105' => 'zcf-b1-0b217-scaledPriceAuthority-stTIA'
    }
  },
  {
    vatID: 'v192',
    name: 'zcf-b1-991f5f-ATOM-USD_price_feed',
    uniqueImporters: Map(3) {
      'v8' => 'priceAuthority',
      'v191' => 'zcf-b1-9f877-ATOM-USD_price_feed-governor',
      'v201' => 'zcf-b1-affe49-scaledPriceAuthority-ATOM'
    }
  },
  {
    vatID: 'v194',
    name: 'zcf-b1-991f5f-stATOM-USD_price_feed',
    uniqueImporters: Map(3) {
      'v8' => 'priceAuthority',
      'v193' => 'zcf-b1-9f877-stATOM-USD_price_feed-governor',
      'v202' => 'zcf-b1-affe49-scaledPriceAuthority-stATOM'
    }
  },
  {
    vatID: 'v196',
    name: 'zcf-b1-991f5f-stOSMO-USD_price_feed',
    uniqueImporters: Map(3) {
      'v8' => 'priceAuthority',
      'v195' => 'zcf-b1-9f877-stOSMO-USD_price_feed-governor',
      'v203' => 'zcf-b1-affe49-scaledPriceAuthority-stOSMO'
    }
  },
  {
    vatID: 'v198',
    name: 'zcf-b1-991f5f-stTIA-USD_price_feed',
    uniqueImporters: Map(3) {
      'v8' => 'priceAuthority',
      'v197' => 'zcf-b1-9f877-stTIA-USD_price_feed-governor',
      'v204' => 'zcf-b1-affe49-scaledPriceAuthority-stTIA'
    }
  },
  {
    vatID: 'v200',
    name: 'zcf-b1-991f5f-stkATOM-USD_price_feed',
    uniqueImporters: Map(3) {
      'v8' => 'priceAuthority',
      'v199' => 'zcf-b1-9f877-stkATOM-USD_price_feed-governor',
      'v205' => 'zcf-b1-affe49-scaledPriceAuthority-stkATOM'
    }
  },
  {
    vatID: 'v218',
    name: 'zcf-b1-eca5eb-dATOM-USD_price_feed',
    uniqueImporters: Map(3) {
      'v8' => 'priceAuthority',
      'v216' => 'zcf-b1-f8e26-scaledPriceAuthority-dATOM',
      'v217' => 'zcf-b1-9f877-dATOM-USD_price_feed-governor'
    }
  }
]
> console.table(
    uniqueImporterData.map(({ vatID, name, uniqueImporters }) => {
      const vatIdFromPartialName = inName =>
        [...uniqueImporters.entries()].find(entry => entry[1].includes(inName))?.[0];
      const governor = vatIdFromPartialName("-governor");
      const scaledPriceAuthority = vatIdFromPartialName("-scaledPriceAuthority-");
      const priceAuthority = vatIdFromPartialName("priceAuthority");
      return { vatID, name, governor, scaledPriceAuthority, priceAuthority };
    })
  )
┌─────────┬────────┬────────────────────────────────────────┬──────────┬──────────────────────┬────────────────┐
│ (index) │ vatID  │ name                                   │ governor │ scaledPriceAuthority │ priceAuthority │
├─────────┼────────┼────────────────────────────────────────┼──────────┼──────────────────────┼────────────────┤
│ 0       │ 'v29'  │ 'zcf-b1-4522b-ATOM-USD_price_feed'     │ 'v26'    │ 'v46'                │ undefined      │
│ 1       │ 'v68'  │ 'zcf-b1-4522b-stATOM-USD_price_feed'   │ 'v67'    │ 'v69'                │ undefined      │
│ 2       │ 'v98'  │ 'zcf-b1-4522b-stOSMO-USD_price_feed'   │ 'v97'    │ 'v99'                │ undefined      │
│ 3       │ 'v104' │ 'zcf-b1-4522b-stTIA-USD_price_feed'    │ 'v103'   │ 'v105'               │ undefined      │
│ 4       │ 'v192' │ 'zcf-b1-991f5f-ATOM-USD_price_feed'    │ 'v191'   │ 'v201'               │ 'v8'           │
│ 5       │ 'v194' │ 'zcf-b1-991f5f-stATOM-USD_price_feed'  │ 'v193'   │ 'v202'               │ 'v8'           │
│ 6       │ 'v196' │ 'zcf-b1-991f5f-stOSMO-USD_price_feed'  │ 'v195'   │ 'v203'               │ 'v8'           │
│ 7       │ 'v198' │ 'zcf-b1-991f5f-stTIA-USD_price_feed'   │ 'v197'   │ 'v204'               │ 'v8'           │
│ 8       │ 'v200' │ 'zcf-b1-991f5f-stkATOM-USD_price_feed' │ 'v199'   │ 'v205'               │ 'v8'           │
│ 9       │ 'v218' │ 'zcf-b1-eca5eb-dATOM-USD_price_feed'   │ 'v217'   │ 'v216'               │ 'v8'           │
└─────────┴────────┴────────────────────────────────────────┴──────────┴──────────────────────┴────────────────┘
undefined
> // Let's target the vats not referenced by v8 priceAuthority.
undefined
> scanVatStore = refObj =>
    stable.kvGlob(`${refObj.vatID}.vs.*`, `*${refObj.vref}*`)
    .filter(kv => kv.value.match(RegExp(String.raw`\b${refObj.vref}\b`)));
[Function: scanVatStore]
> getRefs = kvEntry =>
    stable.getRefs(kvEntry.key.replace(/.*[.](.*:)?/, ""), kvEntry.key.split(".")[0])
    .map(({ vatID, ...data }) => ({
      vatID,
      vatName: stable.vatsByID.get(vatID).name,
      ...data,
      ...(data.kind ? { value: kvEntry.value } : {})
    }));
[Function: getRefs]
> logTable = (values, colCount) => console.table(
    values.reduce((rows, value) => {
      const lastRow = rows.at(-1);
      if (lastRow?.length < colCount) {
        lastRow.push(value);
      } else {
        rows.push([value]);
      }
      return rows;
    }, [])
  )
[Function: logTable]
> logTable(Object.keys( ({ M, matches, mustMatch } = await import("@endo/patterns")).M ).sort(), 6)
┌─────────┬────────────────┬──────────────┬───────────────┬─────────────┬───────────┬────────────┐
│ (index) │ 0              │ 1            │ 2             │ 3           │ 4         │ 5          │
├─────────┼────────────────┼──────────────┼───────────────┼─────────────┼───────────┼────────────┤
│ 0       │ 'and'          │ 'any'        │ 'array'       │ 'arrayOf'   │ 'await'   │ 'bag'      │
│ 1       │ 'bagOf'        │ 'bigint'     │ 'boolean'     │ 'byteArray' │ 'call'    │ 'callWhen' │
│ 2       │ 'containerHas' │ 'eq'         │ 'eref'        │ 'error'     │ 'gt'      │ 'gte'      │
│ 3       │ 'interface'    │ 'key'        │ 'kind'        │ 'lt'        │ 'lte'     │ 'map'      │
│ 4       │ 'mapOf'        │ 'nat'        │ 'neq'         │ 'not'       │ 'null'    │ 'number'   │
│ 5       │ 'opt'          │ 'or'         │ 'partial'     │ 'pattern'   │ 'promise' │ 'raw'      │
│ 6       │ 'record'       │ 'recordOf'   │ 'remotable'   │ 'scalar'    │ 'set'     │ 'setOf'    │
│ 7       │ 'split'        │ 'splitArray' │ 'splitRecord' │ 'string'    │ 'symbol'  │ 'tagged'   │
│ 8       │ 'undefined'    │              │               │             │           │            │
└─────────┴────────────────┴──────────────┴───────────────┴─────────────┴───────────┴────────────┘
undefined
> jsonMatches = (text, patt) => {
    try {
      return matches(harden(JSON.parse(text)), patt);
    } catch (_err) {
      return false;
    }
  };
[Function: jsonMatches]
> void ({ fromCapData } =
    await Promise.all([import("@agoric/client-utils"), import("@endo/far")]).then(
      ([{ boardSlottingMarshaller }, { Far }]) => {
        return boardSlottingMarshaller((slot, iface) => Far("SlotReference"));
      }
    )
  )
undefined
> terminationArgs = Object.fromEntries(
    ["v29", "v68", "v98", "v104"].map(vatID => {
      let lastKey;
      const $saved = {};
      const save = (key, thunk) => { lastKey = key; $saved[key] = thunk(); };
      try {
        save("vatAdminNodeRefs", () => getRefs( scanVatStore({ vatID: "v2", vref: vatID })[0] ));
        save(
          "zoeVatAdminNodeEntries",
          () => scanVatStore($saved.vatAdminNodeRefs.find(refObj => refObj.vatName === "zoe"))
        );
        const ZoeAdminFacetShape = M.splitRecord({
          adminNode: M.any(),
          contractBundleCap: M.any(),
        });
        const zoeAdminFacetEntry = $saved.zoeVatAdminNodeEntries.find(
          kvEntry => jsonMatches(kvEntry.value, ZoeAdminFacetShape)
        );
        save("zoeAdminFacetRefs", () => getRefs(zoeAdminFacetEntry));
        save(
          "bootstrapAdminFacetEntries",
          () =>
            scanVatStore($saved.zoeAdminFacetRefs.find(refObj => refObj.vatName === "bootstrap"))
        );
        // We remember from aeb35aa2e3c3d45895c72efeb2002f36639a91ea that
        // v1 bootstrap virtual collection 8 is Bootstrap Powers "governedContractKits".
        const governedContractKitEntry =
          $saved.bootstrapAdminFacetEntries.find(kvEntry => kvEntry.key.startsWith("v1.vs.vc.8."));
        save("governedContractKitRefs", () => getRefs(governedContractKitEntry));
        save(
          "boardGckEntries",
          () =>
            scanVatStore($saved.governedContractKitRefs.find(refObj => refObj.vatName === "board"))
        );
        save("boardId", () => $saved.boardGckEntries[0].key.replace(/.*sboard/, "board"));
        assert($saved.boardId.match(/^board0[0-9]+$/));
        const gckExportObj = $saved.governedContractKitRefs.find(refObj => refObj.kind);
        save("kitLabel", () => fromCapData(JSON.parse(gckExportObj.value)).label);
        return [vatID, `${$saved.boardId}:${$saved.kitLabel}`];
      } catch (err) {
        return [vatID, { failure: `Failed to save ${lastKey}`, cause: err.message, $saved }];
      }
    })
  )
{
  v29: 'board02963:ATOM-USD_price_feed',
  v68: 'board012113:stATOM-USD_price_feed',
  v98: 'board002164:stOSMO-USD_price_feed',
  v104: 'board043173:stTIA-USD_price_feed'
}
> // Test termination by manually bundling and invoking @agoric/vats/src/proposals/terminate-governed-instance.js.
undefined
> void ({ default: bundleSource } = await import("@endo/bundle-source"))
undefined
> (terminateGovernedModuleSource = (
    await bundleSource(
      "./packages/vats/src/proposals/terminate-governed-instance.js",
      { format: "getExport" },
    )
  ).source).length
492580
> runTerminateGoverned = targetSpecifiers => runCoreEval(`async powers => {
    const moduleSource = ${JSON.stringify(terminateGovernedModuleSource)};
    const { terminateGoverned } = (new Compartment(globalThis)).evaluate(moduleSource)();
    await terminateGoverned(powers, {
      options: { targetSpecifiers: ${JSON.stringify(targetSpecifiers)} }
    });
  }`);
[Function: runTerminateGoverned]
> await runTerminateGoverned([terminationArgs.v104]);
----- terminate-governed-instance ["board043173","stTIA-USD_price_feed"].2  2 alleged governed contract instance kit { adminFacet: Object [Alleged: adminFacet] {}, creatorFacet: Object [Alleged: fluxAggregator creator] {}, governor: Object [Alleged: InstanceHandle] {}, governorAdminFacet: Object [Alleged: adminFacet] {}, governorCreatorFacet: Object [Alleged: ContractGovernorKit creator] {}, instance: Object [Alleged: InstanceHandle] {}, label: 'stTIA-USD_price_feed', publicFacet: Object [Alleged: fluxAggregator public] {} }
----- terminate-governed-instance ["board043173","stTIA-USD_price_feed"].2  3 governor terms { brands: {}, governed: { issuerKeywordRecord: undefined, label: 'stTIA-USD_price_feed', terms: { POLL_INTERVAL: 30n, brandIn: Object [Alleged: Brand] {}, brandOut: Object [Alleged: Brand] {}, description: 'stTIA-USD price feed', governedParams: { Electorate: { type: 'invitation', value: [Object] } }, maxSubmissionCount: 1000, maxSubmissionValue: 115_792_089_237_316_195_423_570_985_008_687_907_853_269_984_665_640_564_039_457_584_007_913_129_639_936n, minSubmissionCount: 2, minSubmissionValue: 1n, restartDelay: 1, timeout: 10, timer: Object [Alleged: timerService] {}, unitAmountIn: { brand: Object [Alleged: Brand] {}, value: 1_000_000n } } }, governedContractInstallation: Object [Alleged: BundleIDInstallation] {}, issuers: {}, timer: Object [Alleged: timerService] {} }
----- terminate-governed-instance ["board043173","stTIA-USD_price_feed"].2  4 instance adminFacet from governor Object [Alleged: adminFacet] {}
Logging sent error stack (Error#9)
Error#9: governed contract ["board043173","stTIA-USD_price_feed"] terminated by terminate-governed-instance
Error: governed contract ["board043173","stTIA-USD_price_feed"] terminated by terminate-governed-instance
 at apply ()
 at Error (/bundled-source/.../node_modules/ses/src/error/tame-error-constructor.js:54)
 at (#30071:14167)
 at (#30071:14160)
 at map ()
 at terminateGoverned (#30071:14160)
 at ()
 at ()

Error#9 ERROR_NOTE: Sent as error:liveSlots:v1#70007
Logging sent error stack (RemoteError(error:liveSlots:v1#70007)#7482)
RemoteError(error:liveSlots:v1#70007)#7482: governed contract ["board043173","stTIA-USD_price_feed"] terminated by terminate-governed-instance
Error: governed contract ["board043173","stTIA-USD_price_feed"] terminated by terminate-governed-instance
 at apply ()
 at Error (/bundled-source/.../node_modules/ses/src/error/tame-error-constructor.js:60)
 at makeError (/bundled-source/.../node_modules/ses/src/error/assert.js:352)
 at decodeErrorCommon (/bundled-source/.../node_modules/@endo/marshal/src/marshal.js:309)
 at decodeFromSmallcaps (/bundled-source/.../node_modules/@endo/marshal/src/encodeToSmallcaps.js:437)
 at map ()
 at map ()
 at fromCapData (/bundled-source/.../node_modules/@endo/marshal/src/marshal.js:398)
 at deliver (/bundled-source/.../packages/swingset-liveslots/src/liveslots.js:895)
 at dispatchToUserspace (/bundled-source/.../packages/swingset-liveslots/src/liveslots.js:1331)
 at runWithoutMetering (/bundled-source/.../packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js:59)
 at ()

RemoteError(error:liveSlots:v1#70007)#7482 ERROR_NOTE: Sent as error:liveSlots:v9#77487
Logging sent error stack (RemoteError(error:liveSlots:v9#77487)#3)
RemoteError(error:liveSlots:v9#77487)#3: governed contract ["board043173","stTIA-USD_price_feed"] terminated by terminate-governed-instance
Error: governed contract ["board043173","stTIA-USD_price_feed"] terminated by terminate-governed-instance
 at construct ()
 at Error (/bundled-source/.../node_modules/ses/src/error/tame-error-constructor.js:56)
 at makeError (/bundled-source/.../node_modules/ses/src/error/assert.js:243)
 at decodeErrorCommon (/bundled-source/.../node_modules/@endo/marshal/src/marshal.js:281)
 at decodeFromSmallcaps (/bundled-source/.../node_modules/@endo/marshal/src/encodeToSmallcaps.js:434)
 at map ()
 at map ()
 at fromCapData (/bundled-source/.../node_modules/@endo/marshal/src/marshal.js:356)
 at deliver (/bundled-source/.../packages/swingset-liveslots/src/liveslots.js:1084)
 at dispatchToUserspace (/bundled-source/.../packages/swingset-liveslots/src/liveslots.js:1509)
 at runWithoutMetering (/bundled-source/.../packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js:60)
 at ()

RemoteError(error:liveSlots:v9#77487)#3 ERROR_NOTE: Sent as error:liveSlots:v2#70003
kernel terminating vat v104 (failure=true)

<--- Last few GCs --->

[494668:0x1f810f20] 57896362 ms: Scavenge 1998.4 (2079.8) -> 1998.1 (2079.3) MB, 2.61 / 0.00 ms  (average mu = 0.988, current mu = 0.987) allocation failure;
[494668:0x1f810f20] 57906028 ms: Scavenge 1998.8 (2079.3) -> 1998.5 (2080.5) MB, 3.15 / 0.00 ms  (average mu = 0.988, current mu = 0.987) allocation failure;
[494668:0x1f810f20] 57916526 ms: Mark-Compact 2074.9 (2156.1) -> 2023.8 (2103.0) MB, 1592.73 / 0.00 ms  (average mu = 0.980, current mu = 0.973) allocation failure; scavenge might not succeed

<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0xb8d11b node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node]
 2: 0xf01b70 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
 3: 0xf01e57 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
 4: 0x1113aa5  [node]
 5: 0x112b928 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
 6: 0x1101a41 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
 7: 0x1102bd5 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
 8: 0x10e0226 v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [node]
 9: 0x153c086 v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [node]
10: 0x7fb092699ef6
```

Fine, just verify that core-eval code sees the right things.
```console
$ ./packages/cosmic-swingset/tools/inquisitor.mjs mainnet-pre-u21.sqlite
Loading slog sender modules: @agoric/telemetry/src/flight-recorder.js
Launching SwingSet kernel
buildSwingset
[bridge] received { args: [ 'highPriorityQueue.tail' ], method: 'get' }
[bridge] received { args: [ 'highPriorityQueue.head' ], method: 'get' }
[bridge] received { args: [ 'actionQueue.tail' ], method: 'get' }
[bridge] received { args: [ 'actionQueue.head' ], method: 'get' }
Launched SwingSet kernel
endowments: kvStore swingStore getLastBlockInfo pushQueueRecord pushCoreEval runNextBlock EV controller krefOf kser kslot kunser mutations runCoreEval stable
endowments.stable: db getRefs kvGet kvGetJSON kvGlob scanVatStore vatsByID vatsByName
> terminationArgs = {
    v29: 'board02963:ATOM-USD_price_feed',
    v68: 'board012113:stATOM-USD_price_feed',
    v98: 'board002164:stOSMO-USD_price_feed',
    v104: 'board043173:stTIA-USD_price_feed'
  }
{
  v29: 'board02963:ATOM-USD_price_feed',
  v68: 'board012113:stATOM-USD_price_feed',
  v98: 'board002164:stOSMO-USD_price_feed',
  v104: 'board043173:stTIA-USD_price_feed'
}
> await runCoreEval(`async ({ consume: { board, governedContractKits: kits, zoe } }) => {
    const terminationArgs = ${JSON.stringify(Object.values(terminationArgs))};
    for (const arg of terminationArgs) {
      console.log("");
      console.log("@", arg);
      const handle = await E(board).getValue(arg.split(":")[0]);
      const kit = await E(kits).get(handle);
      const log = (label, obj) => {
        console.log(label);
        for (const [k, v] of Object.entries(obj)) console.log("  *", k, v);
      };
      log("kit", kit);
      const govTerms = await E(zoe).getTerms(kit.governor);
      log("governor terms", govTerms);
      console.log(
        "governor is",
        await E(kit.governorCreatorFacet).getAdminFacet().then(() => "live", err => err?.message)
      );
    }
  }`)

@ board02963:ATOM-USD_price_feed
kit
  * adminFacet Object [Alleged: adminFacet] {}
  * creatorFacet Object [Alleged: fluxAggregator creator] {}
  * governor Object [Alleged: InstanceHandle] {}
  * governorAdminFacet Object [Alleged: adminFacet] {}
  * governorCreatorFacet Object [Alleged: ContractGovernorKit creator] {}
  * instance Object [Alleged: InstanceHandle] {}
  * label ATOM-USD_price_feed
  * publicFacet Object [Alleged: fluxAggregator public] {}
governor terms
  * brands {}
  * governed { issuerKeywordRecord: undefined, label: 'ATOM-USD_price_feed', terms: { POLL_INTERVAL: 30, brandIn: Object [Alleged: Brand] {}, brandOut: Object [Alleged: Brand] {}, description: 'ATOM-USD price feed', governedParams: { Electorate: { type: 'invitation', value: { brand: [Object], value: [Array] } } }, maxSubmissionCount: 1000, maxSubmissionValue: 9007199254740991, minSubmissionCount: 3, minSubmissionValue: 1, restartDelay: 1, timeout: 10, timer: Object [Alleged: timerService] {}, unitAmountIn: { brand: Object [Alleged: Brand] {}, value: 1_000_000n } } }
  * governedContractInstallation Object [Alleged: BundleIDInstallation] {}
  * issuers {}
  * timer Object [Alleged: timerService] {}
governor is live

@ board012113:stATOM-USD_price_feed
kit
  * adminFacet Object [Alleged: adminFacet] {}
  * creatorFacet Object [Alleged: fluxAggregator creator] {}
  * governor Object [Alleged: InstanceHandle] {}
  * governorAdminFacet Object [Alleged: adminFacet] {}
  * governorCreatorFacet Object [Alleged: ContractGovernorKit creator] {}
  * instance Object [Alleged: InstanceHandle] {}
  * label stATOM-USD_price_feed
  * publicFacet Object [Alleged: fluxAggregator public] {}
governor terms
  * brands {}
  * governed { issuerKeywordRecord: undefined, label: 'stATOM-USD_price_feed', terms: { POLL_INTERVAL: 30n, brandIn: Object [Alleged: Brand] {}, brandOut: Object [Alleged: Brand] {}, description: 'stATOM-USD price feed', governedParams: { Electorate: { type: 'invitation', value: { brand: [Object], value: [Array] } } }, maxSubmissionCount: 1000, maxSubmissionValue: 115_792_089_237_316_195_423_570_985_008_687_907_853_269_984_665_640_564_039_457_584_007_913_129_639_936n, minSubmissionCount: 2, minSubmissionValue: 1n, restartDelay: 1, timeout: 10, timer: Object [Alleged: timerService] {}, unitAmountIn: { brand: Object [Alleged: Brand] {}, value: 1_000_000n } } }
  * governedContractInstallation Object [Alleged: BundleIDInstallation] {}
  * issuers {}
  * timer Object [Alleged: timerService] {}
governor is live

@ board002164:stOSMO-USD_price_feed
kit
  * adminFacet Object [Alleged: adminFacet] {}
  * creatorFacet Object [Alleged: fluxAggregator creator] {}
  * governor Object [Alleged: InstanceHandle] {}
  * governorAdminFacet Object [Alleged: adminFacet] {}
  * governorCreatorFacet Object [Alleged: ContractGovernorKit creator] {}
  * instance Object [Alleged: InstanceHandle] {}
  * label stOSMO-USD_price_feed
  * publicFacet Object [Alleged: fluxAggregator public] {}
governor terms
  * brands {}
  * governed { issuerKeywordRecord: undefined, label: 'stOSMO-USD_price_feed', terms: { POLL_INTERVAL: 30n, brandIn: Object [Alleged: Brand] {}, brandOut: Object [Alleged: Brand] {}, description: 'stOSMO-USD price feed', governedParams: { Electorate: { type: 'invitation', value: { brand: [Object], value: [Array] } } }, maxSubmissionCount: 1000, maxSubmissionValue: 115_792_089_237_316_195_423_570_985_008_687_907_853_269_984_665_640_564_039_457_584_007_913_129_639_936n, minSubmissionCount: 2, minSubmissionValue: 1n, restartDelay: 1, timeout: 10, timer: Object [Alleged: timerService] {}, unitAmountIn: { brand: Object [Alleged: Brand] {}, value: 1_000_000n } } }
  * governedContractInstallation Object [Alleged: BundleIDInstallation] {}
  * issuers {}
  * timer Object [Alleged: timerService] {}
governor is live

@ board043173:stTIA-USD_price_feed
kit
  * adminFacet Object [Alleged: adminFacet] {}
  * creatorFacet Object [Alleged: fluxAggregator creator] {}
  * governor Object [Alleged: InstanceHandle] {}
  * governorAdminFacet Object [Alleged: adminFacet] {}
  * governorCreatorFacet Object [Alleged: ContractGovernorKit creator] {}
  * instance Object [Alleged: InstanceHandle] {}
  * label stTIA-USD_price_feed
  * publicFacet Object [Alleged: fluxAggregator public] {}
governor terms
  * brands {}
  * governed { issuerKeywordRecord: undefined, label: 'stTIA-USD_price_feed', terms: { POLL_INTERVAL: 30n, brandIn: Object [Alleged: Brand] {}, brandOut: Object [Alleged: Brand] {}, description: 'stTIA-USD price feed', governedParams: { Electorate: { type: 'invitation', value: { brand: [Object], value: [Array] } } }, maxSubmissionCount: 1000, maxSubmissionValue: 115_792_089_237_316_195_423_570_985_008_687_907_853_269_984_665_640_564_039_457_584_007_913_129_639_936n, minSubmissionCount: 2, minSubmissionValue: 1n, restartDelay: 1, timeout: 10, timer: Object [Alleged: timerService] {}, unitAmountIn: { brand: Object [Alleged: Brand] {}, value: 1_000_000n } } }
  * governedContractInstallation Object [Alleged: BundleIDInstallation] {}
  * issuers {}
  * timer Object [Alleged: timerService] {}
governor is live
undefined
```

</details>

### Security Considerations
It is **absolutely critical** to target the correct vats. Please carefully review the above derivation and its correspondence with the upgrade handler code.

### Scaling Considerations
mainnet vat-cleanup from #11274 raised no concerns: https://github.com/Agoric/agoric-sdk/pull/11274#issuecomment-3198305217

### Documentation Considerations
n/a

### Testing Considerations
Targeting a3p-integration vats would be nice, but I don't currently have a swing-store for the above explanation (nor the availability to get one). I'm comfortable with handling this against mainfork.

### Upgrade Considerations
Verification is best accomplished by looking at the work reported in `vat-cleanup` slog entries and watching that block times do not climb (or at least do not remain elevated).