### PR TITLE
fix(SwingSet): Tolerate absence of a kpid from maybeFreeKrefs

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1458,8 +1458,16 @@ export default function buildKernel(
       queueToKref(vatAdminRootKref, method, args, 'logFailure');
     }
 
-    kernelKeeper.processRefcounts();
     const crankNum = kernelKeeper.getCrankNumber();
+    const { lostObjects } = kernelKeeper.processRefcounts();
+    if (lostObjects.length) {
+      console.log(
+        `⚠️ Ignoring lost objects from crankNum ${crankNum}`,
+        lostObjects,
+        message,
+        crankResults,
+      );
+    }
     kernelKeeper.incrementCrankNumber();
     const { crankhash, activityhash } = kernelKeeper.emitCrankHashes();
     finish({


### PR DESCRIPTION
...on suspicion that its absence stems database rollback after a failed delivery

koid absence was already tolerated.

Fixes #12138

## Description
Rather than crash the kernel when `processRefcounts` encounters unknown krefs from `maybeFreeKrefs`, accumulate and log the information to the console and move on.

### Security Considerations
None known

### Scaling Considerations
n/a

### Documentation Considerations
TBD

### Testing Considerations
Verified manually; automated testing TBD.

### Upgrade Considerations
To be included in a minor bump of [agoric-upgrade-22a](https://github.com/Agoric/agoric-sdk/releases/tag/agoric-upgrade-22a). Also safe to hot patch outside of the formal upgrade process.