### PR TITLE
feat(client-utils): Support FQDNs in AGORIC_NET for parseNetworkSpec and fetchNetworkConfig/fetchEnvNetworkConfig

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -38,9 +38,11 @@ Description: if nonempty, its contents must use one of the following formats:
          and https://github.com/cosmos/chain-registry )
       * `rpcAddrs`: an array of endpoints that are expected to respond to
         cosmos-sdk RPC requests
-  - "$subdomain,$chainId": a subdomain of rpc.agoric.net that is expected to
-    respond to cosmos-sdk RPC requests, and a Cosmos Chain ID to associate with
-    it
+  - "$subdomain,$chainId": a single-word subdomain of rpc.agoric.net that is
+    expected to respond to cosmos-sdk RPC requests, and a Cosmos Chain ID to
+    associate with it
+  - "$fqdn,$chainId": a fully-qualified domain name that is expected to respond
+    to cosmos-sdk RPC requests, and a Cosmos Chain ID to associate with it
 
 The default is usually `'local'`, which uses RPC endpoint http://0.0.0.0:26657
 and chain ID "agoriclocal".

--- a/services/ymax-planner/README.md
+++ b/services/ymax-planner/README.md
@@ -80,8 +80,9 @@ Environment variables:
   [Agoric SDK Environment Variables](../../docs/env.md), either "$subdomain" for
   requesting MinimalNetworkConfig from URL
   [https://$subdomain.agoric.net/network-config](https://all.agoric.net/) or
-  "$subdomain,$chainId" for sending cosmos-sdk RPC requests to
-  $subdomain.rpc.agoric.net and assuming the chain ID (default derived from `CLUSTER`, falling back to "local")
+  "$subdomain,$chainId" or "$fqdn,$chainId" for sending cosmos-sdk RPC requests
+  to $subdomain.rpc.agoric.net or $fqdn (respectively) and assuming the chain ID
+  (default derived from `CLUSTER`, falling back to "local")
 - `ALCHEMY_API_KEY`: API key for accessing Alchemy’s Ethereum RPC endpoint (required, but not verified at startup)
 - `GCP_PROJECT_ID`: For fetching an unset `MNEMONIC` from the Google Cloud Secret Manager (default "simulationlab")
 - `GCP_SECRET_NAME`: For fetching an unset `MNEMONIC` from the Google Cloud Secret Manager (default "YMAX_CONTROL_MNEMONIC")


### PR DESCRIPTION
## Description
`AGORIC_NET=agoric-rpc.polkachu.com,agoric-3` will now work, rather than trying to connect to https://agoric-rpc.polkachu.com.rpc.agoric.net:443 .

### Security Considerations
None.

### Scaling Considerations
n/a

### Documentation Considerations
Updates [env.md](https://github.com/Agoric/agoric-sdk/blob/master/docs/env.md) and the [ymax-planner README](https://github.com/Agoric/agoric-sdk/blob/master/services/ymax-planner/README.md).

### Testing Considerations
Skipped for now.

### Upgrade Considerations
None; this is backwards-compatible with single-word rpc.agoric.net subdomains, which are the only ones that work right now.