### PR TITLE
chore: ymax deployment tooling for Aave on ethereum-sepolia via devnet

### DIFF
--- a/multichain-testing/.gitignore
+++ b/multichain-testing/.gitignore
@@ -12,3 +12,6 @@ logs/
 *-pool-config.json
 wasm-artifacts/
 xcs-contracts-info.json
+
+# task marker temp files
+,*

--- a/multichain-testing/Makefile
+++ b/multichain-testing/Makefile
@@ -211,3 +211,55 @@ usdc-available: ./scripts/noble-usdn-lab.ts
 			} \
 		) \
 	)
+
+
+DEPLOY=../packages/portfolio-deploy
+
+,ymax0-bundle-id: $(DEPLOY)/dist/bundle-ymax0.json
+	(echo -n b1-; jq -r .endoZipBase64Sha512 $(DEPLOY)/dist/bundle-ymax0.json) >$@
+
+$(DEPLOY)/dist/bundle-ymax0.json: $(DEPLOY)/dist/portfolio.contract.bundle.js
+	(cd $(DEPLOY); \
+	 npx bundle-source --cache-json dist/ ./dist/portfolio.contract.bundle.js ymax0)
+
+$(DEPLOY)/dist/portfolio.contract.bundle.js:
+	(cd $(DEPLOY); yarn build)
+
+PUBLISHER=gov2.devnet
+publish-ymax0: ,ymax0-installed
+
+,ymax0-installed: $(DEPLOY)/dist/bundle-ymax0.json
+	agd keys --keyring-backend=test show $(PUBLISHER)
+	AGORIC_NET=devnet ./scripts/install-bundle.ts $< >$@ || (rm $@; false)
+
+yctrl-redeploy: ,ymax0-deployed
+
+REASON=
+NETCONFIG=https://devnet.agoric.net/network-config
+,ymax0-deployed: $(DEPLOY)/dist/bundle-ymax0.json ,ymax0-bundle-id ,ymax0-installed
+	@[ -n "$$MNEMONIC" ] || (echo "ymaxControl MNEMONIC not set; see gov keys sheet"; false)
+	if [ -n "$$REASON" ]; then AGORIC_NET=devnet ./scripts/ymax-tool.ts --terminate "$(REASON)"; else true; fi
+	AGORIC_NET=devnet ./scripts/ymax-tool.ts --installAndStart $$(cat ,ymax0-bundle-id)
+	agoric follow -B $(NETCONFIG) -lF :published.agoricNames.instance >$@ || (rm $@; false)
+
+,creatorFacet: ,ymax0-deployed
+	AGORIC_NET=devnet ./scripts/ymax-tool.ts --getCreatorFacet
+	touch $@
+
+# see gov keys sheet
+PLANNER=agoric140yw0u2qrvmrgp33ejpddgnrwpm74vpfpx5v7n
+,invitePlanner: ,creatorFacet
+	AGORIC_NET=devnet ./scripts/ymax-tool.ts --pruneStorage --invitePlanner $(PLANNER)
+	touch $@
+	@echo now use planner MNEMONIC: ymax-tool.ts --redeem
+
+# TODO: get from vstorage
+FEE_ACCT=agoric1rqqy9r0s4ahl8agr89f200gch78hnef3jckf4vntqe4p67rsxegs9qpzjw
+DEV_NODE=https://devnet.rpc.agoric.net:443
+SIG_OPTS=--chain-id=agoricdev-25 --gas-adjustment=1.5 --gas=auto
+fund-fee-acct:
+	agd tx bank send gov1.devnet $(FEE_ACCT) 120000000ubld -y -b block --node=$(DEV_NODE) $(SIG_OPTS)
+
+aave-e2e:
+	@[ -n "$$MNEMONIC" ] || (echo "trader MNEMONIC not set; see noble-usdn-lab.ts"; false)
+	AGORIC_NET=devnet ./scripts/ymax-tool.ts --positions '{"Aave":0.1}' --target-allocation '{"Aave_Ethereum":100}'

--- a/multichain-testing/scripts/install-bundle.ts
+++ b/multichain-testing/scripts/install-bundle.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env -S node --import ts-blank-space/register
+import '@endo/init/debug.js';
+
+import {
+  installBundle,
+  txFlags,
+} from '@agoric/deploy-script-support/src/permissioned-deployment.js';
+import { makeCmdRunner, makeFileRd } from '@agoric/pola-io';
+import { execa } from 'execa';
+import { toCLIOptions } from '@agoric/internal';
+import { fetchEnvNetworkConfig } from '@agoric/client-utils';
+
+const Usage = '_script_ bundle.json';
+
+const main = async (
+  argv = process.argv,
+  env = process.env,
+  {
+    execFile = (cmd, args, opts) =>
+      execa({ verbose: 'short' })(cmd, args, opts),
+    fetch = globalThis.fetch,
+  } = {},
+) => {
+  const [bundleFn] = argv.slice(2);
+  if (!bundleFn) throw Error(Usage);
+
+  const {
+    chainName: chainId,
+    rpcAddrs: [node],
+  } = await fetchEnvNetworkConfig({ env, fetch });
+  const agdq = makeCmdRunner('agd', { execFile }).withFlags('--node', node);
+  const from = 'gov2.devnet'; // XXX
+  const agdTx = agdq.withFlags(
+    ...toCLIOptions(txFlags({ node, from, chainId })),
+    '--yes',
+  );
+
+  await installBundle(agdTx, makeFileRd(bundleFn));
+  console.warn('TODO: wait for confirmation/error in vstorage');
+};
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -4,63 +4,106 @@
  */
 import '@endo/init';
 
