### PR TITLE
fix(portfolio-contract): Propagate graph arc minimum flow into LP solver input

### DIFF
--- a/packages/portfolio-contract/tools/network/buildGraph.ts
+++ b/packages/portfolio-contract/tools/network/buildGraph.ts
@@ -21,6 +21,7 @@ export interface FlowEdge {
   src: AssetPlaceRef;
   dest: AssetPlaceRef;
   capacity?: number; // numeric for LP; derived from bigint
+  min?: number; // numeric for LP; derived from bigint
   variableFee: number; // cost coefficient per unit flow in basis points
   fixedFee?: number; // optional fixed cost (cheapest mode)
   timeFixed?: number; // optional time cost (fastest mode)
@@ -260,6 +261,7 @@ export const makeGraphFromDefinition = (
   for (const link of spec.links) {
     addOrReplaceEdge(link.src, link.dest, {
       capacity: link.capacity === undefined ? undefined : Number(link.capacity),
+      min: link.min === undefined ? undefined : Number(link.min),
       variableFee: link.variableFeeBps ?? 0,
       fixedFee: link.flatFee === undefined ? undefined : Number(link.flatFee),
       timeFixed: link.timeSec,

--- a/packages/portfolio-contract/tools/network/network-spec.ts
+++ b/packages/portfolio-contract/tools/network/network-spec.ts
@@ -90,8 +90,8 @@ export interface LinkSpec {
   feeMode?: FeeMode; // how fees apply to transation using this link. See plan-solve.ts
 
   // Policy / guardrails (optional)
-  priority?: number; // tie-break hint
-  enabled?: boolean; // admin toggle
+  // priority?: number; // tie-break hint
+  // enabled?: boolean; // admin toggle
 }
 
 // Overall network definition


### PR DESCRIPTION
## Description
LinkSpec already had a `min` field, but FlowEdge was missing an analog.