### PR TITLE
fix(ymax-planner): Run with 6-second heartbeats

### DIFF
--- a/services/ymax-planner/src/cosmos-rpc.ts
+++ b/services/ymax-planner/src/cosmos-rpc.ts
@@ -67,8 +67,12 @@ export class CosmosRPCClient extends JSONRPCClient {
       this.#subscriptions.clear();
     });
 
-    ws.addEventListener('error', ev => {
-      const err = new Error(`WebSocket ${wsUrl.href} error: ${ev}`);
+    ws.addEventListener('error', event => {
+      const cause = event.error;
+      const err = new Error(
+        `WebSocket ${wsUrl.href} error: ${cause?.message}`,
+        { cause },
+      );
       this.#openedPK.reject(err);
       this.#closedPK.reject(err);
       for (const sub of this.#subscriptions.values()) {

--- a/services/ymax-planner/src/cosmos-rpc.ts
+++ b/services/ymax-planner/src/cosmos-rpc.ts
@@ -16,7 +16,9 @@ export class CosmosRPCClient extends JSONRPCClient {
     number,
     {
       query: string;
-      notified: (response: JSONRPCResponse) => void;
+      notify: (response: JSONRPCResponse) => void;
+      finish: () => void;
+      fail: (error: unknown) => void;
       unsubscribe: () => void;
     }
   >;
@@ -47,6 +49,9 @@ export class CosmosRPCClient extends JSONRPCClient {
 
     ws.addEventListener('close', () => {
       this.#closedPK.resolve();
+      for (const sub of this.#subscriptions.values()) {
+        sub.finish();
+      }
       this.#subscriptions.clear();
     });
 
@@ -54,6 +59,10 @@ export class CosmosRPCClient extends JSONRPCClient {
       const err = new Error(`WebSocket ${wsUrl.href} error: ${ev}`);
       this.#openedPK.reject(err);
       this.#closedPK.reject(err);
+      for (const sub of this.#subscriptions.values()) {
+        sub.fail(err);
+      }
+      this.#subscriptions.clear();
     });
 
     ws.addEventListener('message', event => {
@@ -61,7 +70,7 @@ export class CosmosRPCClient extends JSONRPCClient {
       const response = JSON.parse(str);
       const sub = this.#subscriptions.get(response.id);
       if (sub) {
-        sub.notified(response);
+        sub.notify(response);
       }
       this.receive(response);
     });
@@ -117,7 +126,7 @@ export class CosmosRPCClient extends JSONRPCClient {
 
     type Cell = { head: JSONRPCResponse; tail: Promise<Cell> };
     let lastPK = Promise.withResolvers<Cell>();
-    let nextCell = lastPK.promise;
+    let nextCellP = lastPK.promise;
 
     const subscriptionKits = [...newQueries.keys()].map(query => {
       const subP = this.request('subscribe', { query });
@@ -133,7 +142,18 @@ export class CosmosRPCClient extends JSONRPCClient {
       };
       this.#subscriptions.set(subId, {
         query,
-        notified: (response: JSONRPCResponse) => {
+        finish: () => {
+          readyKit.isSettled = true;
+          readyKit.resolve(undefined);
+          // @ts-expect-error undefined is not a Cell but indicates conclusion
+          lastPK.resolve(undefined);
+        },
+        fail: (err: unknown) => {
+          readyKit.isSettled = true;
+          readyKit.reject(err);
+          lastPK.reject(err);
+        },
+        notify: (response: JSONRPCResponse) => {
           // Ignore an initial empty-result response.
           if (!readyKit.isSettled) {
             readyKit.isSettled = true;
@@ -163,19 +183,17 @@ export class CosmosRPCClient extends JSONRPCClient {
     // console.log('wait forever?');
     try {
       while (true) {
-        // console.log('wait for next event');
-        const { head, tail } = await nextCell;
-        nextCell = tail;
+        const nextCell = await nextCellP;
+        if (!nextCell) break;
+        const { head, tail } = nextCell;
+        nextCellP = tail;
         if (head.error) {
-          // Propagate errors non-fatally.
+          // Propagate application-level errors non-fatally.
           yield Promise.reject(Error(head.error.message));
           continue;
         }
         yield head.result;
       }
-    } catch (error) {
-      console.error('Subscription error:', error);
-      lastPK.reject(error);
     } finally {
       for (const { unsubscribe } of subscriptionKits) {
         unsubscribe();

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -1,3 +1,11 @@
+import timersPromises from 'node:timers/promises';
+
+import { SigningStargateClient } from '@cosmjs/stargate';
+import * as ws from 'ws';
+
+import { Fail, q } from '@endo/errors';
+import { isPrimitive } from '@endo/pass-style';
+
 import {
   fetchEnvNetworkConfig,
   getInvocationUpdate,
@@ -6,10 +14,6 @@ import {
   reflectWalletStore,
 } from '@agoric/client-utils';
 import { objectMetaMap } from '@agoric/internal';
-import { Fail, q } from '@endo/errors';
-import { isPrimitive } from '@endo/pass-style';
-
-import { SigningStargateClient } from '@cosmjs/stargate';
 
 import { loadConfig } from './config.ts';
 import { CosmosRestClient } from './cosmos-rest-client.ts';
@@ -37,9 +41,11 @@ export const main = async (
   {
     env = process.env,
     fetch = globalThis.fetch,
+    generateInterval = timersPromises.setInterval,
     now = Date.now,
     setTimeout = globalThis.setTimeout,
     connectWithSigner = SigningStargateClient.connectWithSigner,
+    WebSocket = ws.WebSocket,
   } = {},
 ) => {
   const delay = ms =>
@@ -56,7 +62,10 @@ export const main = async (
   const agoricRpcAddr = networkConfig.rpcAddrs[0];
   console.warn('Initializing planner', networkConfig);
 
-  const rpc = new CosmosRPCClient(agoricRpcAddr);
+  const rpc = new CosmosRPCClient(agoricRpcAddr, {
+    WebSocket,
+    heartbeats: generateInterval(6000),
+  });
   await rpc.opened();
   await assertChainId(rpc, networkConfig.chainName, (...args) =>
     console.warn('Agoric chain status', ...args),

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -130,10 +130,15 @@ export const main = async (
     now,
     gasEstimator,
   };
-  await startEngine(powers, {
-    contractInstance: config.contractInstance,
-    depositBrandName: env.DEPOSIT_BRAND_NAME || 'USDC',
-    feeBrandName: env.FEE_BRAND_NAME || 'BLD',
-  });
+  try {
+    await startEngine(powers, {
+      contractInstance: config.contractInstance,
+      depositBrandName: env.DEPOSIT_BRAND_NAME || 'USDC',
+      feeBrandName: env.FEE_BRAND_NAME || 'BLD',
+    });
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
 };
 harden(main);


### PR DESCRIPTION
Fixes #12126

## Description
Run ymax-planner with 6-second heartbeats (via websocket ping/pong frames), crashing the process for restart by supervisor when a ping doesn't get a pong response in time.
* fix(ymax-planner): Finalize CosmosRPCClient subscriptions upon websocket close/error
* feat(ymax-planner): Add heartbeat logic to CosmosRPCClient
  _Note that this locks us in to the "ws" packages, because the WHATWG WebSocket API does not expose ping/pong frames._
* fix(ymax-planner): Run with 6-second heartbeats

### Security Considerations
None known

### Scaling Considerations
Any downtime incurs catchup proportional to its duration. This is more significant for resolver functionality than for planner functionality, but both are able to recover.

### Documentation Considerations
n/a

### Testing Considerations
Tested manually.

### Upgrade Considerations
Safe to deploy immediately.