### PR TITLE
Optimize board

### DIFF
--- a/a3p-integration/proposals/z:acceptance/yarn.lock
+++ b/a3p-integration/proposals/z:acceptance/yarn.lock
@@ -169,6 +169,7 @@ __metadata:
   resolution: "@agoric/internal@portal:../../agoric-sdk/packages/internal::locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@agoric/base-zone": "workspace:*"
+    "@endo/cache-map": "npm:^1.1.0"
     "@endo/common": "npm:^1.2.13"
     "@endo/compartment-mapper": "npm:^1.6.3"
     "@endo/errors": "npm:^1.2.13"

--- a/multichain-testing/yarn.lock
+++ b/multichain-testing/yarn.lock
@@ -179,6 +179,7 @@ __metadata:
   resolution: "@agoric/internal@portal:../packages/internal::locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@agoric/base-zone": "workspace:*"
+    "@endo/cache-map": "npm:^1.1.0"
     "@endo/common": "npm:^1.2.13"
     "@endo/compartment-mapper": "npm:^1.6.3"
     "@endo/errors": "npm:^1.2.13"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "type-coverage": "^2.29.7",
     "typedoc": "^0.26.7",
     "typedoc-plugin-markdown": "^4.2.1",
-    "typescript": "~5.9.2",
+    "typescript": "~5.9.3",
     "typescript-eslint": "^8.40.0"
   },
   "resolutions": {

--- a/packages/cache/src/store.js
+++ b/packages/cache/src/store.js
@@ -7,6 +7,7 @@ import { withGroundState, makeState } from './state.js';
 
 /**
  * @import {ERemote} from '@agoric/internal'
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {Passable, RemotableObject} from '@endo/pass-style';
  * @import {Key, Pattern} from '@endo/patterns';
  */
@@ -113,7 +114,7 @@ const applyCacheTransaction = async (
 
 /**
  * @param {MapStore<string, import('./state.js').State>} stateStore
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  * @returns {Promise<string>}
  */
 const stringifyStateStore = async (stateStore, marshaller) => {
@@ -177,7 +178,7 @@ export const makeScalarStoreCoordinator = (
  * Don't write any marshalled value that's older than what's already pushed
  *
  * @param {MapStore<string, import('./state.js').State>} stateStore
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  * @param {ERemote<StorageNode>} storageNode
  * @returns {<T>(storedValue: T) => Promise<T>}
  */
@@ -207,7 +208,7 @@ const makeLastWinsUpdater = (stateStore, marshaller, storageNode) => {
  * currently enforce any cache eviction, but that would be a useful feature.
  *
  * @param {ERemote<StorageNode>} storageNode
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  */
 export const makeChainStorageCoordinator = (storageNode, marshaller) => {
   const stateStore = makeScalarBigMapStore('stateKey');

--- a/packages/fast-usdc-contract/src/exos/status-manager.ts
+++ b/packages/fast-usdc-contract/src/exos/status-manager.ts
@@ -19,10 +19,8 @@ import type {
 } from '@agoric/fast-usdc/src/types.js';
 import type { RepayAmountKWR } from '@agoric/fast-usdc/src/utils/fees.js';
 import type { ERemote } from '@agoric/internal';
-import type {
-  Marshaller,
-  StorageNode,
-} from '@agoric/internal/src/lib-chainStorage.js';
+import type { StorageNode } from '@agoric/internal/src/lib-chainStorage.js';
+import type { EMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import type { MapStore, SetStore } from '@agoric/store';
 import { AmountKeywordRecordShape } from '@agoric/zoe/src/typeGuards.js';
 import type { Zone } from '@agoric/zone';
@@ -38,7 +36,7 @@ import { makeSettlementMatcher } from '../utils/settlement-matcher.ts';
 
 interface StatusManagerPowers {
   log?: LogFn;
-  marshaller: ERemote<Marshaller>;
+  marshaller: ERemote<EMarshaller>;
   routeHealth: RouteHealth;
 }
 

--- a/packages/fast-usdc-contract/src/fast-usdc.contract.ts
+++ b/packages/fast-usdc-contract/src/fast-usdc.contract.ts
@@ -44,6 +44,7 @@ import type {
   Marshaller,
   StorageNode,
 } from '@agoric/internal/src/lib-chainStorage.js';
+import type { EMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import type { ContractMeta, Invitation, ZCF } from '@agoric/zoe';
 import type { Zone } from '@agoric/zone';
 import { prepareAdvancer } from './exos/advancer.ts';
@@ -84,7 +85,7 @@ harden(meta);
 
 const publishFeeConfig = (
   node: ERemote<StorageNode>,
-  marshaller: ERemote<Marshaller>,
+  marshaller: ERemote<EMarshaller>,
   feeConfig: FeeConfig,
 ) => {
   const feeNode = E(node).makeChildNode(FEE_NODE);

--- a/packages/fast-usdc-contract/src/fast-usdc.contract.ts
+++ b/packages/fast-usdc-contract/src/fast-usdc.contract.ts
@@ -44,7 +44,10 @@ import type {
   Marshaller,
   StorageNode,
 } from '@agoric/internal/src/lib-chainStorage.js';
-import type { EMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
+import {
+  wrapRemoteMarshaller,
+  type EMarshaller,
+} from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import type { ContractMeta, Invitation, ZCF } from '@agoric/zoe';
 import type { Zone } from '@agoric/zone';
 import { prepareAdvancer } from './exos/advancer.ts';
@@ -123,7 +126,7 @@ export const contract = async (
 
   // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
   // once withOrchestration provides a wrapped marshaller, don't re-wrap.
-  const cachingMarshaller: ERemote<EMarshaller> = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
   const { makeRecorderKit } = prepareRecorderKitMakers(
     zone.mapStore('vstorage'),
     cachingMarshaller,

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -16,7 +16,8 @@ import { ElectorateCreatorI, ElectoratePublicI } from './typeGuards.js';
 import { prepareVoterKit } from './voterKit.js';
 
 /**
- * @import {Remote} from '@agoric/internal';
+ * @import {Remote, ERemote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {MapStore} from '@agoric/swingset-liveslots';
  * @import {ContractMeta, Invitation, ZCF} from '@agoric/zoe';
  * @import {ElectorateCreatorFacet, CommitteeElectoratePublic, QuestionDetails, OutcomeRecord, AddQuestion} from './types.js';
@@ -75,9 +76,15 @@ export const start = (zcf, privateArgs, baggage) => {
   const questionNode = E(privateArgs.storageNode).makeChildNode(
     'latestQuestion',
   );
+
+  const { marshaller: remoteMarshaller } = privateArgs;
+
+  /** @type {ERemote<EMarshaller>} */
+  const cachingMarshaller = remoteMarshaller;
+
   /** @type {StoredPublishKit<QuestionDetails>} */
   const { subscriber: questionsSubscriber, publisher: questionsPublisher } =
-    makeStoredPublishKit(questionNode, privateArgs.marshaller);
+    makeStoredPublishKit(questionNode, cachingMarshaller);
 
   const makeCommitteeVoterInvitation = index => {
     // https://github.com/Agoric/agoric-sdk/pull/3448/files#r704003612
@@ -156,7 +163,7 @@ export const start = (zcf, privateArgs, baggage) => {
         /** @type {StoredPublishKit<OutcomeRecord>} */
         const { publisher: outcomePublisher } = makeStoredPublishKit(
           outcomeNode,
-          privateArgs.marshaller,
+          cachingMarshaller,
         );
 
         return startCounter(

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -3,6 +3,7 @@ import { M } from '@agoric/store';
 import { E } from '@endo/eventual-send';
 
 import { StorageNodeShape } from '@agoric/internal';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import { prepareExo, provideDurableMapStore } from '@agoric/vat-data';
 import { EmptyProposalShape } from '@agoric/zoe/src/typeGuards.js';
 import {
@@ -16,8 +17,7 @@ import { ElectorateCreatorI, ElectoratePublicI } from './typeGuards.js';
 import { prepareVoterKit } from './voterKit.js';
 
 /**
- * @import {Remote, ERemote} from '@agoric/internal';
- * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
+ * @import {Remote} from '@agoric/internal';
  * @import {MapStore} from '@agoric/swingset-liveslots';
  * @import {ContractMeta, Invitation, ZCF} from '@agoric/zoe';
  * @import {ElectorateCreatorFacet, CommitteeElectoratePublic, QuestionDetails, OutcomeRecord, AddQuestion} from './types.js';
@@ -79,8 +79,7 @@ export const start = (zcf, privateArgs, baggage) => {
 
   const { marshaller: remoteMarshaller } = privateArgs;
 
-  /** @type {ERemote<EMarshaller>} */
-  const cachingMarshaller = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   /** @type {StoredPublishKit<QuestionDetails>} */
   const { subscriber: questionsSubscriber, publisher: questionsPublisher } =

--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -14,6 +14,7 @@ import { CONTRACT_ELECTORATE } from './contractGovernance/governParam.js';
 
 /**
  * @import {ERemote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {ContractMeta, Installation, Instance, Invitation, ZCF} from '@agoric/zoe';
  * @import {VoteCounterCreatorFacet, VoteCounterPublicFacet, QuestionSpec, OutcomeRecord, AddQuestion, AddQuestionReturn, GovernanceSubscriptionState, GovernanceTerms, GovernedApis, GovernedCreatorFacet, GovernedPublicFacet} from './types.js';
  * @import {Baggage} from '@agoric/vat-data';
@@ -254,7 +255,7 @@ const facetHelpers = (zcf, paramManager) => {
  * @param {Invitation} initialPoserInvitation
  * @param {M} paramTypesMap
  * @param {ERemote<StorageNode>} [storageNode]
- * @param {ERemote<Marshaller>} [marshaller]
+ * @param {ERemote<EMarshaller>} [marshaller]
  * @param {object} [overrides]
  */
 const handleParamGovernance = (

--- a/packages/inter-protocol/src/auction/auctioneer.js
+++ b/packages/inter-protocol/src/auction/auctioneer.js
@@ -35,8 +35,8 @@ import { makeScheduler } from './scheduler.js';
 import { AuctionState } from './util.js';
 
 /**
- * @import {Remote} from '@agoric/internal';
- * @import {TypedPattern} from '@agoric/internal';
+ * @import {Remote, ERemote, TypedPattern} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {MapStore} from '@agoric/store';
  * @import {Baggage} from '@agoric/vat-data';
  * @import {ContractOf} from '@agoric/zoe/src/zoeService/utils.js';
@@ -425,11 +425,16 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   let bookCounter = 0;
 
+  const { marshaller: remoteMarshaller } = privateArgs;
+
+  /** @type {ERemote<EMarshaller>} */
+  const cachingMarshaller = remoteMarshaller;
+
   const makeDurablePublishKit = prepareDurablePublishKit(
     baggage,
     'Auction publish kit',
   );
-  const makeRecorder = prepareRecorder(baggage, privateArgs.marshaller);
+  const makeRecorder = prepareRecorder(baggage, cachingMarshaller);
 
   const makeRecorderKit = defineRecorderKit({
     makeRecorder,
@@ -535,7 +540,7 @@ export const start = async (zcf, privateArgs, baggage) => {
       privateArgs.initialPoserInvitation,
       auctioneerParamTypes,
       privateArgs.storageNode,
-      privateArgs.marshaller,
+      cachingMarshaller,
     );
 
   const tradeEveryBook = () => {

--- a/packages/inter-protocol/src/auction/auctioneer.js
+++ b/packages/inter-protocol/src/auction/auctioneer.js
@@ -7,6 +7,7 @@ import { Far } from '@endo/marshal';
 import { AmountMath, AmountShape, BrandShape } from '@agoric/ertp';
 import { handleParamGovernance } from '@agoric/governance';
 import { makeTracer } from '@agoric/internal';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import { prepareDurablePublishKit } from '@agoric/notifier';
 import { mustMatch } from '@agoric/store';
 import { appendToStoredArray } from '@agoric/store/src/stores/store-utils.js';
@@ -35,8 +36,7 @@ import { makeScheduler } from './scheduler.js';
 import { AuctionState } from './util.js';
 
 /**
- * @import {Remote, ERemote, TypedPattern} from '@agoric/internal';
- * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
+ * @import {Remote, TypedPattern} from '@agoric/internal';
  * @import {MapStore} from '@agoric/store';
  * @import {Baggage} from '@agoric/vat-data';
  * @import {ContractOf} from '@agoric/zoe/src/zoeService/utils.js';
@@ -427,8 +427,7 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   const { marshaller: remoteMarshaller } = privateArgs;
 
-  /** @type {ERemote<EMarshaller>} */
-  const cachingMarshaller = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   const makeDurablePublishKit = prepareDurablePublishKit(
     baggage,

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -3,6 +3,7 @@
 import { prepareIssuerKit } from '@agoric/ertp';
 import { handleParamGovernance } from '@agoric/governance';
 import { makeTracer, StorageNodeShape } from '@agoric/internal';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import { prepareDurablePublishKit } from '@agoric/notifier';
 import { M } from '@agoric/store';
 import { provideAll } from '@agoric/zoe/src/contractSupport/durability.js';
@@ -15,8 +16,7 @@ const trace = makeTracer('FluxAgg', false);
 /**
  * @import {Baggage} from '@agoric/vat-data'
  * @import {TimerService} from '@agoric/time'
- * @import {Remote, ERemote} from '@agoric/internal';
- * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
+ * @import {Remote} from '@agoric/internal';
  */
 
 /** @type {ContractMeta} */
@@ -91,8 +91,7 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   trace('awaited args');
 
-  /** @type {ERemote<EMarshaller>} */
-  const cachingMarshaller = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   const makeDurablePublishKit = prepareDurablePublishKit(
     baggage,

--- a/packages/inter-protocol/src/price/fluxAggregatorContract.js
+++ b/packages/inter-protocol/src/price/fluxAggregatorContract.js
@@ -15,7 +15,8 @@ const trace = makeTracer('FluxAgg', false);
 /**
  * @import {Baggage} from '@agoric/vat-data'
  * @import {TimerService} from '@agoric/time'
- * @import {Remote} from '@agoric/internal';
+ * @import {Remote, ERemote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  */
 
 /** @type {ContractMeta} */
@@ -81,7 +82,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   const {
     highPrioritySendersManager,
     initialPoserInvitation,
-    marshaller,
+    marshaller: remoteMarshaller,
     namesByAddressAdmin,
     storageNode,
   } = privateArgs;
@@ -90,11 +91,14 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   trace('awaited args');
 
+  /** @type {ERemote<EMarshaller>} */
+  const cachingMarshaller = remoteMarshaller;
+
   const makeDurablePublishKit = prepareDurablePublishKit(
     baggage,
     'Price Aggregator publish kit',
   );
-  const makeRecorder = prepareRecorder(baggage, marshaller);
+  const makeRecorder = prepareRecorder(baggage, cachingMarshaller);
 
   const makeFluxAggregatorKit = await prepareFluxAggregatorKit(
     baggage,
@@ -121,7 +125,7 @@ export const start = async (zcf, privateArgs, baggage) => {
       // No governed parameters. Governance just for API methods.
     },
     storageNode,
-    marshaller,
+    cachingMarshaller,
   );
 
   trace('got makeDurableGovernorFacet', makeDurableGovernorFacet);

--- a/packages/inter-protocol/src/provisionPool.js
+++ b/packages/inter-protocol/src/provisionPool.js
@@ -18,7 +18,8 @@ import {
 } from './provisionPoolKit.js';
 
 /**
- * @import {Remote} from '@agoric/internal';
+ * @import {Remote, ERemote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {Amount, Brand, Payment, Purse} from '@agoric/ertp';
  * @import {ContractMeta, Invitation, StandardTerms, ZCF} from '@agoric/zoe';
  * @import {GovernanceTerms} from '@agoric/governance/src/types.js';
@@ -64,9 +65,14 @@ harden(meta);
 export const start = async (zcf, privateArgs, baggage) => {
   const { poolBank, metricsOverride } = privateArgs;
 
+  const { marshaller: remoteMarshaller } = privateArgs;
+
+  /** @type {ERemote<EMarshaller>} */
+  const cachingMarshaller = remoteMarshaller;
+
   const { makeRecorderKit } = prepareRecorderKitMakers(
     baggage,
-    privateArgs.marshaller,
+    cachingMarshaller,
   );
 
   // Governance

--- a/packages/inter-protocol/src/provisionPool.js
+++ b/packages/inter-protocol/src/provisionPool.js
@@ -6,6 +6,7 @@ import {
   publicMixinAPI,
 } from '@agoric/governance';
 import { InvitationShape } from '@agoric/governance/src/typeGuards.js';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import { M } from '@agoric/store';
 import { prepareExo } from '@agoric/vat-data';
 import { provideSingleton } from '@agoric/zoe/src/contractSupport/durability.js';
@@ -18,8 +19,7 @@ import {
 } from './provisionPoolKit.js';
 
 /**
- * @import {Remote, ERemote} from '@agoric/internal';
- * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
+ * @import {Remote} from '@agoric/internal';
  * @import {Amount, Brand, Payment, Purse} from '@agoric/ertp';
  * @import {ContractMeta, Invitation, StandardTerms, ZCF} from '@agoric/zoe';
  * @import {GovernanceTerms} from '@agoric/governance/src/types.js';
@@ -66,9 +66,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   const { poolBank, metricsOverride } = privateArgs;
 
   const { marshaller: remoteMarshaller } = privateArgs;
-
-  /** @type {ERemote<EMarshaller>} */
-  const cachingMarshaller = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   const { makeRecorderKit } = prepareRecorderKitMakers(
     baggage,

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -45,6 +45,9 @@ import { makeNatAmountShape } from '../contractSupport.js';
 
 /**
  * @import {EReturn} from '@endo/far';
+ * @import {TypedPattern, Remote, ERemote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
+ * @import {Baggage} from '@agoric/vat-data'
  * @import {ContractMeta, FeeMintAccess, Installation} from '@agoric/zoe';
  */
 
@@ -61,11 +64,6 @@ import { makeNatAmountShape } from '../contractSupport.js';
  *   given by this contract
  * @property {Amount<'nat'>} totalMintedProvided running sum of Minted ever
  *   given by this contract
- */
-
-/**
- * @import {TypedPattern, Remote} from '@agoric/internal';
- * @import {Baggage} from '@agoric/vat-data'
  */
 
 /** @type {ContractMeta} */
@@ -128,9 +126,14 @@ export const start = async (zcf, privateArgs, baggage) => {
   const { anchorBrand, anchorPerMinted } = zcf.getTerms();
   console.log('PSM Starting', anchorBrand, anchorPerMinted);
 
+  const { marshaller: remoteMarshaller } = privateArgs;
+
+  /** @type {ERemote<EMarshaller>} */
+  const cachingMarshaller = remoteMarshaller;
+
   const { makeRecorderKit } = prepareRecorderKitMakers(
     baggage,
-    privateArgs.marshaller,
+    cachingMarshaller,
   );
 
   const { stableMint } = await provideAll(baggage, {
@@ -157,7 +160,7 @@ export const start = async (zcf, privateArgs, baggage) => {
         WantMintedFee: ParamTypes.RATIO,
       },
       privateArgs.storageNode,
-      privateArgs.marshaller,
+      cachingMarshaller,
     );
 
   const anchorPool = provideEmptySeat(zcf, baggage, 'anchorPoolSeat');

--- a/packages/inter-protocol/src/psm/psm.js
+++ b/packages/inter-protocol/src/psm/psm.js
@@ -12,6 +12,7 @@ import {
   publicMixinAPI,
 } from '@agoric/governance';
 import { StorageNodeShape } from '@agoric/internal';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import { M, prepareExo, provide } from '@agoric/vat-data';
 import {
   atomicTransfer,
@@ -45,8 +46,7 @@ import { makeNatAmountShape } from '../contractSupport.js';
 
 /**
  * @import {EReturn} from '@endo/far';
- * @import {TypedPattern, Remote, ERemote} from '@agoric/internal';
- * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
+ * @import {TypedPattern, Remote} from '@agoric/internal';
  * @import {Baggage} from '@agoric/vat-data'
  * @import {ContractMeta, FeeMintAccess, Installation} from '@agoric/zoe';
  */
@@ -127,9 +127,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   console.log('PSM Starting', anchorBrand, anchorPerMinted);
 
   const { marshaller: remoteMarshaller } = privateArgs;
-
-  /** @type {ERemote<EMarshaller>} */
-  const cachingMarshaller = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   const { makeRecorderKit } = prepareRecorderKitMakers(
     baggage,

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -2,6 +2,7 @@
 
 import { handleParamGovernance } from '@agoric/governance';
 import { makeTracer } from '@agoric/internal';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import {
   prepareRecorderKitMakers,
   provideAll,
@@ -10,7 +11,6 @@ import { prepareAssetReserveKit } from './assetReserveKit.js';
 
 /**
  * @import {ERemote} from '@agoric/internal';
- * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {Baggage} from '@agoric/vat-data'
  * @import {EReturn} from '@endo/far';
  * @import {ContractOf} from '@agoric/zoe/src/zoeService/utils.js';
@@ -60,9 +60,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   // to state and don't require reference to baggage.
 
   const { marshaller: remoteMarshaller } = privateArgs;
-
-  /** @type {ERemote<EMarshaller>} */
-  const cachingMarshaller = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   const { makeRecorderKit } = prepareRecorderKitMakers(
     baggage,

--- a/packages/inter-protocol/src/reserve/assetReserve.js
+++ b/packages/inter-protocol/src/reserve/assetReserve.js
@@ -10,6 +10,8 @@ import { prepareAssetReserveKit } from './assetReserveKit.js';
 
 /**
  * @import {ERemote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
+ * @import {Baggage} from '@agoric/vat-data'
  * @import {EReturn} from '@endo/far';
  * @import {ContractOf} from '@agoric/zoe/src/zoeService/utils.js';
  * @import {Allocation, ContractMeta, FeeMintAccess, Installation} from '@agoric/zoe';
@@ -29,8 +31,6 @@ harden(meta);
  *   reduceLiquidationShortfall: (reduction: Amount) => void;
  * }} ShortfallReportingFacet
  */
-
-/** @import {Baggage} from '@agoric/vat-data' */
 
 /**
  * Asset Reserve holds onto assets for the Inter Protocol, and can dispense it
@@ -59,9 +59,14 @@ export const start = async (zcf, privateArgs, baggage) => {
   // accessed via the `state` object. The latter means updates are made directly
   // to state and don't require reference to baggage.
 
+  const { marshaller: remoteMarshaller } = privateArgs;
+
+  /** @type {ERemote<EMarshaller>} */
+  const cachingMarshaller = remoteMarshaller;
+
   const { makeRecorderKit } = prepareRecorderKitMakers(
     baggage,
-    privateArgs.marshaller,
+    cachingMarshaller,
   );
 
   const storageNode = await privateArgs.storageNode;
@@ -88,7 +93,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     privateArgs.initialPoserInvitation,
     {},
     privateArgs.storageNode,
-    privateArgs.marshaller,
+    cachingMarshaller,
   );
 
   const { governorFacet } = makeDurableGovernorFacet(

--- a/packages/inter-protocol/src/vaultFactory/params.js
+++ b/packages/inter-protocol/src/vaultFactory/params.js
@@ -17,6 +17,7 @@ import { amountPattern, ratioPattern } from '../contractSupport.js';
 
 /**
  * @import {ERemote, Remote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {MapStore} from '@agoric/store';
  * @import {PriceAuthority} from '@agoric/zoe/tools/types.js';
  */
@@ -182,7 +183,7 @@ harden(makeGovernedTerms);
  * NB: changes from initial values will be lost upon restart
  *
  * @param {import('@agoric/vat-data').Baggage} baggage
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  * @param {Record<string, VaultManagerParamOverrides>} managerParamOverrides
  */
 export const provideVaultParamManagers = (

--- a/packages/inter-protocol/src/vaultFactory/vaultDirector.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultDirector.js
@@ -44,6 +44,7 @@ import {
  * @import {TransferPart, ZCF, ZCFMint, ZCFSeat} from '@agoric/zoe';
  * @import {EReturn} from '@endo/far';
  * @import {TypedPattern, ERemote, Remote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  */
 
 const trace = makeTracer('VD', true);
@@ -107,7 +108,7 @@ export const makeAllManagersDo = (collateralManagers, vaultManagers) => {
  * @param {ERef<import('@agoric/time').TimerService>} timer
  * @param {ERef<import('../auction/auctioneer.js').AuctioneerPublicFacet>} auctioneer
  * @param {ERemote<StorageNode>} storageNode
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit} makeRecorderKit
  * @param {import('@agoric/zoe/src/contractSupport/recorder.js').MakeERecorderKit} makeERecorderKit
  * @param {Record<string, import('./params.js').VaultManagerParamOverrides>} managerParams

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -19,6 +19,7 @@ import { CONTRACT_ELECTORATE } from '@agoric/governance';
 import { makeParamManagerFromTerms } from '@agoric/governance/src/contractGovernance/typedParamManager.js';
 import { validateElectorate } from '@agoric/governance/src/contractHelper.js';
 import { makeTracer, StorageNodeShape } from '@agoric/internal';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import { makeStoredSubscription, makeSubscriptionKit } from '@agoric/notifier';
 import { M } from '@agoric/store';
 import { provideAll } from '@agoric/zoe/src/contractSupport/durability.js';
@@ -30,8 +31,7 @@ import { SHORTFALL_INVITATION_KEY, vaultDirectorParamTypes } from './params.js';
 import { provideDirector } from './vaultDirector.js';
 
 /**
- * @import {Remote, ERemote} from '@agoric/internal';
- * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
+ * @import {Remote} from '@agoric/internal';
  * @import {ContractMeta, FeeMintAccess, HandleOffer, Invitation, OfferHandler, TransferPart, ZCF, ZCFMint, ZCFSeat} from '@agoric/zoe';
  * @import {ContractOf} from '@agoric/zoe/src/zoeService/utils.js';
  * @import {PriceAuthority, PriceDescription, PriceQuote, PriceQuoteValue, PriceQuery,} from '@agoric/zoe/tools/types.js';
@@ -96,8 +96,7 @@ export const start = async (zcf, privateArgs, baggage) => {
     directorParamOverrides,
   } = privateArgs;
 
-  /** @type {ERemote<EMarshaller>} */
-  const cachingMarshaller = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   trace('awaiting debtMint');
   const { debtMint } = await provideAll(baggage, {

--- a/packages/inter-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultManager.js
@@ -67,6 +67,7 @@ import { AuctionPFShape } from '../auction/auctioneer.js';
 
 /**
  * @import {ERemote, Remote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {MapStore, SetStore} from '@agoric/store';
  * @import {EReturn} from '@endo/far';
  * @import {ZCFMint} from '@agoric/zoe';
@@ -219,7 +220,7 @@ const collateralEphemera = makeEphemeraProvider(() => /** @type {any} */ ({}));
  * @param {import('@agoric/swingset-liveslots').Baggage} baggage
  * @param {{
  *   zcf: import('./vaultFactory.js').VaultFactoryZCF;
- *   marshaller: ERemote<Marshaller>;
+ *   marshaller: ERemote<EMarshaller>;
  *   makeRecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').MakeRecorderKit;
  *   makeERecorderKit: import('@agoric/zoe/src/contractSupport/recorder.js').MakeERecorderKit;
  *   factoryPowers: import('./vaultDirector.js').FactoryPowersFacet;

--- a/packages/inter-protocol/test/provisionPool.test.js
+++ b/packages/inter-protocol/test/provisionPool.test.js
@@ -584,6 +584,9 @@ test('provisionPool publishes metricsOverride promptly', async t => {
 
   const metrics = E(facets.publicFacet).getMetrics();
 
+  // Without this the test seems sensitive to the number of turn the start operation takes
+  await eventLoopIteration();
+
   const {
     head: { value: initialMetrics },
   } = await E(metrics).subscribeAfter();

--- a/packages/inter-protocol/test/vaultFactory/vault-collateralization.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vault-collateralization.test.js
@@ -50,6 +50,7 @@ test('totalDebt calculation includes compoundedInterest', async t => {
 
   t.log('give some collateral (adjustBalances); no change to debt');
   await E(vd).giveCollateral(50n, aeth);
+  await eventLoopIteration();
   const v1debtAfterGive = await E(vd.vault()).getCurrentDebt();
   t.deepEqual(v1debtAfterGive, v1debtAfterDay, 'no debt change');
 

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@agoric/base-zone": "workspace:*",
+    "@endo/cache-map": "^1.1.0",
     "@endo/common": "^1.2.13",
     "@endo/compartment-mapper": "^1.6.3",
     "@endo/errors": "^1.2.13",

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -10,6 +10,7 @@ import * as cb from './callback.js';
  * @import {ERef} from '@endo/far';
  * @import {Marshal, Passable} from '@endo/marshal';
  * @import {Remote, ERemote, TypedPattern} from './types.js';
+ * @import {EMarshaller} from './marshal/wrap-marshaller.js';
  */
 
 /** @typedef {Marshal<unknown>} Marshaller */
@@ -296,7 +297,7 @@ harden(makeStorageNodeChild);
 // TODO find a better module for this
 /**
  * @param {ERemote<StorageNode>} storageNode
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  * @returns {(value: Passable) => Promise<void>}
  */
 export const makeSerializeToStorage = (storageNode, marshaller) => {

--- a/packages/internal/src/marshal/wrap-marshaller.js
+++ b/packages/internal/src/marshal/wrap-marshaller.js
@@ -1,9 +1,12 @@
 // @ts-check
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/far';
 
 /**
  * @import {EOnly} from '@endo/eventual-send';
  * @import {Simplify} from '@endo/pass-style';
- * @import {Marshal} from '@endo/marshal';
+ * @import {CapData, Passable, Marshal} from '@endo/marshal';
+ * @import {ERemote} from '../types.js';
  */
 
 /**
@@ -14,4 +17,34 @@
  * @typedef {Simplify<EOnly<Marshal<Slot>>>} EMarshaller
  */
 
-export {};
+/**
+ * @template [Slot=unknown]
+ * @param {ERemote<Pick<EMarshaller<Slot>, 'fromCapData' | 'toCapData'>>} marshaller
+ * @returns {ReturnType<typeof Far<EMarshaller<Slot>>>}
+ */
+export const wrapRemoteMarshallerDirectSend = marshaller => {
+  /**
+   * @param {Passable} val
+   * @returns {Promise<CapData<Slot>>}
+   */
+  const toCapData = val => E(marshaller).toCapData(val);
+
+  /**
+   * @param {CapData<Slot>} data
+   * @returns {Promise<Passable>}
+   */
+  const fromCapData = data => E(marshaller).fromCapData(data);
+
+  return Far('wrapped remote marshaller', {
+    toCapData,
+    fromCapData,
+
+    // for backwards compatibility
+    /** @deprecated use toCapData */
+    serialize: toCapData,
+    /** @deprecated use fromCapData */
+    unserialize: fromCapData,
+  });
+};
+
+export const wrapRemoteMarshaller = wrapRemoteMarshallerDirectSend;

--- a/packages/internal/src/marshal/wrap-marshaller.js
+++ b/packages/internal/src/marshal/wrap-marshaller.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { makeCacheMapKit } from '@endo/cache-map';
 import { Fail, q } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/far';
@@ -7,6 +8,7 @@ import { makeMarshal } from '@endo/marshal';
 import { makeInaccessibleVal } from './inaccessible-val.js';
 
 /**
+ * @import {WeakMapAPI} from '@endo/cache-map';
  * @import {EOnly} from '@endo/eventual-send';
  * @import {RemotableObject, Simplify} from '@endo/pass-style';
  * @import {CapData, Passable, Marshal, MakeMarshalOptions} from '@endo/marshal';
@@ -85,15 +87,7 @@ const { slotToWrapper, wrapperToSlot } = (() => {
  *   SlotWrapper
  */
 
-/**
- * A cache uses the WeakMap interface subset but holds keys strongly.
- *
- * @template K
- * @template V
- * @typedef {Pick<Map<K, V>, Exclude<keyof WeakMap<WeakKey, any>, 'set'>> & {
- *   set: (key: K, value: V) => WeakMapAPI<K, V>;
- * }} WeakMapAPI
- */
+const capacityOfDefaultCache = 50;
 
 // TODO(https://github.com/Agoric/agoric-sdk/issues/12111)
 // Check cost of using virtual-aware WeakMap in liveslots
@@ -101,10 +95,13 @@ const { slotToWrapper, wrapperToSlot } = (() => {
  * @template K
  * @template V
  * @param {boolean} [weakKey]
- * @todo Replace with an evicting cache map
  */
 const makeDefaultCacheMap = weakKey =>
-  /** @type {WeakMapAPI<K, V>} */ (weakKey ? new WeakMap() : new Map());
+  /** @type {WeakMapAPI<K, V>} */ (
+    makeCacheMapKit(capacityOfDefaultCache, {
+      makeMap: weakKey ? WeakMap : Map,
+    }).cache
+  );
 
 /**
  * Wraps a marshaller, either sync or async, local or remote, into a local async

--- a/packages/internal/src/marshal/wrap-marshaller.js
+++ b/packages/internal/src/marshal/wrap-marshaller.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+/**
+ * @import {EOnly} from '@endo/eventual-send';
+ * @import {Simplify} from '@endo/pass-style';
+ * @import {Marshal} from '@endo/marshal';
+ */
+
+/**
+ * A Marshaller which methods may be async. Use this type to indicate accepting
+ * either a sync or async marshaller, usually through `E` eventual-sends.
+ *
+ * @template [Slot=unknown]
+ * @typedef {Simplify<EOnly<Marshal<Slot>>>} EMarshaller
+ */
+
+export {};

--- a/packages/internal/src/marshal/wrap-marshaller.js
+++ b/packages/internal/src/marshal/wrap-marshaller.js
@@ -1,11 +1,15 @@
 // @ts-check
+import { Fail, q } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/far';
+import { PASS_STYLE } from '@endo/pass-style';
+import { makeMarshal } from '@endo/marshal';
+import { makeInaccessibleVal } from './inaccessible-val.js';
 
 /**
  * @import {EOnly} from '@endo/eventual-send';
- * @import {Simplify} from '@endo/pass-style';
- * @import {CapData, Passable, Marshal} from '@endo/marshal';
+ * @import {RemotableObject, Simplify} from '@endo/pass-style';
+ * @import {CapData, Passable, Marshal, MakeMarshalOptions} from '@endo/marshal';
  * @import {ERemote} from '../types.js';
  */
 
@@ -16,6 +20,272 @@ import { Far } from '@endo/far';
  * @template [Slot=unknown]
  * @typedef {Simplify<EOnly<Marshal<Slot>>>} EMarshaller
  */
+
+const { slotToWrapper, wrapperToSlot } = (() => {
+  /** @typedef {'Remotable' | `Alleged: ${string}`} InterfaceSpec */
+
+  /** @template [Slot=unknown] */
+  class SlotWrapper {
+    /** @type {Slot} */
+    #slot;
+
+    /** @type {InterfaceSpec} */
+    [Symbol.toStringTag];
+
+    /**
+     * @param {Slot} slot
+     * @param {string} [iface]
+     */
+    constructor(slot, iface) {
+      if (iface == null || iface === 'Remotable') {
+        iface = 'Remotable';
+      } else if (!iface.startsWith('Alleged: ')) {
+        iface = `Alleged: ${iface}`;
+      }
+      this.#slot = slot;
+      this[Symbol.toStringTag] = /** @type {InterfaceSpec} */ (iface);
+    }
+
+    /** @param {SlotWrapper} wrapper */
+    static getSlot(wrapper) {
+      return wrapper.#slot;
+    }
+  }
+  Object.defineProperties(SlotWrapper.prototype, {
+    [PASS_STYLE]: { value: 'remotable' },
+    [Symbol.toStringTag]: { value: 'Alleged: SlotWrapper' },
+  });
+  Reflect.deleteProperty(SlotWrapper.prototype, 'constructor');
+  harden(SlotWrapper);
+
+  /**
+   * @type {<Slot = unknown>(
+   *   wrapper: SlotWrapper<Slot> & RemotableObject<InterfaceSpec>,
+   * ) => Slot}
+   */
+  const getSlot = SlotWrapper.getSlot;
+
+  return {
+    /**
+     * @template [Slot=unknown]
+     * @param {Slot} slot
+     * @param {string} [iface]
+     */
+    slotToWrapper: (slot, iface) =>
+      /** @type {SlotWrapper<Slot> & RemotableObject<InterfaceSpec>} */ (
+        harden(new SlotWrapper(slot, iface))
+      ),
+
+    wrapperToSlot: getSlot,
+  };
+})();
+
+/**
+ * @template [Slot=unknown] @typedef {ReturnType<typeof slotToWrapper<Slot>>}
+ *   SlotWrapper
+ */
+
+/**
+ * Wraps a marshaller, either sync or async, local or remote, into a local async
+ * marshaller which only sends slots for resolution to the wrapped marshaller.
+ *
+ * Assumes that a null-ish slot value is a severed presence that can be resolved
+ * locally.
+ *
+ * @template [Slot=unknown]
+ * @param {ERemote<Pick<EMarshaller<Slot>, 'fromCapData' | 'toCapData'>>} marshaller
+ * @param {MakeMarshalOptions} [marshalOptions]
+ * @returns {ReturnType<typeof Far<EMarshaller<Slot>>>}
+ */
+export const wrapRemoteMarshallerSendSlotsOnly = (
+  marshaller,
+  {
+    serializeBodyFormat = 'smallcaps',
+    errorTagging = 'off', // Disable error tagging by default
+    ...otherMarshalOptions
+  } = {},
+) => {
+  const marshalOptions = harden({
+    serializeBodyFormat,
+    errorTagging,
+    ...otherMarshalOptions,
+  });
+  // The implementation of this wrapped marshaller internally uses 2 marshallers
+  // to transform the CapData into a Passable structure and vice-versa:
+  // - A cap pass-through marshaller which places capabilities as-is in the slots.
+  //   When unserializing CapData with null-ish slots, a severed presence is created.
+  //   This pass-through marshaller is used to locally process the structure, and
+  //   separate capabilities into a slots array for potential resolution by the
+  //   wrapped marshaller.
+  // - A "SlotWrapper" marshaller used to wrap into remotables the slots of the
+  //   wrapped marshaller. When unserializing CapData, it is used to recreate
+  //   CapData of a simple array of non-severed capabilities for resolution by
+  //   the wrapped marshaller. When serializing to CapData, it allows extracting
+  //   the slots from the capabilities array serialized by the wrapped marshaller.
+
+  /** @type {Marshal<object | null>} */
+  const passThroughMarshaller = makeMarshal(
+    undefined,
+    (slot, iface) => slot ?? makeInaccessibleVal(iface),
+    marshalOptions,
+  );
+
+  /** @type {Map<Slot, SlotWrapper<NonNullable<Slot>>>} */
+  const currentSlotToWrapper = new Map();
+
+  const convertWrapperToSlot = /** @type {typeof wrapperToSlot<Slot>} */ (
+    wrapperToSlot
+  );
+  /**
+   * @param {Slot} slot
+   * @param {string | undefined} [iface]
+   */
+  const convertSlotToWrapper = (slot, iface) => {
+    if (slot == null) {
+      // The wrapped marshaller may send us CapData with a null slot. These are not
+      // meant to be considered equivalent with each other, so bypass mapping.
+      return slotToWrapper(slot, iface);
+    }
+    let wrapper = currentSlotToWrapper.get(slot);
+    if (!wrapper) {
+      wrapper = slotToWrapper(slot, iface);
+      currentSlotToWrapper.set(slot, wrapper);
+    }
+
+    return wrapper;
+  };
+
+  /** @type {Pick<Marshal<Slot>, 'toCapData' | 'fromCapData'>} */
+  const slotWrapperMarshaller = makeMarshal(
+    convertWrapperToSlot,
+    convertSlotToWrapper,
+    marshalOptions,
+  );
+
+  /**
+   * Resolves an array of wrapped marshaller's slots to an array of
+   * capabilities.
+   *
+   * This is used by `fromCapData` to map slots before using the pass-through
+   * marshaller to recreate the passable data.
+   *
+   * @param {Slot[]} slots
+   * @param {(index: number) => SlotWrapper<NonNullable<Slot>>} getWrapper
+   * @returns {Promise<(object | null)[]>}
+   */
+  const mapSlotsToCaps = async (slots, getWrapper) => {
+    let hasCap = false;
+    const slotWrapperMappedSlots = harden(
+      slots.map((slot, index) => {
+        if (slot == null) return null;
+        hasCap = true;
+        return getWrapper(index);
+      }),
+    );
+    if (!hasCap) return slotWrapperMappedSlots;
+
+    const slotsOnlyCapData = slotWrapperMarshaller.toCapData(
+      slotWrapperMappedSlots,
+    );
+    return E(marshaller).fromCapData(slotsOnlyCapData);
+  };
+
+  /**
+   * Resolves an array of capabilities into an array of slots of the wrapped
+   * marshaller.
+   *
+   * This is used by `toCapData` to map slots after the pass-through marshaller
+   * has serialized the passable data.
+   *
+   * @param {object[]} caps
+   * @returns {Promise<Slot[]>}
+   */
+  const mapCapsToSlots = async caps => {
+    if (caps.length === 0) {
+      return caps;
+    }
+    const mappedSlotsCapData = await E(marshaller).toCapData(caps);
+    try {
+      /** @type {SlotWrapper<Slot>[]} */
+      const slotWrapperMappedSlots =
+        slotWrapperMarshaller.fromCapData(mappedSlotsCapData);
+      return slotWrapperMappedSlots.map(slotWrapper =>
+        convertWrapperToSlot(slotWrapper),
+      );
+    } finally {
+      // We're done with the slotWrapperMarshaller, clear its state
+      currentSlotToWrapper.clear();
+    }
+  };
+
+  /**
+   * Unfortunately CapData only contains iface information for slotted
+   * capabilities nested inside the body, which means we need to process the
+   * body to extract it. Maybe in the future CapData could be extended to carry
+   * this separately. See https://github.com/endojs/endo/issues/2991
+   *
+   * Since this helper is used internally to ultimately provide SlotWrapper
+   * objects to the corresponding marshaller, and that we use the same
+   * marshaller to extract the iface information, directly return the full
+   * SlotWrapper object instead of just the iface.
+   *
+   * @param {CapData<Slot>} data
+   */
+  const makeIfaceExtractor = data => {
+    const { slots } = data;
+    /** @param {number} index */
+    const getWrapper = index => {
+      const slot = slots[index];
+      let wrapper = currentSlotToWrapper.get(slot);
+      if (!wrapper) {
+        void slotWrapperMarshaller.fromCapData(data);
+      }
+      wrapper = currentSlotToWrapper.get(slot);
+      if (!wrapper) {
+        throw Fail`Marshaller didn't create wrapper for slot ${q(slot)} (index=${q(index)})`;
+      }
+      return wrapper;
+    };
+
+    return getWrapper;
+  };
+
+  /**
+   * @param {Passable} val
+   * @returns {Promise<CapData<Slot>>}
+   */
+  const toCapData = async val => {
+    const capData = passThroughMarshaller.toCapData(val);
+    const mappedSlots = await mapCapsToSlots(capData.slots);
+    return harden({ ...capData, slots: mappedSlots });
+  };
+
+  /**
+   * @param {CapData<Slot>} data
+   * @returns {Promise<Passable>}
+   */
+  const fromCapData = async data => {
+    const getWrapper = makeIfaceExtractor(data);
+    await null;
+    try {
+      const mappedSlots = await mapSlotsToCaps(data.slots, getWrapper);
+      return passThroughMarshaller.fromCapData({ ...data, slots: mappedSlots });
+    } finally {
+      currentSlotToWrapper.clear();
+    }
+  };
+
+  return Far('wrapped remote marshaller', {
+    toCapData,
+    fromCapData,
+
+    // for backwards compatibility
+    /** @deprecated use toCapData */
+    serialize: toCapData,
+    /** @deprecated use fromCapData */
+    unserialize: fromCapData,
+  });
+};
 
 /**
  * @template [Slot=unknown]
@@ -47,4 +317,4 @@ export const wrapRemoteMarshallerDirectSend = marshaller => {
   });
 };
 
-export const wrapRemoteMarshaller = wrapRemoteMarshallerDirectSend;
+export const wrapRemoteMarshaller = wrapRemoteMarshallerSendSlotsOnly;

--- a/packages/internal/test/marshal.test.js
+++ b/packages/internal/test/marshal.test.js
@@ -75,9 +75,15 @@ const checkRemoteMarshallerValueInvariants = (t, val) => {
   let hasCap = false;
   for (const elem of val) {
     const passStyle = passStyleOf(elem);
-    if (passStyle !== 'null') {
-      t.is(passStyle, 'remotable');
-      hasCap = true;
+    switch (passStyle) {
+      case 'null':
+      case 'undefined':
+        break;
+      case 'remotable':
+        hasCap = true;
+        break;
+      default:
+        t.fail(`Unexpected pass-style: ${passStyle}`);
     }
   }
   t.true(hasCap);
@@ -123,21 +129,71 @@ test('wrapRemoteMarshaller - empty slots', async t => {
   t.deepEqual(clone, specimen);
 });
 
-test('wrapRemoteMarshaller - with slots', async t => {
+const withSlots = test.macro(async (t, { withCache } = {}) => {
+  let valueHookCalled = false;
   const marshaller = makeMockMarshaller({
     valueHook: val => {
-      checkRemoteMarshallerValueInvariants(t, val);
+      if (valueHookCalled && withCache) {
+        unexpectedMarshallerInvocation(t, val);
+      } else {
+        valueHookCalled = true;
+        checkRemoteMarshallerValueInvariants(t, val);
+      }
     },
   });
-  const wrappedMarshaller = wrapRemoteMarshaller(marshaller);
+  const wrappedMarshaller = wrapRemoteMarshaller(
+    marshaller,
+    {},
+    withCache
+      ? {} // default caches
+      : {
+          slotToVal: null,
+          valToSlot: null,
+        },
+  );
 
   const specimen = harden({ foo: 42, bar: Far('bar', { sentinel() {} }) });
 
+  // Will populate the cache
   const capData = await wrappedMarshaller.toCapData(specimen);
+  // Will hit the cache
   const clone = await wrappedMarshaller.fromCapData(capData);
 
   t.deepEqual(clone, specimen);
   t.is(clone.bar, specimen.bar);
+
+  // Will hit the cache
+  const capData2 = await wrappedMarshaller.toCapData(specimen);
+
+  const caches = {
+    slotToVal: withCache ? new Map() : null,
+    valToSlot: withCache ? new Map() : null,
+  };
+  const wrappedMarshaller2 = wrapRemoteMarshaller(marshaller, {}, caches);
+  valueHookCalled = false;
+
+  // Populate the cache
+  const clone2 = await wrappedMarshaller2.fromCapData(capData2);
+  t.true(valueHookCalled);
+  t.deepEqual(clone2, specimen);
+
+  if (withCache) {
+    const cap = specimen.bar;
+    const slot = capData2.slots[0];
+    t.is(caches.slotToVal?.get(slot), cap);
+    t.is(caches.valToSlot?.get(cap), slot);
+  }
+
+  // Hit the cache
+  const clone3 = await wrappedMarshaller2.fromCapData(capData2);
+  t.deepEqual(clone3, specimen);
+});
+
+test('wrapRemoteMarshaller - with slots - without cache', withSlots, {
+  withCache: false,
+});
+test('wrapRemoteMarshaller - with slots - with cache', withSlots, {
+  withCache: true,
 });
 
 test('wrapRemoteMarshaller - read-only marshaller', async t => {
@@ -162,25 +218,39 @@ test('wrapRemoteMarshaller - read-only marshaller', async t => {
   t.deepEqual(clone, { ...specimen, bar: makeInaccessibleVal('bar') });
 });
 
-test('wrapRemoteMarshaller - null and non-null slots', async t => {
+const withNullAndNonNullSlots = test.macro(async (t, { withCache }) => {
   const sharedCap = Far('shared', { sentinel() {} });
 
   const mockSotToVal = new Map();
   const mockValToSlot = new WeakMap();
 
+  let valueHookCalled = false;
   const writeMarshaller = makeMockMarshaller({ mockSotToVal, mockValToSlot });
   const marshaller = makeMockMarshaller({
     mockSotToVal,
     mockValToSlot,
     valueHook: val => {
-      checkRemoteMarshallerValueInvariants(t, val);
+      if (valueHookCalled && withCache) {
+        unexpectedMarshallerInvocation(t, val);
+      } else {
+        valueHookCalled = true;
+        checkRemoteMarshallerValueInvariants(t, val);
+      }
     },
     readOnly: true,
   });
 
-  const wrappedMarshaller = wrapRemoteMarshaller(marshaller);
+  const cacheSeveredVal = withCache === 'includeSevered';
+  const caches = {
+    slotToVal: withCache ? new Map() : null,
+    valToSlot: withCache ? new Map() : null,
+    cacheSeveredVal,
+  };
+  const wrappedMarshaller = wrapRemoteMarshaller(marshaller, {}, caches);
 
-  writeMarshaller.toCapData(sharedCap);
+  const {
+    slots: [sharedSlot],
+  } = writeMarshaller.toCapData(sharedCap);
 
   const specimen = harden({
     foo: 42,
@@ -189,10 +259,54 @@ test('wrapRemoteMarshaller - null and non-null slots', async t => {
   });
 
   const capData = await wrappedMarshaller.toCapData(specimen);
-  const clone = await wrappedMarshaller.fromCapData(capData);
+  if (withCache) {
+    t.is(caches.slotToVal?.get(sharedSlot), sharedCap);
+    t.is(caches.valToSlot?.get(sharedCap), sharedSlot);
 
+    if (cacheSeveredVal) {
+      t.is(caches.valToSlot?.get(specimen.bar), null);
+      t.is(caches.valToSlot?.size, 2);
+    } else {
+      t.false(caches.valToSlot?.has(specimen.bar));
+      t.is(caches.valToSlot?.size, 1);
+    }
+
+    // Must never cache a null slot
+    t.false(caches.slotToVal?.has(null));
+    t.is(caches.slotToVal?.size, 1);
+  }
+  const clone = await wrappedMarshaller.fromCapData(capData);
   t.deepEqual(clone, { ...specimen, bar: makeInaccessibleVal('bar') });
+
+  if (!cacheSeveredVal) {
+    // Without caching of severed val, toCapData will have to invoke the marshaller again
+    // That invocation will have an `undefined` value for the cached sharedCap.
+    valueHookCalled = false;
+  }
+  const capData2 = await wrappedMarshaller.toCapData(specimen);
+  if (withCache) {
+    // Must not have updated slot cache for the (maybe cached) severed value
+    t.false(caches.slotToVal?.has(null));
+    t.is(caches.slotToVal?.size, 1);
+  }
+  t.deepEqual(capData2, capData);
 });
+
+test(
+  'wrapRemoteMarshaller - null and non-null slots - without cache',
+  withNullAndNonNullSlots,
+  { withCache: false },
+);
+test(
+  'wrapRemoteMarshaller - null and non-null slots - with cache',
+  withNullAndNonNullSlots,
+  { withCache: true },
+);
+test(
+  'wrapRemoteMarshaller - null and non-null slots - with cache of severed values',
+  withNullAndNonNullSlots,
+  { withCache: 'includeSevered' },
+);
 
 test('wrapRemoteMarshaller preserves identity in fromCapData', async t => {
   const src = makeMockMarshaller();

--- a/packages/internal/test/marshal.test.js
+++ b/packages/internal/test/marshal.test.js
@@ -193,3 +193,15 @@ test('wrapRemoteMarshaller - null and non-null slots', async t => {
 
   t.deepEqual(clone, { ...specimen, bar: makeInaccessibleVal('bar') });
 });
+
+test('wrapRemoteMarshaller preserves identity in fromCapData', async t => {
+  const src = makeMockMarshaller();
+  const wrappedMarshaller = wrapRemoteMarshaller(src);
+
+  const specimen = Far('BLD Brand');
+  const capData = await src.toCapData(specimen);
+
+  const presence1 = await wrappedMarshaller.fromCapData(capData);
+  const presence2 = await wrappedMarshaller.fromCapData(capData);
+  t.is(presence1, presence2);
+});

--- a/packages/internal/test/marshal.test.js
+++ b/packages/internal/test/marshal.test.js
@@ -1,0 +1,195 @@
+// @ts-check
+import test from 'ava';
+
+import { Far, getInterfaceOf, makeMarshal, passStyleOf } from '@endo/marshal';
+import { Fail, q } from '@endo/errors';
+import { makeInaccessibleVal } from '../src/marshal/inaccessible-val.js';
+import { wrapRemoteMarshallerSendSlotsOnly as wrapRemoteMarshaller } from '../src/marshal/wrap-marshaller.js';
+
+/**
+ * @import {Marshal} from '@endo/marshal';
+ * @import {Farable} from '@endo/exo';
+ */
+
+/**
+ * @param {object} [options]
+ * @param {Map<string, object>} [options.mockSotToVal]
+ * @param {WeakMap<object, string>} [options.mockValToSlot]
+ * @param {(val: any, direction: 'from' | 'to') => void} [options.valueHook]
+ * @param {boolean} [options.readOnly]
+ * @returns {Farable<
+ *   Pick<Marshal<string | null>, 'fromCapData' | 'toCapData'>
+ * >}
+ */
+const makeMockMarshaller = ({
+  mockSotToVal = new Map(),
+  mockValToSlot = new WeakMap(),
+  valueHook,
+  readOnly = false,
+} = {}) => {
+  let nextId = 1;
+  const marshaller = makeMarshal(
+    val => {
+      if (!mockValToSlot.has(val) && !readOnly) {
+        const nextSlot = `mock${nextId}`;
+        nextId += 1;
+        mockValToSlot.set(val, nextSlot);
+        mockSotToVal.set(`${nextSlot}.(${getInterfaceOf(val)})`, val);
+      }
+      return mockValToSlot.get(val) || null;
+    },
+    (slot, iface) => {
+      if (slot === null) {
+        return makeInaccessibleVal(iface);
+      }
+      return (
+        mockSotToVal.get(`${slot}.(${iface})`) ||
+        Fail`Unknown mock slot ${q(slot)} for iface ${q(iface)}. Known entries: ${q([...mockSotToVal.keys()])}`
+      );
+    },
+    {
+      serializeBodyFormat: 'smallcaps',
+    },
+  );
+
+  return Far('mock marshaller', {
+    toCapData(val) {
+      valueHook?.(val, 'to');
+      return marshaller.toCapData(val);
+    },
+    fromCapData(data) {
+      const val = marshaller.fromCapData(data);
+      valueHook?.(val, 'from');
+      return val;
+    },
+  });
+};
+
+/**
+ * @param {import('ava').ExecutionContext} t
+ * @param {any} val
+ */
+const checkRemoteMarshallerValueInvariants = (t, val) => {
+  t.true(Array.isArray(val));
+  t.true(val.length > 0);
+  let hasCap = false;
+  for (const elem of val) {
+    const passStyle = passStyleOf(elem);
+    if (passStyle !== 'null') {
+      t.is(passStyle, 'remotable');
+      hasCap = true;
+    }
+  }
+  t.true(hasCap);
+};
+
+const unexpectedMarshallerInvocation = (t, val) => {
+  t.log('Unexpected marshalled value', val);
+  t.fail('Remote marshaller should not have been invoked');
+};
+
+test.before(t => {
+  const marshaller = makeMockMarshaller();
+
+  const specimen = harden({ remotable: Far('bar', { sentinel() {} }) });
+  const specimen2 = harden({ remotable: Far('bar', { sentinel() {} }) });
+
+  const marshalledSpecimen = marshaller.fromCapData(
+    marshaller.toCapData(specimen),
+  );
+
+  // These tests rely on the fact `deepEqual` performs an identity check on
+  // functions and that marshal does not pierce the remotable boundary, so that
+  // `sentinel` is a proxy to check that the remotable identity is preserved.
+
+  t.deepEqual(marshalledSpecimen, specimen);
+  t.notDeepEqual(specimen, specimen2);
+});
+
+test('wrapRemoteMarshaller - empty slots', async t => {
+  const marshaller = makeMockMarshaller({
+    valueHook: val => {
+      unexpectedMarshallerInvocation(t, val);
+    },
+  });
+
+  const wrappedMarshaller = wrapRemoteMarshaller(marshaller);
+
+  const specimen = harden({ foo: 42, err: Error('bar') });
+
+  const capData = await wrappedMarshaller.toCapData(specimen);
+  const clone = await wrappedMarshaller.fromCapData(capData);
+
+  t.deepEqual(clone, specimen);
+});
+
+test('wrapRemoteMarshaller - with slots', async t => {
+  const marshaller = makeMockMarshaller({
+    valueHook: val => {
+      checkRemoteMarshallerValueInvariants(t, val);
+    },
+  });
+  const wrappedMarshaller = wrapRemoteMarshaller(marshaller);
+
+  const specimen = harden({ foo: 42, bar: Far('bar', { sentinel() {} }) });
+
+  const capData = await wrappedMarshaller.toCapData(specimen);
+  const clone = await wrappedMarshaller.fromCapData(capData);
+
+  t.deepEqual(clone, specimen);
+  t.is(clone.bar, specimen.bar);
+});
+
+test('wrapRemoteMarshaller - read-only marshaller', async t => {
+  const marshaller = makeMockMarshaller({
+    valueHook: (val, direction) => {
+      if (direction === 'from') {
+        unexpectedMarshallerInvocation(t, val);
+      } else {
+        checkRemoteMarshallerValueInvariants(t, val);
+      }
+    },
+    readOnly: true,
+  });
+  const wrappedMarshaller = wrapRemoteMarshaller(marshaller);
+
+  const specimen = harden({ foo: 42, bar: Far('bar', { sentinel() {} }) });
+
+  const capData = await wrappedMarshaller.toCapData(specimen);
+  const clone = await wrappedMarshaller.fromCapData(capData);
+
+  t.like(capData, { slots: [null] });
+  t.deepEqual(clone, { ...specimen, bar: makeInaccessibleVal('bar') });
+});
+
+test('wrapRemoteMarshaller - null and non-null slots', async t => {
+  const sharedCap = Far('shared', { sentinel() {} });
+
+  const mockSotToVal = new Map();
+  const mockValToSlot = new WeakMap();
+
+  const writeMarshaller = makeMockMarshaller({ mockSotToVal, mockValToSlot });
+  const marshaller = makeMockMarshaller({
+    mockSotToVal,
+    mockValToSlot,
+    valueHook: val => {
+      checkRemoteMarshallerValueInvariants(t, val);
+    },
+    readOnly: true,
+  });
+
+  const wrappedMarshaller = wrapRemoteMarshaller(marshaller);
+
+  writeMarshaller.toCapData(sharedCap);
+
+  const specimen = harden({
+    foo: 42,
+    bar: Far('bar', { sentinel() {} }),
+    shared: sharedCap,
+  });
+
+  const capData = await wrappedMarshaller.toCapData(specimen);
+  const clone = await wrappedMarshaller.fromCapData(capData);
+
+  t.deepEqual(clone, { ...specimen, bar: makeInaccessibleVal('bar') });
+});

--- a/packages/notifier/src/stored-notifier.js
+++ b/packages/notifier/src/stored-notifier.js
@@ -9,7 +9,8 @@ import { observeNotifier } from './asyncIterableAdaptor.js';
  * @import {ERef} from '@endo/far';
  * @import {BaseNotifier, Notifier} from './types.js';
  * @import {ERemote} from '@agoric/internal';
- * @import {Marshaller, StoredFacet, StorageNode, Unserializer} from '@agoric/internal/src/lib-chainStorage.js';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
+ * @import {StoredFacet, StorageNode, Unserializer} from '@agoric/internal/src/lib-chainStorage.js';
  * @import {PassableCap} from '@endo/pass-style';
  */
 
@@ -30,7 +31,7 @@ import { observeNotifier } from './asyncIterableAdaptor.js';
  * @template {PassableCap} T
  * @param {ERef<Notifier<T>>} notifier
  * @param {ERemote<StorageNode>} storageNode
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  * @returns {StoredNotifier<T>}
  */
 export const makeStoredNotifier = (notifier, storageNode, marshaller) => {

--- a/packages/notifier/src/storesub.js
+++ b/packages/notifier/src/storesub.js
@@ -12,6 +12,7 @@ import { subscribeEach } from './subscribe.js';
  * @import {ERef} from '@endo/far';
  * @import {IterationObserver, LatestTopic, Notifier, NotifierRecord, PublicationRecord, Publisher, PublishKit, StoredPublishKit, StoredSubscription, StoredSubscriber, Subscriber, Subscription, UpdateRecord} from '../src/types.js';
  * @import {StorageNode, Unserializer} from '@agoric/internal/src/lib-chainStorage.js';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  */
 
 /**
@@ -48,7 +49,7 @@ export const forEachPublicationRecord = async (subscriber, consumeValue) => {
  * @template {import('@endo/marshal').PassableCap} T
  * @param {Subscriber<T>} subscriber
  * @param {ERemote<StorageNode>} storageNode
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  * @returns {StoredSubscriber<T>}
  */
 export const makeStoredSubscriber = (subscriber, storageNode, marshaller) => {
@@ -93,7 +94,7 @@ export const makeStoredSubscriber = (subscriber, storageNode, marshaller) => {
  * @template T
  * @param {Subscription<T>} subscription
  * @param {ERemote<StorageNode> | null} [storageNode]
- * @param {ERemote<Marshaller>} [marshaller]
+ * @param {ERemote<EMarshaller>} [marshaller]
  * @returns {StoredSubscription<T>}
  */
 export const makeStoredSubscription = (
@@ -179,7 +180,7 @@ harden(makeStoredSubscription);
  *
  * @template [T=unknown]
  * @param {ERemote<StorageNode> | null} [storageNode]
- * @param {ERemote<Marshaller>} [marshaller]
+ * @param {ERemote<EMarshaller>} [marshaller]
  * @param {string} [childPath]
  * @returns {StoredPublisherKit<T>}
  */
@@ -214,7 +215,7 @@ export const makeStoredPublisherKit = (storageNode, marshaller, childPath) => {
  *
  * @template [T=unknown]
  * @param {ERemote<StorageNode>} storageNode
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  * @returns {StoredPublishKit<T>}
  */
 export const makeStoredPublishKit = (storageNode, marshaller) => {

--- a/packages/orchestration/src/examples/stake-bld.contract.js
+++ b/packages/orchestration/src/examples/stake-bld.contract.js
@@ -16,7 +16,8 @@ import { makeZoeTools } from '../utils/zoe-tools.js';
 
 /**
  * @import {NameHub} from '@agoric/vats';
- * @import {Remote} from '@agoric/internal';
+ * @import {Remote, ERemote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {TimerService} from '@agoric/time';
  * @import {LocalChain} from '@agoric/vats/src/localchain.js';
  * @import {ZCF} from '@agoric/zoe';
@@ -38,9 +39,15 @@ const trace = makeTracer('StakeBld');
 export const start = async (zcf, privateArgs, baggage) => {
   const zone = makeDurableZone(baggage);
 
+  const { marshaller: remoteMarshaller } = privateArgs;
+  // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
+  // once withOrchestration provides a wrapped marshaller, don't re-wrap.
+  /** @type {ERemote<EMarshaller>} */
+  const cachingMarshaller = remoteMarshaller;
+
   const { makeRecorderKit } = prepareRecorderKitMakers(
     baggage,
-    privateArgs.marshaller,
+    cachingMarshaller,
   );
   const vowTools = prepareVowTools(zone.subZone('vows'));
 

--- a/packages/orchestration/src/examples/stake-bld.contract.js
+++ b/packages/orchestration/src/examples/stake-bld.contract.js
@@ -2,6 +2,7 @@
  * @file Stake BLD contract
  */
 import { makeTracer } from '@agoric/internal';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import { heapVowE as E, prepareVowTools } from '@agoric/vow/vat.js';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { withdrawFromSeat } from '@agoric/zoe/src/contractSupport/zoeHelpers.js';
@@ -16,8 +17,7 @@ import { makeZoeTools } from '../utils/zoe-tools.js';
 
 /**
  * @import {NameHub} from '@agoric/vats';
- * @import {Remote, ERemote} from '@agoric/internal';
- * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
+ * @import {Remote} from '@agoric/internal';
  * @import {TimerService} from '@agoric/time';
  * @import {LocalChain} from '@agoric/vats/src/localchain.js';
  * @import {ZCF} from '@agoric/zoe';
@@ -42,8 +42,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   const { marshaller: remoteMarshaller } = privateArgs;
   // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
   // once withOrchestration provides a wrapped marshaller, don't re-wrap.
-  /** @type {ERemote<EMarshaller>} */
-  const cachingMarshaller = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   const { makeRecorderKit } = prepareRecorderKitMakers(
     baggage,

--- a/packages/orchestration/src/examples/stake-ica.contract.js
+++ b/packages/orchestration/src/examples/stake-ica.contract.js
@@ -17,6 +17,7 @@ const trace = makeTracer('StakeIca');
 /**
  * @import {Baggage} from '@agoric/vat-data';
  * @import {ERemote, Remote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {CosmosChainInfo, CosmosInterchainService, Denom, DenomDetail} from '@agoric/orchestration';
  * @import {ContractMeta, Invitation, ZCF, ZCFSeat} from '@agoric/zoe';
  * @import {IBCConnectionID, NameHub} from '@agoric/vats';
@@ -70,7 +71,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   const {
     agoricNames,
     cosmosInterchainService: orchestration,
-    marshaller,
+    marshaller: remoteMarshaller,
     storageNode,
     timer,
   } = privateArgs;
@@ -84,7 +85,15 @@ export const start = async (zcf, privateArgs, baggage) => {
       ),
   });
 
-  const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);
+  // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
+  // once withOrchestration provides a wrapped marshaller, don't re-wrap.
+  /** @type {ERemote<EMarshaller>} */
+  const cachingMarshaller = remoteMarshaller;
+
+  const { makeRecorderKit } = prepareRecorderKitMakers(
+    baggage,
+    cachingMarshaller,
+  );
 
   const vowTools = prepareVowTools(zone.subZone('vows'));
 

--- a/packages/orchestration/src/examples/stake-ica.contract.js
+++ b/packages/orchestration/src/examples/stake-ica.contract.js
@@ -1,6 +1,7 @@
 /** @file Example contract that uses orchestration */
 
 import { makeTracer, StorageNodeShape } from '@agoric/internal';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import { TimerServiceShape } from '@agoric/time';
 import { heapVowE as E, prepareVowTools } from '@agoric/vow/vat.js';
 import {
@@ -17,7 +18,6 @@ const trace = makeTracer('StakeIca');
 /**
  * @import {Baggage} from '@agoric/vat-data';
  * @import {ERemote, Remote} from '@agoric/internal';
- * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {CosmosChainInfo, CosmosInterchainService, Denom, DenomDetail} from '@agoric/orchestration';
  * @import {ContractMeta, Invitation, ZCF, ZCFSeat} from '@agoric/zoe';
  * @import {IBCConnectionID, NameHub} from '@agoric/vats';
@@ -87,8 +87,7 @@ export const start = async (zcf, privateArgs, baggage) => {
 
   // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
   // once withOrchestration provides a wrapped marshaller, don't re-wrap.
-  /** @type {ERemote<EMarshaller>} */
-  const cachingMarshaller = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   const { makeRecorderKit } = prepareRecorderKitMakers(
     baggage,

--- a/packages/orchestration/src/examples/swap-anything.contract.js
+++ b/packages/orchestration/src/examples/swap-anything.contract.js
@@ -1,5 +1,6 @@
 import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
 import { makeTracer } from '@agoric/internal';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import { E } from '@endo/far';
 import { M } from '@endo/patterns';
 import { decodeAddressHook } from '@agoric/cosmic-proto/address-hooks.js';
@@ -13,8 +14,6 @@ import { registerChainsAndAssets } from '../utils/chain-hub-helper.js';
 const trace = makeTracer('SwapAnything.Contract');
 const interfaceTODO = undefined;
 /**
- * @import {ERemote} from '@agoric/internal';
- * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {Remote, Vow} from '@agoric/vow';
  * @import {Zone} from '@agoric/zone';
  * @import {OrchestrationPowers, OrchestrationTools} from '../utils/start-helper.js';
@@ -65,8 +64,7 @@ export const contract = async (
   const { marshaller: remoteMarshaller } = privateArgs;
   // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
   // once withOrchestration provides a wrapped marshaller, don't re-wrap.
-  /** @type {ERemote<EMarshaller>} */
-  const cachingMarshaller = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   const makeLocalAccount = orchestrate(
     'makeLocalAccount',

--- a/packages/orchestration/src/examples/swap-anything.contract.js
+++ b/packages/orchestration/src/examples/swap-anything.contract.js
@@ -13,6 +13,8 @@ import { registerChainsAndAssets } from '../utils/chain-hub-helper.js';
 const trace = makeTracer('SwapAnything.Contract');
 const interfaceTODO = undefined;
 /**
+ * @import {ERemote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {Remote, Vow} from '@agoric/vow';
  * @import {Zone} from '@agoric/zone';
  * @import {OrchestrationPowers, OrchestrationTools} from '../utils/start-helper.js';
@@ -59,6 +61,12 @@ export const contract = async (
   /** @type {(msg: string) => Vow<void>} */
   const log = (msg, level = 'info') =>
     vowTools.watch(E(logNode).setValue(JSON.stringify({ msg, level })));
+
+  const { marshaller: remoteMarshaller } = privateArgs;
+  // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
+  // once withOrchestration provides a wrapped marshaller, don't re-wrap.
+  /** @type {ERemote<EMarshaller>} */
+  const cachingMarshaller = remoteMarshaller;
 
   const makeLocalAccount = orchestrate(
     'makeLocalAccount',
@@ -155,7 +163,7 @@ export const contract = async (
   void vowTools.when(sharedLocalAccountP, async lca => {
     sharedLocalAccount = lca;
     await sharedLocalAccount.monitorTransfers(tap);
-    const encoded = await E(privateArgs.marshaller).toCapData({
+    const encoded = await E(cachingMarshaller).toCapData({
       sharedLocalAccount: sharedLocalAccount.getAddress(),
     });
     void E(privateArgs.storageNode).setValue(JSON.stringify(encoded));

--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -1,4 +1,5 @@
 import { prepareAsyncFlowTools } from '@agoric/async-flow';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import { prepareVowTools } from '@agoric/vow';
 import { prepareRecorderKitMakers } from '@agoric/zoe/src/contractSupport/recorder.js';
 import { makeDurableZone } from '@agoric/zone/durable.js';
@@ -227,8 +228,7 @@ export const withOrchestration =
     const { storageNode: _, ...requiredOrchPowers } = allOrchPowers;
     const { publishAccountInfo, chainInfoValueShape } = opts ?? {};
 
-    /** @type {ERemote<EMarshaller>} */
-    const cachingMarshaller = remoteMarshaller;
+    const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
     const { zone, ...tools } = provideOrchestration(
       zcf,

--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -15,6 +15,7 @@ import { makeZcfTools } from './zcf-tools.js';
 /**
  * @import {ERemote} from '@agoric/internal';
  * @import {StorageNode} from '@agoric/internal/src/lib-chainStorage.js';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {LocalChain} from '@agoric/vats/src/localchain.js';
  * @import {TimerService} from '@agoric/time';
  * @import {Baggage} from '@agoric/vat-data';
@@ -54,7 +55,7 @@ import { makeZcfTools } from './zcf-tools.js';
  * @param {ZCF} zcf
  * @param {Baggage} baggage
  * @param {OrchestrationPowers} remotePowers
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  * @param {object} [opts]
  * @param {WithOrchestrationOpts['chainInfoValueShape']} [opts.chainInfoValueShape]
  * @internal

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -228,6 +228,10 @@ const makeScenario = () => {
 
   const baggage = makeScalarBigMapStore('b1') as Baggage;
   const zone = makeDurableZone(baggage);
+  // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
+  // once withOrchestration provides a wrapped marshaller to contracts so
+  // should the test setup. Right now `withOrchestration` does wrap the
+  // marshaller but only for the recorder kit, which we don't bother to do here
   const marshaller = makeFakeBoard().getReadonlyMarshaller();
   const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);
 

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -8,7 +8,6 @@ import {
   makeTracer,
   mustMatch,
   NonNullish,
-  type ERemote,
   type Remote,
   type TypedPattern,
 } from '@agoric/internal';
@@ -16,7 +15,7 @@ import type {
   Marshaller,
   StorageNode,
 } from '@agoric/internal/src/lib-chainStorage.js';
-import type { EMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import {
   ChainInfoShape,
   DenomDetailShape,
@@ -271,7 +270,7 @@ export const contract = async (
 
   // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
   // once withOrchestration provides a wrapped marshaller, don't re-wrap.
-  const cachingMarshaller: ERemote<EMarshaller> = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   const resolverZone = zone.subZone('Resolver');
   const makeResolverKit = prepareResolverKit(resolverZone, zcf, {

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -8,6 +8,7 @@ import {
   makeTracer,
   mustMatch,
   NonNullish,
+  type ERemote,
   type Remote,
   type TypedPattern,
 } from '@agoric/internal';
@@ -15,6 +16,7 @@ import type {
   Marshaller,
   StorageNode,
 } from '@agoric/internal/src/lib-chainStorage.js';
+import type { EMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import {
   ChainInfoShape,
   DenomDetailShape,
@@ -228,7 +230,7 @@ export const contract = async (
     assetInfo,
     axelarIds,
     contracts,
-    marshaller,
+    marshaller: remoteMarshaller,
     storageNode,
     gmpAddresses,
   } = privateArgs;
@@ -267,11 +269,15 @@ export const contract = async (
   const proposalShapes = makeProposalShapes(brands.USDC, brands.Access);
   const offerArgsShapes = makeOfferArgsShapes(brands.USDC);
 
+  // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
+  // once withOrchestration provides a wrapped marshaller, don't re-wrap.
+  const cachingMarshaller: ERemote<EMarshaller> = remoteMarshaller;
+
   const resolverZone = zone.subZone('Resolver');
   const makeResolverKit = prepareResolverKit(resolverZone, zcf, {
     vowTools,
     pendingTxsNode: E(storageNode).makeChildNode(PENDING_TXS_NODE_KEY),
-    marshaller,
+    marshaller: cachingMarshaller,
   });
   const {
     client: resolverClient,
@@ -354,7 +360,7 @@ export const contract = async (
     offerArgsShapes,
     transferChannels,
     portfoliosNode: E(storageNode).makeChildNode('portfolios'),
-    marshaller,
+    marshaller: cachingMarshaller,
     usdcBrand: brands.USDC,
   });
 

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -3,10 +3,8 @@
  */
 import { AmountMath, type Brand } from '@agoric/ertp';
 import { makeTracer, mustMatch, type ERemote } from '@agoric/internal';
-import type {
-  Marshaller,
-  StorageNode,
-} from '@agoric/internal/src/lib-chainStorage.js';
+import type { StorageNode } from '@agoric/internal/src/lib-chainStorage.js';
+import type { EMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import {
   type AccountId,
   type CaipChainId,
@@ -193,7 +191,7 @@ export const preparePortfolioKit = (
     vowTools: VowTools;
     zcf: ZCF;
     portfoliosNode: ERemote<StorageNode>;
-    marshaller: ERemote<Marshaller>;
+    marshaller: ERemote<EMarshaller>;
     usdcBrand: Brand<'nat'>;
   },
 ) => {

--- a/packages/portfolio-contract/src/resolver/resolver.exo.ts
+++ b/packages/portfolio-contract/src/resolver/resolver.exo.ts
@@ -7,10 +7,8 @@
  */
 
 import { makeTracer, type ERemote } from '@agoric/internal';
-import type {
-  Marshaller,
-  StorageNode,
-} from '@agoric/internal/src/lib-chainStorage.js';
+import type { StorageNode } from '@agoric/internal/src/lib-chainStorage.js';
+import type { EMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import type { AccountId } from '@agoric/orchestration';
 import { type Vow, type VowKit, type VowTools } from '@agoric/vow';
 import type { ZCF, ZCFSeat } from '@agoric/zoe';
@@ -103,7 +101,7 @@ export const prepareResolverKit = (
   }: {
     vowTools: VowTools;
     pendingTxsNode: ERemote<StorageNode>;
-    marshaller: ERemote<Marshaller>;
+    marshaller: ERemote<EMarshaller>;
   },
 ) => {
   const writeToNode = (

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -47,6 +47,7 @@ import { prepareOfferWatcher, makeWatchOfferOutcomes } from './offerWatcher.js';
 
 /**
  * @import {ERemote, Remote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {Amount, Brand, Issuer, Payment, Purse} from '@agoric/ertp';
  * @import {WeakMapStore, MapStore} from '@agoric/store'
  * @import {InvitationDetails, PaymentPKeywordRecord, Proposal, UserSeat} from '@agoric/zoe';
@@ -185,7 +186,7 @@ const trace = makeTracer('SmrtWlt');
  *   invitationIssuer: Issuer<'set'>;
  *   invitationBrand: Brand<'set'>;
  *   invitationDisplayInfo: DisplayInfo;
- *   publicMarshaller: Remote<Marshaller>;
+ *   publicMarshaller: ERemote<EMarshaller>;
  *   zoe: ERef<ZoeService>;
  * }} SharedParams
  *

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -20,6 +20,7 @@ import { shape } from './typeGuards.js';
 /**
  * @import {ERemote} from '@agoric/internal';
  * @import {StorageNode} from '@agoric/internal/src/lib-chainStorage.js';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {MapStore} from '@agoric/swingset-liveslots';
  * @import {NameHub} from '@agoric/vats';
  */
@@ -231,7 +232,7 @@ export const prepare = async (zcf, privateArgs, baggage) => {
     invitationIssuer,
     invitationBrand,
     invitationDisplayInfo,
-    publicMarshaller,
+    publicMarshaller: remotePublicMarshaller,
   } = await provideAll(baggage, {
     invitationIssuer: () => invitationIssuerP,
     invitationBrand: () => E(invitationIssuerP).getBrand(),
@@ -242,12 +243,15 @@ export const prepare = async (zcf, privateArgs, baggage) => {
 
   const registry = makeAssetRegistry(assetPublisher);
 
+  /** @type {ERemote<EMarshaller>} */
+  const publicCachingMarshaller = remotePublicMarshaller;
+
   const shared = harden({
     agoricNames,
     invitationBrand,
     invitationDisplayInfo,
     invitationIssuer,
-    publicMarshaller,
+    publicMarshaller: publicCachingMarshaller,
     registry,
     zoe,
   });

--- a/packages/smart-wallet/src/walletFactory.js
+++ b/packages/smart-wallet/src/walletFactory.js
@@ -8,6 +8,7 @@
  */
 
 import { makeTracer, WalletName } from '@agoric/internal';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import { observeIteration, subscribeEach } from '@agoric/notifier';
 import { M, makeExo, makeScalarMapStore, mustMatch } from '@agoric/store';
 import { makeAtomicProvider } from '@agoric/store/src/stores/store-utils.js';
@@ -20,7 +21,6 @@ import { shape } from './typeGuards.js';
 /**
  * @import {ERemote} from '@agoric/internal';
  * @import {StorageNode} from '@agoric/internal/src/lib-chainStorage.js';
- * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {MapStore} from '@agoric/swingset-liveslots';
  * @import {NameHub} from '@agoric/vats';
  */
@@ -243,8 +243,7 @@ export const prepare = async (zcf, privateArgs, baggage) => {
 
   const registry = makeAssetRegistry(assetPublisher);
 
-  /** @type {ERemote<EMarshaller>} */
-  const publicCachingMarshaller = remotePublicMarshaller;
+  const publicCachingMarshaller = wrapRemoteMarshaller(remotePublicMarshaller);
 
   const shared = harden({
     agoricNames,

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -14,6 +14,7 @@ import {
 
 /**
  * @import {ERemote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {EReturn} from '@endo/far';
  * @import {AdminFacet, ContractOf, InvitationAmount, ZCFMint} from '@agoric/zoe';
  */
@@ -39,7 +40,7 @@ const StableUnit = BigInt(10 ** Stable.displayInfo.decimalPlaces);
  * been provisioned.
  *
  * @param {string[]} oldAddresses
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  * @param {ERemote<StorageNode>} walletStorageNode
  */
 const publishRevivableWalletState = async (

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -18,6 +18,7 @@ import { crc6 } from './crc.js';
 
 /**
  * @import {ERemote, TypedPattern} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {RemotableObject} from '@endo/pass-style';
  * @import {CapData} from '@endo/marshal';
  * @import {Key} from '@endo/patterns';
@@ -378,7 +379,7 @@ export const prepareRecorderFactory = zone => {
 
   /**
    * @param {string} label
-   * @param {ERemote<Marshaller>} marshaller
+   * @param {ERemote<EMarshaller>} marshaller
    */
   const prepareRecorderKit = (label, marshaller) => {
     const myZone = zone.subZone(label);

--- a/packages/zoe/src/contractSupport/recorder.js
+++ b/packages/zoe/src/contractSupport/recorder.js
@@ -11,6 +11,7 @@ import { E } from '@endo/eventual-send';
 
 /**
  * @import {TypedPattern, ERemote, Remote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  */
 
 /**
@@ -44,7 +45,7 @@ import { E } from '@endo/eventual-send';
  * Wrap a Publisher to record all the values to chain storage.
  *
  * @param {import('@agoric/vat-data').Baggage} baggage
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  */
 export const prepareRecorder = (baggage, marshaller) => {
   const makeRecorder = prepareExoClass(
@@ -194,7 +195,7 @@ harden(defineERecorderKit);
  * When there is, prepare the kinds separately and pass to the kit definers.
  *
  * @param {import('@agoric/vat-data').Baggage} baggage
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  */
 export const prepareRecorderKit = (baggage, marshaller) => {
   const makeDurablePublishKit = prepareDurablePublishKit(
@@ -214,7 +215,7 @@ export const prepareRecorderKit = (baggage, marshaller) => {
  * `makeERecorderKit` is for closures that must return a `subscriber` synchronously but can defer the `recorder`.
  *
  * @param {import('@agoric/vat-data').Baggage} baggage
- * @param {ERemote<Marshaller>} marshaller
+ * @param {ERemote<EMarshaller>} marshaller
  */
 export const prepareRecorderKitMakers = (baggage, marshaller) => {
   const makeDurablePublishKit = prepareDurablePublishKit(

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -29,6 +29,7 @@ import {
 } from '../contractSupport/index.js';
 
 /**
+ * @import {Remote} from '@agoric/internal';
  * @import {LegacyMap} from '@agoric/store'
  * @import {ContractOf} from '../zoeService/utils.js';
  * @import {PriceDescription, PriceQuote, PriceQuoteValue, PriceQuery,} from '@agoric/zoe/tools/types.js';
@@ -60,9 +61,9 @@ const priceDescriptionFromQuote = quote => quote.quoteAmount.value[0];
  * unitAmountIn: Amount<'nat'>,
  * }>} zcf
  * @param {{
- * marshaller: Marshaller,
+ * marshaller: Remote<Marshaller>,
  * quoteMint?: ERef<Mint<'set', PriceDescription>>,
- * storageNode: ERef<StorageNode>,
+ * storageNode: Remote<StorageNode>,
  * }} privateArgs
  */
 const start = async (zcf, privateArgs) => {

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -1,5 +1,6 @@
 import { AmountMath } from '@agoric/ertp';
 import { assertAllDefined } from '@agoric/internal';
+import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import { notForProductionUse } from '@agoric/internal/src/magic-cookie-test-only.js';
 import {
   makeNotifierKit,
@@ -29,8 +30,7 @@ import {
 } from '../contractSupport/index.js';
 
 /**
- * @import {Remote, ERemote} from '@agoric/internal';
- * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
+ * @import {Remote} from '@agoric/internal';
  * @import {LegacyMap} from '@agoric/store'
  * @import {ContractOf} from '../zoeService/utils.js';
  * @import {PriceDescription, PriceQuote, PriceQuoteValue, PriceQuery,} from '@agoric/zoe/tools/types.js';
@@ -81,8 +81,7 @@ const start = async (zcf, privateArgs) => {
   const { marshaller: remoteMarshaller, storageNode } = privateArgs;
   assertAllDefined({ remoteMarshaller, storageNode });
 
-  /** @type {ERemote<EMarshaller>} */
-  const cachingMarshaller = remoteMarshaller;
+  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   /** @type {ERef<Mint<'set', PriceDescription>>} */
   const quoteMint =

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -29,7 +29,8 @@ import {
 } from '../contractSupport/index.js';
 
 /**
- * @import {Remote} from '@agoric/internal';
+ * @import {Remote, ERemote} from '@agoric/internal';
+ * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {LegacyMap} from '@agoric/store'
  * @import {ContractOf} from '../zoeService/utils.js';
  * @import {PriceDescription, PriceQuote, PriceQuoteValue, PriceQuery,} from '@agoric/zoe/tools/types.js';
@@ -77,8 +78,11 @@ const start = async (zcf, privateArgs) => {
   assertAllDefined({ brandIn, brandOut, POLL_INTERVAL, timer, unitAmountIn });
 
   assert(privateArgs, 'Missing privateArgs in priceAggregator start');
-  const { marshaller, storageNode } = privateArgs;
-  assertAllDefined({ marshaller, storageNode });
+  const { marshaller: remoteMarshaller, storageNode } = privateArgs;
+  assertAllDefined({ remoteMarshaller, storageNode });
+
+  /** @type {ERemote<EMarshaller>} */
+  const cachingMarshaller = remoteMarshaller;
 
   /** @type {ERef<Mint<'set', PriceDescription>>} */
   const quoteMint =
@@ -118,7 +122,7 @@ const start = async (zcf, privateArgs) => {
   // For publishing priceAuthority values to off-chain storage
   const { publisher, subscriber } = makeStoredPublishKit(
     storageNode,
-    marshaller,
+    cachingMarshaller,
   );
 
   const zoe = zcf.getZoeService();

--- a/packages/zoe/test/unitTests/contracts/priceAggregator.test.js
+++ b/packages/zoe/test/unitTests/contracts/priceAggregator.test.js
@@ -165,7 +165,9 @@ test.before('setup aggregator and oracles', async t => {
 
     const timer = buildManualTimer(() => {}, 0n, { eventLoopIteration });
     const POLL_INTERVAL = 1n;
-    const storageNode = E(storageRoot).makeChildNode('priceAggregator');
+    const storageNode = await E(
+      E(storageRoot).makeChildNode('priceAggregator'),
+    ).makeChildNode('ATOM-USD_price_feed');
     const aggregator = await E(zoe).startInstance(
       aggregatorInstallation,
       undefined,
@@ -178,7 +180,7 @@ test.before('setup aggregator and oracles', async t => {
       },
       {
         marshaller,
-        storageNode: E(storageNode).makeChildNode('ATOM-USD_price_feed'),
+        storageNode,
       },
     );
     return { ...aggregator, mockStorageRoot: storageRoot };

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,7 +979,7 @@ __metadata:
     type-coverage: "npm:^2.29.7"
     typedoc: "npm:^0.26.7"
     typedoc-plugin-markdown: "npm:^4.2.1"
-    typescript: "npm:~5.9.2"
+    typescript: "npm:~5.9.3"
     typescript-eslint: "npm:^8.40.0"
   dependenciesMeta:
     better-sqlite3@10.1.0:
@@ -3336,7 +3336,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmology/types@npm:^1.12.4, @cosmology/types@npm:^1.13.2":
+"@cosmology/types@npm:^1.12.4, @cosmology/types@npm:^1.12.5, @cosmology/types@npm:^1.13.0, @cosmology/types@npm:^1.13.2":
   version: 1.13.2
   resolution: "@cosmology/types@npm:1.13.2"
   dependencies:
@@ -3346,33 +3346,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmology/types@npm:^1.12.5, @cosmology/types@npm:^1.13.0":
-  version: 1.13.0
-  resolution: "@cosmology/types@npm:1.13.0"
-  dependencies:
-    case: "npm:1.6.3"
-    fast-json-patch: "npm:3.1.1"
-  checksum: 10c0/ab436c9e05d5bb5dfe3c1c91507989ff2d895892505cb82caa25b60c91d0a7ae466e8601f5489f94eb16ea08e9b3faf90af3b75308f2815e41e5de5477dcc628
-  languageName: node
-  linkType: hard
-
-"@cosmology/utils@npm:^1.10.6":
+"@cosmology/utils@npm:^1.10.6, @cosmology/utils@npm:^1.10.7, @cosmology/utils@npm:^1.11.0":
   version: 1.11.2
   resolution: "@cosmology/utils@npm:1.11.2"
   dependencies:
     "@cosmology/types": "npm:^1.13.2"
     dotty: "npm:0.1.2"
   checksum: 10c0/55faa38deb9955f542b2fb0a62ef154854fe88539a587afc82dc8c24a6d1cffc0cac95eb55f21c988943068ac02b2ee211d240a9defc90ed8f1e3c82d1126881
-  languageName: node
-  linkType: hard
-
-"@cosmology/utils@npm:^1.10.7, @cosmology/utils@npm:^1.11.0":
-  version: 1.11.0
-  resolution: "@cosmology/utils@npm:1.11.0"
-  dependencies:
-    "@cosmology/types": "npm:^1.13.0"
-    dotty: "npm:0.1.2"
-  checksum: 10c0/9a924a6636a26df4f31a2461144848f1767a28371db0d045cdb5979c4f2e5b3aafe4a5862d83e9fcf1ba12d58123d49742643feadf0f3d4ea2fa8b718aff7969
   languageName: node
   linkType: hard
 
@@ -4094,17 +4074,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.32.0":
+"@eslint/js@npm:9.32.0, @eslint/js@npm:^9.14.0":
   version: 9.32.0
   resolution: "@eslint/js@npm:9.32.0"
   checksum: 10c0/f71e8f9146638d11fb15238279feff98801120a4d4130f1c587c4f09b024ff5ec01af1ba88e97ba6b7013488868898a668f77091300cc3d4394c7a8ed32d2667
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:^9.14.0":
-  version: 9.20.0
-  resolution: "@eslint/js@npm:9.20.0"
-  checksum: 10c0/10e7b5b9e628b5192e8fc6b0ecd27cf48322947e83e999ff60f9f9e44ac8d499138bcb9383cbfa6e51e780d53b4e76ccc2d1753b108b7173b8404fd484d37328
   languageName: node
   linkType: hard
 
@@ -4172,17 +4145,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grpc/grpc-js@npm:^1.10.9":
-  version: 1.12.2
-  resolution: "@grpc/grpc-js@npm:1.12.2"
-  dependencies:
-    "@grpc/proto-loader": "npm:^0.7.13"
-    "@js-sdsl/ordered-map": "npm:^4.4.2"
-  checksum: 10c0/0370bdec80a5d73f0929c4b7a882af3b0ca85ed1fda361ce3986b705eb2aa9be59bba39a18b99cc05080d5c0819b319a56796dfde248375971ba64efd55fc9d6
-  languageName: node
-  linkType: hard
-
-"@grpc/grpc-js@npm:^1.12.6":
+"@grpc/grpc-js@npm:^1.10.9, @grpc/grpc-js@npm:^1.12.6":
   version: 1.13.4
   resolution: "@grpc/grpc-js@npm:1.13.4"
   dependencies:
@@ -6139,12 +6102,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=13.7.0, @types/node@npm:~22.9.0":
-  version: 22.9.4
-  resolution: "@types/node@npm:22.9.4"
+"@types/node@npm:*, @types/node@npm:>=13.7.0, @types/node@npm:^22.0.0, @types/node@npm:^22.10.2":
+  version: 22.17.1
+  resolution: "@types/node@npm:22.17.1"
   dependencies:
-    undici-types: "npm:~6.19.8"
-  checksum: 10c0/85521424033d32c2cb2279f1a2dfe9a3630f253a4c877352607eece2b5fe45ddd80acc608dfcef9ae9c2b385203332e53cc1b6cb15c958504b26011ddcf65d4f
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/b04063bdabfc4146af05d14d4fd23ee68615194473d0ef971ddef549b80b791f52c8f93abdd8d1092ee0257f3dea862fa233519244fd051e79233cdce614de14
   languageName: node
   linkType: hard
 
@@ -6157,12 +6120,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^22.0.0, @types/node@npm:^22.10.2":
-  version: 22.17.1
-  resolution: "@types/node@npm:22.17.1"
+"@types/node@npm:~22.9.0":
+  version: 22.9.4
+  resolution: "@types/node@npm:22.9.4"
   dependencies:
-    undici-types: "npm:~6.21.0"
-  checksum: 10c0/b04063bdabfc4146af05d14d4fd23ee68615194473d0ef971ddef549b80b791f52c8f93abdd8d1092ee0257f3dea862fa233519244fd051e79233cdce614de14
+    undici-types: "npm:~6.19.8"
+  checksum: 10c0/85521424033d32c2cb2279f1a2dfe9a3630f253a4c877352607eece2b5fe45ddd80acc608dfcef9ae9c2b385203332e53cc1b6cb15c958504b26011ddcf65d4f
   languageName: node
   linkType: hard
 
@@ -6545,16 +6508,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.0, acorn@npm:^8.14.0, acorn@npm:^8.14.1, acorn@npm:^8.6.0, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
-  version: 8.14.1
-  resolution: "acorn@npm:8.14.1"
-  bin:
-    acorn: bin/acorn
-  checksum: 10c0/dbd36c1ed1d2fa3550140000371fcf721578095b18777b85a79df231ca093b08edc6858d75d6e48c73e431c174dcf9214edbd7e6fa5911b93bd8abfa54e47123
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.15.0":
+"acorn@npm:^8.11.0, acorn@npm:^8.14.0, acorn@npm:^8.14.1, acorn@npm:^8.15.0, acorn@npm:^8.6.0, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -7745,7 +7699,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.5.2":
+"chokidar@npm:^3.5.2, chokidar@npm:^3.5.3":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -7761,25 +7715,6 @@ __metadata:
     fsevents:
       optional: true
   checksum: 10c0/8361dcd013f2ddbe260eacb1f3cb2f2c6f2b0ad118708a343a5ed8158941a39cb8fb1d272e0f389712e74ee90ce8ba864eece9e0e62b9705cb468a2f6d917462
-  languageName: node
-  linkType: hard
-
-"chokidar@npm:^3.5.3":
-  version: 3.5.3
-  resolution: "chokidar@npm:3.5.3"
-  dependencies:
-    anymatch: "npm:~3.1.2"
-    braces: "npm:~3.0.2"
-    fsevents: "npm:~2.3.2"
-    glob-parent: "npm:~5.1.2"
-    is-binary-path: "npm:~2.1.0"
-    is-glob: "npm:~4.0.1"
-    normalize-path: "npm:~3.0.0"
-    readdirp: "npm:~3.6.0"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: 10c0/1076953093e0707c882a92c66c0f56ba6187831aa51bb4de878c1fec59ae611a3bf02898f190efec8e77a086b8df61c2b2a3ea324642a0558bdf8ee6c5dc9ca1
   languageName: node
   linkType: hard
 
@@ -7827,17 +7762,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^4.0.0, ci-info@npm:^4.3.0":
+"ci-info@npm:^4.0.0, ci-info@npm:^4.2.0, ci-info@npm:^4.3.0":
   version: 4.3.0
   resolution: "ci-info@npm:4.3.0"
   checksum: 10c0/60d3dfe95d75c01454ec1cfd5108617dd598a28a2a3e148bd7e1523c1c208b5f5a3007cafcbe293e6fd0a5a310cc32217c5dc54743eeabc0a2bec80072fc055c
-  languageName: node
-  linkType: hard
-
-"ci-info@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "ci-info@npm:4.2.0"
-  checksum: 10c0/37a2f4b6a213a5cf835890eb0241f0d5b022f6cfefde58a69e9af8e3a0e71e06d6ad7754b0d4efb9cd2613e58a7a33996d71b56b0d04242722e86666f3f3d058
   languageName: node
   linkType: hard
 
@@ -9685,7 +9613,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:^6.13.0":
+"ethers@npm:^6.13.0, ethers@npm:^6.13.4":
   version: 6.15.0
   resolution: "ethers@npm:6.15.0"
   dependencies:
@@ -9697,21 +9625,6 @@ __metadata:
     tslib: "npm:2.7.0"
     ws: "npm:8.17.1"
   checksum: 10c0/0a4581b662fe46a889a524d3aba43dc6f0ac59b3ae08dce678ee4b5799aab4906109ab24684c9644deedfc9d6e79b59faccecbeda9b6b7ceb085724d596a49e9
-  languageName: node
-  linkType: hard
-
-"ethers@npm:^6.13.4":
-  version: 6.13.4
-  resolution: "ethers@npm:6.13.4"
-  dependencies:
-    "@adraffy/ens-normalize": "npm:1.10.1"
-    "@noble/curves": "npm:1.2.0"
-    "@noble/hashes": "npm:1.3.2"
-    "@types/node": "npm:22.7.5"
-    aes-js: "npm:4.0.0-beta.5"
-    tslib: "npm:2.7.0"
-    ws: "npm:8.17.1"
-  checksum: 10c0/efcf9f39f841e38af68ec23cdbd745432c239c256aac4929842d1af04e55d7be0ff65e462f1cf3e93586f43f7bdcc0098fd56f2f7234f36d73e466521a5766ce
   languageName: node
   linkType: hard
 
@@ -11099,17 +11012,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^7.0.0":
+"ignore@npm:^7.0.0, ignore@npm:^7.0.3":
   version: 7.0.5
   resolution: "ignore@npm:7.0.5"
   checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
-  languageName: node
-  linkType: hard
-
-"ignore@npm:^7.0.3":
-  version: 7.0.4
-  resolution: "ignore@npm:7.0.4"
-  checksum: 10c0/90e1f69ce352b9555caecd9cbfd07abe7626d312a6f90efbbb52c7edca6ea8df065d66303863b30154ab1502afb2da8bc59d5b04e1719a52ef75bbf675c488eb
   languageName: node
   linkType: hard
 
@@ -14534,17 +14440,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.1":
+"pirates@npm:^4.0.1, pirates@npm:^4.0.4":
   version: 4.0.7
   resolution: "pirates@npm:4.0.7"
   checksum: 10c0/a51f108dd811beb779d58a76864bbd49e239fa40c7984cd11596c75a121a8cc789f1c8971d8bb15f0dbf9d48b76c05bb62fcbce840f89b688c0fa64b37e8478a
-  languageName: node
-  linkType: hard
-
-"pirates@npm:^4.0.4":
-  version: 4.0.6
-  resolution: "pirates@npm:4.0.6"
-  checksum: 10c0/00d5fa51f8dded94d7429700fb91a0c1ead00ae2c7fd27089f0c5b63e6eca36197fe46384631872690a66f390c5e27198e99006ab77ae472692ab9c2ca903f36
   languageName: node
   linkType: hard
 
@@ -14843,27 +14742,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.0, protobufjs@npm:^7.3.2":
-  version: 7.4.0
-  resolution: "protobufjs@npm:7.4.0"
-  dependencies:
-    "@protobufjs/aspromise": "npm:^1.1.2"
-    "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.4"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
-    "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.0"
-    "@protobufjs/path": "npm:^1.1.2"
-    "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.0"
-    "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10c0/a5460a63fe596523b9a067cbce39a6b310d1a71750fda261f076535662aada97c24450e18c5bc98a27784f70500615904ff1227e1742183509f0db4fdede669b
-  languageName: node
-  linkType: hard
-
-"protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.3":
+"protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.0, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.3":
   version: 7.5.4
   resolution: "protobufjs@npm:7.5.4"
   dependencies:
@@ -16641,23 +16520,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.11, tinyglobby@npm:^0.2.14":
+"tinyglobby@npm:^0.2.11, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14":
   version: 0.2.14
   resolution: "tinyglobby@npm:0.2.14"
   dependencies:
     fdir: "npm:^6.4.4"
     picomatch: "npm:^4.0.2"
   checksum: 10c0/f789ed6c924287a9b7d3612056ed0cda67306cd2c80c249fd280cf1504742b12583a2089b61f4abbd24605f390809017240e250241f09938054c9b363e51c0a6
-  languageName: node
-  linkType: hard
-
-"tinyglobby@npm:^0.2.12":
-  version: 0.2.13
-  resolution: "tinyglobby@npm:0.2.13"
-  dependencies:
-    fdir: "npm:^6.4.4"
-    picomatch: "npm:^4.0.2"
-  checksum: 10c0/ef07dfaa7b26936601d3f6d999f7928a4d1c6234c5eb36896bb88681947c0d459b7ebe797022400e555fe4b894db06e922b95d0ce60cb05fd827a0a66326b18c
   languageName: node
   linkType: hard
 
@@ -17151,13 +17020,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.1.6 - 5.9.x, typescript@npm:^5.4.5, typescript@npm:^5.9.2, typescript@npm:~5.9.2":
-  version: 5.9.2
-  resolution: "typescript@npm:5.9.2"
+"typescript@npm:5.1.6 - 5.9.x, typescript@npm:^5.4.5, typescript@npm:^5.9.2, typescript@npm:~5.9.2, typescript@npm:~5.9.3":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/cd635d50f02d6cf98ed42de2f76289701c1ec587a363369255f01ed15aaf22be0813226bff3c53e99d971f9b540e0b3cc7583dbe05faded49b1b0bed2f638a18
+  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
   languageName: node
   linkType: hard
 
@@ -17181,13 +17050,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.1.6 - 5.9.x#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.9.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.9.2#optional!builtin<compat/typescript>":
-  version: 5.9.2
-  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=5786d5"
+"typescript@patch:typescript@npm%3A5.1.6 - 5.9.x#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.9.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.9.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.9.3#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/34d2a8e23eb8e0d1875072064d5e1d9c102e0bdce56a10a25c0b917b8aa9001a9cf5c225df12497e99da107dc379360bc138163c66b55b95f5b105b50578067e
+  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,6 +773,7 @@ __metadata:
   dependencies:
     "@agoric/base-zone": "workspace:*"
     "@agoric/cosmic-proto": "workspace:*"
+    "@endo/cache-map": "npm:^1.1.0"
     "@endo/common": "npm:^1.2.13"
     "@endo/compartment-mapper": "npm:^1.6.3"
     "@endo/errors": "npm:^1.2.13"


### PR DESCRIPTION
closes: #10744, #11692

## Description

Adds a remote marshaller wrapper capable of marshalling pure data locally, only sending slots to the remote marshaller, and caches slots previously resolved.

Before introducing this wrapped marshaller, the PR update types and refactors the vats start functions to wrap the remote marshaller received in private args.

### Security Considerations

None

### Scaling Considerations

Should greatly reduce messages sent to the board to only the first time a capability needs to be mapped. To avoid unbounded growth, a capacity-bounded cache is used.

### Documentation Considerations
None

### Testing Considerations
Adds a unit test of the wrapped marshaller.
Correctness of the refactor to use the wrapped marshaller relies on static types and existing tests continuing to pass. I had to adjust a couple inter-protocol test that were sensitive to the number of turns taken to publish metrics.

### Upgrade Considerations
Only upgraded vats will benefit from this optimization. This PR in itself does not schedule any vat upgrades. We should consider upgrading the smart wallet as the major beneficiary to this optimization.
