### PR TITLE
chore: update resolver lookback logic to handle recent transactions

### DIFF
--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -96,7 +96,11 @@ const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
     };
     const transferStatus = await (opts.mode === 'live'
       ? watchCctpTransfer({ ...watchArgs, timeoutMs: opts.timeoutMs })
-      : lookBackCctp({ ...watchArgs, publishTimeMs: opts.publishTimeMs }));
+      : lookBackCctp({
+          ...watchArgs,
+          publishTimeMs: opts.publishTimeMs,
+          chainId: caipId,
+        }));
 
     await resolvePendingTx({
       signingSmartWalletKit: ctx.signingSmartWalletKit,
@@ -130,7 +134,11 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
     };
     const transferStatus = await (opts.mode === 'live'
       ? watchGmp({ ...watchArgs, timeoutMs: opts.timeoutMs })
-      : lookBackGmp({ ...watchArgs, publishTimeMs: opts.publishTimeMs }));
+      : lookBackGmp({
+          ...watchArgs,
+          publishTimeMs: opts.publishTimeMs,
+          chainId: caipId,
+        }));
 
     await resolvePendingTx({
       signingSmartWalletKit: ctx.signingSmartWalletKit,

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -238,6 +238,7 @@ const findBlockByTimestamp = async (
 export const buildTimeWindow = async (
   provider: JsonRpcProvider,
   publishTimeMs: number,
+  log: (...args: unknown[]) => void,
   fudgeFactorMs = 5 * 60 * 1000, // 5 minutes to account for cross-chain clock differences
 ) => {
   const adjustedTime = publishTimeMs - fudgeFactorMs;
@@ -251,16 +252,17 @@ export const buildTimeWindow = async (
   const currentBlockInfo = await provider.getBlock(currentBlock);
   const currentBlockTime = (currentBlockInfo?.timestamp || 0) * 1000;
 
-  // End time is in the past
   if (endTime <= currentBlockTime) {
+    log('end time is in the past');
     return { fromBlock, toBlock: currentBlock };
   }
 
-  // End time is in the future - estimate blocks ahead
+  log('end time is in the future - estimate blocks ahead');
   const SINGLE_BLOCK_TIME_MS = 2_000; // one number for all chains
 
   const timeUntilEnd = endTime - currentBlockTime;
   const estimatedFutureBlocks = Math.ceil(timeUntilEnd / SINGLE_BLOCK_TIME_MS);
+  log('future blocks', estimatedFutureBlocks);
 
   const toBlock = currentBlock + estimatedFutureBlocks;
   return { fromBlock, toBlock };

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -295,7 +295,8 @@ export const buildTimeWindow = async (
 
   const fromBlockInfo = await provider.getBlock(fromBlock);
   const fromBlockTime = (fromBlockInfo?.timestamp || 0) * 1000;
-  const endTime = fromBlockTime + TX_TIMEOUT_MS;
+  // Add fudgeFactorMs back to TX_TIMEOUT_MS to compensate for the earlier subtraction
+  const endTime = fromBlockTime + TX_TIMEOUT_MS + fudgeFactorMs;
 
   const currentBlock = await provider.getBlockNumber();
   const currentBlockInfo = await provider.getBlock(currentBlock);

--- a/services/ymax-planner/src/watchers/cctp-watcher.ts
+++ b/services/ymax-planner/src/watchers/cctp-watcher.ts
@@ -166,7 +166,7 @@ export const lookBackCctp = async ({
     // TODO: Consider async iteration pattern for more flexible log scanning
     // See: https://github.com/Agoric/agoric-sdk/pull/11915#discussion_r2353872425
     const matchingEvent = await scanEvmLogsInChunks(
-      { provider, baseFilter, fromBlock, toBlock, log },
+      { provider, baseFilter, fromBlock, toBlock, chainId, log },
       ev => {
         try {
           const t = parseTransferLog(ev);

--- a/services/ymax-planner/src/watchers/cctp-watcher.ts
+++ b/services/ymax-planner/src/watchers/cctp-watcher.ts
@@ -146,6 +146,7 @@ export const lookBackCctp = async ({
     const { fromBlock, toBlock } = await buildTimeWindow(
       provider,
       publishTimeMs,
+      log,
     );
 
     log(

--- a/services/ymax-planner/src/watchers/cctp-watcher.ts
+++ b/services/ymax-planner/src/watchers/cctp-watcher.ts
@@ -1,5 +1,6 @@
 import type { Filter, JsonRpcProvider, Log } from 'ethers';
 import { id, zeroPadValue, getAddress, ethers } from 'ethers';
+import type { CaipChainId } from '@agoric/orchestration';
 import { buildTimeWindow, scanEvmLogsInChunks } from '../support.ts';
 import { TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
 
@@ -137,9 +138,11 @@ export const lookBackCctp = async ({
   toAddress,
   expectedAmount,
   publishTimeMs,
+  chainId,
   log = () => {},
 }: CctpWatch & {
   publishTimeMs: number;
+  chainId: CaipChainId;
 }): Promise<boolean> => {
   await null;
   try {
@@ -147,6 +150,7 @@ export const lookBackCctp = async ({
       provider,
       publishTimeMs,
       log,
+      chainId,
     );
 
     log(

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -91,6 +91,7 @@ export const lookBackGmp = async ({
     const { fromBlock, toBlock } = await buildTimeWindow(
       provider,
       publishTimeMs,
+      log,
     );
 
     log(

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -1,5 +1,6 @@
 import { ethers, type Filter, type JsonRpcProvider, type Log } from 'ethers';
 import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types';
+import type { CaipChainId } from '@agoric/orchestration';
 import { buildTimeWindow, scanEvmLogsInChunks } from '../support.ts';
 import { TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
 
@@ -84,14 +85,19 @@ export const lookBackGmp = async ({
   contractAddress,
   txId,
   publishTimeMs,
+  chainId,
   log = () => {},
-}: WatchGmp & { publishTimeMs: number }): Promise<boolean> => {
+}: WatchGmp & {
+  publishTimeMs: number;
+  chainId: CaipChainId;
+}): Promise<boolean> => {
   await null;
   try {
     const { fromBlock, toBlock } = await buildTimeWindow(
       provider,
       publishTimeMs,
       log,
+      chainId,
     );
 
     log(

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -111,7 +111,7 @@ export const lookBackGmp = async ({
     };
 
     const matchingEvent = await scanEvmLogsInChunks(
-      { provider, baseFilter, fromBlock, toBlock, log },
+      { provider, baseFilter, fromBlock, toBlock, chainId, log },
       ev => ev.topics[1] === expectedIdTopic,
     );
 

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -270,8 +270,9 @@ test('handlePendingTx resolves old pending CCTP transaction successfully', async
   t.deepEqual(logs, [
     `[${txId}] handling ${TxType.CCTP_TO_EVM} tx`,
     `[${txId}] end time is in the future - estimate blocks ahead`,
-    `[${txId}] future blocks 744`,
-    `[${txId}] Searching blocks ${expectedFromBlock} → 775 for Transfer to ${recipientAddress} with amount ${txAmount}`,
+    `[${txId}] using block time 300ms for chain eip155:42161`,
+    `[${txId}] future blocks 4960`,
+    `[${txId}] Searching blocks ${expectedFromBlock} → 4991 for Transfer to ${recipientAddress} with amount ${txAmount}`,
     `[${txId}] [LogScan] Searching chunk ${expectedFromBlock} → 14`,
     `[${txId}] Check: amount=${txAmount}`,
     `[${txId}] [LogScan] Match in tx=${event.transactionHash}`,
@@ -349,8 +350,9 @@ test('handlePendingTx resolves old pending GMP transaction successfully', async 
   t.deepEqual(logs, [
     `[${txId}] handling ${TxType.GMP} tx`,
     `[${txId}] end time is in the future - estimate blocks ahead`,
-    `[${txId}] future blocks 744`,
-    `[${txId}] Searching blocks ${expectedFromBlock} → 775 for MulticallExecuted with txId ${txId} at ${contractAddress}`,
+    `[${txId}] using block time 300ms for chain eip155:42161`,
+    `[${txId}] future blocks 4960`,
+    `[${txId}] Searching blocks ${expectedFromBlock} → 4991 for MulticallExecuted with txId ${txId} at ${contractAddress}`,
     `[${txId}] [LogScan] Searching chunk ${expectedFromBlock} → 14`,
     `[${txId}] [LogScan] Match in tx=${event.transactionHash}`,
     `[${txId}] GMP tx resolved`,

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -269,7 +269,9 @@ test('handlePendingTx resolves old pending CCTP transaction successfully', async
 
   t.deepEqual(logs, [
     `[${txId}] handling ${TxType.CCTP_TO_EVM} tx`,
-    `[${txId}] Searching blocks ${expectedFromBlock} → 31 for Transfer to ${recipientAddress} with amount ${txAmount}`,
+    `[${txId}] end time is in the future - estimate blocks ahead`,
+    `[${txId}] future blocks 744`,
+    `[${txId}] Searching blocks ${expectedFromBlock} → 775 for Transfer to ${recipientAddress} with amount ${txAmount}`,
     `[${txId}] [LogScan] Searching chunk ${expectedFromBlock} → 14`,
     `[${txId}] Check: amount=${txAmount}`,
     `[${txId}] [LogScan] Match in tx=${event.transactionHash}`,
@@ -346,7 +348,9 @@ test('handlePendingTx resolves old pending GMP transaction successfully', async 
 
   t.deepEqual(logs, [
     `[${txId}] handling ${TxType.GMP} tx`,
-    `[${txId}] Searching blocks ${expectedFromBlock} → 31 for MulticallExecuted with txId ${txId} at ${contractAddress}`,
+    `[${txId}] end time is in the future - estimate blocks ahead`,
+    `[${txId}] future blocks 744`,
+    `[${txId}] Searching blocks ${expectedFromBlock} → 775 for MulticallExecuted with txId ${txId} at ${contractAddress}`,
     `[${txId}] [LogScan] Searching chunk ${expectedFromBlock} → 14`,
     `[${txId}] [LogScan] Match in tx=${event.transactionHash}`,
     `[${txId}] GMP tx resolved`,

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -221,6 +221,70 @@ test('handlePendingTx throws error for unsupported transaction type', async t =>
   );
 });
 
+test('resolves a 31 min old pending CCTP transaction in lookback mode', async t => {
+  const logs: string[] = [];
+  const mockLog = (...args: unknown[]) => logs.push(args.join(' '));
+
+  const txId = 'tx1';
+  const txAmount = 1_000_000n;
+  const recipientAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const destinationAddress = `eip155:42161:${recipientAddress}`;
+  const chainId = 'eip155:42161';
+
+  const cctpTx = createMockPendingTxData({
+    type: TxType.CCTP_TO_EVM,
+    amount: txAmount,
+    destinationAddress,
+  });
+
+  const opts = createMockPendingTxOpts();
+  const mockProvider = opts.evmProviders[chainId] as any;
+
+  const currentTimeMs = 1700000000; // 2023-11-14T22:13:20Z
+  const txTimestampMs = currentTimeMs - 31 * 60 * 1000; // 31 min ago
+  const avgBlockTimeMs = 300; // 300 ms per block on eip155:42161
+
+  const latestBlock = 1_450_031;
+  mockProvider.getBlockNumber = async () => latestBlock;
+
+  mockProvider.getBlock = async (blockNumber: number) => {
+    const blocksAgo = latestBlock - blockNumber;
+    const ts = currentTimeMs - blocksAgo * avgBlockTimeMs;
+    return { timestamp: Math.floor(ts / 1000) };
+  };
+
+  const event = createMockTransferEvent(
+    opts.usdcAddresses[chainId],
+    txAmount,
+    recipientAddress,
+  );
+  mockProvider.getLogs = async () => [event];
+
+  await handlePendingTx(
+    { txId, ...cctpTx },
+    {
+      ...opts,
+      log: mockLog,
+    },
+    txTimestampMs,
+  );
+
+  const currentBlock = await mockProvider.getBlockNumber();
+  const fromBlock = 1442834;
+  const toBlock = currentBlock;
+  const expectedChunkEnd = Math.min(fromBlock + 10 - 1, toBlock);
+
+  t.deepEqual(logs, [
+    `[${txId}] handling ${TxType.CCTP_TO_EVM} tx`,
+    `[${txId}] end time is in the past`,
+    `[${txId}] Searching blocks ${fromBlock} → ${toBlock} for Transfer to ${recipientAddress} with amount ${txAmount}`,
+    `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${expectedChunkEnd}`,
+    `[${txId}] Check: amount=${txAmount}`,
+    `[${txId}] [LogScan] Match in tx=${event.transactionHash}`,
+    `[${txId}] CCTP tx resolved`,
+  ]);
+});
+
 test('resolves a 10 second old pending CCTP transaction in lookback mode', async t => {
   const logs: string[] = [];
   const mockLog = (...args: unknown[]) => logs.push(args.join(' '));

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -352,6 +352,73 @@ test('resolves a 28 min old pending CCTP transaction in lookback mode', async t 
   ]);
 });
 
+test('resolves a transaction published at current time in lookback mode', async t => {
+  const logs: string[] = [];
+  const mockLog = (...args: unknown[]) => logs.push(args.join(' '));
+
+  const txId = 'tx1';
+  const txAmount = 1_000_000n;
+  const recipientAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const destinationAddress = `eip155:42161:${recipientAddress}`;
+  const chainId = 'eip155:42161';
+
+  const cctpTx = createMockPendingTxData({
+    type: TxType.CCTP_TO_EVM,
+    amount: txAmount,
+    destinationAddress,
+  });
+
+  const opts = createMockPendingTxOpts();
+  const mockProvider = opts.evmProviders[chainId] as any;
+
+  const currentTimeMs = 1700000000; // 2023-11-14T22:13:20Z
+  const txTimestampMs = currentTimeMs; // published exactly now
+  const avgBlockTimeMs = 300; // 300 ms per block on eip155:42161
+
+  const latestBlock = 1_450_031;
+  mockProvider.getBlockNumber = async () => latestBlock;
+
+  mockProvider.getBlock = async (blockNumber: number) => {
+    const blocksAgo = latestBlock - blockNumber;
+    const ts = currentTimeMs - blocksAgo * avgBlockTimeMs;
+    return { timestamp: Math.floor(ts / 1000) };
+  };
+
+  const event = createMockTransferEvent(
+    opts.usdcAddresses[chainId],
+    txAmount,
+    recipientAddress,
+  );
+  mockProvider.getLogs = async () => [event];
+
+  await handlePendingTx(
+    { txId, ...cctpTx },
+    {
+      ...opts,
+      log: mockLog,
+    },
+    txTimestampMs,
+  );
+
+  const currentBlock = await mockProvider.getBlockNumber();
+  const fromBlock = 1449034;
+  const expectedFutureBlocks = 6000;
+  const toBlock = currentBlock + expectedFutureBlocks;
+  const expectedChunkEnd = Math.min(fromBlock + 10 - 1, toBlock);
+
+  t.deepEqual(logs, [
+    `[${txId}] handling ${TxType.CCTP_TO_EVM} tx`,
+    `[${txId}] end time is in the future - estimate blocks ahead`,
+    `[${txId}] using block time 300ms for chain eip155:42161`,
+    `[${txId}] future blocks ${expectedFutureBlocks}`,
+    `[${txId}] Searching blocks ${fromBlock} → ${toBlock} for Transfer to ${recipientAddress} with amount ${txAmount}`,
+    `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${expectedChunkEnd}`,
+    `[${txId}] Check: amount=${txAmount}`,
+    `[${txId}] [LogScan] Match in tx=${event.transactionHash}`,
+    `[${txId}] CCTP tx resolved`,
+  ]);
+});
+
 test('resolves a 10 second old pending CCTP transaction in lookback mode', async t => {
   const logs: string[] = [];
   const mockLog = (...args: unknown[]) => logs.push(args.join(' '));


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes:
- https://github.com/Agoric/agoric-sdk/issues/12002

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
The ymax-planner service monitors pending cross-chain transactions and resolves them by scanning EVM blockchain logs. When the planner starts up, it processes any pending transaction in `lookback mode`. For that, it must determine a block range to search:
  - `fromBlock`: Starting point based on transaction publish time(on vstorage) minus a fudge factor (5 minutes for clock differences)
  - `toBlock`: Ending point within which the transaction should be confirmed/completed.

**The bug:** The `master` implementation simply used the current block number as `toBlock`:
```js
  const toBlock = await provider.getBlockNumber();
```

This was wrong because pending transactions have a 30-minute timeout window from their publish time (`TX_TIMEOUT_MS = 30 * 60 * 1000`). For a transaction published recently (e.g., 10 seconds ago, or 28 minutes ago), the timeout window extends into the future - meaning the transaction confirmation event could appear in blocks that haven't been mined yet.

Using the current block as `toBlock` created a narrow search window that:
  1. `Missed valid confirmations`: If a transaction was confirmed in a block that will be mined in the next few minutes (but before the 30-minute timeout), the search would not find it.
  2. `Caused premature failures`: The system might incorrectly mark transactions as failed when they were actually still within their valid confirmation window.

**Solution:** The fix implements a future block estimation in the `lookback mode`. When `buildTimeWindow` calculates the search range, it now determines whether the transaction's 30-minute timeout window extends beyond the current EVM chain time. For old transactions where the timeout has passed, it simply searches up to the current block. But for recent transactions where the timeout extends into the future, it calculates how much time remains until timeout and estimates the corresponding future block number using chain-specific block times (e.g., 300ms for Arbitrum, 12s for Ethereum).

The formula `estimatedFutureBlocks = Math.ceil((endTime - currentBlockTime) / blockTimeMs)` projects how many blocks will be mined before the timeout expires, and sets `toBlock = currentBlock + estimatedFutureBlocks`. This ensures the search window covers the entire validity period where a confirmation could legitimately appear. 

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
New tests have been added to verify the changes introduced in this PR. As well as the existing test assertions were also updated.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
Nothing major. To use these changes on mainnet a new deployment of the `ymax-planner` is required.