### PR TITLE
chore: use USDCn a_tokens instead of USDC

### DIFF
--- a/packages/portfolio-deploy/src/axelar-configs.js
+++ b/packages/portfolio-deploy/src/axelar-configs.js
@@ -110,8 +110,8 @@ const aaveUsdcAddresses = harden({
   mainnet: {
     Ethereum: '0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c', // https://search.onaave.com/?q=atoken%20usdc%20aavev3ethereum
     Avalanche: '0x625E7708f30cA75bfd92586e17077590C60eb4cD', // https://search.onaave.com/?q=atoken%20usdc%20aavev3avalanche
-    Arbitrum: '0x625E7708f30cA75bfd92586e17077590C60eb4cD', // https://search.onaave.com/?q=atoken%20usdc%20aavev3arbitrum
-    Optimism: '0x625E7708f30cA75bfd92586e17077590C60eb4cD', // https://search.onaave.com/?q=atoken%20usdc%20aavev3optimism
+    Arbitrum: '0x724dc807b04555b71ed48a6896b6F41593b8C637', // https://search.onaave.com/?q=atoken%20usdcn%20aavev3arbitrum // token is USDCn not USDC on Arbitrum
+    Optimism: '0x38d693cE1dF5AaDF7bC62595A37D667aD57922e5', // https://search.onaave.com/?q=atoken%20usdcn%20aavev3optimism  // token is USDCn not USDC on Optimism
     Base: '0x4e65fE4DbA92790696d040ac24Aa414708F5c0AB', // https://search.onaave.com/?q=atoken%20usdc%20aavev3base
   },
   testnet: {


### PR DESCRIPTION
closes: #11960 

## Description
During address verification, It was discovered that Optimism and Arbitrum call the Circle USDC token as `USDCn` in their [registry](https://search.onaave.com/):
https://search.onaave.com/?q=usdcn%20underlying%20optimism
https://search.onaave.com/?q=usdcn%20underlying%20arbitrum

This discrepancy does not exist for other chains, leading us to use USDC A_TOKEN addresses from this registry instead of USDCn A_TOKEN addresses


### Upgrade Considerations
Contract must be restarted using `installAndStart` for these changes to take effect.
