### PR TITLE
CI (ymax-planner): Auto Deploy ymax0-planner  on Image Publish

### DIFF
--- a/.github/scripts/check_digest.sh
+++ b/.github/scripts/check_digest.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Inputs
+GCE_INSTANCE="${1:-}"
+GCE_ZONE="${2:-}"
+TARGET_IMAGE="${3:-}"
+OUTPUT_FILE="${4:-$GITHUB_OUTPUT}"
+
+if [[ -z "$GCE_INSTANCE" || -z "$GCE_ZONE" || -z "$TARGET_IMAGE" ]]; then
+  echo "Usage: $0 <GCE_INSTANCE> <GCE_ZONE> <TARGET_IMAGE> [OUTPUT_FILE]" >&2
+  exit 1
+fi
+
+echo "Target image: $TARGET_IMAGE"
+
+# Get current container declaration from instance metadata
+DECL=$(
+  gcloud compute instances describe "$GCE_INSTANCE" \
+    --zone "$GCE_ZONE" \
+    --format=json \
+    | jq -r '.metadata.items[]? | select(.key=="gce-container-declaration") | .value'
+)
+
+# Compare digest with deployed image
+if [[ -n "$DECL" ]] && printf '%s\n' "$DECL" | grep -F "$TARGET_IMAGE" > /dev/null 2>&1; then
+  echo "VM $GCE_INSTANCE already configured with this digest. Skipping deploy."
+  echo "should_deploy=false" >> "$OUTPUT_FILE"
+else
+  echo "Digest differs (or not set) on $GCE_INSTANCE. Will deploy."
+  echo "should_deploy=true" >> "$OUTPUT_FILE"
+fi

--- a/.github/scripts/deploy_vm.sh
+++ b/.github/scripts/deploy_vm.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Inputs
+GCE_INSTANCE="${1:-}"
+GCE_ZONE="${2:-}"
+IMAGE="${3:-}"
+ENV_FILE="${4:-./.env.gcp}"
+
+if [[ -z "$GCE_INSTANCE" || -z "$GCE_ZONE" || -z "$IMAGE" ]]; then
+  echo "Usage: $0 <GCE_INSTANCE> <GCE_ZONE> <IMAGE> [ENV_FILE]" >&2
+  exit 1
+fi
+
+echo "Deploying to $GCE_INSTANCE: $IMAGE"
+
+gcloud compute instances update-container "$GCE_INSTANCE" \
+  --zone "$GCE_ZONE" \
+  --container-env-file "$ENV_FILE" \
+  --container-image "$IMAGE"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -260,19 +260,15 @@ jobs:
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
 
-  deploy-ymax-planner:
+  # it only actually deploys if there is a change in the Docker digest
+  deploy-ymax0-planner:
     needs: docker-ymax
     if: needs.docker-ymax.result == 'success'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - instance: ymax-planner-template-20250903-125004 #ymax0-planner
-            env_secret: YMAX0_PLANNER_ENV
-          - instance: ymax1-planner #ymax1-planner
-            env_secret: YMAX1_PLANNER_ENV
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Auth to Google Cloud (SA key)
         uses: google-github-actions/auth@v2
         with:
@@ -281,47 +277,29 @@ jobs:
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Write .env file from JSON (per-target)
+      - name: Write .env file from JSON
         shell: bash
         run: |
           jq -r 'to_entries[] | "\(.key)=\(.value)"' \
-            <<< '${{ secrets[matrix.target.env_secret] }}' > .env.gcp
+            <<< '${{ secrets.YMAX0_PLANNER_ENV }}' > .env.gcp
 
-      - name: Check if VM already has this digest
+      - name: Check if VM already has docker image digest
         id: decide
         shell: bash
         env:
-          GCE_INSTANCE: ${{ matrix.target.instance }}
+          # ymax0-planner vm: https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-a/instances/ymax-planner-template-20250903-125004?inv=1&invt=Ab56Cw&project=simulationlab
+          GCE_INSTANCE: ymax-planner-template-20250903-125004
           GCE_ZONE: ${{ env.GCE_ZONE }}
         run: |
           TARGET="ghcr.io/agoric/agoric-sdk:ymax-planner@${{ needs.docker-ymax.outputs.digest }}"
-          echo "Target image: $TARGET"
+          .github/scripts/check_digest.sh "$GCE_INSTANCE" "$GCE_ZONE" "$TARGET"
 
-          DECL=$(
-            gcloud compute instances describe "$GCE_INSTANCE" \
-              --zone "$GCE_ZONE" \
-              --format=json \
-            | jq -r '.metadata.items[]? | select(.key=="gce-container-declaration") | .value'
-          )
-
-          if [ -n "$DECL" ] && printf '%s\n' "$DECL" | grep -F "$TARGET" >/dev/null 2>&1; then
-            echo "VM $GCE_INSTANCE already configured with this digest. Skipping deploy."
-            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Digest differs (or not set) on $GCE_INSTANCE. Will deploy."
-            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Update GCE container (by digest)
+      - name: Update GCE Ymax0 container (by digest)
         if: steps.decide.outputs.should_deploy == 'true'
         shell: bash
         env:
