### PR TITLE
chore: add sender address verification for Axelar GMP transactions

### DIFF
--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -307,6 +307,7 @@ export const contract = async (
     zcf,
     vowTools,
     axelarIds,
+    gmpAddresses,
     rebalance,
     parseInboundTransfer: parseInboundTransfer,
     proposalShapes,

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -313,7 +313,10 @@ export const contract = async (
     proposalShapes,
     offerArgsShapes,
     timer: timerService,
-    chainHubTools: { getChainInfo: chainHub.getChainInfo.bind(chainHub) },
+    chainHubTools: {
+      getChainInfo: chainHub.getChainInfo.bind(chainHub),
+      getChainsAndConnection: chainHub.getChainsAndConnection.bind(chainHub),
+    },
     portfoliosNode: E(storageNode).makeChildNode('portfolios'),
     marshaller,
     usdcBrand: brands.USDC,

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -33,7 +33,7 @@ import {
   SupportedChain,
   YieldProtocol,
 } from '@agoric/portfolio-api/src/constants.js';
-import type { AxelarId } from './portfolio.contract.js';
+import type { AxelarId, GmpAddresses } from './portfolio.contract.js';
 import type { LocalAccount, NobleAccount } from './portfolio.flows.js';
 import { preparePosition, type Position } from './pos.exo.js';
 import type { makeOfferArgsShapes } from './type-guards-steps.js';
@@ -141,6 +141,7 @@ export const preparePortfolioKit = (
   zone: Zone,
   {
     axelarIds,
+    gmpAddresses,
     rebalance,
     parseInboundTransfer,
     timer,
@@ -154,6 +155,7 @@ export const preparePortfolioKit = (
     usdcBrand,
   }: {
     axelarIds: AxelarId;
+    gmpAddresses: GmpAddresses;
     rebalance: (
       seat: ZCFSeat,
       offerArgs: OfferArgsFor['rebalance'],
@@ -261,6 +263,11 @@ export const preparePortfolioKit = (
 
           const { extra } = parsed;
           if (!extra.memo) return;
+          if (extra.sender !== gmpAddresses.AXELAR_GMP) {
+            throw Error(
+              `Invalid GMP sender: expected ${gmpAddresses.AXELAR_GMP}, got ${extra.sender}`,
+            );
+          }
           const memo: AxelarGmpIncomingMemo = JSON.parse(extra.memo); // XXX unsound! use typed pattern
 
           const result = (

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -263,7 +263,7 @@ export const preparePortfolioKit = (
           }
 
           // Validate that this is really from Axelar to Agoric on the expected
-          // channel.  We do this after parseInboundTransfer so that that
+          // channel. We do this after parseInboundTransfer so that that
           // function can be simpler and not need to know about Axelar or
           // channels.
           const [_agoric, _axelar, connection] = await vowTools.when(

--- a/packages/portfolio-contract/test/portfolio.exo.test.ts
+++ b/packages/portfolio-contract/test/portfolio.exo.test.ts
@@ -6,6 +6,7 @@ import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
 import type { StorageNode } from '@agoric/internal/src/lib-chainStorage.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import { gmpAddresses } from './mocks.ts';
 
 const { brand: USDC } = makeIssuerKit('USDC');
 
@@ -33,6 +34,7 @@ test('portfolio exo caches storage nodes', async t => {
     // rest are not used
     zcf: null as any,
     axelarIds: null as any,
+    gmpAddresses,
     vowTools: null as any,
     timer: null as any,
     chainHubTools: null as any,

--- a/packages/portfolio-contract/test/portfolio.flows.test.ts
+++ b/packages/portfolio-contract/test/portfolio.flows.test.ts
@@ -311,6 +311,7 @@ const mocks = (
   const makePortfolioKit = preparePortfolioKit(zone, {
     zcf: mockZCF,
     axelarIds: axelarIdsMock,
+    gmpAddresses,
     vowTools,
     timer,
     chainHubTools,

--- a/packages/portfolio-contract/test/portfolio.flows.test.ts
+++ b/packages/portfolio-contract/test/portfolio.flows.test.ts
@@ -18,7 +18,9 @@ import {
 } from '@agoric/internal/src/storage-test-utils.js';
 import {
   denomHash,
+  type ActualChainInfo,
   type ChainInfo,
+  type IBCConnectionInfo,
   type Orchestrator,
 } from '@agoric/orchestration';
 import { buildGasPayload } from '@agoric/orchestration/src/utils/gmp.js';
@@ -310,20 +312,24 @@ const mocks = (
       }
       return axelarCCTPConfig[chainName];
     },
-    getChainsAndConnection: (primaryChainName, secondaryChainName) => {
-      const primaryChain = chainHubTools.getChainInfo(primaryChainName);
-      const secondaryChain = chainHubTools.getChainInfo(secondaryChainName);
-      return [
-        primaryChain,
-        secondaryChain,
-        {
-          transferChannel: {
-            channelId: 'channel-0',
-            counterpartyChannelId: 'channel-1',
-          },
-        },
-      ] as const;
-    },
+    getChainsAndConnection: <C1 extends string, C2 extends string>(
+      primaryChainName: C1,
+      secondaryChainName: C2,
+    ) =>
+      vowTools.asVow(() => {
+        const primaryChain = chainHubTools.getChainInfo(primaryChainName);
+        const secondaryChain = chainHubTools.getChainInfo(secondaryChainName);
+        return [
+          primaryChain,
+          secondaryChain,
+          {
+            transferChannel: {
+              channelId: 'channel-0',
+              counterpartyChannelId: 'channel-1',
+            },
+          } as unknown,
+        ] as [ActualChainInfo<C1>, ActualChainInfo<C2>, IBCConnectionInfo];
+      }),
   });
 
   const rebalanceHost = (seat, offerArgs, kit) =>

--- a/packages/portfolio-contract/test/supports.ts
+++ b/packages/portfolio-contract/test/supports.ts
@@ -5,6 +5,7 @@ import {
   denomHash,
   withChainCapabilities,
   type ChainInfo,
+  type CosmosChainAddress,
   type CosmosChainInfo,
   type Denom,
 } from '@agoric/orchestration';
@@ -22,10 +23,12 @@ import { encodeAbiParameters } from 'viem';
 import { gmpAddresses } from './mocks.ts';
 
 export const makeIncomingEVMEvent = ({
+  sender = gmpAddresses.AXELAR_GMP,
   address = '0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092',
   sourceChain,
   target = makeTestAddress(0), // agoric1q...p7zqht
 }: {
+  sender?: `${string}1${string}`;
   address?: `0x${string}`;
   sourceChain: string;
   target?: string;
@@ -40,6 +43,7 @@ export const makeIncomingEVMEvent = ({
     axelarConnections.transferChannel.counterPartyChannelId;
 
   return makeIncomingVTransferEvent({
+    sender,
     sourceChannel: axelarToAgoricChannel,
     destinationChannel: agoricToAxelarChannel,
     target,

--- a/packages/portfolio-contract/test/supports.ts
+++ b/packages/portfolio-contract/test/supports.ts
@@ -19,6 +19,7 @@ import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { E } from '@endo/far';
 import type { ExecutionContext } from 'ava';
 import { encodeAbiParameters } from 'viem';
+import { gmpAddresses } from './mocks.ts';
 
 export const makeIncomingEVMEvent = ({
   address = '0x126cf3AC9ea12794Ff50f56727C7C66E26D9C092',
@@ -60,7 +61,7 @@ export const makeIncomingEVMEvent = ({
 };
 
 export const makeIncomingVTransferEvent = ({
-  sender = makeTestAddress(),
+  sender = gmpAddresses.AXELAR_GMP,
   sourcePort = 'transfer',
   sourceChannel = 'channel-1',
   destinationPort = 'transfer',

--- a/packages/portfolio-contract/test/supports.ts
+++ b/packages/portfolio-contract/test/supports.ts
@@ -5,7 +5,6 @@ import {
   denomHash,
   withChainCapabilities,
   type ChainInfo,
-  type CosmosChainAddress,
   type CosmosChainInfo,
   type Denom,
 } from '@agoric/orchestration';
@@ -38,14 +37,13 @@ export const makeIncomingEVMEvent = ({
   const axelarConnections =
     fetchedChainInfo.agoric.connections['axelar-dojo-1'];
 
-  const axelarToAgoricChannel = axelarConnections.transferChannel.channelId;
-  const agoricToAxelarChannel =
-    axelarConnections.transferChannel.counterPartyChannelId;
+  const agoricChannel = axelarConnections.transferChannel.channelId;
+  const axelarChannel = axelarConnections.transferChannel.counterPartyChannelId;
 
-  return makeIncomingVTransferEvent({
+  const result = makeIncomingVTransferEvent({
     sender,
-    sourceChannel: axelarToAgoricChannel,
-    destinationChannel: agoricToAxelarChannel,
+    sourceChannel: axelarChannel,
+    destinationChannel: agoricChannel,
     target,
     memo: JSON.stringify({
       source_chain: sourceChain,
@@ -62,14 +60,13 @@ export const makeIncomingEVMEvent = ({
       type: 1,
     }),
   });
+  return result;
 };
 
 export const makeIncomingVTransferEvent = ({
-  sender = gmpAddresses.AXELAR_GMP,
-  sourcePort = 'transfer',
-  sourceChannel = 'channel-1',
-  destinationPort = 'transfer',
-  destinationChannel = 'channel-2',
+  sender = makeTestAddress(),
+  sourceChannel = 'channel-1' as `channel-${number}`,
+  destinationChannel = 'channel-2' as `channel-${number}`,
   target = 'agoric1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp7zqht',
   hookQuery = {},
   receiver = encodeAddressHook(target, hookQuery),
@@ -84,10 +81,8 @@ export const makeIncomingVTransferEvent = ({
     sender,
     target: target,
     receiver,
-    source_port: sourcePort,
-    source_channel: sourceChannel,
-    destination_port: destinationPort,
-    destination_channel: destinationChannel,
+    sourceChannel,
+    destinationChannel,
     memo,
   });
 };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://github.com/Agoric/agoric-sdk/issues/11891

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
The `receiveUpCall` listener now verifies that the sender originates from the trusted `AXELAR_GMP` address(`axelar1dv4u5k73pzqrxlzujxg3qp8kvc3pje7jtdvu72npnt5zhq05ejcsn5qme5`) in `portfolio.exo.ts:266`.

This enhancement blocks malicious actors from submitting forged GMP transactions via untrusted addresses, reducing the attack surface for cross-chain transaction manipulation.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Existing test suite is enough to verify this change. Added an additional test as well to verify `receiveUpCall` failure upon a `sender` besides Axelar GMP Account.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- Nothing critical. Just requires a contract upgrade via the ymax-controller. 
- Although it's not anywhere in Axelar docs, but if the Axelar GMP Account changes, it will require a contract upgrade.