### PR TITLE
chore: unblock `master` and `dev-upgrade-*` branches

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -285,19 +285,19 @@ jobs:
         run: make --directory packages/cosmic-swingset install
         working-directory: agoric-sdk
 
-      - name: verify SDK image didn't change
-        # In the future when we can rebuild the SDK image with resolved endo packages, it would
-        # be expected that the SDK image previously built has changed
-        if: steps.restore-node.outputs.endo-branch == 'NOPE'
-        run: |
-          original=$(docker inspect --format "{{.ID}}" ghcr.io/agoric/agoric-sdk:unreleased)
-          yarn build:sdk
-          new=$(docker inspect --format "{{.ID}}" ghcr.io/agoric/agoric-sdk:unreleased)
-          if [ "$original" != "$new" ]; then
-            echo "New SDK docker image ($new) changed after restore-node (original $original)" 1>&2
-            exit 1
-          fi
-        working-directory: agoric-sdk/a3p-integration
+      # - name: verify SDK image didn't change
+      #   # In the future when we can rebuild the SDK image with resolved endo packages, it would
+      #   # be expected that the SDK image previously built has changed
+      #   if: steps.restore-node.outputs.endo-branch == 'NOPE'
+      #   run: |
+      #     original=$(docker inspect --format "{{.ID}}" ghcr.io/agoric/agoric-sdk:unreleased)
+      #     yarn build:sdk
+      #     new=$(docker inspect --format "{{.ID}}" ghcr.io/agoric/agoric-sdk:unreleased)
+      #     if [ "$original" != "$new" ]; then
+      #       echo "New SDK docker image ($new) changed after restore-node (original $original)" 1>&2
+      #       exit 1
+      #     fi
+      #   working-directory: agoric-sdk/a3p-integration
 
       - id: get-loadgen-branch
         name: Get the appropriate loadgen branch

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@yarnpkg/types": "^4.0.1",
     "ava": "^5.3.0",
     "c8": "^10.1.3",
-    "conventional-changelog-conventionalcommits": "^4.6.0",
+    "conventional-changelog-conventionalcommits": "^9.1.0",
     "eslint": "^9.32.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-jessie": "^0.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,7 +966,7 @@ __metadata:
     "@yarnpkg/types": "npm:^4.0.1"
     ava: "npm:^5.3.0"
     c8: "npm:^10.1.3"
-    conventional-changelog-conventionalcommits: "npm:^4.6.0"
+    conventional-changelog-conventionalcommits: "npm:^9.1.0"
     eslint: "npm:^9.32.0"
     eslint-config-airbnb-base: "npm:^15.0.0"
     eslint-config-jessie: "npm:^0.0.6"
@@ -8328,14 +8328,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-conventionalcommits@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "conventional-changelog-conventionalcommits@npm:4.6.0"
+"conventional-changelog-conventionalcommits@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "conventional-changelog-conventionalcommits@npm:9.1.0"
   dependencies:
     compare-func: "npm:^2.0.0"
-    lodash: "npm:^4.17.15"
-    q: "npm:^1.5.1"
-  checksum: 10c0/87d4868288d0a03d3f94796bf5245888d326eca75cd3bcef188ed6aa8315150015087cf854a2d6f5ab678ff5294dd81916c40e4f36be4d59113af1b13e845e2d
+  checksum: 10c0/b1dfbb8ce5983bb80837c35f089fb0f9603a1b067f34be680f88fde20871792e461e29d119d468bc293f38a1ca916c1c40a841f8c049a0a1efaa40582f4fecc9
   languageName: node
   linkType: hard
 
@@ -15112,13 +15110,6 @@ __metadata:
   version: 5.0.1
   resolution: "pure-rand@npm:5.0.1"
   checksum: 10c0/56fb43edf336ac939564d60535597a4182a6310627c4c7c54ef22499223a3d967bfa6d05a9c95c45ed5324bb7167de57a25e3fac5495dd4409672c08166d7973
-  languageName: node
-  linkType: hard
-
-"q@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "q@npm:1.5.1"
-  checksum: 10c0/7855fbdba126cb7e92ef3a16b47ba998c0786ec7fface236e3eb0135b65df36429d91a86b1fff3ab0927b4ac4ee88a2c44527c7c3b8e2a37efbec9fe34803df4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
refs: #XXXX

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Master is currently broken and not allowing PRs to merge due to an sdk image hash mismatch even when images are the same. Temporarily disabling it for now to unblock both master and release u22.

Moreover, bumps `conventional-changelog-conventionalcommits` to 9.1.0 (latest) to get rid of 
```
lerna-lite ERR! Error: `whatBump` must be a function
lerna-lite ERR!     at Bumper.bump (file:///Users/mujahid/Documents/GitHub/release/agoric-sdk/node_modules/conventional-recommended-bump/dist/bumper.js:148:19)
lerna-lite ERR!     at file:///Users/mujahid/Documents/GitHub/release/agoric-sdk/node_modules/@lerna-lite/version/dist/conventional-commits/recommend-version.js:47:46
node:internal/process/promises:391
    triggerUncaughtException(err, true /* fromPromise */);
    ^

Error: `whatBump` must be a function
    at Bumper.bump (file:///Users/mujahid/Documents/GitHub/release/agoric-sdk/node_modules/conventional-recommended-bump/dist/bumper.js:148:19)
    at file:///Users/mujahid/Documents/GitHub/release/agoric-sdk/node_modules/@lerna-lite/version/dist/conventional-commits/recommend-version.js:47:46
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
None that I'm aware of.

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
None

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
None

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
CI should pass

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
None
