### PR TITLE
Refactor internal marshal utils

### DIFF
--- a/a3p-integration/proposals/z:acceptance/test/test-lib/rpc.js
+++ b/a3p-integration/proposals/z:acceptance/test/test-lib/rpc.js
@@ -14,7 +14,7 @@
 import {
   boardSlottingMarshaller,
   makeBoardRemote,
-} from '@agoric/internal/src/marshal.js';
+} from '@agoric/internal/src/marshal/board-client-utils.js';
 import { E, Far } from '@endo/far';
 import { Fail } from '@endo/errors';
 

--- a/packages/boot/test/bootstrapTests/vaults-integration.test.ts
+++ b/packages/boot/test/bootstrapTests/vaults-integration.test.ts
@@ -4,11 +4,11 @@ import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { Fail } from '@endo/errors';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { SECONDS_PER_DAY } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
-import { unmarshalFromVstorage } from '@agoric/internal/src/marshal.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { makeMarshal } from '@endo/marshal';
 import {
   makeAgoricNamesRemotesFromFakeStorage,
+  unmarshalFromVstorage,
   slotToBoardRemote,
 } from '@agoric/vats/tools/board-utils.js';
 import type { TestFn } from 'ava';

--- a/packages/boot/tools/drivers.ts
+++ b/packages/boot/tools/drivers.ts
@@ -51,7 +51,7 @@ export const makeWalletFactoryDriver = async (
     'namesByAddressAdmin',
   );
 
