### PR TITLE
refactor: improve resolver types and simplify constructing EvmContext

### DIFF
--- a/packages/portfolio-contract/src/resolver/types.ts
+++ b/packages/portfolio-contract/src/resolver/types.ts
@@ -48,28 +48,27 @@ export type PublishedTx = {
   status: TxStatus;
 };
 
+const publishedTxRequiredFields = harden({
+  // Format: `${chainId}:${chainId}:${remoteAddess}`
+  destinationAddress: M.string(),
+  status: M.or(TxStatus.PENDING),
+});
+
+// `amount` is optional for GMP but required for CCTP
+const publishedTxCctpRequiredFields = { amount: M.nat() };
 export const PublishedTxShape: TypedPattern<PublishedTx> = M.or(
-  // CCTP_TO_EVM and CCTP_TO_NOBLE require amount
   M.splitRecord(
     {
       type: M.or(TxType.CCTP_TO_EVM, TxType.CCTP_TO_NOBLE),
-      destinationAddress: M.string(), // Format: `${chainId}:${chainId}:${remotAddess}`
-      status: M.or(TxStatus.PENDING),
-      amount: M.nat(),
+      ...publishedTxRequiredFields,
+      ...publishedTxCctpRequiredFields,
     },
     {},
     {},
   ),
-  // GMP has optional amount
   M.splitRecord(
-    {
-      type: M.or(TxType.GMP),
-      destinationAddress: M.string(),
-      status: M.or(TxStatus.PENDING),
-    },
-    {
-      amount: M.nat(),
-    },
+    { type: M.or(TxType.GMP), ...publishedTxRequiredFields },
+    publishedTxCctpRequiredFields,
     {},
   ),
 );

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -421,7 +421,7 @@ export const processPendingTxEvents = async (
         console.error(`⚠️ Failed to process pendingTx: ${txId}`, error);
       };
 
-      void handlePendingTxFn({ ...evmCtx }, tx, {
+      void handlePendingTxFn(evmCtx, tx, {
         log: logFn,
       }).catch(errorHandler);
     }

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -11,7 +11,7 @@ import { getConfig } from './config.ts';
 import { CosmosRestClient } from './cosmos-rest-client.ts';
 import { CosmosRPCClient } from './cosmos-rpc.ts';
 import { startEngine } from './engine.ts';
-import { createEVMContext } from './support.ts';
+import { buildEvmDependencies } from './support.ts';
 import { SpectrumClient } from './spectrum-client.ts';
 
 const assertChainId = async (rpc: CosmosRPCClient, chainId: string) => {
@@ -69,14 +69,21 @@ export const main = async (
     retries: config.cosmosRest.retries,
   });
 
-  const evmCtx = await createEVMContext({
+  const { evmProviders, usdcAddresses } = await buildEvmDependencies({
     clusterName,
     alchemyApiKey: config.alchemyApiKey,
   });
 
-  const powers = { evmCtx, rpc, spectrum, cosmosRest, signingSmartWalletKit };
+  const powers = {
+    evmProviders,
+    rpc,
+    spectrum,
+    cosmosRest,
+    signingSmartWalletKit,
+  };
   await startEngine(powers, {
     depositIbcDenom: env.DEPOSIT_IBC_DENOM || 'USDC',
+    usdcAddresses,
   });
 };
 harden(main);

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -80,7 +80,7 @@ type CreateContextParams = {
 
 export type EvmProviders = Partial<Record<CaipChainId, JsonRpcProvider>>;
 
-export const createEVMContext = async ({
+export const buildEvmDependencies = async ({
   clusterName,
   alchemyApiKey,
 }: CreateContextParams): Promise<

--- a/services/ymax-planner/test/config.test.ts
+++ b/services/ymax-planner/test/config.test.ts
@@ -6,7 +6,7 @@ import {
   type ClusterName,
   type SecretManager,
 } from '../src/config.ts';
-import { createEVMContext } from '../src/support.ts';
+import { buildEvmDependencies } from '../src/support.ts';
 
 const { entries, keys } = Object;
 
@@ -203,9 +203,9 @@ test('loadConfig rejects empty required values', async t => {
   });
 });
 
-// --- Unit tests for createEVMContext ---
-test('createEVMContext generates valid testnet context', async t => {
-  const result = await createEVMContext({
+// --- Unit tests for buildEvmDependencies ---
+test('buildEvmDependencies generates valid testnet output', async t => {
+  const result = await buildEvmDependencies({
     clusterName: 'testnet',
     alchemyApiKey: 'test1234',
   });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->


## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

The PR addresses some of the feedback I received after merging https://github.com/Agoric/agoric-sdk/pull/11871. 

- Extract common field definitions in `PublishedTxShape` to reduce duplication and improve maintainability of the
  `PublishedTx` type definition.
- Flatten the nested `evmCtx` structure in `Powers` type and extract evmContext construction into a reusable
  variable.
