### PR TITLE
fix(portfolio-contract): Start a flow when openPortfolio includes an initial deposit

### DIFF
--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -447,13 +447,14 @@ export const preparePortfolioKit = (
             this.facets.reporter.publishStatus();
           }
         },
-        startFlow(detail: FlowDetail) {
-          const { nextFlowId, flowsRunning } = this.state;
-          this.state.nextFlowId = nextFlowId + 1;
+        startFlow(detail: FlowDetail, steps?: MovementDesc[]) {
+          const { nextFlowId: flowId, flowsRunning } = this.state;
+          this.state.nextFlowId = flowId + 1;
           const sync: VowKit<MovementDesc[]> = vowTools.makeVowKit();
-          flowsRunning.init(nextFlowId, harden({ sync, ...detail }));
+          if (steps) sync.resolver.resolve(steps);
+          flowsRunning.init(flowId, harden({ sync, ...detail }));
           this.facets.reporter.publishStatus();
-          return { stepsP: sync.vow, flowId: nextFlowId };
+          return { stepsP: sync.vow, flowId };
         },
         providePosition(
           poolKey: PoolKey,

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -1114,26 +1114,23 @@ export const openPortfolio = (async (
       await registerNobleForwardingAccount(sender, dest, forwarding, traceP);
     }
 
-    if (offerArgs.targetAllocation) {
-      kit.manager.setTargetAllocation(offerArgs.targetAllocation);
-    }
-
     const { give } = seat.getProposal() as ProposalType['openPortfolio'];
-    if (offerArgs.flow) {
-      try {
+    try {
+      if (offerArgs.flow) {
+        // XXX only for testing recovery?
+        await rebalance(orch, ctxI, seat, offerArgs, kit);
+      } else if (offerArgs.targetAllocation) {
+        kit.manager.setTargetAllocation(offerArgs.targetAllocation);
         if (give.Deposit) {
           await executePlan(orch, ctxI, seat, offerArgs, kit, {
             type: 'deposit',
             amount: give.Deposit,
           });
-        } else {
-          // XXX only for testing recovery?
-          await rebalance(orch, ctxI, seat, offerArgs, kit);
         }
-      } catch (err) {
-        traceP('⚠️ initial flow failed', err);
-        if (!seat.hasExited()) seat.fail(err);
       }
+    } catch (err) {
+      traceP('⚠️ initial flow failed', err);
+      if (!seat.hasExited()) seat.fail(err);
     }
 
     const publicSubscribers: GuestInterface<PublicSubscribers> = {

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -865,20 +865,21 @@ export const rebalance = (async (
   const traceP = makeTracer('rebalance').sub(`portfolio${id}`);
   const proposal = seat.getProposal() as ProposalType['rebalance'];
   traceP('proposal', proposal.give, proposal.want, offerArgs);
+  const { flow, targetAllocation } = offerArgs;
 
   await null;
   let flowId: number | undefined;
   try {
-    if (offerArgs.targetAllocation) {
-      kit.manager.setTargetAllocation(offerArgs.targetAllocation);
-    } else if ((offerArgs.flow || []).some(step => step.dest === '+agoric')) {
-      // steps include a deposit that the planner should respond to
+    if (targetAllocation) {
+      kit.manager.setTargetAllocation(targetAllocation);
+    } else if (flow?.some(step => step.dest === '+agoric')) {
+      // flow includes a deposit that the planner should respond to
       kit.manager.incrPolicyVersion();
     }
 
-    if (offerArgs.flow) {
+    if (flow) {
       ({ flowId } = kit.manager.startFlow({ type: 'rebalance' }));
-      await stepFlow(orch, ctx, seat, offerArgs.flow, kit, traceP, flowId);
+      await stepFlow(orch, ctx, seat, flow, kit, traceP, flowId);
     }
 
     if (!seat.hasExited()) {

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -878,7 +878,7 @@ export const rebalance = (async (
     }
 
     if (flow) {
-      ({ flowId } = kit.manager.startFlow({ type: 'rebalance' }));
+      ({ flowId } = kit.manager.startFlow({ type: 'rebalance' }, flow));
       await stepFlow(orch, ctx, seat, flow, kit, traceP, flowId);
     }
 

--- a/packages/portfolio-contract/test/target-allocation.test.ts
+++ b/packages/portfolio-contract/test/target-allocation.test.ts
@@ -14,18 +14,13 @@ const ackNFA = (utils, ix = 0) =>
 
 test('openPortfolio stores and publishes target allocation', async t => {
   const { trader1, common } = await setupTrader(t);
-  const { usdc } = common.brands;
 
   // target: 60% USDN, 40% Aave on Arbitrum
   const targetAllocation = { USDN: 6000n, Aave_Arbitrum: 4000n };
 
   // Open portfolio with target allocation
   await Promise.all([
-    trader1.openPortfolio(
-      t,
-      { Deposit: usdc.units(1_000) },
-      { targetAllocation },
-    ),
+    trader1.openPortfolio(t, {}, { targetAllocation }),
     ackNFA(common.utils),
   ]);
 

--- a/packages/portfolio-contract/test/target-allocation.test.ts
+++ b/packages/portfolio-contract/test/target-allocation.test.ts
@@ -107,20 +107,12 @@ test('multiple portfolios have independent allocations', async t => {
 
   // Open portfolios with different allocations
   await Promise.all([
-    trader1.openPortfolio(
-      t,
-      { Deposit: usdc.units(5_000) },
-      { targetAllocation: allocation1 },
-    ),
+    trader1.openPortfolio(t, {}, { targetAllocation: allocation1 }),
     ackNFA(common.utils, 0),
   ]);
 
   await Promise.all([
-    trader2.openPortfolio(
-      t,
-      { Deposit: usdc.units(7_000) },
-      { targetAllocation: allocation2 },
-    ),
+    trader2.openPortfolio(t, {}, { targetAllocation: allocation2 }),
     ackNFA(common.utils, -1),
   ]);
 

--- a/packages/portfolio-contract/test/ymax-scenario.test.ts
+++ b/packages/portfolio-contract/test/ymax-scenario.test.ts
@@ -4,6 +4,7 @@
 // prepare-test-env has to go 1st; use a blank line to separate it
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
+import { inspect } from 'node:util';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { AxelarChain } from '@agoric/portfolio-api/src/constants.js';
 import { Fail } from '@endo/errors';

--- a/packages/portfolio-contract/test/ymax-scenario.test.ts
+++ b/packages/portfolio-contract/test/ymax-scenario.test.ts
@@ -54,9 +54,9 @@ const rebalanceScenarioMacro = test.macro({
   async exec(t, description: string) {
     const { trader1, common, started, zoe } = await setupTrader(t);
     const scenarios = await scenariosP;
-    const scenario = scenarios[description];
-    if (!scenario) return t.fail(`Scenario "${description}" not found`);
-    t.log('start', description);
+    const rawScenario = scenarios[description];
+    if (!rawScenario) return t.fail(`Scenario "${description}" not found`);
+    t.log('start', description, inspect(rawScenario, { depth: 5 }));
 
     const { ibcBridge } = common.mocks;
     for (const money of [
@@ -71,8 +71,8 @@ const rebalanceScenarioMacro = test.macro({
     }
 
     const { usdc } = common.brands;
-    const sceneB = withBrand(scenario, usdc.brand);
-    const sceneBP = scenario.previous
+    const scenario = withBrand(rawScenario, usdc.brand);
+    const previous = scenario.previous
       ? withBrand(scenarios[scenario.previous], usdc.brand)
       : undefined;
 
@@ -141,21 +141,21 @@ const rebalanceScenarioMacro = test.macro({
       return { result, payouts };
     };
 
-    const openOnly = Object.keys(sceneB.before).length === 0;
-    openOnly || sceneBP || Fail`no previous scenario for ${description}`;
+    const openOnly = Object.keys(scenario.before).length === 0;
+    openOnly || previous || Fail`no previous scenario for ${description}`;
     const openResult = await (openOnly
-      ? openPortfolioAndAck(sceneB.proposal.give, sceneB.offerArgs)
-      : openPortfolioAndAck(sceneBP!.proposal.give, sceneBP!.offerArgs));
+      ? openPortfolioAndAck(scenario.proposal.give, scenario.offerArgs)
+      : openPortfolioAndAck(previous!.proposal.give, previous!.offerArgs));
 
     const { payouts } = await (async () => {
       if (openOnly) return openResult;
 
       const rebalanceP = trader1.rebalance(
         t,
-        sceneB.proposal,
-        sceneB.offerArgs,
+        scenario.proposal,
+        scenario.offerArgs,
       );
-      await ackSteps(sceneB.offerArgs);
+      await ackSteps(scenario.offerArgs);
       const result = await rebalanceP;
       return result;
     })();
@@ -171,11 +171,11 @@ const rebalanceScenarioMacro = test.macro({
 
     const txfrs = await trader1.netTransfersByPosition();
     t.log('net transfers by position', txfrs);
-    t.deepEqual(txfrs, sceneB.after, 'net transfers should match After row');
+    t.deepEqual(txfrs, scenario.after, 'net transfers should match After row');
 
     t.log('payouts', payouts);
     const { Access: _, ...skipAssets } = payouts;
-    t.deepEqual(skipAssets, sceneB.payouts, 'payouts');
+    t.deepEqual(skipAssets, scenario.payouts, 'payouts');
 
     // XXX: inspect bridge for netTransfersByPosition chains?
   },


### PR DESCRIPTION
Fixes #12114

## Description
If `openPortfolio` is called with a Deposit, use `executePlan` rather than `rebalance` to coördinate with the planner.

### Security Considerations
None known. This effectively tacks on a "deposit" flow to the existing "open portfolio" flow.

### Scaling Considerations
None; the planner is already expected to respond to deposits.

### Documentation Considerations
n/a

### Testing Considerations
Fixes for existing tests are in progress.

### Upgrade Considerations
The planner is already expecting and prepared to respond to deposit flows. This should follow the usual `ymaxControl.upgrade(...)` pattern.