### PR TITLE
chore: listen for MultiCallStatus events for pending gmp tx

### DIFF
--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -330,6 +330,7 @@ type ScanOpts = {
   chainId: CaipChainId;
   chunkSize?: number;
   log?: (...args: unknown[]) => void;
+  signal?: AbortSignal;
 };
 
 /**
@@ -348,10 +349,15 @@ export const scanEvmLogsInChunks = async (
     chainId,
     chunkSize = 10,
     log = () => {},
+    signal,
   } = opts;
 
   await null;
   for (let start = fromBlock; start <= toBlock; ) {
+    if (signal?.aborted) {
+      log('[LogScan] Aborted');
+      return undefined;
+    }
     const end = Math.min(start + chunkSize - 1, toBlock);
     const currentBlock = await provider.getBlockNumber();
 

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -4,8 +4,12 @@ import type { CaipChainId } from '@agoric/orchestration';
 import { buildTimeWindow, scanEvmLogsInChunks } from '../support.ts';
 import { TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
 
+// TODO: Remove once all contracts are upgraded to emit MulticallStatus
 const MULTICALL_EXECUTED_SIGNATURE = ethers.id(
   'MulticallExecuted(string,(bool,bytes)[])',
+);
+const MULTICALL_STATUS_SIGNATURE = ethers.id(
+  'MulticallStatus(string,bool,uint256)',
 );
 
 type WatchGmp = {
@@ -28,13 +32,17 @@ export const watchGmp = ({
 }): Promise<boolean> => {
   return new Promise(resolve => {
     const expectedIdTopic = ethers.keccak256(ethers.toUtf8Bytes(txId));
-    const filter = {
+    const statusFilter = {
+      address: contractAddress,
+      topics: [MULTICALL_STATUS_SIGNATURE, expectedIdTopic],
+    };
+    const executedFilter = {
       address: contractAddress,
       topics: [MULTICALL_EXECUTED_SIGNATURE, expectedIdTopic],
     };
 
     log(
-      `Watching for MulticallExecuted events for txId: ${txId} at contract: ${contractAddress}`,
+      `Watching for MulticallStatus and MulticallExecuted events for txId: ${txId} at contract: ${contractAddress}`,
     );
 
     let executionFound = false;
@@ -47,6 +55,22 @@ export const watchGmp = ({
         void provider.off(event, listener);
       }
       listeners = [];
+    };
+
+    const listenForStatus = (eventLog: Log) => {
+      log(
+        `MulticallStatus detected: txId=${txId} contract=${contractAddress} tx=${eventLog.transactionHash}`,
+      );
+
+      // Check if this log matches our expected txId
+      if (eventLog.topics[1] === expectedIdTopic) {
+        log(`✓ MulticallStatus matches txId: ${txId}`);
+        executionFound = true;
+        cleanup();
+        resolve(true);
+      } else {
+        log(`MulticallStatus txId mismatch for ${txId}`);
+      }
     };
 
     const listenForExecution = (eventLog: Log) => {
@@ -65,13 +89,15 @@ export const watchGmp = ({
       }
     };
 
-    void provider.on(filter, listenForExecution);
-    listeners.push({ event: filter, listener: listenForExecution });
+    void provider.on(statusFilter, listenForStatus);
+    void provider.on(executedFilter, listenForExecution);
+    listeners.push({ event: statusFilter, listener: listenForStatus });
+    listeners.push({ event: executedFilter, listener: listenForExecution });
 
     timeoutId = setTimeout(() => {
       if (!executionFound) {
         log(
-          `✗ No MulticallExecuted found for txId ${txId} within ${timeoutMs / 60000} minutes`,
+          `✗ No MulticallStatus or MulticallExecuted found for txId ${txId} within ${timeoutMs / 60000} minutes`,
         );
         cleanup();
         resolve(false);
@@ -101,22 +127,57 @@ export const lookBackGmp = async ({
     );
 
     log(
-      `Searching blocks ${fromBlock} → ${toBlock} for MulticallExecuted with txId ${txId} at ${contractAddress}`,
+      `Searching blocks ${fromBlock} → ${toBlock} for MulticallStatus or MulticallExecuted with txId ${txId} at ${contractAddress}`,
     );
     const expectedIdTopic = ethers.keccak256(ethers.toUtf8Bytes(txId));
 
-    const baseFilter: Filter = {
+    const statusFilter: Filter = {
+      address: contractAddress,
+      topics: [MULTICALL_STATUS_SIGNATURE, expectedIdTopic],
+    };
+
+    const executedFilter: Filter = {
       address: contractAddress,
       topics: [MULTICALL_EXECUTED_SIGNATURE, expectedIdTopic],
     };
 
-    const matchingEvent = await scanEvmLogsInChunks(
-      { provider, baseFilter, fromBlock, toBlock, chainId, log },
-      ev => ev.topics[1] === expectedIdTopic,
-    );
+    const [statusEvent, executedEvent] = await Promise.all([
+      scanEvmLogsInChunks(
+        {
+          provider,
+          baseFilter: statusFilter,
+          fromBlock,
+          toBlock,
+          chainId,
+          log,
+        },
+        ev => ev.topics[1] === expectedIdTopic,
+      ),
+      scanEvmLogsInChunks(
+        {
+          provider,
+          baseFilter: executedFilter,
+          fromBlock,
+          toBlock,
+          chainId,
+          log,
+        },
+        ev => ev.topics[1] === expectedIdTopic,
+      ),
+    ]);
 
-    if (!matchingEvent) log(`No matching MulticallExecuted found`);
-    return !!matchingEvent;
+    if (statusEvent) {
+      log(`Found MulticallStatus event`);
+      return true;
+    }
+
+    if (executedEvent) {
+      log(`Found MulticallExecuted event`);
+      return true;
+    }
+
+    log(`No matching MulticallStatus or MulticallExecuted found`);
+    return false;
   } catch (error) {
     log(`Error:`, error);
     return false;

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -141,7 +141,7 @@ export const lookBackGmp = async ({
       topics: [MULTICALL_EXECUTED_SIGNATURE, expectedIdTopic],
     };
 
-    const [statusEvent, executedEvent] = await Promise.all([
+    const matchingEvent = await Promise.race([
       scanEvmLogsInChunks(
         {
           provider,
@@ -166,13 +166,8 @@ export const lookBackGmp = async ({
       ),
     ]);
 
-    if (statusEvent) {
-      log(`Found MulticallStatus event`);
-      return true;
-    }
-
-    if (executedEvent) {
-      log(`Found MulticallExecuted event`);
+    if (matchingEvent) {
+      log(`Found matching event`);
       return true;
     }
 

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -56,7 +56,7 @@ test('handlePendingTx processes GMP transaction successfully', async t => {
 
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
-    `[${txId}] Watching for MulticallExecuted events for txId: ${txId} at contract: ${contractAddress}`,
+    `[${txId}] Watching for MulticallStatus and MulticallExecuted events for txId: ${txId} at contract: ${contractAddress}`,
     `[${txId}] MulticallExecuted detected: txId=${txId} contract=${contractAddress} tx=0x123abc`,
     `[${txId}] ✓ MulticallExecuted matches txId: ${txId}`,
     `[${txId}] GMP tx resolved`,
@@ -94,8 +94,8 @@ test('handlePendingTx times out GMP transaction with no matching event', async t
 
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
-    `[${txId}] Watching for MulticallExecuted events for txId: ${txId} at contract: ${contractAddress}`,
-    `[${txId}] ✗ No MulticallExecuted found for txId ${txId} within 0.05 minutes`,
+    `[${txId}] Watching for MulticallStatus and MulticallExecuted events for txId: ${txId} at contract: ${contractAddress}`,
+    `[${txId}] ✗ No MulticallStatus or MulticallExecuted found for txId ${txId} within 0.05 minutes`,
     `[${txId}] GMP tx resolved`,
   ]);
 });

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -572,7 +572,7 @@ test('resolves a 10 second old pending GMP transaction in lookback mode', async 
     `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${expectedChunkEnd}`,
     `[${txId}] [LogScan] Match in tx=${event.transactionHash}`,
     `[${txId}] [LogScan] Match in tx=${event.transactionHash}`,
-    `[${txId}] Found MulticallStatus event`,
+    `[${txId}] Found matching event`,
     `[${txId}] GMP tx resolved`,
   ]);
 });

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -567,9 +567,12 @@ test('resolves a 10 second old pending GMP transaction in lookback mode', async 
     `[${txId}] end time is in the future - estimate blocks ahead`,
     `[${txId}] using block time 300ms for chain eip155:42161`,
     `[${txId}] future blocks ${expectedFutureBlocks}`,
-    `[${txId}] Searching blocks ${fromBlock} → ${toBlock} for MulticallExecuted with txId ${txId} at ${contractAddress}`,
+    `[${txId}] Searching blocks ${fromBlock} → ${toBlock} for MulticallStatus or MulticallExecuted with txId ${txId} at ${contractAddress}`,
+    `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${expectedChunkEnd}`,
     `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${expectedChunkEnd}`,
     `[${txId}] [LogScan] Match in tx=${event.transactionHash}`,
+    `[${txId}] [LogScan] Match in tx=${event.transactionHash}`,
+    `[${txId}] Found MulticallStatus event`,
     `[${txId}] GMP tx resolved`,
   ]);
 });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
The Factory contract was recently updated to emit `MulticallStatus(string,bool,uint256)` instead of `MulticallExecuted(string,(bool,bytes)[])`. To ensure resolver operates as expected during the migration period, it needs to listen for both events.


### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
This change introduces backward compatibility for a contract event migration. To successfully resolve GMP transactions especially the ones related to Avalanche, we need to deploy this planner update first.