-          GCE_INSTANCE: ${{ matrix.target.instance }}
+          GCE_INSTANCE: ymax-planner-template-20250903-125004
           GCE_ZONE: ${{ env.GCE_ZONE }}
         run: |
           IMAGE="ghcr.io/agoric/agoric-sdk:ymax-planner@${{ needs.docker-ymax.outputs.digest }}"
-          echo "Deploying to $GCE_INSTANCE: $IMAGE"
-          gcloud compute instances update-container "$GCE_INSTANCE" \
-            --zone "$GCE_ZONE" \
-            --container-env-file ./.env.gcp \
-            --container-image="$IMAGE"
+          .github/scripts/deploy_vm.sh "$GCE_INSTANCE" "$GCE_ZONE" "$IMAGE" "./.env.gcp"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -223,6 +223,7 @@ jobs:
     outputs:
       tag: '${{ steps.docker-tags.outputs.tags }}'
       tags: '${{ steps.docker-tags.outputs.tags }} ${{ needs.snapshot.outputs.tag }}'
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
       - uses: depot/setup-action@v1
@@ -241,6 +242,7 @@ jobs:
           echo "BUILD_TAG=${{ needs.snapshot.outputs.tag }}" >> $GITHUB_ENV
       - name: Build and Push ymax-planner
         uses: depot/build-push-action@v1
+        id: build
         with:
           file: services/ymax-planner/Dockerfile
           context: ./
@@ -257,3 +259,69 @@ jobs:
           from: ${{ secrets.NOTIFY_EMAIL_FROM }}
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
+
+  deploy-ymax-planner:
+    needs: docker-ymax
+    if: needs.docker-ymax.result == 'success'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - instance: ymax-planner-template-20250903-125004 #ymax0-planner
+            env_secret: YMAX0_PLANNER_ENV
+          - instance: ymax1-planner #ymax1-planner
+            env_secret: YMAX1_PLANNER_ENV
+
+    steps:
+      - name: Auth to Google Cloud (SA key)
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Write .env file from JSON (per-target)
+        shell: bash
+        run: |
+          jq -r 'to_entries[] | "\(.key)=\(.value)"' \
+            <<< '${{ secrets[matrix.target.env_secret] }}' > .env.gcp
+
+      - name: Check if VM already has this digest
+        id: decide
+        shell: bash
+        env:
+          GCE_INSTANCE: ${{ matrix.target.instance }}
+          GCE_ZONE: ${{ env.GCE_ZONE }}
+        run: |
+          TARGET="ghcr.io/agoric/agoric-sdk:ymax-planner@${{ needs.docker-ymax.outputs.digest }}"
+          echo "Target image: $TARGET"
+
+          DECL=$(
+            gcloud compute instances describe "$GCE_INSTANCE" \
+              --zone "$GCE_ZONE" \
+              --format=json \
+            | jq -r '.metadata.items[]? | select(.key=="gce-container-declaration") | .value'
+          )
+
+          if [ -n "$DECL" ] && printf '%s\n' "$DECL" | grep -F "$TARGET" >/dev/null 2>&1; then
+            echo "VM $GCE_INSTANCE already configured with this digest. Skipping deploy."
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Digest differs (or not set) on $GCE_INSTANCE. Will deploy."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update GCE container (by digest)
+        if: steps.decide.outputs.should_deploy == 'true'
+        shell: bash
+        env:
+          GCE_INSTANCE: ${{ matrix.target.instance }}
+          GCE_ZONE: ${{ env.GCE_ZONE }}
+        run: |
+          IMAGE="ghcr.io/agoric/agoric-sdk:ymax-planner@${{ needs.docker-ymax.outputs.digest }}"
+          echo "Deploying to $GCE_INSTANCE: $IMAGE"
+          gcloud compute instances update-container "$GCE_INSTANCE" \
+            --zone "$GCE_ZONE" \
+            --container-env-file ./.env.gcp \
+            --container-image="$IMAGE"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://github.com/Agoric/agoric-private/issues/369
refs: https://github.com/Agoric/agoric-private/issues/369

## Description
This PR adds Continuous Deployment pipeline for ymax planner (for ymax0 VM only).

Here's step-wise detail:

- Deploy to GCE VM using the image digest for deterministic releases

- Load VM envs from secret.

- Skip deploy when the VM already runs the same digest (idempotent)

- Build once, then deploy to two target VMs in a simple matrix flow

**GH Secrets:**
- YMAX0_PLANNER_ENV
- GCP_SA_KEY (Service account for with compute access to run gcloud commands)

**Success Tested build?**
Here's a successful build on test VMs using same workflow code:
https://github.com/Agoric/agoric-sdk/actions/runs/18412915170

The source PR of this build:
https://github.com/Agoric/agoric-sdk/pull/12081



### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
