### PR TITLE
fix(ymax-planner): Call CosmosRPCClient error logic directly upon heartbeat timeout

### DIFF
--- a/services/ymax-planner/src/cosmos-rpc.ts
+++ b/services/ymax-planner/src/cosmos-rpc.ts
@@ -96,7 +96,12 @@ export class CosmosRPCClient extends JSONRPCClient {
         for await (const _ of heartbeats) {
           if (this.#isClosed) break;
           if (!gotPong) {
-            onError(Error('pong timeout'));
+            const err = Error('WebSocket pong timeout');
+            Object.defineProperty(err, 'code', {
+              value: 'WEBSOCKET_PONG_TIMEOUT',
+              enumerable: true,
+            });
+            onError(err);
             ws.terminate();
             break;
           }

--- a/services/ymax-planner/src/cosmos-rpc.ts
+++ b/services/ymax-planner/src/cosmos-rpc.ts
@@ -121,6 +121,11 @@ export class CosmosRPCClient extends JSONRPCClient {
     });
   }
 
+  async send(payload: any) {
+    if (this.#isClosed) throw Error('already closed');
+    return super.send(payload);
+  }
+
   receive(response: JSONRPCResponse) {
     // console.log('Received RPC response:', response);
     return super.receive(response);

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -774,6 +774,13 @@ export const startEngine = async (
   }
 
   // We expect to run forever, but the server can terminate our connection.
+  await null;
+  const closeEvent = await Promise.race([rpc.closed(), Promise.resolve()]);
+  if (closeEvent) {
+    const { code, reason, wasClean } = closeEvent;
+    const cleanly = q(wasClean ? 'cleanly' : 'not cleanly');
+    Fail`⚠️ rpc.subscribeAll finished (${cleanly}) with code ${q(code)}: ${q(reason)}`;
+  }
   Fail`⚠️ rpc.subscribeAll finished`;
 };
 harden(startEngine);

--- a/services/ymax-planner/src/entrypoint.ts
+++ b/services/ymax-planner/src/entrypoint.ts
@@ -41,6 +41,6 @@ import { main } from './main.ts';
 })()
   .then(() => process.exit())
   .catch(err => {
-    console.error('Error in main:', err);
+    console.error(err);
     process.exit(1);
   });

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -130,15 +130,10 @@ export const main = async (
     now,
     gasEstimator,
   };
-  try {
-    await startEngine(powers, {
-      contractInstance: config.contractInstance,
-      depositBrandName: env.DEPOSIT_BRAND_NAME || 'USDC',
-      feeBrandName: env.FEE_BRAND_NAME || 'BLD',
-    });
-  } catch (err) {
-    console.error(err);
-    throw err;
-  }
+  await startEngine(powers, {
+    contractInstance: config.contractInstance,
+    depositBrandName: env.DEPOSIT_BRAND_NAME || 'USDC',
+    feeBrandName: env.FEE_BRAND_NAME || 'BLD',
+  });
 };
 harden(main);


### PR DESCRIPTION
...rather than going through WebSocket instance events.

Ref #12128

## Description
Basically just replaces an inappropriate `ws.emit('error', Error('pong timeout'))` with `onError(Error('pong timeout')); ws.terminate()` and refactors code related to that. Also includes some minor cleanup to call `rejectAllPendingRequests` as needed and block `send`ing from an already-closed connection.

### Security Considerations
None known.

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Tested manually.

### Upgrade Considerations
Safe to deploy immediately.