### PR TITLE
ci: disable flaky tests

### DIFF
--- a/.github/workflows/multichain-e2e.yml
+++ b/.github/workflows/multichain-e2e.yml
@@ -99,9 +99,11 @@ jobs:
 
   orchestration-queries-hermes:
     name: Orchestration Queries - Hermes
+    # Don't run on PRs or call, only on dispatch.
+    # TODO(#11788): reenable conditions once flake is understood.
+    # github.event_name == 'workflow_call' ||
+    # github.event_name == 'pull_request' ||
     if: |
-      github.event_name == 'workflow_call' ||
-      github.event_name == 'pull_request' ||
       (github.event_name == 'workflow_dispatch' && inputs.test_type == 'orchestration-queries-hermes')
     uses: ./.github/workflows/multichain-e2e-template.yml
     with:

--- a/packages/cosmic-swingset/test/prometheus.test.ts
+++ b/packages/cosmic-swingset/test/prometheus.test.ts
@@ -250,8 +250,9 @@ const testPrometheusMetrics = async t => {
   t.log(`compared ${comparisonCount} values`);
 };
 
-if (!IS_SUBPROCESS_RETRY) {
+// TODO(#11175): skip flaky test
+if (false && !IS_SUBPROCESS_RETRY) {
   avaRetry(test, 'Prometheus metric definitions', testPrometheusMetrics);
 } else {
-  test('Prometheus metric definitions', testPrometheusMetrics);
+  test.skip('Prometheus metric definitions', testPrometheusMetrics);
 }


### PR DESCRIPTION
refs: #11788, #11175

## Description
Disable the Hermes queries multi-chain test when running in PRs (workflow call)
Disable the prometheus cosmic-swingset test

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
TODO added to reenable

### Testing Considerations
Disabling flaky tests.

### Upgrade Considerations
None