+import type { PortfolioPlanner } from '@aglocal/portfolio-contract/src/planner.exo.ts';
+import type { start as YMaxStart } from '@aglocal/portfolio-contract/src/portfolio.contract.ts';
+import type { MovementDesc } from '@aglocal/portfolio-contract/src/type-guards-steps.ts';
 import {
   TargetAllocationShape,
   type OfferArgsFor,
   type ProposalType,
+  type TargetAllocation,
 } from '@aglocal/portfolio-contract/src/type-guards.ts';
-import { makePortfolioSteps } from '@aglocal/portfolio-contract/tools/portfolio-actors.ts';
+import {
+  makePortfolioQuery,
+  makePortfolioSteps,
+} from '@aglocal/portfolio-contract/tools/portfolio-actors.ts';
+import {
+  axelarConfigTestnet,
+  gmpAddresses as gmpConfigs,
+} from '@aglocal/portfolio-deploy/src/axelar-configs.js';
+import type { ContractControl } from '@aglocal/portfolio-deploy/src/contract-control.js';
+import { lookupInterchainInfo } from '@aglocal/portfolio-deploy/src/orch.start.js';
+import { findOutdated } from '@aglocal/portfolio-deploy/src/vstorage-outdated.js';
 import {
   fetchEnvNetworkConfig,
+  makeSigningSmartWalletKit,
   makeSmartWalletKit,
+  type SigningSmartWalletKit,
+  type VstorageKit,
 } from '@agoric/client-utils';
-import { CodecHelper } from '@agoric/cosmic-proto';
-import { MsgWalletSpendAction as MsgWalletSpendActionType } from '@agoric/cosmic-proto/agoric/swingset/msgs.js';
 import { AmountMath } from '@agoric/ertp';
-import { multiplyBy, parseRatio } from '@agoric/ertp/src/ratio.js';
-import { makeTracer, mustMatch, type TypedPattern } from '@agoric/internal';
-import type { BridgeAction } from '@agoric/smart-wallet/src/smartWallet.js';
-import { stringToPath } from '@cosmjs/crypto';
-import { fromBech32 } from '@cosmjs/encoding';
 import {
-  DirectSecp256k1HdWallet,
-  Registry,
-  type GeneratedType,
-} from '@cosmjs/proto-signing';
-import { SigningStargateClient, type StdFee } from '@cosmjs/stargate';
+  multiplyBy,
+  parseRatio,
+  type ParsableNumber,
+} from '@agoric/ertp/src/ratio.js';
+import {
+  makeTracer,
+  mustMatch,
+  objectMap,
+  type TypedPattern,
+} from '@agoric/internal';
+import { YieldProtocol } from '@agoric/portfolio-api/src/constants.js';
+import type { OfferStatus } from '@agoric/smart-wallet/src/offers.js';
+import type { NameHub } from '@agoric/vats';
+import type { StartedInstanceKit as ZStarted } from '@agoric/zoe/src/zoeService/utils';
+import { SigningStargateClient } from '@cosmjs/stargate';
+import { M } from '@endo/patterns';
 import { parseArgs } from 'node:util';
+import {
+  reflectWalletStore,
+  walletUpdates,
+} from '../tools/wallet-store-reflect.ts';
 
-const MsgWalletSpendAction = CodecHelper(MsgWalletSpendActionType);
+type YMaxStartFn = typeof YMaxStart;
 
 const getUsage = (
   programName: string,
-): string => `USAGE: ${programName} [Deposit] [options]
+): string => `USAGE: ${programName} [options]
 Options:
   --skip-poll         Skip polling for offer result
   --exit-success      Exit with success code even if errors occur
+  --positions         JSON string of opening positions (e.g. '{"USDN":6000,"Aave":4000}')
   --target-allocation JSON string of target allocation (e.g. '{"USDN":6000,"Aave_Arbitrum":4000}')
