### PR TITLE
KLUDGE: allow planner to resolve GMP makeAccount calls

### DIFF
--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -43,7 +43,10 @@ import {
   objectMap,
   type TypedPattern,
 } from '@agoric/internal';
-import { YieldProtocol } from '@agoric/portfolio-api/src/constants.js';
+import {
+  AxelarChain,
+  YieldProtocol,
+} from '@agoric/portfolio-api/src/constants.js';
 import type { OfferStatus } from '@agoric/smart-wallet/src/offers.js';
 import type { NameHub } from '@agoric/vats';
 import type { StartedInstanceKit as ZStarted } from '@agoric/zoe/src/zoeService/utils';
@@ -88,6 +91,9 @@ const parseToolArgs = (argv: string[]) =>
       invitePlanner: { type: 'string' },
       pruneStorage: { type: 'boolean', default: false },
       'submit-for': { type: 'string' },
+      'resolve-account-for': { type: 'string' },
+      unsafeRemoteAddress: { type: 'string' },
+      chainName: { type: 'string' },
       help: { type: 'boolean', short: 'h', default: false },
     },
     allowPositionals: false,
@@ -430,6 +436,26 @@ const main = async (
     const policyVersion = 0; // XXX should get from vstorage
     const rebalanceCount = 0;
     await planner.submit(portfolioId, [], policyVersion, rebalanceCount);
+    return;
+  }
+
+  if (values['resolve-account-for']) {
+    const portfolioId = Number(values['resolve-account-for']);
+    const { chainName, unsafeRemoteAddress: remoteAddress } = values;
+    const planner = walletStore.get<PortfolioPlanner>('planner');
+    trace(
+      'KLUDGE!!! resolve',
+      chainName,
+      'account for',
+      portfolioId,
+      'to',
+      remoteAddress,
+    );
+    await planner.UNSAFEresolveEVMAddress(
+      portfolioId,
+      chainName as AxelarChain,
+      remoteAddress as `0x${string}`,
+    );
     return;
   }
 

--- a/packages/portfolio-contract/test/planner.exo.test.ts
+++ b/packages/portfolio-contract/test/planner.exo.test.ts
@@ -3,6 +3,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { makeIssuerKit } from '@agoric/ertp';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import type { ActualChainInfo } from '@agoric/orchestration';
 import { makeFakeBoard } from '@agoric/vats/tools/board-utils.js';
 import { prepareVowTools } from '@agoric/vow';
 import type { ZCF } from '@agoric/zoe';
@@ -58,6 +59,16 @@ test('planner exo submit method', async t => {
     getPortfolio: mockGetPortfolio,
     shapes: makeOfferArgsShapes(USDC),
     vowTools: vt,
+    chainHubTools: {
+      getChainInfo: <K extends string>(_c: K) =>
+        vt.asVow(
+          async () =>
+            ({
+              namespace: 'eip155',
+              reference: '1234',
+            }) as unknown as ActualChainInfo<K>,
+        ),
+    },
   });
 
   const planner = makePlanner();


### PR DESCRIPTION
## Description / Documentation / Security Considerations

Due to integration testing difficulties, provide an alternative way to resolve EVM addresses.

Usage:

```console
$ MNEMONIC='abc...' ./scripts/ymax-tool.ts --resolve-account-for 3 --chainName Arbitrum --unsafeRemoteAddress 0x23424
```

with the planner MNEMONIC.

### Scaling / Upgrade Considerations

n/a

### Testing Considerations

no automated tests


