### PR TITLE
fix(SwingSet): Tolerate absence of a kpid from maybeFreeKrefs

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1475,8 +1475,16 @@ export default function buildKernel(
       queueToKref(vatAdminRootKref, method, args, 'logFailure');
     }
 
-    kernelKeeper.processRefcounts();
     const crankNum = kernelKeeper.getCrankNumber();
+    const { lostKrefs } = kernelKeeper.processRefcounts();
+    if (lostKrefs.length) {
+      console.log(
+        `⚠️ Ignoring lost krefs from crankNum ${crankNum}`,
+        lostKrefs,
+        message,
+        crankResults,
+      );
+    }
     kernelKeeper.incrementCrankNumber();
     const { crankhash, activityhash } = kernelKeeper.emitCrankHashes();
     finish({

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1194,6 +1194,8 @@ export default function buildKernel(
         // prettier-ignore
         return `changeVatOptions ${message.vatID} options: ${JSON.stringify(message.options)}`;
       case 'startVat':
+      case 'cleanup-terminated-vat':
+      case 'negated-gc-action':
       case 'bringOutYourDead':
         return `${message.type} ${message.vatID}`;
       default:

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1489,7 +1489,9 @@ export default function buildKernel(
 
     const crankNum = kernelKeeper.getCrankNumber();
     const { lostKrefs } = kernelKeeper.processRefcounts();
-    if (lostKrefs.length) {
+    // Lost krefs are expected for GC, but can also occur when a crank is rolled
+    // back.
+    if (lostKrefs.length && !isGCType(messageType)) {
       const vatID = crankResults.didDelivery;
       console.log(
         `⚠️ Ignoring lost krefs from crankNum ${crankNum} ${vatID} ${messageSummary}`,

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1379,15 +1379,15 @@ export default function buildKernel(
   async function processDeliveryMessage(message) {
     const messageType = message.type;
     const messageSummary = legibilizeMessage(message);
+    const crankNum = kernelKeeper.getCrankNumber();
 
     kdebug('');
-    // prettier-ignore
-    kdebug(`processQ crank ${kernelKeeper.getCrankNumber()} ${JSON.stringify(message)}`);
+    kdebug(`processQ crank ${crankNum} ${JSON.stringify(message)}`);
     kdebug(messageSummary);
 
     const finish = kernelSlog.startDuration(['crank-start', 'crank-finish'], {
       crankType: 'delivery',
-      crankNum: kernelKeeper.getCrankNumber(),
+      crankNum,
       messageType,
       message,
     });
@@ -1487,7 +1487,6 @@ export default function buildKernel(
       queueToKref(vatAdminRootKref, method, args, 'logFailure');
     }
 
-    const crankNum = kernelKeeper.getCrankNumber();
     const { lostKrefs } = kernelKeeper.processRefcounts();
     // Lost krefs are expected for GC, but can also occur when a crank is rolled
     // back.

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1369,10 +1369,13 @@ export default function buildKernel(
    */
   async function processDeliveryMessage(message) {
     const messageType = message.type;
+    const messageSummary = legibilizeMessage(message);
+
     kdebug('');
     // prettier-ignore
     kdebug(`processQ crank ${kernelKeeper.getCrankNumber()} ${JSON.stringify(message)}`);
-    kdebug(legibilizeMessage(message));
+    kdebug(messageSummary);
+
     const finish = kernelSlog.startDuration(['crank-start', 'crank-finish'], {
       crankType: 'delivery',
       crankNum: kernelKeeper.getCrankNumber(),
@@ -1478,8 +1481,9 @@ export default function buildKernel(
     const crankNum = kernelKeeper.getCrankNumber();
     const { lostKrefs } = kernelKeeper.processRefcounts();
     if (lostKrefs.length) {
+      const vatID = crankResults.didDelivery;
       console.log(
-        `⚠️ Ignoring lost krefs from crankNum ${crankNum}`,
+        `⚠️ Ignoring lost krefs from crankNum ${crankNum} ${vatID} ${messageSummary}`,
         lostKrefs,
         message,
         crankResults,

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1412,7 +1412,7 @@ export default function buildKernel(
 
     kernelKeeper.establishCrankSavepoint('deliver');
     const crankResults = await deliverRunQueueEvent(message);
-    // { abort/commit, deduct, terminate+notify, consumeMessage }
+    let didSnapshot = false;
 
     if (message.type === 'cleanup-terminated-vat') {
       const { cleanups } = crankResults;
@@ -1445,7 +1445,7 @@ export default function buildKernel(
     } else {
       const vatID = crankResults.didDelivery;
       if (vatID) {
-        await vatWarehouse.maybeSaveSnapshot(vatID);
+        didSnapshot = await vatWarehouse.maybeSaveSnapshot(vatID);
       }
     }
     const { computrons, meterID } = crankResults;
@@ -1493,7 +1493,7 @@ export default function buildKernel(
     if (lostKrefs.length && !isGCType(messageType)) {
       const vatID = crankResults.didDelivery;
       console.log(
-        `⚠️ Ignoring lost krefs from crankNum ${crankNum} ${vatID} ${messageSummary}`,
+        `⚠️ Ignoring lost krefs from crankNum ${crankNum} ${vatID} ${messageSummary}${didSnapshot ? ' + snapshot' : ''}`,
         lostKrefs,
         message,
         crankResults,

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -43,6 +43,23 @@ import { makeVatAdminHooks } from './vat-admin-hooks.js';
 /**
  * @import {MeterConsumption, VatDeliveryObject, VatDeliveryResult, VatSyscallObject, VatSyscallResult} from '@agoric/swingset-liveslots';
  * @import {PolicyInputCleanupCounts} from '../types-external.js';
+ * @import {
+ *   VatID,
+ *   InternalDynamicVatOptions,
+ *   RunQueueEvent,
+ *   RunQueueEventNotify,
+ *   RunQueueEventSend,
+ *   RunQueueEventCreateVat,
+ *   RunQueueEventUpgradeVat,
+ *   RunQueueEventChangeVatOptions,
+ *   RunQueueEventStartVat,
+ *   RunQueueEventDropExports,
+ *   RunQueueEventRetireExports,
+ *   RunQueueEventRetireImports,
+ *   RunQueueEventNegatedGCAction,
+ *   RunQueueEventBringOutYourDead,
+ *   RunQueueEventCleanupTerminatedVat,
+ * } from '../types-internal.js';
  */
 
 function abbreviateReplacer(_, arg) {
@@ -1265,25 +1282,6 @@ export default function buildKernel(
   }
 
   const gcMessages = ['dropExports', 'retireExports', 'retireImports'];
-
-  /**
-   * @typedef { import('../types-internal.js').VatID } VatID
-   * @typedef { import('../types-internal.js').InternalDynamicVatOptions } InternalDynamicVatOptions
-   *
-   * @typedef { import('../types-internal.js').RunQueueEventNotify } RunQueueEventNotify
-   * @typedef { import('../types-internal.js').RunQueueEventSend } RunQueueEventSend
-   * @typedef { import('../types-internal.js').RunQueueEventCreateVat } RunQueueEventCreateVat
-   * @typedef { import('../types-internal.js').RunQueueEventUpgradeVat } RunQueueEventUpgradeVat
-   * @typedef { import('../types-internal.js').RunQueueEventChangeVatOptions } RunQueueEventChangeVatOptions
-   * @typedef { import('../types-internal.js').RunQueueEventStartVat } RunQueueEventStartVat
-   * @typedef { import('../types-internal.js').RunQueueEventDropExports } RunQueueEventDropExports
-   * @typedef { import('../types-internal.js').RunQueueEventRetireExports } RunQueueEventRetireExports
-   * @typedef { import('../types-internal.js').RunQueueEventRetireImports } RunQueueEventRetireImports
-   * @typedef { import('../types-internal.js').RunQueueEventNegatedGCAction } RunQueueEventNegatedGCAction
-   * @typedef { import('../types-internal.js').RunQueueEventBringOutYourDead } RunQueueEventBringOutYourDead
-   * @typedef { import('../types-internal.js').RunQueueEventCleanupTerminatedVat } RunQueueEventCleanupTerminatedVat
-   * @typedef { import('../types-internal.js').RunQueueEvent } RunQueueEvent
-   */
 
   /**
    *

--- a/packages/SwingSet/src/kernel/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vat-warehouse.js
@@ -570,6 +570,7 @@ export function makeVatWarehouse({
    *
    * @param {VatID} vatID
    * @param {number} [minDeliveryCount]
+   * @returns {Promise<boolean>} whether a snapshot was saved
    */
   async function maybeSaveSnapshot(vatID, minDeliveryCount = snapshotInterval) {
     kernelKeeper.vatIsAlive(vatID) || Fail`${q(vatID)}: not alive`;

--- a/packages/SwingSet/test/gc-actions.test.js
+++ b/packages/SwingSet/test/gc-actions.test.js
@@ -27,7 +27,7 @@ test('gc actions', t => {
     },
     getObjectRefCount(kref) {
       const [reachable, recognizable] = rc[kref];
-      return { reachable, recognizable };
+      return { exists: true, reachable, recognizable };
     },
     // @ts-expect-error mock
     emitCrankHashes() {},

--- a/packages/SwingSet/test/upgrade/upgrade.test.js
+++ b/packages/SwingSet/test/upgrade/upgrade.test.js
@@ -828,7 +828,7 @@ test('failed upgrade - explode', async t => {
   // vat? only the console?
 });
 
-test.failing('failed upgrade - lost promise export', async t => {
+test('failed upgrade - lost promise export', async t => {
   const config = makeConfigFromPaths('../../tools/bootstrap-relay.js', {
     defaultManagerType: 'xs-worker',
     defaultReapInterval: 'never',

--- a/packages/SwingSet/tools/vat-puppet.js
+++ b/packages/SwingSet/tools/vat-puppet.js
@@ -140,7 +140,15 @@ export const makeReflectionMethods = (vatPowers, baggage, vatParameters) => {
 };
 harden(makeReflectionMethods);
 
-export function buildRootObject(vatPowers, vatParameters, baggage) {
+export async function buildRootObject(vatPowers, vatParameters, baggage) {
   const methods = makeReflectionMethods(vatPowers, baggage, vatParameters);
-  return Far('root', methods);
+  const rootObject = Far('root', methods);
+
+  const { initialCalls = [] } = vatParameters || {};
+  await null;
+  for (const [methodName, ...args] of initialCalls) {
+    await rootObject[methodName](...args);
+  }
+
+  return rootObject;
 }

--- a/packages/SwingSet/tools/vat-puppet.js
+++ b/packages/SwingSet/tools/vat-puppet.js
@@ -147,17 +147,18 @@ export const makeReflectionMethods = (vatPowers, baggage, vatParameters) => {
     },
 
     /**
-     * Returns a remotable with methods that return provided values. Invocations
-     * of those methods and their arguments are captured for later retrieval by
-     * `getCallLogForRemotable`.
+     * Return a remotable with a method for each property of an optional object
+     * that returns the corresponding property value. Invocations of those
+     * methods and their arguments are captured for later retrieval by
+     * `getLogForRemotable`.
      *
      * @param {string} [label]
-     * @param {Record<string, any>} [fields]
+     * @param {Record<string, any>} [methodReturnValues]
      */
-    makeRemotable: (label = 'Remotable', fields = {}) => {
+    makeRemotable: (label = 'Remotable', methodReturnValues = {}) => {
       /** @type {CallLog} */
       const callLog = [];
-      const methods = objectMap(fields, (value, name) =>
+      const methods = objectMap(methodReturnValues, (value, name) =>
         makeSpy(value, name, callLog),
       );
       const remotable = Far(label, { ...methods });
@@ -166,12 +167,18 @@ export const makeReflectionMethods = (vatPowers, baggage, vatParameters) => {
     },
 
     /**
+     * Return a copy of a remotable's call log.
+     *
      * @param {object} remotable
      * @returns {CallLog}
      */
-    getCallLogForRemotable: remotable =>
-      callLogsByRemotable.get(remotable) ||
-      Fail`unknown remotable ${q(remotable)}`,
+    getLogForRemotable: remotable => {
+      const callLog =
+        callLogsByRemotable.get(remotable) ||
+        Fail`unknown remotable ${q(remotable)}`;
+      // Return an immutable copy of the mutable original.
+      return harden([...callLog]);
+    },
 
     throw: message => {
       throw Error(message);


### PR DESCRIPTION
 ...on suspicion that its absence stems from database rollback after a failed delivery

koid absence was already tolerated.

Ref #12135
Fixes #12138

## Description
Rather than crash the kernel when `processRefcounts` encounters unknown krefs from `maybeFreeKrefs`, accumulate the krefs and log them to the console (except for GC messages like bringOutYourDead) and move on.

### Security Considerations
None known.

### Scaling Considerations
n/a

### Documentation Considerations
Covered by inline comments.

### Testing Considerations
Added unit test coverage.

### Upgrade Considerations
Similar changes are already on mainnet via #12135, and no further considerations apply here.