### PR TITLE
support custom signing data in SmartWalletKit

### DIFF
--- a/multichain-testing/tools/wallet-store-reflect.ts
+++ b/multichain-testing/tools/wallet-store-reflect.ts
@@ -76,19 +76,21 @@ export const reflectWalletStore = (
         if (method === 'then') return undefined;
         const boundMethod = async (...args) => {
           const id = `${method}.${retryOpts.fresh()}`;
-          const tx = await sig.invokeEntry(
-            logged('invoke', {
-              id,
-              targetName,
-              method,
-              args,
-              ...(saveResult ? { saveResult } : {}),
-            }),
-          );
-          if (tx.result.transaction.code !== 0) {
-            throw Error(tx.result.transaction.rawLog);
+          const message = logged('invoke', {
+            id,
+            targetName,
+            method,
+            args,
+            ...(saveResult ? { saveResult } : {}),
+          });
+          const tx = await sig.sendBridgeAction({
+            method: 'invokeEntry',
+            message,
+          });
+          if (tx.code !== 0) {
+            throw Error(tx.rawLog);
           }
-          lastTx = tx.result.transaction;
+          lastTx = tx;
           await up.invocation(id);
           return saveResult ? makeEntryProxy(saveResult.name) : undefined;
         };

--- a/packages/client-utils/src/signing-smart-wallet-kit.ts
+++ b/packages/client-utils/src/signing-smart-wallet-kit.ts
@@ -3,12 +3,18 @@ import type {
   OfferSpec,
 } from '@agoric/smart-wallet/src/offers.js';
 import type { BridgeAction } from '@agoric/smart-wallet/src/smartWallet.js';
-import type { SigningStargateClient, StdFee } from '@cosmjs/stargate';
+import type {
+  DeliverTxResponse,
+  SignerData,
+  SigningStargateClient,
+  StdFee,
+} from '@cosmjs/stargate';
 import { toAccAddress } from '@cosmjs/stargate/build/queryclient/utils.js';
 import type { EReturn } from '@endo/far';
 import { MsgWalletSpendAction } from './codegen/agoric/swingset/msgs.js';
 import { makeStargateClientKit } from './signing-client.js';
 import { type SmartWalletKit } from './smart-wallet-kit.js';
+import { TxRaw } from './codegen/cosmos/tx/v1beta1/tx.js';
 
 // TODO parameterize as part of https://github.com/Agoric/agoric-sdk/issues/5912
 const defaultFee: StdFee = {
@@ -50,17 +56,36 @@ export const makeSigningSmartWalletKit = async (
     ) => walletUtils.pollOffer(address, ...args),
   };
 
-  const sendBridgeAction = (action: BridgeAction, fee: StdFee = defaultFee) => {
+  const sendBridgeAction = async (
+    action: BridgeAction,
+    fee: StdFee = defaultFee,
+    memo: string = '',
+    signerData?: SignerData,
+  ): Promise<DeliverTxResponse> => {
     const msgSpend = MsgWalletSpendAction.fromPartial({
       owner: toAccAddress(address),
       spendAction: JSON.stringify(walletUtils.marshaller.toCapData(action)),
     });
 
-    return client.signAndBroadcast(
+    const messages = [
+      { typeUrl: MsgWalletSpendAction.typeUrl, value: msgSpend },
+    ];
+
+    if (!signerData) {
+      return client.signAndBroadcast(address, messages, fee, memo);
+    }
+
+    // Explicit signing data
+    const signedTx = await client.sign(
       address,
-      [{ typeUrl: MsgWalletSpendAction.typeUrl, value: msgSpend }],
+      messages,
       fee,
+      memo,
+      signerData,
     );
+
+    const txBytes = TxRaw.encode(signedTx).finish();
+    return client.broadcastTx(txBytes);
   };
 
   const executeOffer = async (offer: OfferSpec) => {

--- a/packages/client-utils/src/signing-smart-wallet-kit.ts
+++ b/packages/client-utils/src/signing-smart-wallet-kit.ts
@@ -89,8 +89,9 @@ export const makeSigningSmartWalletKit = async (
   };
 
   const executeOffer = async (offer: OfferSpec): Promise<OfferStatus> => {
-    const before = await client.getBlock();
+    const offerP = walletUtils.pollOffer(address, offer.id);
 
+    // Await for rejection handling
     await sendBridgeAction(
       harden({
         method: 'executeOffer',
@@ -98,7 +99,7 @@ export const makeSigningSmartWalletKit = async (
       }),
     );
 
-    return walletUtils.pollOffer(address, offer.id, before.header.height);
+    return offerP;
   };
 
   return Object.freeze({

--- a/packages/client-utils/src/signing-smart-wallet-kit.ts
+++ b/packages/client-utils/src/signing-smart-wallet-kit.ts
@@ -41,11 +41,14 @@ export const makeSigningSmartWalletKit = async (
     rpcAddr: walletUtils.networkConfig.rpcAddrs[0],
   });
 
+  // Omit deprecated utilities
+  const { storedWalletState: _, ...swk } = walletUtils;
+
   const query = {
-    readPublished: walletUtils.readPublished,
-    vstorage: walletUtils.vstorage,
-    getLastUpdate: () => walletUtils.getLastUpdate(address),
-    getCurrentWalletRecord: () => walletUtils.getCurrentWalletRecord(address),
+    readPublished: swk.readPublished,
+    vstorage: swk.vstorage,
+    getLastUpdate: () => swk.getLastUpdate(address),
+    getCurrentWalletRecord: () => swk.getCurrentWalletRecord(address),
     pollOffer: (
       ...args: Parameters<SmartWalletKit['pollOffer']> extends [
         any,
@@ -53,7 +56,7 @@ export const makeSigningSmartWalletKit = async (
       ]
         ? Rest
         : never
-    ) => walletUtils.pollOffer(address, ...args),
+    ) => swk.pollOffer(address, ...args),
   };
 
   const sendBridgeAction = async (
@@ -64,7 +67,7 @@ export const makeSigningSmartWalletKit = async (
   ): Promise<DeliverTxResponse> => {
     const msgSpend = MsgWalletSpendAction.fromPartial({
       owner: toAccAddress(address),
-      spendAction: JSON.stringify(walletUtils.marshaller.toCapData(action)),
+      spendAction: JSON.stringify(swk.marshaller.toCapData(action)),
     });
 
     const messages = [
@@ -89,7 +92,7 @@ export const makeSigningSmartWalletKit = async (
   };
 
   const executeOffer = async (offer: OfferSpec): Promise<OfferStatus> => {
-    const offerP = walletUtils.pollOffer(address, offer.id);
+    const offerP = swk.pollOffer(address, offer.id);
 
     // Await for rejection handling
     await sendBridgeAction(
@@ -103,8 +106,7 @@ export const makeSigningSmartWalletKit = async (
   };
 
   return Object.freeze({
-    networkConfig: walletUtils.networkConfig,
-    marshaller: walletUtils.marshaller,
+    ...swk,
     query,
     address,
     /**

--- a/packages/client-utils/src/vstorage-kit.js
+++ b/packages/client-utils/src/vstorage-kit.js
@@ -110,9 +110,11 @@ export const makeVstorageKit = ({ fetch }, networkConfig) => {
 
     /**
      * Read latest at path and unmarshal it
-     * @type {(path: string) => Promise<unknown>}
+     * @template T
+     * @type {(path: string) => Promise<T>}
      */
     const readLatestHead = path =>
+      // @ts-expect-error cast
       vstorage.readLatest(path).then(unserializeHead);
 
     /**

--- a/packages/client-utils/test/signing-smart-wallet-kit.test.ts
+++ b/packages/client-utils/test/signing-smart-wallet-kit.test.ts
@@ -4,6 +4,7 @@ import { decodeHex } from '@agoric/internal/src/hex.js';
 import type { EncodeObject } from '@cosmjs/proto-signing';
 import type {
   DeliverTxResponse,
+  SignerData,
   SigningStargateClient,
   StdFee,
 } from '@cosmjs/stargate';
@@ -13,8 +14,11 @@ import { makeSmartWalletKit } from '../src/smart-wallet-kit.js';
 
 const mockSigner = () => {
   const calls: any[] = [];
+  const signCalls: any[] = [];
+  const broadcastCalls: any[] = [];
   const connectWithSigner: typeof SigningStargateClient.connectWithSigner =
     async () => {
+      // @ts-expect-error incomplete mock
       return {
         async signAndBroadcast(
           signerAddress: string,
@@ -27,9 +31,29 @@ const mockSigner = () => {
           const resp = { code: 42 } as DeliverTxResponse;
           return resp;
         },
+        async sign(
+          signerAddress: string,
+          messages: readonly EncodeObject[],
+          fee: StdFee,
+          memo: string,
+          signerData: SignerData,
+        ) {
+          signCalls.push({ signerAddress, messages, fee, memo, signerData });
+          const mockTxRaw = {
+            bodyBytes: new Uint8Array(),
+            authInfoBytes: new Uint8Array(),
+            signatures: [],
+          };
+          return mockTxRaw;
+        },
+        async broadcastTx(txBytes: Uint8Array) {
+          broadcastCalls.push({ txBytes });
+          const resp = { code: 43 } as DeliverTxResponse;
+          return resp;
+        },
       } as SigningStargateClient;
     };
-  return { calls, connectWithSigner };
+  return { calls, signCalls, broadcastCalls, connectWithSigner };
 };
 
 const notImplemented = () => {
@@ -101,4 +125,99 @@ test('sendBridgeAction supports fee param', async t => {
   t.like(calls[0], {
     fee: { amount: [{ denom: 'ubld', amount: '123' }], gas: '1234567' },
   });
+});
+
+test('sendBridgeAction uses explicit signing when signerData provided', async t => {
+  const { calls, signCalls, broadcastCalls, connectWithSigner } = mockSigner();
+
+  const walletUtils = await makeSmartWalletKit(
+    { fetch: notImplemented, delay: notImplemented, names: false },
+    LOCAL_CONFIG,
+  );
+
+  const signing = await makeSigningSmartWalletKit(
+    { connectWithSigner, walletUtils },
+    mnemonic,
+  );
+
+  const signerData: SignerData = {
+    accountNumber: 123,
+    sequence: 456,
+    chainId: 'test-chain',
+  };
+
+  const actual = await signing.sendBridgeAction(
+    harden({ method: 'tryExitOffer', offerId: 'bid-1' }),
+    undefined, // use default fee
+    'test memo',
+    signerData,
+  );
+
+  // Should use explicit signing path, not signAndBroadcast
+  t.deepEqual(actual, { code: 43 });
+  t.is(calls.length, 0, 'signAndBroadcast should not be called');
+  t.is(signCalls.length, 1, 'sign should be called once');
+  t.is(broadcastCalls.length, 1, 'broadcastTx should be called once');
+
+  t.like(signCalls[0], {
+    signerAddress: 'agoric1yupasge4528pgkszg9v328x4faxtkldsnygwjl',
+    messages: [
+      {
+        typeUrl: '/agoric.swingset.MsgWalletSpendAction',
+        value: {
+          owner: decodeHex(
+            '2703d823 35a28e14 5a024159 151cd54f 4cbb7db0'.replace(/ /g, ''),
+          ),
+          spendAction:
+            '{"body":"#{\\"method\\":\\"tryExitOffer\\",\\"offerId\\":\\"bid-1\\"}","slots":[]}',
+        },
+      },
+    ],
+    fee: { amount: [{ denom: 'ubld', amount: '500000' }], gas: '19700000' },
+    memo: 'test memo',
+    signerData,
+  });
+
+  t.true(broadcastCalls[0].txBytes instanceof Uint8Array);
+});
+
+test('sendBridgeAction with signerData supports custom fee', async t => {
+  const { signCalls, broadcastCalls, connectWithSigner } = mockSigner();
+
+  const walletUtils = await makeSmartWalletKit(
+    { fetch: notImplemented, delay: notImplemented, names: false },
+    LOCAL_CONFIG,
+  );
+
+  const signing = await makeSigningSmartWalletKit(
+    { connectWithSigner, walletUtils },
+    mnemonic,
+  );
+
+  const customFee: StdFee = {
+    gas: '9999999',
+    amount: [{ denom: 'ubld', amount: '999' }],
+  };
+
+  const signerData: SignerData = {
+    accountNumber: 789,
+    sequence: 101112,
+    chainId: 'custom-chain',
+  };
+
+  await signing.sendBridgeAction(
+    // @ts-expect-error incomplete mock
+    harden({ method: 'executeOffer', offer: { id: 'test-offer' } }),
+    customFee,
+    'custom memo',
+    signerData,
+  );
+
+  t.is(signCalls.length, 1);
+  t.like(signCalls[0], {
+    fee: customFee,
+    memo: 'custom memo',
+    signerData,
+  });
+  t.is(broadcastCalls.length, 1);
 });

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -672,10 +672,13 @@ export const startEngine = async (
     for (const { portfolioId, stepsRecord } of portfolioOps.filter(x => !!x)) {
       if (!stepsRecord) continue;
       const { policyVersion, rebalanceCount, steps } = stepsRecord;
-      const result = await signingSmartWalletKit.invokeEntry({
-        targetName: 'planner',
-        method: 'submit',
-        args: [portfolioId, steps, policyVersion, rebalanceCount],
+      const result = await signingSmartWalletKit.sendBridgeAction({
+        method: 'invokeEntry',
+        message: {
+          targetName: 'planner',
+          method: 'submit',
+          args: [portfolioId, steps, policyVersion, rebalanceCount],
+        },
       });
       console.log('result', result);
     }


### PR DESCRIPTION
supports: https://github.com/Agoric/agoric-sdk/pull/11968

## Description
https://github.com/Agoric/agoric-sdk/pull/11968 needs the ability to add custom signing data. This adds that to `sendBridgeAction`.

It also composes SmartWalletKit so something holding a SigningSmartWalletKit can add new functionality.

It also makes some other design and implementation fixes noticed while working on that.

### Security Considerations
custom signing data

### Scaling Considerations
n/a

### Documentation Considerations
not yet

### Testing Considerations
CI covers thoroughly

### Upgrade Considerations
n/a