### PR TITLE
portfolio-api type improvements

### DIFF
--- a/packages/portfolio-api/package.json
+++ b/packages/portfolio-api/package.json
@@ -24,7 +24,8 @@
   "devDependencies": {
     "ava": "^5.3.0",
     "c8": "^10.1.3",
-    "ts-blank-space": "^0.6.2"
+    "ts-blank-space": "^0.6.2",
+    "tsd": "^0.33.0"
   },
   "ava": {
     "extensions": {

--- a/packages/portfolio-api/src/constants.js
+++ b/packages/portfolio-api/src/constants.js
@@ -46,7 +46,13 @@ harden(AxelarChain);
  * @enum {(typeof SupportedChain)[keyof typeof SupportedChain]}
  */
 export const SupportedChain = /** @type {const} */ ({
-  ...AxelarChain,
+  // ...AxelarChain works locally but gets lost in .d.ts generation
+  Arbitrum: 'Arbitrum',
+  Avalanche: 'Avalanche',
+  Base: 'Base',
+  Ethereum: 'Ethereum',
+  Optimism: 'Optimism',
+  // Unique to this object
   agoric: 'agoric',
   noble: 'noble',
   // XXX: check privateArgs for chainInfo for all of these

--- a/packages/portfolio-api/src/type-guards.ts
+++ b/packages/portfolio-api/src/type-guards.ts
@@ -1,0 +1,17 @@
+import type { InterChainAccountRef, LocalChainAccountRef } from './types.js';
+
+/**
+ * Does it match the pattern, without regard to supported chains.
+ */
+export const isLocalChainAccountRef = (
+  ref: string,
+): ref is LocalChainAccountRef => ref.startsWith('+');
+harden(isLocalChainAccountRef);
+
+/**
+ * Does it match the pattern, without regard to supported chains.
+ */
+export const isInterChainAccountRef = (
+  ref: string,
+): ref is InterChainAccountRef => ref.startsWith('@');
+harden(isInterChainAccountRef);

--- a/packages/portfolio-api/src/types.ts
+++ b/packages/portfolio-api/src/types.ts
@@ -88,6 +88,7 @@ export type StatusFor = {
     accountIdByChain: Partial<Record<SupportedChain, AccountId>>;
     accountsPending?: SupportedChain[];
     depositAddress?: Bech32Address;
+    /** Noble Forwarding Address (NFA) registered by the contract for the `@agoric` address */
     nobleForwardingAddress?: Bech32Address;
     targetAllocation?: TargetAllocation;
     /** incremented by the contract every time the user sends a transaction that the planner should respond to */

--- a/packages/portfolio-api/src/types.ts
+++ b/packages/portfolio-api/src/types.ts
@@ -10,10 +10,18 @@ import type { PublishedTx } from './resolver.js';
 
 export type SeatKeyword = 'Cash' | 'Deposit';
 
+/**
+ * Reference to a local chain accounts (LCA).
+ * '+agoric' is published as `depositAddress`
+ */
+export type LocalChainAccountRef = '+agoric';
+
+export type InterChainAccountRef = `@${SupportedChain}`;
+
 export type AssetPlaceRef =
   | `<${SeatKeyword}>`
-  | '+agoric' // deposit LCA
-  | `@${SupportedChain}`
+  | LocalChainAccountRef
+  | InterChainAccountRef
   | InstrumentId;
 
 type Empty = Record<never, NatAmount>;

--- a/packages/portfolio-api/test/types.test-d.ts
+++ b/packages/portfolio-api/test/types.test-d.ts
@@ -1,0 +1,160 @@
+import type { NatAmount } from '@agoric/ertp';
+import type {
+  AccountId,
+  Bech32Address,
+  CosmosChainAddress,
+} from '@agoric/orchestration';
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd';
+import type { SupportedChain, YieldProtocol } from '../src/constants.js';
+import { AxelarChain } from '../src/constants.js';
+import type { InstrumentId } from '../src/instruments.js';
+import type { PublishedTx } from '../src/resolver.js';
+import type {
+  AssetPlaceRef,
+  FlowDetail,
+  FlowKey,
+  FlowStatus,
+  FlowStep,
+  InterChainAccountRef,
+  LocalChainAccountRef,
+  PortfolioKey,
+  ProposalType,
+  SeatKeyword,
+  StatusFor,
+  TargetAllocation,
+} from '../src/types.js';
+
+declare const natAmount: NatAmount;
+declare const accountId: AccountId;
+declare const bech32Address: Bech32Address;
+declare const cosmosAddress: CosmosChainAddress;
+declare const publishedTx: PublishedTx;
+declare const yieldProtocol: YieldProtocol;
+declare const supportedChain: SupportedChain;
+declare const instrumentId: InstrumentId;
+
+expectAssignable<SeatKeyword>('Cash');
+expectAssignable<SeatKeyword>('Deposit');
+expectNotAssignable<SeatKeyword>('Flow');
+
+expectAssignable<LocalChainAccountRef>('+agoric');
+expectNotAssignable<LocalChainAccountRef>('+other');
+expectNotAssignable<LocalChainAccountRef>('@agoric');
+
+expectAssignable<InterChainAccountRef>('@Base');
+expectNotAssignable<InterChainAccountRef>('Arbitrum');
+
+expectAssignable<AssetPlaceRef>('<Deposit>');
+expectAssignable<AssetPlaceRef>('+agoric');
+expectAssignable<AssetPlaceRef>(instrumentId);
+expectNotAssignable<AssetPlaceRef>('Deposit');
+
+const targetAllocation: TargetAllocation = {
+  [instrumentId]: 100n,
+  Aave_Base: 250n,
+};
+
+expectNotAssignable<TargetAllocation>({ Arbitrary: 100n });
+
+const emptyGive: ProposalType['openPortfolio']['give'] = {};
+const openPortfolio = {
+  give: {
+    Deposit: natAmount,
+    Access: natAmount,
+  },
+  want: {},
+} satisfies ProposalType['openPortfolio'];
+expectType<ProposalType['openPortfolio']['give']>(emptyGive);
+expectType<ProposalType['openPortfolio']>(openPortfolio);
+
+const rebalanceDeposit = {
+  give: { Deposit: natAmount },
+  want: {},
+} satisfies ProposalType['rebalance'];
+expectType<ProposalType['rebalance']>(rebalanceDeposit);
+expectNotAssignable<ProposalType['rebalance']>({
+  want: { Deposit: natAmount },
+  give: {},
+});
+
+const withdrawProposal = {
+  want: { Cash: natAmount },
+  give: {},
+} satisfies ProposalType['withdraw'];
+expectType<ProposalType['withdraw']>(withdrawProposal);
+expectNotAssignable<ProposalType['withdraw']>({
+  give: { Deposit: natAmount },
+  want: {},
+});
+
+expectAssignable<FlowDetail>({ type: 'rebalance' });
+expectAssignable<FlowDetail>({ type: 'deposit', amount: natAmount });
+expectNotAssignable<FlowDetail>({ type: 'deposit' });
+
+expectAssignable<FlowStatus>({ state: 'run', step: 1, how: 'start' });
+expectAssignable<FlowStatus>({
+  state: 'fail',
+  step: 1,
+  how: 'submit',
+  error: 'boom',
+});
+expectNotAssignable<FlowStatus>({ state: 'done', step: 1 });
+
+const assetRef: AssetPlaceRef = '<Cash>';
+
+const flowStep: FlowStep = {
+  how: 'send',
+  amount: natAmount,
+  src: assetRef,
+  dest: '+agoric',
+};
+
+const flowSteps: FlowStep[] = [flowStep, { ...flowStep, dest: '@Base' }];
+
+expectType<FlowKey>('flow1');
+expectNotAssignable<FlowKey>('flow');
+
+expectType<PortfolioKey>('portfolio2');
+expectNotAssignable<PortfolioKey>('portfolio');
+
+const flowsRunning: Record<FlowKey, FlowDetail> = {
+  flow1: { type: 'withdraw', amount: natAmount },
+};
+
+const status: StatusFor = {
+  contract: {
+    contractAccount: cosmosAddress.value,
+  },
+  pendingTx: publishedTx,
+  portfolios: {
+    addPortfolio: 'portfolio1',
+  },
+  portfolio: {
+    positionKeys: [instrumentId],
+    accountIdByChain: { [supportedChain]: accountId },
+    accountsPending: [supportedChain],
+    depositAddress: bech32Address,
+    nobleForwardingAddress: bech32Address,
+    targetAllocation,
+    policyVersion: 1,
+    rebalanceCount: 0,
+    flowCount: 0,
+    flowsRunning,
+  },
+  position: {
+    protocol: yieldProtocol,
+    accountId,
+    netTransfers: natAmount,
+    totalIn: natAmount,
+    totalOut: natAmount,
+  },
+  flow: { state: 'done' },
+  flowSteps,
+};
+
+expectType<StatusFor>(status);
+
+// Ensure every Axelar chain key is covered by SupportedChain.
+expectAssignable<keyof typeof SupportedChain>(
+  null as unknown as keyof typeof AxelarChain,
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,6 +940,7 @@ __metadata:
     ava: "npm:^5.3.0"
     c8: "npm:^10.1.3"
     ts-blank-space: "npm:^0.6.2"
+    tsd: "npm:^0.33.0"
   bin:
     portfolio-api: ./src/cli/bin.js
   languageName: unknown


### PR DESCRIPTION
incidental

## Description

Fix the `SupportedChain` type.

Break apart `AssetPlaceRef` to support YDS `reserved` calculation

Add type tests

A couple small refactors from https://github.com/Agoric/agoric-sdk/pull/12110

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
improved

### Testing Considerations
CI

### Upgrade Considerations
none