### PR TITLE
fix(cosmos): pick up cometbft patch for GHSA-hrhf-2vcr-ghch

### DIFF
--- a/golang/cosmos/go.mod
+++ b/golang/cosmos/go.mod
@@ -263,7 +263,7 @@ replace (
 	// use cometbft
 	// Use our fork at least until post-v0.34.14 is released with
 	// https://github.com/cometbft/cometbft/issue/6899 resolved.
-	github.com/cometbft/cometbft => github.com/agoric-labs/cometbft v0.38.17-alpha.agoric.1
+	github.com/cometbft/cometbft => github.com/agoric-labs/cometbft v0.38.17-alpha.agoric.1.1
 	github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.50.14-alpha.agoric.3
 	github.com/cosmos/ibc-go/modules/capability => github.com/agoric-labs/ibc-go/modules/capability v1.0.1-v8.7.0-alpha.agoric.1
 

--- a/golang/cosmos/go.sum
+++ b/golang/cosmos/go.sum
@@ -227,8 +227,8 @@ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/
 github.com/adlio/schema v1.3.6 h1:k1/zc2jNfeiZBA5aFTRy37jlBIuCkXCm0XmvpzCKI9I=
 github.com/adlio/schema v1.3.6/go.mod h1:qkxwLgPBd1FgLRHYVCmQT/rrBr3JH38J9LjmVzWNudg=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
-github.com/agoric-labs/cometbft v0.38.17-alpha.agoric.1 h1:NmKLLSctK9CXt0X92b2N+kh790o0jwaADSTsuv4ADRA=
-github.com/agoric-labs/cometbft v0.38.17-alpha.agoric.1/go.mod h1:5l0SkgeLRXi6bBfQuevXjKqML1jjfJJlvI1Ulp02/o4=
+github.com/agoric-labs/cometbft v0.38.17-alpha.agoric.1.1 h1:gA1sxgpycMwbTFTpJ6xc8RgDd8+riEGltFw3rOO/bLA=
+github.com/agoric-labs/cometbft v0.38.17-alpha.agoric.1.1/go.mod h1:5l0SkgeLRXi6bBfQuevXjKqML1jjfJJlvI1Ulp02/o4=
 github.com/agoric-labs/cosmos-sdk v0.50.14-alpha.agoric.3 h1:sDVooA9+hDskJv2XHTCN6J5FT5AuvfRFkP5FXoznGeg=
 github.com/agoric-labs/cosmos-sdk v0.50.14-alpha.agoric.3/go.mod h1:xEBva4dbDLcZcPQx3/yuSz3272k9XJKxl7O1J5oagsw=
 github.com/agoric-labs/cosmos-sdk/client/v2 v2.0.0-v0.50.14-alpha.agoric.2 h1:6nR9bQSscriuHcj6nTtDFGjsMuoOeaGT+nDL/q83pdE=


### PR DESCRIPTION
refs: GHSA-hrhf-2vcr-ghch

## Description
Update cometbft with [cherry-pick](https://github.com/agoric-labs/cometbft/commit/188cb2ac6bb9aa3ab3d115672b73336be888dc84) of https://github.com/cometbft/cometbft/commit/be5677c3e58f998b7f67bb6186dd2c9b81a041a1

### Security Considerations
Fixes GHSA-hrhf-2vcr-ghch

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
None

### Upgrade Considerations
According to interchain team, this fix can be applied as consensus, so we will tag `agoric-upgrade-22a` and `@agoric/sdk@68` without going through a full release process that would change package versions.
