### PR TITLE
refactor: stop using deprecated "sloppy" interface option

### DIFF
--- a/packages/inter-protocol/src/price/fluxAggregatorKit.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorKit.js
@@ -223,7 +223,11 @@ export const prepareFluxAggregatorKit = async (
     baggage,
     'fluxAggregator',
     {
-      creator: M.interface('fluxAggregator creatorFacet', {}, { sloppy: true }),
+      creator: M.interface(
+        'fluxAggregator creatorFacet',
+        {},
+        { defaultGuards: 'passable' },
+      ),
       public: M.interface('fluxAggregator publicFacet', {
         getPriceAuthority: M.call().returns(M.any()),
         getPublicTopics: M.call().returns({

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -324,9 +324,9 @@ export const prepareVaultManagerKit = (
       }),
       helper: M.interface(
         'helper',
-        // not exposed so sloppy okay
+        // not exposed so using `defaultGuards` is fine.
         {},
-        { sloppy: true },
+        { defaultGuards: 'passable' },
       ),
       manager: M.interface('manager', {
         getGovernedParams: M.call().returns(M.remotable('governedParams')),

--- a/packages/internal/src/typeGuards.js
+++ b/packages/internal/src/typeGuards.js
@@ -13,8 +13,8 @@ export const StorageNodeShape = M.remotable('StorageNode');
 export const UnguardedHelperI = M.interface(
   'helper',
   {},
-  // not exposed so sloppy okay
-  { sloppy: true },
+  // not exposed so using `defaultGuards` is fine.
+  { defaultGuards: 'passable' },
 );
 
 /**

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -94,7 +94,7 @@ export const createSeatManager = (
     return activeZCFSeats.get(zcfSeat);
   };
 
-  const ZCFSeatI = M.interface('ZCFSeat', {}, { sloppy: true });
+  const ZCFSeatI = M.interface('ZCFSeat', {}, { defaultGuards: 'passable' });
 
   const makeZCFSeatInternal = prepareExoClass(
     zcfBaggage,


### PR DESCRIPTION

closes: #XXXX
refs: #XXXX

## Description

The copilot text at https://github.com/Agoric/agoric-sdk/pull/11931#pullrequestreview-3221694226 seems like a fine description.

This PR refactors the codebase to replace the deprecated "sloppy" interface option with the newer "defaultGuards: 'passable'" option in Marshal interface definitions.

Updates interface definitions from { sloppy: true } to { defaultGuards: 'passable' }
Updates associated comments to reflect the new interface option terminology
Maintains the same functional behavior while using the current API

### Security Considerations

Should be semantically identical, but easier to understand, so slight security improvement

### Scaling Considerations
none
### Documentation Considerations
If we can stop using `sloppy` completely, perhaps we can avoid documenting it in normal developer-facing documentation.

### Testing Considerations
Adequate testing already in heap-classes.test.js in `@endo/exo`

### Upgrade Considerations

Since we still support the deprecated option at this time, none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated interface guard configurations to use standardized validation policies across multiple components, enhancing internal consistency and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->