### PR TITLE
chore: return tx ID from registerTransaction

### DIFF
--- a/packages/portfolio-contract/src/pos-gmp.flows.ts
+++ b/packages/portfolio-contract/src/pos-gmp.flows.ts
@@ -186,11 +186,12 @@ export const CCTP = {
     await ica.depositForBurn(destinationAddress, denomAmount);
 
     trace(`CCTP transaction initiated, waiting for confirmation...`);
-    await ctx.cctpClient.registerTransaction(
+    const { vow: cctpVow } = await ctx.cctpClient.registerTransaction(
       TxType.CCTP,
       destinationAddress,
       amount.value,
     );
+    await cctpVow;
     trace(`CCTP transaction completed after confirmation`);
   },
   recover: async (_ctx, amount, src, dest) => {

--- a/packages/portfolio-contract/src/resolver/resolver.exo.ts
+++ b/packages/portfolio-contract/src/resolver/resolver.exo.ts
@@ -45,7 +45,7 @@ const ClientFacetI = M.interface('ResolverClient', {
     M.or(...Object.values(TxType)),
     M.string(),
     M.nat(),
-  ).returns(VowShape),
+  ).returns(M.splitRecord({ vow: VowShape, txId: M.string() })),
 });
 
 const ReporterI = M.interface('Reporter', {
@@ -133,14 +133,14 @@ export const prepareResolverKit = (
           type: TxType,
           destinationAddress: AccountId,
           amountValue: NatValue,
-        ): Vow<void> {
+        ): { vow: Vow<void>; txId: TxId } {
           const txId: TxId = `tx${this.state.index}`;
           this.state.index += 1;
 
           const { transactionRegistry } = this.state;
           if (transactionRegistry.has(txId)) {
             trace(`Transaction already registered: ${txId}`);
-            return transactionRegistry.get(txId).vowKit.vow;
+            return { vow: transactionRegistry.get(txId).vowKit.vow, txId };
           }
           const vowKit = vowTools.makeVowKit<void>();
           transactionRegistry.init(
@@ -154,7 +154,7 @@ export const prepareResolverKit = (
           );
 
           trace(`Registered pending transaction: ${txId}`);
-          return vowKit.vow;
+          return { vow: vowKit.vow, txId };
         },
       },
       reporter: {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
This PR builds on the transaction resolver work in https://github.com/Agoric/agoric-sdk/pull/11818 (by @frazarshad and @amessbee). See https://github.com/Agoric/agoric-sdk/issues/11853 on why we need this `txId`


### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
None.

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
None.

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
We should document the role of `txId` in multiple places.  
- It is stored under the `published.ymax0.pendingTxs` vstorage path.  
- It will also be passed to the remote account contract on the EVM side via `sendGMPContractCall`.  
- Upon successful transaction completion, that contract will emit the `txId`.  
- Our resolver service will then trace completion by filtering logs from the remote account contract that match this `txId`.  

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Current test suite should be enough to test these changes.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
I see the following things happening:
- The remote account wallet contract must be updated to emit `txId` after successful transactions.  
   - This requires redeploying the updated EVM contracts on mainnet/testnet.  
- The resolver service implementation must be updated to trace GMP transactions by matching `txId` values.  