+  --redeem            redeem invitation
+  --contract=[ymax0]  agoricNames.instance name of contract that issued invitation
+  --description=[planner]
+  --submit-for <id>   submit (empty) plan for portfolio <id>
   -h, --help          Show this help message`;
 
-const toAccAddress = (address: string): Uint8Array => {
-  return fromBech32(address).data;
-};
+const parseToolArgs = (argv: string[]) =>
+  parseArgs({
+    args: argv.slice(2),
+    options: {
+      positions: { type: 'string', default: '{}' },
+      'skip-poll': { type: 'boolean', default: false },
+      'exit-success': { type: 'boolean', default: false },
+      'target-allocation': { type: 'string' },
+      redeem: { type: 'boolean', default: false },
+      contract: { type: 'string', default: 'ymax0' },
+      description: { type: 'string', default: 'planner' },
+      getCreatorFacet: { type: 'boolean', default: false },
+      terminate: { type: 'string' },
+      installAndStart: { type: 'string' },
+      invitePlanner: { type: 'string' },
+      pruneStorage: { type: 'boolean', default: false },
+      'submit-for': { type: 'string' },
+      help: { type: 'boolean', short: 'h', default: false },
+    },
+    allowPositionals: false,
+  });
+
+type GoalData = Partial<Record<YieldProtocol, ParsableNumber>>;
+const YieldProtocolShape = M.or(...Object.keys(YieldProtocol));
+const ParseableNumberShape = M.or(M.number(), M.string());
+const GoalDataShape: TypedPattern<GoalData> = M.recordOf(
+  YieldProtocolShape,
+  ParseableNumberShape,
+);
 
 const trace = makeTracer('YMXTool');
 const { fromEntries } = Object;
 const { make } = AmountMath;
-
-const AgoricMsgs = {
-  MsgWalletSpendAction: {
-    typeUrl: '/agoric.swingset.MsgWalletSpendAction',
-    aminoType: 'swingset/WalletSpendAction',
-  },
-};
-const agoricRegistryTypes: [string, GeneratedType][] = [
-  [
-    AgoricMsgs.MsgWalletSpendAction.typeUrl,
-    MsgWalletSpendActionType as GeneratedType,
-  ],
-];
 
 const parseTypedJSON = <T>(
   json: string,
@@ -71,127 +114,214 @@ const parseTypedJSON = <T>(
   let result: unknown;
   try {
     result = harden(JSON.parse(json, reviver));
+    mustMatch(result, shape);
   } catch (err) {
     throw makeError(err);
   }
-  mustMatch(result, shape);
   return result;
 };
 
-const openPosition = async (
-  volume: number | string | undefined,
+type SmartWalletKit = Awaited<ReturnType<typeof makeSmartWalletKit>>;
+
+const noPoll = (wk: SmartWalletKit): SmartWalletKit => ({
+  ...wk,
+  pollOffer: async () => {
+    trace('polling skippped');
+    return harden({ status: 'polling skipped' } as unknown as OfferStatus);
+  },
+});
+
+const openPositions = async (
+  goalData: GoalData,
   {
-    address,
-    client,
-    walletKit,
-    now,
-    skipPoll = false,
-    targetAllocationJson,
+    sig,
+    when,
+    targetAllocation,
+    id = `open-${new Date(when).toISOString()}`,
   }: {
-    address: string;
-    client: SigningStargateClient;
-    walletKit: Awaited<ReturnType<typeof makeSmartWalletKit>>;
-    now: () => number;
-    skipPoll?: boolean;
-    targetAllocationJson?: string;
+    sig: SigningSmartWalletKit;
+    when: number;
+    targetAllocation?: TargetAllocation;
+    id?: string;
   },
 ) => {
+  const { readPublished } = sig.query;
+  const { USDC, BLD } = fromEntries(
+    await readPublished('agoricNames.brand'),
+  ) as Record<string, Brand<'nat'>>;
   // XXX PoC26 in devnet published.agoricNames.brand doesn't match vbank
-  const brand = fromEntries(
-    (await walletKit.readPublished('agoricNames.vbankAsset')).map(([_d, a]) => [
-      a.issuerName,
-      a.brand,
-    ]),
-  );
-  const { USDC, PoC26 } = brand as Record<string, Brand<'nat'>>;
+  const { upoc26 } = fromEntries(await readPublished('agoricNames.vbankAsset'));
 
-  const amount =
-    volume && multiplyBy(make(USDC, 1_000_000n), parseRatio(volume, USDC));
-  const { give, steps } = amount
-    ? makePortfolioSteps({ USDN: amount })
-    : { give: {}, steps: [] };
+  const toAmt = (num: ParsableNumber) =>
+    multiplyBy(make(USDC, 1_000_000n), parseRatio(num, USDC));
+  const goal = objectMap(goalData, toAmt);
+  console.debug('TODO: address Ethereum-only limitation');
+  const evm = 'Ethereum';
+  const { give: giveWFees } = makePortfolioSteps(goal, { evm, feeBrand: BLD });
+  // XXX WIP: contract is to pay BLD fee
+  const { GmpFee: _gf, ...give } = giveWFees;
   const proposal: ProposalType['openPortfolio'] = {
     give: {
       ...give,
-      ...(PoC26 && { Access: make(PoC26, 1n) }),
+      ...(upoc26 && { Access: make(upoc26.brand, 1n) }),
     },
   };
 
-  const parseTargetAllocation = () => {
-    if (!targetAllocationJson) return undefined;
-    const targetAllocation = parseTypedJSON(
-      targetAllocationJson,
-      TargetAllocationShape,
-      (_k, v) => (typeof v === 'number' ? BigInt(v) : v),
-      err => Error(`Invalid target allocation JSON: ${err.message}`),
-    );
-    return harden({ targetAllocation });
-  };
-
+  // planner will supply remaining steps
+  const steps: MovementDesc[] = [
+    { src: '<Deposit>', dest: '+agoric', amount: give.Deposit },
+  ];
   const offerArgs: OfferArgsFor['openPortfolio'] = {
     flow: steps,
-    ...parseTargetAllocation(),
+    ...(targetAllocation && { targetAllocation }),
   };
-  trace('opening portfolio', proposal.give);
-  const action: BridgeAction = harden({
-    method: 'executeOffer',
-    offer: {
-      id: `open-${new Date(now()).toISOString()}`,
-      invitationSpec: {
-        source: 'agoricContract',
-        instancePath: ['ymax0'],
-        callPipe: [['makeOpenPortfolioInvitation']],
+
+  trace(id, 'opening portfolio', proposal.give, steps);
+  const tx = await sig.sendBridgeAction(
+    harden({
+      method: 'executeOffer',
+      offer: {
+        id,
+        invitationSpec: {
+          source: 'agoricContract',
+          instancePath: ['ymax0'],
+          callPipe: [['makeOpenPortfolioInvitation']],
+        },
+        proposal,
+        offerArgs,
       },
-      proposal,
-      offerArgs,
-    },
-  });
+    }),
+  );
+  if (tx.code !== 0) throw Error(tx.rawLog);
 
-  const msgSpend = MsgWalletSpendAction.fromPartial({
-    owner: toAccAddress(address),
-    spendAction: JSON.stringify(walletKit.marshaller.toCapData(action)),
-  });
+  // result is UNPUBLISHED
+  await walletUpdates(sig.query.getLastUpdate, {
+    log: trace,
+    setTimeout,
+  }).offerResult(id);
 
-  const fee: StdFee = {
-    amount: [{ denom: 'ubld', amount: '30000' }], // XXX enough?
-    gas: '197000',
+  const { offerToPublicSubscriberPaths } =
+    await sig.query.getCurrentWalletRecord();
+  const path = fromEntries(offerToPublicSubscriberPaths)[id]
+    .portfolio as `${string}.portfolios.portfolio${number}`;
+  return {
+    id,
+    path,
+    tx: { hash: tx.transactionHash, height: tx.height },
   };
-  const before = await client.getBlock();
-  console.log('signAndBroadcast', address, msgSpend, fee);
-  const actual = await client.signAndBroadcast(
-    address,
-    [{ typeUrl: MsgWalletSpendAction.typeUrl, value: msgSpend }],
-    fee,
-  );
-  trace('tx', actual);
+};
 
-  if (skipPoll) {
-    trace('skipping poll as per skipPoll flag');
-    const status = { result: { transaction: actual } };
-    return status;
-  }
+/**
+ * Build a NameHub suitable for use by lookupInterchainInfo,
+ * filtering odd stuff found in devnet.
+ *
+ * @param vsk
+ */
+const agoricNamesForChainInfo = (vsk: VstorageKit) => {
+  const { vstorage } = vsk;
+  const { readPublished } = vsk;
 
-  trace(
-    'starting to poll for offer result from block height',
-    before.header.height,
-  );
-  const status = await walletKit.pollOffer(
-    address,
-    action.offer.id,
-    before.header.height,
-  );
+  const byChainId = {};
 
-  trace('final offer status', status);
-  if ('error' in status) {
-    trace('offer failed with error', status.error);
-    throw Error(status.error);
-  }
-  trace('offer completed successfully', {
-    statusType: 'success',
-    result: status.result,
+  const chainEntries = async (kind: string) => {
+    const out: [string, unknown][] = [];
+    const children = await vstorage.keys(`published.agoricNames.${kind}`);
+    for (const child of children) {
+      console.debug('readPublished', kind, child);
+      const value = await readPublished(`agoricNames.${kind}.${child}`);
+      // console.debug(kind, child, value);
+      if (kind === 'chain') {
+        const { chainId, namespace } = value as Record<string, string>;
+        if (namespace !== 'cosmos') {
+          console.warn('namespace?? skipping', kind, child, value);
+          continue;
+        }
+        if (typeof chainId === 'string') {
+          if (chainId in byChainId) throw Error(`oops! ${child} ${chainId}`);
+          byChainId[chainId] = value;
+        }
+      }
+      out.push([child, value]);
+    }
+    if (kind === 'chainConnection') {
+      const relevantConnections = out.filter(([key, _val]) => {
+        const [c1, c2] = key.split('_'); // XXX incomplete
+        return c1 in byChainId && c2 in byChainId;
+      });
+      return harden(relevantConnections);
+    }
+    return harden(out);
+  };
+
+  const lookup = async (kind: string) => {
+    switch (kind) {
+      case 'chain':
+      case 'chainConnection':
+        return harden({
+          entries: () => chainEntries(kind),
+        });
+      default:
+        return harden({
+          entries: async () => {
+            // console.debug(kind, 'entries');
+            return readPublished(`agoricNames.${kind}`) as Promise<
+              [[string, unknown]]
+            >;
+          },
+        });
+    }
+  };
+
+  const refuse = () => {
+    throw Error('access denied');
+  };
+
+  const agoricNames: NameHub = harden({
+    lookup,
+    entries: refuse,
+    has: refuse,
+    keys: refuse,
+    values: refuse,
   });
 
-  return status;
+  return agoricNames;
+};
+
+/**
+ * Build privateArgsOverrides sufficient to add new EVM chains.
+ *
+ * @param vsk
+ * @param axelarConfig
+ * @param gmpAddresses
+ */
+const overridesForEthChainInfo = async (
+  vsk: VstorageKit,
+  axelarConfig = axelarConfigTestnet,
+  gmpAddresses = gmpConfigs.testnet,
+) => {
+  const { chainInfo: cosmosChainInfo } = await lookupInterchainInfo(
+    agoricNamesForChainInfo(vsk),
+    { agoric: ['ubld'], noble: ['uusdc'], axelar: ['uaxl'] },
+  );
+  const chainInfo = {
+    ...cosmosChainInfo,
+    ...objectMap(axelarConfig, info => info.chainInfo),
+  };
+
+  const privateArgsOverrides: Pick<
+    Parameters<YMaxStartFn>[1],
+    'axelarIds' | 'chainInfo' | 'contracts' | 'gmpAddresses'
+  > = harden({
+    axelarIds: objectMap(axelarConfig, c => c.axelarId),
+    contracts: objectMap(axelarConfig, c => c.contracts),
+    chainInfo,
+    gmpAddresses,
+  });
+  console.log(
+    'privateArgsOverrides',
+    JSON.stringify(privateArgsOverrides, null, 2),
+  );
+  return privateArgsOverrides;
 };
 
 const main = async (
@@ -201,30 +331,14 @@ const main = async (
     fetch = globalThis.fetch,
     setTimeout = globalThis.setTimeout,
     connectWithSigner = SigningStargateClient.connectWithSigner,
+    now = Date.now,
   } = {},
 ) => {
-  // Parse command line arguments using node:util's parseArgs
-  const { values, positionals } = parseArgs({
-    args: argv.slice(2),
-    options: {
-      'skip-poll': { type: 'boolean', default: false },
-      'exit-success': { type: 'boolean', default: false },
-      'target-allocation': { type: 'string' },
-      help: { type: 'boolean', short: 'h', default: false },
-    },
-    allowPositionals: true,
-  });
+  const { values } = parseToolArgs(argv);
 
-  // Extract options
-  const skipPoll = values['skip-poll'];
-  const exitSuccess = values['exit-success'];
-  const targetAllocationJson = values['target-allocation'];
-  const [volume] = positionals;
-
-  // Show help if requested
   if (values.help) {
-    console.log(getUsage(argv[1]));
-    process.exit(values.help ? 0 : 1);
+    console.error(getUsage(argv[1]));
+    return;
   }
 
   const { MNEMONIC } = env;
@@ -233,29 +347,127 @@ const main = async (
   const delay = ms =>
     new Promise(resolve => setTimeout(resolve, ms)).then(_ => {});
   const networkConfig = await fetchEnvNetworkConfig({ env, fetch });
-  const walletKit = await makeSmartWalletKit({ fetch, delay }, networkConfig);
-  const signer = await DirectSecp256k1HdWallet.fromMnemonic(MNEMONIC, {
-    prefix: 'agoric',
-    hdPaths: [stringToPath(`m/44'/564'/0'/0/0`)],
-  });
-  const [{ address }] = await signer.getAccounts();
-  const client = await connectWithSigner(networkConfig.rpcAddrs[0], signer, {
-    registry: new Registry(agoricRegistryTypes),
+  const walletKit0 = await makeSmartWalletKit({ fetch, delay }, networkConfig);
+  const walletKit = values['skip-poll'] ? noPoll(walletKit0) : walletKit0;
+  const sig = await makeSigningSmartWalletKit(
+    { connectWithSigner, walletUtils: walletKit },
+    MNEMONIC,
+  );
+  trace('address', sig.address);
+  const walletStore = reflectWalletStore(sig, {
+    setTimeout,
+    log: trace,
+    fresh: () => new Date(now()).toISOString(),
   });
 
-  try {
-    // Pass the parsed options to openPosition
-    await openPosition(volume, {
-      address,
-      client,
-      walletKit,
-      now: Date.now,
-      skipPoll,
-      targetAllocationJson,
+  if (values.redeem) {
+    const { contract, description } = values;
+    trace('getting instance', contract);
+    const { [contract]: instance } = fromEntries(
+      await walletKit.readPublished('agoricNames.instance'),
+    );
+    const result = await walletStore.saveOfferResult(
+      { instance, description },
+      description.replace(/^deliver /, ''),
+    );
+    trace('redeem result', result);
+    return;
+  }
+
+  const yc = walletStore.get<ContractControl<YMaxStartFn>>('ymaxControl');
+
+  if (values.getCreatorFacet) {
+    await walletStore.savingResult('creatorFacet', () => yc.getCreatorFacet());
+    return;
+  }
+
+  if (values.terminate) {
+    const { terminate: message } = values;
+    await yc.terminate({ message });
+    return;
+  }
+
+  if (values.installAndStart) {
+    const { installAndStart: bundleId } = values;
+    const { BLD, USDC } = fromEntries(
+      await walletKit.readPublished('agoricNames.issuer'),
+    );
+
+    // work around goofy devnet PoC token
+    const { upoc26 } = fromEntries(
+      await walletKit.readPublished('agoricNames.vbankAsset'),
+    );
+
+    await yc.installAndStart({
+      bundleId,
+      issuers: { USDC, BLD, Fee: BLD, Access: upoc26.issuer },
+      privateArgsOverrides: await overridesForEthChainInfo(walletKit),
     });
+    return;
+  }
+
+  if (values.pruneStorage) {
+    console.error('finding outdated vstorage...');
+    const toPrune = await findOutdated(walletKit.vstorage);
+    console.log('toPrune', toPrune);
+    await yc.pruneChainStorage(toPrune);
+  }
+
+  if (values.invitePlanner) {
+    const { invitePlanner: planner } = values;
+    const cf =
+      walletStore.get<ZStarted<YMaxStartFn>['creatorFacet']>('creatorFacet');
+    const { postalService } = fromEntries(
+      await walletKit.readPublished('agoricNames.instance'),
+    );
+    await cf.deliverPlannerInvitation(planner, postalService);
+    return;
+  }
+
+  if (values['submit-for']) {
+    const portfolioId = Number(values['submit-for']);
+    const planner = walletStore.get<PortfolioPlanner>('planner');
+    await planner.submit(portfolioId, []);
+    return;
+  }
+
+  const positionData = parseTypedJSON(values.positions, GoalDataShape);
+  const targetAllocation = values['target-allocation']
+    ? parseTypedJSON(
+        values['target-allocation'],
+        TargetAllocationShape,
+        (_k, v) => (typeof v === 'number' ? BigInt(v) : v),
+        err => Error(`Invalid target allocation JSON: ${err.message}`),
+      )
+    : undefined;
+  console.debug({ positionData, targetAllocation });
+  try {
+    const opened = await openPositions(positionData, {
+      sig,
+      when: now(),
+      targetAllocation,
+    });
+    trace('opened', opened);
+    const { path } = opened;
+    // XXX would be nice if readPublished allowed ^published.
+    const subPath = path.replace(/^published./, '') as typeof path;
+    const pq = makePortfolioQuery(walletKit.readPublished, subPath);
+    const status = await pq.getPortfolioStatus();
+    trace('status', status);
+    if (status.depositAddress && env.AGORIC_NET === 'devnet') {
+      // XXX devnet explorer seems to support this query
+      const apiAddr = 'https://devnet.explorer.agoric.net';
+      const url = `${apiAddr}/api/cosmos/bank/v1beta1/balances/${status.depositAddress}`;
+      const result = await fetch(url).then(r => r.json());
+      if (result.balances) {
+        console.log(status.depositAddress, result.balances);
+      } else {
+        console.error(url, 'failed', result);
+      }
+    }
   } catch (err) {
     // If we should exit with success code, throw a special non-error object
-    if (exitSuccess) {
+    if (values['exit-success']) {
       throw { exitSuccess: true, originalError: err };
     }
     throw err;

--- a/multichain-testing/tools/wallet-store-reflect.ts
+++ b/multichain-testing/tools/wallet-store-reflect.ts
@@ -1,0 +1,127 @@
+import type { SigningSmartWalletKit } from '@agoric/client-utils';
+import { retryUntilCondition, type RetryOptions } from '@agoric/client-utils';
+import type { UpdateRecord } from '@agoric/smart-wallet/src/smartWallet.js';
+import type { EMethods } from '@agoric/vow/src/E.js';
+
+export const walletUpdates = (
+  getLastUpdate: () => Promise<UpdateRecord>,
+  retryOpts: RetryOptions & {
+    log: (...args: any[]) => void;
+    setTimeout: typeof globalThis.setTimeout;
+  },
+) => {
+  return harden({
+    invocation: async (id: string | number) => {
+      const done = (await retryUntilCondition(
+        getLastUpdate,
+        update =>
+          update.updated === 'invocation' &&
+          update.id === id &&
+          !!(update.result || update.error),
+        `${id}`,
+        retryOpts,
+      )) as UpdateRecord & { updated: 'invocation' };
+      if (done.error) throw Error(done.error);
+      return done.result;
+    },
+    offerResult: async (id: string | number) => {
+      const done = (await retryUntilCondition(
+        getLastUpdate,
+        update =>
+          update.updated === 'offerStatus' &&
+          update.status.id === id &&
+          (!!update.status.result || !!update.status.error),
+        `${id}`,
+        retryOpts,
+      )) as UpdateRecord & { updated: 'offerStatus' };
+      if (done.status.error) throw Error(done.status.error);
+      return done.status.result;
+    },
+    // payoutAmounts: ...
+  });
+};
+
+/**
+ * Reflect wallet store, supporting type-safe invokeEntry
+ *
+ * @param wallet
+ */
+export const reflectWalletStore = (
+  sig: SigningSmartWalletKit,
+  retryOpts: RetryOptions & {
+    log: (...args: any[]) => void;
+    setTimeout: typeof globalThis.setTimeout;
+    fresh: () => number | string;
+  },
+) => {
+  const up = walletUpdates(sig.query.getLastUpdate, retryOpts);
+
+  let saveResult: { name: string; overwrite?: boolean } | undefined = undefined;
+  const savingResult = async <T>(name: string, thunk: () => Promise<T>) => {
+    assert(!saveResult, 'already saving');
+    saveResult = { name, overwrite: true };
+    const result = await thunk();
+    saveResult = undefined;
+    return result;
+  };
+  let lastTx;
+  const logged = (l, x) => {
+    retryOpts.log(l, x);
+    return x;
+  };
+  const makeEntryProxy = (targetName: string) =>
+    new Proxy(harden({}), {
+      get(_t, method, _rx) {
+        assert.typeof(method, 'string');
+        if (method === 'then') return undefined;
+        const boundMethod = async (...args) => {
+          const id = `${method}.${retryOpts.fresh()}`;
+          let tx = await sig.invokeEntry(
+            logged('invoke', {
+              id,
+              targetName,
+              method,
+              args,
+              ...(saveResult ? { saveResult } : {}),
+            }),
+          );
+          if (tx.result.transaction.code !== 0)
+            throw Error(tx.result.transaction.rawLog);
+          lastTx = tx.result.transaction;
+          await up.invocation(id);
+          return saveResult ? makeEntryProxy(saveResult.name) : undefined;
+        };
+        return harden(boundMethod);
+      },
+    });
+
+  const saveOfferResult = async <T = unknown>(
+    { instance, description }: { instance: Instance; description: string },
+    name: string = description,
+  ) => {
+    const id = `${description}.${retryOpts.fresh()}`;
+    // XXX return / expose tx info
+    await sig.sendBridgeAction(
+      harden({
+        method: 'executeOffer',
+        offer: {
+          id,
+          invitationSpec: { source: 'purse', description, instance },
+          proposal: {},
+          saveResult: { name, overwrite: true },
+        },
+      }),
+    );
+    await up.offerResult(id);
+    return makeEntryProxy(name) as EMethods<T>;
+  };
+
+  const get = <T>(name: string) => makeEntryProxy(name) as EMethods<T>;
+
+  return harden({
+    get,
+    saveOfferResult,
+    savingResult,
+    getLastTx: () => lastTx,
+  });
+};

--- a/packages/client-utils/src/signing-smart-wallet-kit.ts
+++ b/packages/client-utils/src/signing-smart-wallet-kit.ts
@@ -12,8 +12,8 @@ import { type SmartWalletKit } from './smart-wallet-kit.js';
 
 // TODO parameterize as part of https://github.com/Agoric/agoric-sdk/issues/5912
 const defaultFee: StdFee = {
-  amount: [{ denom: 'ubld', amount: '30000' }], // XXX enough?
-  gas: '197000',
+  amount: [{ denom: 'ubld', amount: '500000' }], // XXX enough?
+  gas: '19700000',
 };
 
 /**

--- a/packages/client-utils/test/signing-smart-wallet-kit.test.ts
+++ b/packages/client-utils/test/signing-smart-wallet-kit.test.ts
@@ -71,7 +71,7 @@ test('sendBridgeAction handles simple action', async t => {
         },
       },
     ],
-    fee: { amount: [{ denom: 'ubld', amount: '30000' }], gas: '197000' },
+    fee: { amount: [{ denom: 'ubld', amount: '500000' }], gas: '19700000' },
   });
 });
 

--- a/packages/portfolio-deploy/scripts/deploy-cli.ts
+++ b/packages/portfolio-deploy/scripts/deploy-cli.ts
@@ -34,12 +34,17 @@ type ParsedArgs = {
   description?: string;
 };
 
+const inheritSterr = opts => ({
+  ...opts,
+  stdio: [...opts.stdio.slice(0, 2), 'inherit'],
+});
+
 const main = async (
   argv = process.argv,
   {
     fetch = globalThis.fetch,
     execFile = (cmd, args, opts) =>
-      execa({ verbose: 'short' })(cmd, args, opts),
+      execa({ verbose: 'short' })(cmd, args, inheritSterr(opts)),
   } = {},
 ) => {
   const getVersion = () =>

--- a/packages/portfolio-deploy/src/vstorage-outdated.js
+++ b/packages/portfolio-deploy/src/vstorage-outdated.js
@@ -1,0 +1,70 @@
+import { NonNullish } from '@agoric/internal';
+import { throwRedacted as Fail } from '@endo/errors';
+
+/**
+ * @import { StreamCell } from '@agoric/internal/src/lib-chainStorage.js';
+ * @import { VStorage } from '@agoric/client-utils';
+ * @import {PruneOpts} from './vstorage-prune.core';
+ */
+
+/**
+ * @param {VStorage} vs
+ * @param {string} start
+ */
+
+async function* depthFirst(vs, start) {
+  /** @param {string} current */
+  async function* visit(current) {
+    const children = await vs.keys(current);
+    for (const child of children) {
+      yield* visit(`${current}.${child}`);
+    }
+    yield current;
+  }
+
+  yield* visit(start);
+}
+
+/** @param {VStorage} vs */
+export const findOutdated = async vs => {
+  const verbose = false; // XXX cli flag
+  const debug = verbose ? console.debug : () => {};
+
+  /** @param {string} path */
+  const getHeightLast = async path => {
+    debug('read', path);
+    // const raw = await vs.readStorage(path);
+    // console.debug({ path, raw });
+    const { blockHeight, values } = /** @type {StreamCell<'string'>} */ (
+      await vs.readAt(path)
+    );
+    return { blockHeight: Number(blockHeight), last: values.at(-1) };
+  };
+
+  const { blockHeight: t0, last } = await getHeightLast(
+    'published.agoricNames.instance',
+  );
+  (last && last.includes('ymax0')) || Fail`no ymax0 instance`;
+  console.error('published.agoricNames.instance blockHeight', t0);
+
+  /** @type {PruneOpts['toPrune']} */
+  const toPrune = {};
+
+  const noData = ['.portfolios', '.flows', '.positions'];
+  for await (const path of depthFirst(vs, 'published.ymax0.portfolios')) {
+    if (noData.some(tail => path.endsWith(tail))) continue;
+    const { blockHeight: age } = await getHeightLast(path);
+    const ok = age >= t0;
+    debug({ path, age, t0, ok });
+    if (!ok) {
+      const parts = path.split('.');
+      const child = NonNullish(parts.at(-1));
+      const parent = parts.slice(0, -1).join('.');
+      if (!(parent in toPrune)) {
+        toPrune[parent] = [];
+      }
+      toPrune[parent].push(child);
+    }
+  }
+  return harden(toPrune);
+};

--- a/packages/portfolio-deploy/src/vstorage-prune.build.js
+++ b/packages/portfolio-deploy/src/vstorage-prune.build.js
@@ -10,15 +10,12 @@
 /* global globalThis */
 import { fetchEnvNetworkConfig, makeVStorage } from '@agoric/client-utils';
 import { makeHelpers } from '@agoric/deploy-script-support';
-import { NonNullish } from '@agoric/internal';
-import { Fail } from '@endo/errors';
 import { getManifestForPruneVStorage } from './vstorage-prune.core.js';
+import { findOutdated } from './vstorage-outdated.js';
 
 const sourceSpec = './vstorage-prune.core.js';
 
 /**
- * @import { StreamCell } from '@agoric/internal/src/lib-chainStorage.js';
- * @import { VStorage } from '@agoric/client-utils';
  * @import {CoreEvalBuilder, DeployScriptFunction} from '@agoric/deploy-script-support/src/externalTypes.js';
  * @import {PruneOpts} from './vstorage-prune.core';
  */
@@ -33,68 +30,6 @@ export const defaultProposalBuilder = async (_utils, pruneOpts) =>
     sourceSpec,
     getManifestCall: [getManifestForPruneVStorage.name, { options: pruneOpts }],
   });
-
-/**
- * @param {VStorage} vs
- * @param {string} start
- */
-async function* depthFirst(vs, start) {
-  /** @param {string} current */
-  async function* visit(current) {
-    const children = await vs.keys(current);
-    for (const child of children) {
-      yield* visit(`${current}.${child}`);
-    }
-    yield current;
-  }
-
-  yield* visit(start);
-}
-
-/** @param {VStorage} vs */
-const findOutdated = async vs => {
-  const verbose = false; // XXX cli flag
-  const debug = verbose ? console.debug : () => {};
-
-  /** @param {string} path */
-  const getHeightLast = async path => {
-    debug('read', path);
-    // const raw = await vs.readStorage(path);
-    // console.debug({ path, raw });
-
-    const { blockHeight, values } = /** @type {StreamCell<'string'>} */ (
-      await vs.readAt(path)
-    );
-    return { blockHeight: Number(blockHeight), last: values.at(-1) };
-  };
-
-  const { blockHeight: t0, last } = await getHeightLast(
-    'published.agoricNames.instance',
-  );
-  (last && last.includes('ymax0')) || Fail`no ymax0 instance`;
-  console.error('published.agoricNames.instance blockHeight', t0);
-
-  /** @type {PruneOpts['toPrune']} */
-  const toPrune = {};
-
-  const noData = ['.portfolios', '.flows', '.positions'];
-  for await (const path of depthFirst(vs, 'published.ymax0.portfolios')) {
-    if (noData.some(tail => path.endsWith(tail))) continue;
-    const { blockHeight: age } = await getHeightLast(path);
-    const ok = age >= t0;
-    debug({ path, age, t0, ok });
-    if (!ok) {
-      const parts = path.split('.');
-      const child = NonNullish(parts.at(-1));
-      const parent = parts.slice(0, -1).join('.');
-      if (!(parent in toPrune)) {
-        toPrune[parent] = [];
-      }
-      toPrune[parent].push(child);
-    }
-  }
-  return harden(toPrune);
-};
 
 /** @type {DeployScriptFunction} */
 export default async (


### PR DESCRIPTION
## Description

I suggest review by commit.

These are keepers from recent work on e2e testing of Aave on ethereum-sepolia (rescued  from `lp-ymax-aave-e2e` branch).

 - chore(portfolio-deploy): eth had wrong axelarid

 - `multichain-testing/Makefile`: automate using ymaxControl to (re-) deploy on devnet
   - `make yctrl-redeploy` - build, install bundle; start with ymaxControl
   - `make ,invitePlanner` - " + send a new invitation to the planner
   - fix(portfolio-deploy): deploy-cli: show stderr on failure

 - feat!(ymax-tool): open Aave/Eth position, planner-style
   - refactor(portfolio-deploy): vstorage-outdated
   - chore(client-utils): ensure sufficient fees/gas for ymax privateArgs (fyi @turadg )
   - chore(multichain): tools/wallet-store-reflect

### Security /  Scaling / Upgrade Considerations

unremarkable; no change to on-chain code (aside from axelarid config)

### Documentation Considerations

BREAKING CHANGE: ymax-tool positional cli arg goes from USDN volume number to record of positions

### Testing Considerations

manually tested on devnet

