### PR TITLE
fix(SwingSet): Tolerate absence of a kpid from maybeFreeKrefs

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1458,8 +1458,16 @@ export default function buildKernel(
       queueToKref(vatAdminRootKref, method, args, 'logFailure');
     }
 
-    kernelKeeper.processRefcounts();
     const crankNum = kernelKeeper.getCrankNumber();
+    const { lostObjects } = kernelKeeper.processRefcounts();
+    if (lostObjects.length) {
+      console.log(
+        `⚠️ Ignoring lost objects from crankNum ${crankNum}`,
+        lostObjects,
+        message,
+        crankResults,
+      );
+    }
     kernelKeeper.incrementCrankNumber();
     const { crankhash, activityhash } = kernelKeeper.emitCrankHashes();
     finish({


### PR DESCRIPTION
...on suspicion that it absence stems database rollback after a failed delivery

koid absence was already tolerated.

refs: #12135

## Description
Alternative to #12135 for depot based CI