### PR TITLE
feat(ymax-planner): Look for deposits of a particular denom

### DIFF
--- a/services/ymax-planner/README.md
+++ b/services/ymax-planner/README.md
@@ -76,6 +76,7 @@ Environment variables:
 - `AGORIC_NET`: agoric.net subdomain for requesting URL path `/network-config` to identify `chainName`/`rpcAddrs`/etc. (default `main`)
 - `ALCHEMY_API_KEY`: API key for accessing Alchemy’s Ethereum RPC endpoint (optional, but necessary for using that service)
 - `MNEMONIC`: For the private key used to sign transactions (required)
+- `DEPOSIT_IBC_DENOM`: For identifying funds to manage. Used directly if it starts with "ibc/", otherwise matched against `issuerName` in vstorage data at path "published.agoricNames.vbankAsset" (default `USDC`)
 - `SPECTRUM_API_URL`: URL for the [Spectrum](https://spectrumnodes.com/) API (default `https://pools-api.spectrumnodes.com`)
 - `SPECTRUM_API_TIMEOUT`: Milliseconds to wait for each Spectrum request (default `10000` = 10 seconds)
 - `SPECTRUM_API_RETRIES`: Retry count for Spectrum requests (default `3`)

--- a/services/ymax-planner/README.md
+++ b/services/ymax-planner/README.md
@@ -73,13 +73,13 @@ yarn test
 
 Environment variables:
 
-- `AGORIC_NET`: agoric.net subdomain for requesting URL path `/network-config` to identify `chainName`/`rpcAddrs`/etc. (`main`)
-- `ALCHEMY_API_KEY`: API key for accessing Alchemy’s Ethereum RPC endpoint. Required if you want to connect to Ethereum through Alchemy’s RPC service.
-- `MNEMONIC`: For the private key used to sign transactions
-- `SPECTRUM_API_URL`: URL for the [Spectrum](https://spectrumnodes.com/) API (`https://pools-api.spectrumnodes.com`)
-- `SPECTRUM_API_TIMEOUT`: Milliseconds to wait for each Spectrum request (`10000` = 10 seconds)
-- `SPECTRUM_API_RETRIES`: Retry count for Spectrum requests (`3`)
-- `DOTENV`: Path to environment file containing defaults of above (`.env`)
+- `AGORIC_NET`: agoric.net subdomain for requesting URL path `/network-config` to identify `chainName`/`rpcAddrs`/etc. (default `main`)
+- `ALCHEMY_API_KEY`: API key for accessing Alchemy’s Ethereum RPC endpoint (optional, but necessary for using that service)
+- `MNEMONIC`: For the private key used to sign transactions (required)
+- `SPECTRUM_API_URL`: URL for the [Spectrum](https://spectrumnodes.com/) API (default `https://pools-api.spectrumnodes.com`)
+- `SPECTRUM_API_TIMEOUT`: Milliseconds to wait for each Spectrum request (default `10000` = 10 seconds)
+- `SPECTRUM_API_RETRIES`: Retry count for Spectrum requests (default `3`)
+- `DOTENV`: Path to environment file containing defaults of above (default `.env`)
 
 ## Architecture
 

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -272,7 +272,7 @@ const makeWorkPool = <T, U = T, M extends 'all' | 'allSettled' = 'all'>(
   return harden(results as typeof results & { done: Promise<boolean> });
 };
 
-type IO = {
+type Powers = {
   evmCtx: Omit<EvmContext, 'signingSmartWalletKit' | 'fetch'>;
   rpc: CosmosRPCClient;
   spectrum: SpectrumClient;
@@ -286,6 +286,7 @@ const processPortfolioEvents = async (
   query: SigningSmartWalletKit['query'],
   portfolioKeyForDepositAddr: Map<Bech32Address, string>,
 ) => {
+  await null;
   for (const { path, value: vstorageValue } of portfolioEvents) {
     const streamCell = tryJsonParse(
       vstorageValue,
@@ -319,7 +320,7 @@ const processPortfolioEvents = async (
         }
       }
     }
-    // TODO: Handle portfolio-level path `${VSTORAGE_PATH_PREFIX}.${portfolioKey}` for addition/update of depositAddress.
+    // TODO: Handle portfolio-level path `${PORTFOLIOS_PATH_PREFIX}.${portfolioKey}` for addition/update of depositAddress.
   }
 };
 
@@ -407,14 +408,12 @@ export const processPendingTxEvents = async (
   }
 };
 
-export const startEngine = async ({
-  evmCtx,
-  rpc,
-  spectrum,
-  cosmosRest,
-  signingSmartWalletKit,
-}: IO) => {
+export const startEngine = async (
+  { evmCtx, rpc, spectrum, cosmosRest, signingSmartWalletKit }: Powers,
+  { depositIbcDenom }: { depositIbcDenom: string },
+) => {
   await null;
+  const { query, marshaller } = signingSmartWalletKit;
 
   const chainStatus = await rpc.request('status', {});
   console.warn('agoric chain status', chainStatus);
@@ -470,6 +469,18 @@ export const startEngine = async ({
     agoricInfo,
   );
 
+  const vbankAssets = new Map<string, AssetInfo>(
+    await query.readPublished('agoricNames.vbankAsset'),
+  );
+  const depositAsset = depositIbcDenom.startsWith('ibc/')
+    ? vbankAssets.get(depositIbcDenom)
+    : [...vbankAssets.values()].find(
+        assetInfo => assetInfo.issuerName === depositIbcDenom,
+      );
+  if (!depositAsset) {
+    throw Fail`Could not find vbankAsset for ${q(depositIbcDenom)}`;
+  }
+
   // To avoid data gaps, establish subscriptions before gathering initial state.
   const eventFilters = [
     // vstorage events are in BEGIN_BLOCK/END_BLOCK activity
@@ -484,7 +495,6 @@ export const startEngine = async ({
   // console.log('subscribed to events', eventFilters);
 
   // TODO: verify consumption of paginated data.
-  const { query } = signingSmartWalletKit;
   const portfolioKeys = await query.vstorage.keys(PORTFOLIOS_PATH_PREFIX);
   const portfolioKeyForDepositAddr = new Map() as Map<Bech32Address, string>;
   await makeWorkPool(portfolioKeys, undefined, async portfolioKey => {
@@ -587,7 +597,6 @@ export const startEngine = async ({
     );
 
     // Detect new portfolios.
-    const { marshaller } = signingSmartWalletKit;
     await processPortfolioEvents(
       portfolioEvents,
       marshaller,
@@ -635,33 +644,23 @@ export const startEngine = async ({
       ),
     );
 
-    const vbankAssets = new Map<string, AssetInfo>(
-      depositAddrsWithActivity.size
-        ? await query.readPublished('agoricNames.vbankAsset')
-        : undefined,
-    );
-
     // Respond to deposits.
     const portfolioOps = await Promise.all(
       [...depositAddrsWithActivity.entries()].map(
         async ([addr, portfolioKey]) => {
-          // TODO: maybe snapshot initial balances for deposit amount determination?
-          // For now, require a single denom and assume that the full amount is a new deposit.
           const balances = addrBalances.get(addr);
-          if (balances?.length !== 1) {
-            console.error(
-              `Unclear which denom to handle for ${addr}`,
-              balances?.map(amount => amount.denom),
-            );
+          const deposited = balances?.find(
+            ({ denom }) => denom === depositAsset.denom,
+          );
+          if (!deposited) {
+            console.warn(`No ${q(depositAsset.issuerName)} at ${addr}`);
             return;
           }
-          const { denom, amount: balanceValue } = balances[0];
 
-          const brand = vbankAssets.get(denom)?.brand as
-            | undefined
-            | Brand<'nat'>;
-          if (!brand) throw Fail`no brand found for denom ${q(denom)}`;
-          const amount = AmountMath.make(brand, Nat(BigInt(balanceValue)));
+          const amount = AmountMath.make(
+            depositAsset.brand as Brand<'nat'>,
+            Nat(BigInt(deposited.amount)),
+          );
 
           const unprefixedPortfolioPath = stripPrefix(
             'published.',

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -86,12 +86,15 @@ export const main = async (
     alchemy: config.alchemy,
   });
 
-  await startEngine({
+  const powers = {
     evmCtx,
     rpc,
     spectrum,
     cosmosRest,
     signingSmartWalletKit,
+  };
+  await startEngine(powers, {
+    depositIbcDenom: env.DEPOSIT_IBC_DENOM || 'USDC',
   });
 };
 harden(main);

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -1,0 +1,36 @@
+import test from 'ava';
+
+import type { Brand, DisplayInfo, Issuer } from '@agoric/ertp';
+import type { AssetInfo } from '@agoric/vats/src/vat-bank.js';
+import { Far } from '@endo/pass-style';
+import { pickBalance } from '../src/engine.ts';
+
+const mockDepositAsset = (name: string, assetKind: 'nat') => {
+  // avoid VatData
+  const brand = Far(`${name} brand`) as Brand<'nat'>;
+  const issuer = Far(`${name} issuer`) as Issuer<'nat'>;
+  const displayInfo: DisplayInfo = harden({ assetKind, decimalPlaces: 6 });
+  const denom = 'ibc/123';
+  const depositAsset: AssetInfo = harden({
+    brand,
+    denom,
+    issuer,
+    displayInfo,
+    issuerName: name,
+    proposedName: name,
+  });
+  return depositAsset;
+};
+
+test('ignore additional balances', t => {
+  const usdc = mockDepositAsset('USDC', 'nat');
+  const { denom, brand } = usdc;
+
+  const balances = [
+    { amount: '50', denom },
+    { amount: '123', denom: 'ubld' },
+  ];
+
+  const actual = pickBalance(balances, usdc);
+  t.deepEqual(actual, { brand, value: 50n });
+});


### PR DESCRIPTION
## Description
Accept the issuer name or IBC denom for deposits via environment variable (defaulting to "USDC"), and operate exclusively on that for detecting and transferring deposits.

### Security Considerations
The planner trusts `denom` and `issuerName` data read from vstorage path "published.agoricNames.vbankAsset", which if incorrect could result in legitimate deposits being ignored.
It also treats any `DEPOSIT_IBC_DENOM` values that starts with "ibc/" as an IBC denom rather than an issuer name, so if any asset ever has such an issuer name, refactoring will be necessary in order to look up its actual IBC denom.

### Scaling Considerations
n/a

### Documentation Considerations
README.md updated to document the new `DEPOSIT_IBC_DENOM` environment variable.

### Testing Considerations
We don't yet have a setup for adequately mocking blockchain state against which the planner operates, but it's on the list for me or @mhofman.

### Upgrade Considerations
None.