### PR TITLE
fix: align vstorage posted data with expected resolver handler status

### DIFF
--- a/packages/portfolio-contract/src/resolver/constants.js
+++ b/packages/portfolio-contract/src/resolver/constants.js
@@ -10,6 +10,7 @@
 export const TxStatus = /** @type {const} */ ({
   PENDING: 'pending',
   SUCCESS: 'success',
+  FAILED: 'failed',
 });
 harden(TxStatus);
 

--- a/packages/portfolio-contract/src/resolver/resolver.exo.ts
+++ b/packages/portfolio-contract/src/resolver/resolver.exo.ts
@@ -196,7 +196,7 @@ export const prepareResolverKit = (
           }
           const registryEntry = cctpTransactionRegistry.get(key);
           switch (status) {
-            case 'confirmed':
+            case 'success':
               trace(
                 'CCTP transaction confirmed - resolving pending operation for key:',
                 key,

--- a/packages/portfolio-contract/src/resolver/types.ts
+++ b/packages/portfolio-contract/src/resolver/types.ts
@@ -15,7 +15,7 @@ export type CCTPTransactionKey = `${AccountId}:${bigint}`;
 export type CCTPTransactionDetails = {
   amount: bigint;
   remoteAddress: `0x${string}`;
-  status: 'confirmed' | 'failed';
+  status: TxStatus;
 };
 
 export const CCTPTransactionDetailsShape: TypedPattern<CCTPTransactionDetails> =
@@ -23,7 +23,7 @@ export const CCTPTransactionDetailsShape: TypedPattern<CCTPTransactionDetails> =
     {
       amount: M.nat(),
       remoteAddress: M.string(),
-      status: M.or('confirmed', 'failed'),
+      status: M.or('pending', 'success', 'failed'),
     },
     {},
     {},
@@ -33,7 +33,7 @@ export type CCTPSettlementArgs = {
   chainId: CaipChainId;
   remoteAddress: `0x${string}`;
   amountValue: bigint;
-  status: 'confirmed' | 'failed';
+  status: TxStatus;
   rejectionReason?: string;
   txId: `tx${number}`;
 };
@@ -44,7 +44,7 @@ export const CCTPSettlementArgsShape: TypedPattern<CCTPSettlementArgs> =
       chainId: M.string(), // CaipChainId format
       remoteAddress: M.string(),
       amountValue: M.nat(),
-      status: M.or('confirmed', 'failed'),
+      status: M.or('pending', 'success', 'failed'),
       txId: M.string(), // `tx${number}` format
     },
     {

--- a/packages/portfolio-contract/test/cctp-resolver.test.ts
+++ b/packages/portfolio-contract/test/cctp-resolver.test.ts
@@ -24,7 +24,7 @@ test('CCTP settlement invitation - no pending transaction found', async t => {
     txDetails: {
       amount: amount.value,
       remoteAddress: '0x999999999999999999999999999999999999999',
-      status: 'confirmed' as const,
+      status: 'success' as const,
     },
     txId: 'tx0',
     remoteAxelarChain: 'eip155:42161' as const,

--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -865,7 +865,7 @@ test.serial(
       amount.value,
       'eip155:42161',
       0,
-      'confirmed',
+      'success',
       console.log,
       mockEVMAddress,
     );

--- a/packages/portfolio-contract/test/resolver-helpers.ts
+++ b/packages/portfolio-contract/test/resolver-helpers.ts
@@ -5,6 +5,7 @@ import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import type { UserSeat, ZoeService } from '@agoric/zoe';
 import type { CaipChainId } from '@agoric/orchestration';
 import type { ResolverInvitationMakers } from '../src/resolver/resolver.exo.js';
+import type { TxStatus } from '../src/resolver/constants.js';
 
 /**
  * Helper to get resolver makers from a creator facet.
@@ -43,7 +44,7 @@ export const settleCCTPTransaction = async (
   txDetails: {
     amount: bigint;
     remoteAddress: `0x${string}`;
-    status: 'confirmed' | 'failed';
+    status: TxStatus;
   },
   txNumber: number = 0,
   remoteAxelarChain: CaipChainId,
@@ -85,7 +86,7 @@ export const settleCCTPWithMockReceiver = async (
   amount: bigint,
   remoteAxelarChain: CaipChainId,
   txNumber: number = 0,
-  status: 'confirmed' | 'failed' = 'confirmed',
+  status: TxStatus = 'success',
   log: (message: string, ...args: any[]) => void = console.log,
   mockRemoteAddress: `0x${string}` = '0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092',
 ): Promise<string> => {

--- a/packages/portfolio-contract/test/ymax-scenario.test.ts
+++ b/packages/portfolio-contract/test/ymax-scenario.test.ts
@@ -92,7 +92,7 @@ const rebalanceScenarioMacro = test.macro({
               move.amount.value,
               'eip155:42161' as const, // Arbitrum chain ID
               0,
-              'confirmed',
+              'success',
             );
 
             continue;

--- a/packages/portfolio-deploy/test/portfolio.test.ts
+++ b/packages/portfolio-deploy/test/portfolio.test.ts
@@ -354,7 +354,7 @@ test.skip('CCTP settlement works', async t => {
       txDetails: {
         amount: 10_000n,
         remoteAddress: '0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092',
-        status: 'confirmed',
+        status: 'success',
       },
       remoteAxelarChain: 'eip155:42161',
       txId: 'tx0',
@@ -376,7 +376,7 @@ test.skip('CCTP settlement works', async t => {
         txDetails: {
           amount: 10000n,
           remoteAddress: '0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092',
-          status: 'confirmed',
+          status: 'success',
         },
         txId: 'tx0',
       },
@@ -483,7 +483,7 @@ test.skip('CCTP settlement works across contract restarts', async t => {
       txDetails: {
         amount: 40_000n,
         remoteAddress: '0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092',
-        status: 'confirmed',
+        status: 'success',
       },
       remoteAxelarChain: 'eip155:42161',
       txId: 'tx0',
@@ -507,7 +507,7 @@ test.skip('CCTP settlement works across contract restarts', async t => {
         txDetails: {
           amount: 40000n,
           remoteAddress: '0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092',
-          status: 'confirmed',
+          status: 'success',
         },
         txId: 'tx0',
       },
@@ -592,7 +592,7 @@ test.serial(
           txDetails: {
             amount: 10_000n,
             remoteAddress: '0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092',
-            status: 'confirmed',
+            status: 'success',
           },
           txId: 'tx0',
           remoteAxelarChain: 'eip155:42161',
@@ -656,7 +656,7 @@ test.skip('CCTP settlement works with new invitation after contract remove and s
       txDetails: {
         amount: 10_000n,
         remoteAddress: '0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092',
-        status: 'confirmed',
+        status: 'success',
       },
       remoteAxelarChain: 'eip155:42161',
     },
@@ -677,7 +677,7 @@ test.skip('CCTP settlement works with new invitation after contract remove and s
         txDetails: {
           amount: 10000n,
           remoteAddress: '0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092',
-          status: 'confirmed',
+          status: 'success',
         },
         txId: 'tx0',
       },
@@ -698,7 +698,7 @@ test.skip('CCTP settlement works with new invitation after contract remove and s
         txDetails: {
           amount: 10000n,
           remoteAddress: '0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092',
-          status: 'confirmed',
+          status: 'success',
         },
         txId: 'tx0',
       },


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
This PR ensures that the transaction `status` field posted to vstorage matches exactly what the resolver handler expects.

Previously, vstorage posted `success` or `pending` for `status`, while the resolver handler expected `confirmed` or `failed`. This mismatch caused confusion and incorrect status handling.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
Not applied. 

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
Not applied. 

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
Not applied. 

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Current test suite should be enough to verify this change. But perhaps we should consider adding vstorage snapshots tests for the resolver stuff, @frazarshad @amessbee?

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
Mainly the resolver implementation in #11752 needs to incorporate the `status` type based on this PR. 