### PR TITLE
refactor(portfolio-contract): Enforce planner graph arc non-free cost independent of mode cheapest vs. fastest

### DIFF
--- a/packages/portfolio-contract/tools/graph-diagnose.ts
+++ b/packages/portfolio-contract/tools/graph-diagnose.ts
@@ -246,7 +246,7 @@ export const explainPath = (
   const nodes = graph.nodes;
   const edgeMap = new Map<string, { capacity: number }>();
   for (const e of graph.edges)
-    edgeMap.set(`${e.src}->${e.dest}`, { capacity: e.capacity });
+    edgeMap.set(`${e.src}->${e.dest}`, { capacity: e.capacity ?? Infinity });
   for (let i = 0; i < path.length - 1; i += 1) {
     const src = path[i];
     const dest = path[i + 1];
@@ -320,7 +320,7 @@ export const diagnoseNearMisses = (graph: RebalanceGraph) => {
   const capAdj = new Map<string, string[]>();
   for (const e of graph.edges) {
     (adj.get(e.src) ?? adj.set(e.src, []).get(e.src)!).push(e.dest);
-    if (e.capacity > 0)
+    if (e.capacity === undefined || e.capacity > 0)
       (capAdj.get(e.src) ?? capAdj.set(e.src, []).get(e.src)!).push(e.dest);
   }
   const bfs = (start: string, A: Map<string, string[]>) => {

--- a/packages/portfolio-contract/tools/network/buildGraph.ts
+++ b/packages/portfolio-contract/tools/network/buildGraph.ts
@@ -20,7 +20,7 @@ export interface FlowEdge {
   id: string;
   src: AssetPlaceRef;
   dest: AssetPlaceRef;
-  capacity: number; // numeric for LP; derived from bigint
+  capacity?: number; // numeric for LP; derived from bigint
   variableFee: number; // cost coefficient per unit flow in basis points
   fixedFee?: number; // optional fixed cost (cheapest mode)
   timeFixed?: number; // optional time cost (fastest mode)
@@ -111,7 +111,6 @@ export const buildBaseGraph = (
 
     const chainIsEvm = Object.keys(AxelarChain).includes(chainName);
     const base: Omit<FlowEdge, 'src' | 'dest' | 'id'> = {
-      capacity: 1e15,
       variableFee: vf,
       fixedFee: 0,
       timeFixed: tf,
@@ -220,7 +219,6 @@ export const makeGraphFromDefinition = (
 
   // Force the presence of particular edges.
   const edges = [...graph.edges] as Array<FlowEdge | undefined>;
-  const capacityDefault = 1e15; // not quite MAX_SAFE_INTEGER
   const addOrReplaceEdge = (
     src: AssetPlaceRef,
     dest: AssetPlaceRef,
@@ -239,7 +237,6 @@ export const makeGraphFromDefinition = (
     }
 
     const dataAttrs = customAttrs || {
-      capacity: capacityDefault,
       variableFee: 1,
       fixedFee: 0,
       timeFixed: 1,
@@ -262,7 +259,7 @@ export const makeGraphFromDefinition = (
   // Override the base graph with inter-hub links from spec.
   for (const link of spec.links) {
     addOrReplaceEdge(link.src, link.dest, {
-      capacity: Number(link.capacity ?? capacityDefault),
+      capacity: link.capacity === undefined ? undefined : Number(link.capacity),
       variableFee: link.variableFeeBps ?? 0,
       fixedFee: link.flatFee === undefined ? undefined : Number(link.flatFee),
       timeFixed: link.timeSec,

--- a/packages/portfolio-contract/tools/network/buildGraph.ts
+++ b/packages/portfolio-contract/tools/network/buildGraph.ts
@@ -273,7 +273,11 @@ export const makeGraphFromDefinition = (
 
   // Force unique sequential edge IDs for avoiding collisions in the solver.
   graph.edges = partialMap(edges, edge => (edge ? { ...edge } : undefined));
-  for (let i = 0; i < graph.edges.length; i += 1) graph.edges[i].id = `e${i}`;
+  const width = `${graph.edges.length - 1}`.length;
+  for (let i = 0; i < graph.edges.length; i += 1) {
+    const iPadded = `${i}`.padStart(width, '0');
+    graph.edges[i].id = `e${iPadded}`;
+  }
 
   return graph;
 };

--- a/packages/portfolio-contract/tools/plan-solve.ts
+++ b/packages/portfolio-contract/tools/plan-solve.ts
@@ -147,7 +147,9 @@ export const buildLPModel = (
     const { id, src, dest } = edge;
     const { capacity, variableFee, fixedFee = 0, timeFixed = 0 } = edge;
 
-    throughputConstraints[`through_${id}`] = { min: 0, max: capacity };
+    const throughputConstraint: { min: number; max?: number } = { min: 0 };
+    if (capacity) throughputConstraint.max = capacity;
+    throughputConstraints[`through_${id}`] = throughputConstraint;
 
     // The numbers in graph.supplies should use the same units as fixedFee, but
     // variableFee is in basis points relative to some scaling of those other

--- a/packages/portfolio-contract/tools/plan-solve.ts
+++ b/packages/portfolio-contract/tools/plan-solve.ts
@@ -165,8 +165,8 @@ export const buildLPModel = (
     // The solution may be disrupted by either over- or under-weighting
     // variableFee w.r.t. fixedFee, but not otherwise, and we accept the risk.
     // TODO: Define RebalanceGraph['scale'] to eliminate this guesswork.
-    const magnifiedVariableFee = variableFee / 10_000 + 1;
-    const magnifiedFlatFee = fixedFee * 1e6 + 1; // ensure non-zero
+    const magnifiedVariableFee = variableFee / 10_000;
+    const magnifiedFlatFee = fixedFee * 1e6;
 
     // Dynamic costs for this edge are associated with the numeric `via_${id}`
     // variable, and fixed costs are associated with the binary `pick_${id}`.
@@ -214,6 +214,8 @@ export const buildLPModel = (
       binaryVariables[`pick_${id}`],
       epsilonWeight,
     );
+    // No arc is free.
+    binaryVariables[`pick_${id}`].weight += 1;
   }
 
   // Constrain the net flow from each node.


### PR DESCRIPTION
And make planner graph arc capacity optional to avoid excessively large numbers that throw off the MILP solver.