### PR TITLE
fix: subscribe to NewBlock events instead of NewBlockHeader

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -379,10 +379,11 @@ export const startEngine = async (
   const blockHeightFromSubscriptionResponse = (resp: SubscriptionResponse) => {
     const { type: respType, value: respData } = resp;
     switch (respType) {
-      case 'tendermint/event/NewBlockHeader':
-        return BigInt((respData.header as any).height);
       case 'tendermint/event/Tx':
         return BigInt((respData.TxResult as any).height);
+      case 'tendermint/event/NewBlock':
+        // https://pkg.go.dev/github.com/cometbft/cometbft/types#EventDataNewBlock
+        return BigInt((respData.block as any).header.height);
       default: {
         console.error(
           `🚨 Attempting to read block height from unexpected response type ${respType}`,
@@ -398,7 +399,7 @@ export const startEngine = async (
   // To avoid data gaps, establish subscriptions before gathering initial state.
   const subscriptionFilters = [
     // vstorage events are in BEGIN_BLOCK/END_BLOCK activity
-    "tm.event = 'NewBlockHeader'",
+    "tm.event = 'NewBlock'",
     // transactions
     "tm.event = 'Tx'",
   ];

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -468,7 +468,7 @@ export const startEngine = async (
     const path = `${PENDING_TX_PATH_PREFIX}.${txId}`;
     await null;
     let streamCellJson;
-    let data: unknown;
+    let data;
     try {
       streamCellJson = await query.vstorage.readStorage(path, {
         kind: 'data',


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
- Switched event subscription from `tm.event='NewBlockHeader'` to `tm.event='NewBlock`'
- Updated `blockHeightFromSubscriptionResponse` to handle `tendermint/event/NewBlock` responses
