### PR TITLE
fix: use correct flag value for mainnet detection

### DIFF
--- a/packages/portfolio-deploy/src/portfolio.build.js
+++ b/packages/portfolio-deploy/src/portfolio.build.js
@@ -81,7 +81,7 @@ const build = async (homeP, endowments) => {
     },
   });
 
-  const isMainnet = flags.net === 'devnet';
+  const isMainnet = flags.net === 'mainnet';
   const config = configs[isMainnet ? 'mainnet' : 'testnet'];
 
   if (isMainnet) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Switched from 'devnet' to 'mainnet' when checking `flags.net` so the correct config is loaded for mainnet deployments.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
This change doesn't require us to deploy a new contract version. All we need to do is use `ymax-control` to update the mainnet contract with the right axelar-config. 