### PR TITLE
provide cachingMarshaller in OrchestrationTools

### DIFF
--- a/packages/fast-usdc-contract/src/fast-usdc.contract.ts
+++ b/packages/fast-usdc-contract/src/fast-usdc.contract.ts
@@ -44,10 +44,7 @@ import type {
   Marshaller,
   StorageNode,
 } from '@agoric/internal/src/lib-chainStorage.js';
-import {
-  wrapRemoteMarshaller,
-  type EMarshaller,
-} from '@agoric/internal/src/marshal/wrap-marshaller.js';
+import { type EMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import type { ContractMeta, Invitation, ZCF } from '@agoric/zoe';
 import type { Zone } from '@agoric/zone';
 import { prepareAdvancer } from './exos/advancer.ts';
@@ -122,11 +119,9 @@ export const contract = async (
   assert('USDC' in terms.brands, 'no USDC brand');
   assert('usdcDenom' in terms, 'no usdcDenom');
 
-  const { feeConfig, marshaller: remoteMarshaller, storageNode } = privateArgs;
+  const { feeConfig, storageNode } = privateArgs;
 
-  // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
-  // once withOrchestration provides a wrapped marshaller, don't re-wrap.
-  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
+  const { cachingMarshaller } = tools;
   const { makeRecorderKit } = prepareRecorderKitMakers(
     zone.mapStore('vstorage'),
     cachingMarshaller,

--- a/packages/orchestration/src/examples/stake-bld.contract.js
+++ b/packages/orchestration/src/examples/stake-bld.contract.js
@@ -40,8 +40,7 @@ export const start = async (zcf, privateArgs, baggage) => {
   const zone = makeDurableZone(baggage);
 
   const { marshaller: remoteMarshaller } = privateArgs;
-  // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
-  // once withOrchestration provides a wrapped marshaller, don't re-wrap.
+  //  withOrchestration() provides this but this contract shows how to use orchestration without that
   const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   const { makeRecorderKit } = prepareRecorderKitMakers(

--- a/packages/orchestration/src/examples/stake-ica.contract.js
+++ b/packages/orchestration/src/examples/stake-ica.contract.js
@@ -85,8 +85,7 @@ export const start = async (zcf, privateArgs, baggage) => {
       ),
   });
 
-  // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
-  // once withOrchestration provides a wrapped marshaller, don't re-wrap.
+  //  withOrchestration() provides this but this contract shows how to use orchestration without that
   const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   const { makeRecorderKit } = prepareRecorderKitMakers(

--- a/packages/orchestration/src/examples/swap-anything.contract.js
+++ b/packages/orchestration/src/examples/swap-anything.contract.js
@@ -1,15 +1,14 @@
-import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
+import { decodeAddressHook } from '@agoric/cosmic-proto/address-hooks.js';
 import { makeTracer } from '@agoric/internal';
-import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
+import { InvitationShape } from '@agoric/zoe/src/typeGuards.js';
 import { E } from '@endo/far';
 import { M } from '@endo/patterns';
-import { decodeAddressHook } from '@agoric/cosmic-proto/address-hooks.js';
 import { prepareChainHubAdmin } from '../exos/chain-hub-admin.js';
+import { AnyNatAmountShape } from '../typeGuards.js';
+import { registerChainsAndAssets } from '../utils/chain-hub-helper.js';
 import { withOrchestration } from '../utils/start-helper.js';
 import * as sharedFlows from './shared.flows.js';
 import { swapAnythingViaHook, swapIt } from './swap-anything.flows.js';
-import { AnyNatAmountShape } from '../typeGuards.js';
-import { registerChainsAndAssets } from '../utils/chain-hub-helper.js';
 
 const trace = makeTracer('SwapAnything.Contract');
 const interfaceTODO = undefined;
@@ -46,7 +45,7 @@ export const contract = async (
   zcf,
   privateArgs,
   zone,
-  { chainHub, orchestrate, vowTools, zoeTools },
+  { cachingMarshaller, chainHub, orchestrate, vowTools, zoeTools },
 ) => {
   const creatorFacet = prepareChainHubAdmin(zone, chainHub);
 
@@ -60,11 +59,6 @@ export const contract = async (
   /** @type {(msg: string) => Vow<void>} */
   const log = (msg, level = 'info') =>
     vowTools.watch(E(logNode).setValue(JSON.stringify({ msg, level })));
-
-  const { marshaller: remoteMarshaller } = privateArgs;
-  // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
-  // once withOrchestration provides a wrapped marshaller, don't re-wrap.
-  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
 
   const makeLocalAccount = orchestrate(
     'makeLocalAccount',

--- a/packages/orchestration/src/utils/start-helper.js
+++ b/packages/orchestration/src/utils/start-helper.js
@@ -56,7 +56,7 @@ import { makeZcfTools } from './zcf-tools.js';
  * @param {ZCF} zcf
  * @param {Baggage} baggage
  * @param {OrchestrationPowers} remotePowers
- * @param {ERemote<EMarshaller>} remoteMarshaller
+ * @param {Remote<Marshaller>} remoteMarshaller
  * @param {object} [opts]
  * @param {WithOrchestrationOpts['chainInfoValueShape']} [opts.chainInfoValueShape]
  * @internal

--- a/packages/orchestration/test/staking-ops.test.ts
+++ b/packages/orchestration/test/staking-ops.test.ts
@@ -228,10 +228,8 @@ const makeScenario = () => {
 
   const baggage = makeScalarBigMapStore('b1') as Baggage;
   const zone = makeDurableZone(baggage);
-  // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
-  // once withOrchestration provides a wrapped marshaller to contracts so
-  // should the test setup. Right now `withOrchestration` does wrap the
-  // marshaller but only for the recorder kit, which we don't bother to do here
+  // withOrchestration() provides a cachingMarshaller but this this doesn't use that
+  // helper and doesn't need to exercise caching.
   const marshaller = makeFakeBoard().getReadonlyMarshaller();
   const { makeRecorderKit } = prepareRecorderKitMakers(baggage, marshaller);
 

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -15,7 +15,6 @@ import type {
   Marshaller,
   StorageNode,
 } from '@agoric/internal/src/lib-chainStorage.js';
-import { wrapRemoteMarshaller } from '@agoric/internal/src/marshal/wrap-marshaller.js';
 import {
   ChainInfoShape,
   DenomDetailShape,
@@ -229,7 +228,6 @@ export const contract = async (
     assetInfo,
     axelarIds,
     contracts,
-    marshaller: remoteMarshaller,
     storageNode,
     gmpAddresses,
   } = privateArgs;
@@ -268,9 +266,7 @@ export const contract = async (
   const proposalShapes = makeProposalShapes(brands.USDC, brands.Access);
   const offerArgsShapes = makeOfferArgsShapes(brands.USDC);
 
-  // TODO(https://github.com/Agoric/agoric-sdk/issues/12109):
-  // once withOrchestration provides a wrapped marshaller, don't re-wrap.
-  const cachingMarshaller = wrapRemoteMarshaller(remoteMarshaller);
+  const { cachingMarshaller } = tools;
 
   const resolverZone = zone.subZone('Resolver');
   const makeResolverKit = prepareResolverKit(resolverZone, zcf, {


### PR DESCRIPTION
closes: #12109


## Description

- provide the new `cachingMarshaller` as part of OrchestrationTools
- update all the sites that referenced 12109

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
types show what's available

### Testing Considerations
CI

### Upgrade Considerations
no changes to behavior, just refactor