-  const marshaller = boardSlottingMarshaller(slotToRemotable);
+  const marshaller: Marshaller = boardSlottingMarshaller(slotToRemotable);
 
   const makeWalletDriver = (
     walletAddress: string,

--- a/packages/boot/tools/drivers.ts
+++ b/packages/boot/tools/drivers.ts
@@ -6,7 +6,7 @@ import { NonNullish } from '@agoric/internal';
 import {
   boardSlottingMarshaller,
   unmarshalFromVstorage,
-} from '@agoric/internal/src/marshal.js';
+} from '@agoric/internal/src/marshal/board-client-utils.js';
 import {
   slotToRemotable,
   type FakeStorageKit,

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -18,7 +18,7 @@ import {
   VBankAccount,
   type Remote,
 } from '@agoric/internal';
-import { unmarshalFromVstorage } from '@agoric/internal/src/marshal.js';
+import { unmarshalFromVstorage } from '@agoric/internal/src/marshal/board-client-utils.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { makeTempDirFactory } from '@agoric/internal/src/tmpDir.js';
 import { krefOf } from '@agoric/kmarshal';

--- a/packages/inter-protocol/src/clientSupport.js
+++ b/packages/inter-protocol/src/clientSupport.js
@@ -183,7 +183,7 @@ export const lookupOfferIdForVault = async (vaultId, currentP) => {
 /**
  * @param {Record<
  *   string,
- *   import('@agoric/internal/src/marshal.js').BoardRemote
+ *   import('@agoric/internal/src/marshal/board-client-utils.js').BoardRemote
  * >} brands
  * @param {{ wantMinted: number; giveMinted?: undefined }
  *   | { giveMinted: number; wantMinted?: undefined }} opts

--- a/packages/inter-protocol/src/proposals/startPSM.js
+++ b/packages/inter-protocol/src/proposals/startPSM.js
@@ -11,7 +11,7 @@ import {
   makeHistoryReviver,
   makeBoardRemote,
   slotToBoardRemote,
-} from '@agoric/internal/src/marshal.js';
+} from '@agoric/internal/src/marshal/board-client-utils.js';
 import { deeplyFulfilledObject } from '@agoric/internal';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { Stable } from '@agoric/internal/src/tokens.js';

--- a/packages/internal/src/index.js
+++ b/packages/internal/src/index.js
@@ -15,7 +15,7 @@ export * from './config.js';
 export * from './debug.js';
 export * from './errors.js';
 export * from './js-utils.js';
-export { pureDataMarshaller } from './marshal.js';
+export { pureDataMarshaller } from './marshal/pure-data.js';
 export * from './method-tools.js';
 export * from './metrics.js';
 export * from './natural-sort.js';

--- a/packages/internal/src/lib-chainStorage.js
+++ b/packages/internal/src/lib-chainStorage.js
@@ -8,11 +8,11 @@ import * as cb from './callback.js';
 
 /**
  * @import {ERef} from '@endo/far';
- * @import {Passable} from '@endo/marshal';
+ * @import {Marshal, Passable} from '@endo/marshal';
  * @import {Remote, ERemote, TypedPattern} from './types.js';
  */
 
-/** @typedef {ReturnType<typeof import('@endo/marshal').makeMarshal>} Marshaller */
+/** @typedef {Marshal<unknown>} Marshaller */
 /** @typedef {Pick<Marshaller, 'fromCapData'>} Unserializer */
 
 /**

--- a/packages/internal/src/marshal.js
+++ b/packages/internal/src/marshal.js
@@ -125,10 +125,3 @@ export const makeHistoryReviver = (entries, slotToVal = undefined) => {
 
   return harden({ getItem, children, has });
 };
-
-/** @param {CapData<unknown>} cap */
-const rejectOCap = cap => Fail`${cap} is not pure data`;
-export const pureDataMarshaller = makeMarshal(rejectOCap, rejectOCap, {
-  serializeBodyFormat: 'smallcaps',
-});
-harden(pureDataMarshaller);

--- a/packages/internal/src/marshal.js
+++ b/packages/internal/src/marshal.js
@@ -3,6 +3,7 @@ import { Fail } from '@endo/errors';
 import { Far } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
 import { isStreamCell } from './lib-chainStorage.js';
+import { assertCapData } from './marshal/cap-data.js';
 
 /**
  * @import {CapData} from '@endo/marshal';
@@ -57,20 +58,6 @@ export const boardSlottingMarshaller = (slotToVal = undefined) => {
 };
 
 /**
- * Assert that this is CapData
- *
- * @param {unknown} data
- * @returns {asserts data is CapData<unknown>}
- */
-export const assertCapData = data => {
-  assert.typeof(data, 'object');
-  assert(data);
-  typeof data.body === 'string' || Fail`data has non-string .body ${data.body}`;
-  Array.isArray(data.slots) || Fail`data has non-Array slots ${data.slots}`;
-};
-harden(assertCapData);
-
-/**
  * Read and unmarshal a value from a map representation of vstorage data
  *
  * @param {Map<string, string>} data
@@ -98,7 +85,7 @@ export const unmarshalFromVstorage = (data, key, fromCapData, index) => {
   const marshalled = values.at(index);
   assert.typeof(marshalled, 'string');
 
-  /** @type {import('@endo/marshal').CapData<string>} */
+  /** @type {CapData<string>} */
   const capData = harden(JSON.parse(marshalled));
   assertCapData(capData);
 
@@ -139,7 +126,7 @@ export const makeHistoryReviver = (entries, slotToVal = undefined) => {
   return harden({ getItem, children, has });
 };
 
-/** @param {import('@endo/marshal').CapData<unknown>} cap */
+/** @param {CapData<unknown>} cap */
 const rejectOCap = cap => Fail`${cap} is not pure data`;
 export const pureDataMarshaller = makeMarshal(rejectOCap, rejectOCap, {
   serializeBodyFormat: 'smallcaps',

--- a/packages/internal/src/marshal.js
+++ b/packages/internal/src/marshal.js
@@ -2,12 +2,10 @@
 import { Fail } from '@endo/errors';
 import { Far } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
-import { M } from '@endo/patterns';
 import { isStreamCell } from './lib-chainStorage.js';
 
 /**
  * @import {CapData} from '@endo/marshal';
- * @import {TypedPattern} from './types.js';
  */
 
 /**
@@ -57,13 +55,6 @@ export const boardSlottingMarshaller = (slotToVal = undefined) => {
     serializeBodyFormat: 'smallcaps',
   });
 };
-
-// TODO move CapDataShape to Endo
-/**
- * @type {TypedPattern<CapData<any>>}
- */
-export const CapDataShape = { body: M.string(), slots: M.array() };
-harden(CapDataShape);
 
 /**
  * Assert that this is CapData

--- a/packages/internal/src/marshal/board-client-utils.js
+++ b/packages/internal/src/marshal/board-client-utils.js
@@ -2,8 +2,8 @@
 import { Fail } from '@endo/errors';
 import { Far } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
-import { isStreamCell } from './lib-chainStorage.js';
-import { assertCapData } from './marshal/cap-data.js';
+import { isStreamCell } from '../lib-chainStorage.js';
+import { assertCapData } from './cap-data.js';
 
 /**
  * @import {CapData} from '@endo/marshal';

--- a/packages/internal/src/marshal/cap-data.js
+++ b/packages/internal/src/marshal/cap-data.js
@@ -1,0 +1,20 @@
+// @ts-check
+import { Fail } from '@endo/errors';
+
+/**
+ * @import {CapData} from '@endo/marshal';
+ */
+
+/**
+ * Assert that this is CapData
+ *
+ * @param {unknown} data
+ * @returns {asserts data is CapData<unknown>}
+ */
+export const assertCapData = data => {
+  assert.typeof(data, 'object');
+  assert(data);
+  typeof data.body === 'string' || Fail`data has non-string .body ${data.body}`;
+  Array.isArray(data.slots) || Fail`data has non-Array slots ${data.slots}`;
+};
+harden(assertCapData);

--- a/packages/internal/src/marshal/inaccessible-val.js
+++ b/packages/internal/src/marshal/inaccessible-val.js
@@ -1,0 +1,15 @@
+// @ts-check
+import { Far } from '@endo/far';
+
+const ifaceAllegedPrefix = 'Alleged: ';
+const ifaceInaccessiblePrefix = 'SEVERED: ';
+/**
+ * @param {string | undefined} iface
+ * @returns {any}
+ */
+export const makeInaccessibleVal = iface => {
+  if (typeof iface === 'string' && iface.startsWith(ifaceAllegedPrefix)) {
+    iface = iface.slice(ifaceAllegedPrefix.length);
+  }
+  return Far(`${ifaceInaccessiblePrefix}${iface}`, {});
+};

--- a/packages/internal/src/marshal/pure-data.js
+++ b/packages/internal/src/marshal/pure-data.js
@@ -1,0 +1,14 @@
+// @ts-check
+import { Fail } from '@endo/errors';
+import { makeMarshal } from '@endo/marshal';
+
+/**
+ * @import {CapData} from '@endo/marshal';
+ */
+
+/** @param {CapData<unknown>} cap */
+const rejectOCap = cap => Fail`${cap} is not pure data`;
+export const pureDataMarshaller = makeMarshal(rejectOCap, rejectOCap, {
+  serializeBodyFormat: 'smallcaps',
+});
+harden(pureDataMarshaller);

--- a/packages/internal/src/storage-test-utils.js
+++ b/packages/internal/src/storage-test-utils.js
@@ -5,7 +5,7 @@ import { makeMarshal, Remotable } from '@endo/marshal';
 import { makeTracer } from './debug.js';
 import { NonNullish } from './errors.js';
 import { isStreamCell, makeChainStorageRoot } from './lib-chainStorage.js';
-import { unmarshalFromVstorage } from './marshal.js';
+import { unmarshalFromVstorage } from './marshal/board-client-utils.js';
 import { bindAllMethods } from './method-tools.js';
 import { eventLoopIteration } from './testing-utils.js';
 

--- a/packages/swingset-liveslots/src/capdata.js
+++ b/packages/swingset-liveslots/src/capdata.js
@@ -1,7 +1,7 @@
 import { Fail } from '@endo/errors';
 
 /**
- * @import {assertCapData} from '@agoric/internal/src/marshal.js';
+ * @import {assertCapData} from '@agoric/internal/src/marshal/cap-data.js';
  */
 
 /**

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -13,12 +13,12 @@ import {
 import { E, Far } from '@endo/far';
 import { isRemotable, makeMarshal } from '@endo/marshal';
 
-import { CapDataShape } from '@agoric/internal/src/marshal.js';
 import { crc6 } from './crc.js';
 
 /**
- * @import {ERemote} from '@agoric/internal';
+ * @import {ERemote, TypedPattern} from '@agoric/internal';
  * @import {RemotableObject} from '@endo/pass-style';
+ * @import {CapData} from '@endo/marshal';
  * @import {Key} from '@endo/patterns';
  */
 
@@ -26,6 +26,11 @@ export const DEFAULT_CRC_DIGITS = 2;
 export const DEFAULT_PREFIX = 'board0';
 
 //#region Interface Guards
+
+// TODO move CapDataShape to Endo
+/** @type {TypedPattern<CapData<any>>} */
+const CapDataShape = { body: M.string(), slots: M.array() };
+
 const MarshalI = M.interface('Marshaller', {
   toCapData: M.call(M.any()).returns(CapDataShape),
   serialize: M.call(M.any()).returns(CapDataShape),

--- a/packages/vats/src/lib-board.js
+++ b/packages/vats/src/lib-board.js
@@ -10,9 +10,10 @@ import {
   defineRecorderKit,
   prepareRecorder,
 } from '@agoric/zoe/src/contractSupport/recorder.js';
-import { E, Far } from '@endo/far';
+import { E } from '@endo/far';
 import { isRemotable, makeMarshal } from '@endo/marshal';
 
+import { makeInaccessibleVal } from '@agoric/internal/src/marshal/inaccessible-val.js';
 import { crc6 } from './crc.js';
 
 /**
@@ -187,9 +188,6 @@ const getValue = (id, { prefix, crcDigits, idToVal }) => {
 
 /** @param {BoardState} state */
 const makeSlotToVal = state => {
-  const ifaceAllegedPrefix = 'Alleged: ';
-  const ifaceInaccessiblePrefix = 'SEVERED: ';
-
   /**
    * @param {BoardId} slot
    * @param {string} iface
@@ -201,10 +199,7 @@ const makeSlotToVal = state => {
     }
 
     // Private object.
-    if (typeof iface === 'string' && iface.startsWith(ifaceAllegedPrefix)) {
-      iface = iface.slice(ifaceAllegedPrefix.length);
-    }
-    return Far(`${ifaceInaccessiblePrefix}${iface}`, {});
+    return makeInaccessibleVal(iface);
   };
   return slotToVal;
 };

--- a/packages/vats/tools/board-utils.js
+++ b/packages/vats/tools/board-utils.js
@@ -5,10 +5,10 @@
 
 /**
  * @typedef {{
- *   brand: import('@agoric/internal/src/marshal.js').BoardRemote;
+ *   brand: import('@agoric/internal/src/marshal/board-client-utils.js').BoardRemote;
  *   denom: string;
  *   displayInfo: DisplayInfo;
- *   issuer: import('@agoric/internal/src/marshal.js').BoardRemote;
+ *   issuer: import('@agoric/internal/src/marshal/board-client-utils.js').BoardRemote;
  *   issuerName: string;
  *   proposedName: string;
  * }} VBankAssetDetail
@@ -17,7 +17,7 @@
  * @typedef {{
  *   brand: Record<
  *     string,
- *     import('@agoric/internal/src/marshal.js').BoardRemote
+ *     import('@agoric/internal/src/marshal/board-client-utils.js').BoardRemote
  *   >;
  *   instance: Record<string, Instance>;
  *   installation: Record<string, Installation>;
@@ -30,12 +30,12 @@
 import {
   slotToBoardRemote,
   unmarshalFromVstorage,
-} from '@agoric/internal/src/marshal.js';
+} from '@agoric/internal/src/marshal/board-client-utils.js';
 import { makeScalarBigMapStore } from '@agoric/vat-data';
 import { makeMarshal } from '@endo/marshal';
 import { prepareBoardKit } from '../src/lib-board.js';
 
-export * from '@agoric/internal/src/marshal.js';
+export * from '@agoric/internal/src/marshal/board-client-utils.js';
 
 /**
  * @param {import('@agoric/internal/src/storage-test-utils.js').FakeStorageKit} fakeStorageKit


### PR DESCRIPTION
refs: #12085

## Description

While working on #12085 I originally added the marshaller wrapper in `marshal.js`, not realizing that file mostly get included in client utils and not in vats. This splits `marshal.js` into smaller modules, named after the kind of utils they export. This also incorporates a couple of the refactor to these that #12085 includes.

### Security Considerations
None

### Scaling Considerations
Smaller bundles

### Documentation Considerations
None

### Testing Considerations
None

### Upgrade Considerations
None
