### PR TITLE
allow bare jsdoc return tag in .ts files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -276,8 +276,10 @@ export default [
     files: ['**/*.ts'],
 
     rules: {
+      // Not needed with TypeScript syntax
       'jsdoc/require-param': 'off',
       'jsdoc/require-param-type': 'off',
+      'jsdoc/require-returns-type': 'off',
       'no-undef': 'off',
       '@typescript-eslint/no-unused-vars': [
         'error',

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -1,4 +1,4 @@
-/* eslint-disable jsdoc/require-returns-type, @jessie.js/safe-await-separator */
+/* eslint-disable @jessie.js/safe-await-separator */
 /* eslint-env node */
 
 import childProcessAmbient from 'node:child_process';

--- a/packages/eslint-config/eslint-config.cjs
+++ b/packages/eslint-config/eslint-config.cjs
@@ -109,6 +109,8 @@ module.exports = {
     {
       files: ['**/*.ts'],
       rules: {
+        // Not needed with TypeScript syntax
+        'jsdoc/require-returns-type': 'off',
         // Handled better by tsc
         'import/no-unresolved': 'off',
         'no-unused-vars': 'off',

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -45,8 +45,6 @@ import type { AssetPlaceRef } from './type-guards-steps.js';
 
 export type { OfferArgsFor } from './type-guards-steps.js';
 
-/* eslint jsdoc/require-returns-type: 0 */
-
 // #region preliminaries
 const { keys } = Object;
 

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -1,5 +1,3 @@
-/* eslint-disable jsdoc/require-returns-type */
-
 import { JsonRpcProvider, Log, type Filter } from 'ethers';
 import type { CaipChainId } from '@agoric/orchestration';
 import type { ClusterName } from './config.ts';


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/pull/11974/files#r2372941443

## Description

In `.ts` files, the return type is within the syntax tree, not the JSDoc. Remove lint for for JSDoc type annotation on `@returns`.

# Considerations

Dev-time only. CI suffices.