### PR TITLE
chore: add beefy implementation to getCurrentBalance

### DIFF
--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -146,10 +146,6 @@ export const BeefyPoolPlaces = {
     protocol: 'Beefy',
     chainName: 'Ethereum',
   },
-  Beefy_morphoSeamlessUsdc_Base: {
-    protocol: 'Beefy',
-    chainName: 'Base',
-  },
   Beefy_compoundUsdc_Optimism: {
     protocol: 'Beefy',
     chainName: 'Optimism',
@@ -157,6 +153,10 @@ export const BeefyPoolPlaces = {
   Beefy_compoundUsdc_Arbitrum: {
     protocol: 'Beefy',
     chainName: 'Arbitrum',
+  },
+  Beefy_morphoSeamlessUsdc_Base: {
+    protocol: 'Beefy',
+    chainName: 'Base',
   },
 } as const satisfies Partial<Record<InstrumentId, PoolPlaceInfo>>;
 

--- a/services/ymax-planner/src/beefy-balance-client.ts
+++ b/services/ymax-planner/src/beefy-balance-client.ts
@@ -1,0 +1,190 @@
+/* eslint-disable max-classes-per-file */
+import { Contract, type WebSocketProvider } from 'ethers';
+import { BeefyPoolPlaces } from '@aglocal/portfolio-contract/src/type-guards.js';
+import {
+  axelarConfig,
+  axelarConfigTestnet,
+} from '@aglocal/portfolio-deploy/src/axelar-configs.js';
+import { Fail, q } from '@endo/errors';
+import type { EvmProviders } from './support.js';
+import type { ClusterName } from './config.js';
+
+type CaipChainId = `eip155:${number}`;
+type HexAddress = `0x${string}`;
+type PoolKey = keyof typeof BeefyPoolPlaces;
+type AccountId = `${string}:${string}:${string}`;
+
+/**
+ * Minimal ABI for BeefyVaultV7 contract
+ * @see https://github.com/beefyfinance/beefy-contracts/blob/master/contracts/BIFI/vaults/BeefyVaultV7.sol
+ */
+const BEEFY_VAULT_ABI = [
+  // Get user's vault share balance (mooToken balance)
+  'function balanceOf(address account) external view returns (uint256)',
+  // Get the current price per full share (18 decimals)
+  'function getPricePerFullShare() external view returns (uint256)',
+  // Alternative: some vaults use balance() for total underlying
+  'function balance() external view returns (uint256)',
+  // Total supply of vault shares
+  'function totalSupply() external view returns (uint256)',
+];
+
+interface BeefyBalanceClientPowers {
+  evmProviders: EvmProviders;
+  clusterName: ClusterName;
+  log?: (...args: unknown[]) => void;
+}
+
+export class BeefyBalanceClient {
+  private readonly evmProviders: EvmProviders;
+
+  private readonly clusterName: ClusterName;
+
+  private readonly log: (...args: unknown[]) => void;
+
+  constructor(powers: BeefyBalanceClientPowers) {
+    this.evmProviders = powers.evmProviders;
+    this.clusterName = powers.clusterName;
+    this.log = powers.log ?? (() => {});
+  }
+
+  /**
+   * Parse account ID to extract CAIP chain ID and address
+   * AccountId format: namespace:reference:address (e.g., "eip155:1:0xabc...")
+   */
+  private static parseAccountId(accountId: AccountId): {
+    caipChainId: CaipChainId;
+    address: HexAddress;
+  } {
+    const parts = accountId.split(':');
+    if (parts.length !== 3) {
+      throw Fail`Invalid account ID format: ${q(accountId)}`;
+    }
+    const [namespace, reference, address] = parts;
+    if (namespace !== 'eip155') {
+      throw Fail`Expected eip155 namespace, got ${q(namespace)}`;
+    }
+    return {
+      caipChainId: `${namespace}:${reference}` as CaipChainId,
+      address: address as HexAddress,
+    };
+  }
+
+  /**
+   * Get the WebSocket provider for a given CAIP chain ID
+   */
+  private getProvider(caipChainId: CaipChainId): WebSocketProvider {
+    const provider = this.evmProviders[caipChainId];
+    provider || Fail`No provider available for chain ${q(caipChainId)}`;
+    return provider;
+  }
+
+  /**
+   * Get vault address for a given chain and pool key
+   */
+  private getVaultAddress(chainName: string): HexAddress {
+    const poolKey = Object.keys(BeefyPoolPlaces).find(key => {
+      const place = BeefyPoolPlaces[key as PoolKey];
+      return place.chainName === chainName;
+    }) as PoolKey | undefined;
+
+    if (!poolKey) {
+      throw Fail`No Beefy pool found for chain ${q(chainName)}`;
+    }
+
+    const config =
+      this.clusterName === 'mainnet' ? axelarConfig : axelarConfigTestnet;
+
+    const chainContracts = config[chainName];
+    if (!chainContracts) {
+      throw Fail`No contracts configured for chain ${q(chainName)}`;
+    }
+
+    const vaultAddress = chainContracts.contracts[poolKey];
+    if (!vaultAddress) {
+      throw Fail`No vault address configured for pool ${q(poolKey)} on chain ${q(chainName)}`;
+    }
+
+    return vaultAddress as HexAddress;
+  }
+
+  /**
+   * Get the underlying USDC balance for a user in a Beefy vault
+   *
+   * @param chainName - The chain name (e.g., 'Ethereum', 'Avalanche')
+   * @param accountId - The user's account ID in CAIP format (e.g., 'eip155:1:0xabc...')
+   * @returns The underlying USDC balance in the smallest unit (e.g., USDC has 6 decimals)
+   */
+  async getVaultBalance(
+    chainName: string,
+    accountId: AccountId,
+  ): Promise<bigint> {
+    await null;
+    try {
+      const { caipChainId, address } = BeefyBalanceClient.parseAccountId(accountId);
+
+      const provider = this.getProvider(caipChainId);
+      const vaultAddress = this.getVaultAddress(chainName);
+
+      const vault = new Contract(vaultAddress, BEEFY_VAULT_ABI, provider);
+
+      const shareBalanceRaw = await vault.balanceOf(address);
+      const shareBalance = BigInt(shareBalanceRaw.toString());
+
+      // If user has no shares, return 0
+      if (shareBalance === 0n) {
+        return 0n;
+      }
+
+      // Get price per full share to convert shares to underlying USDC
+      const pricePerShareRaw = await vault.getPricePerFullShare();
+      const pricePerShare = BigInt(pricePerShareRaw.toString());
+
+      // Calculate underlying balance
+      // pricePerShare has 18 decimals, so we need to divide by 1e18
+      const underlyingBalance = (shareBalance * pricePerShare) / 10n**18n;
+
+      // Validate the result is a safe integer
+      Number.isSafeInteger(Number(underlyingBalance)) ||
+        Fail`Invalid balance for chain ${q(chainName)} vault ${vaultAddress} address ${address}: ${underlyingBalance}`;
+
+      return underlyingBalance;
+    } catch (err) {
+      const error = err as Error;
+      throw new BeefyBalanceError(
+        `Failed to fetch Beefy vault balance for ${accountId} on ${chainName}: ${error.message}`,
+        {
+          chainName,
+          accountId,
+          cause: error,
+        },
+      );
+    }
+  }
+
+}
+
+class BeefyBalanceError extends Error {
+  public readonly chainName: string;
+
+  public readonly accountId: AccountId;
+
+  public readonly cause?: Error;
+
+  constructor(
+    message: string,
+    details: {
+      chainName: string;
+      accountId: AccountId;
+      cause?: Error;
+    },
+  ) {
+    const { chainName, accountId, cause } = details;
+    super(message, { cause });
+    this.name = 'BeefyBalanceError';
+    this.chainName = chainName;
+    this.accountId = accountId;
+  }
+}
+
+harden(BeefyBalanceClient);

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -56,6 +56,7 @@ import {
   planWithdrawFromAllocations,
 } from './plan-deposit.ts';
 import type { SpectrumClient } from './spectrum-client.ts';
+import { BeefyBalanceClient } from './beefy-balance-client.js';
 import {
   handlePendingTx,
   type EvmContext,
@@ -164,6 +165,7 @@ type Powers = {
   rpc: CosmosRPCClient;
   spectrum: SpectrumClient;
   cosmosRest: CosmosRestClient;
+  beefyBalance: BeefyBalanceClient;
   signingSmartWalletKit: SigningSmartWalletKit;
   walletStore: ReturnType<typeof reflectWalletStore>;
   getWalletInvocationUpdate: (
@@ -190,6 +192,7 @@ type ProcessPortfolioPowers = Pick<
     portfoliosPathPrefix: string;
     pendingTxPathPrefix: string;
   };
+  beefyBalance: BeefyBalanceClient;
 };
 
 const processPortfolioEvents = async (
@@ -206,6 +209,7 @@ const processPortfolioEvents = async (
     getWalletInvocationUpdate,
     spectrum,
     vstoragePathPrefixes,
+    beefyBalance,
 
     portfolioKeyForDepositAddr,
   }: ProcessPortfolioPowers,
@@ -234,7 +238,7 @@ const processPortfolioEvents = async (
     const currentBalances = await getCurrentBalances(
       portfolioStatus,
       depositBrand,
-      { cosmosRest, spectrum },
+      { cosmosRest, spectrum, beefyBalance },
     );
     const errorContext: Record<string, unknown> = {
       flowDetail,
@@ -497,6 +501,7 @@ export const startEngine = async (
     getWalletInvocationUpdate,
     now,
     gasEstimator,
+    beefyBalance,
   }: Powers,
   {
     contractInstance,
@@ -515,7 +520,7 @@ export const startEngine = async (
 
   // Test balance querying (using dummy addresses for now).
   {
-    const balanceQueryPowers = { spectrum, cosmosRest };
+    const balanceQueryPowers = { spectrum, cosmosRest, beefyBalance };
     const poolPlaceInfoByProtocol = new Map(
       values(PoolPlaces).map(info => [info.protocol, info]),
     );
@@ -621,6 +626,7 @@ export const startEngine = async (
     getWalletInvocationUpdate,
     spectrum,
     vstoragePathPrefixes,
+    beefyBalance,
 
     portfolioKeyForDepositAddr,
   });

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -21,6 +21,7 @@ import { CosmosRPCClient } from './cosmos-rpc.ts';
 import { startEngine } from './engine.ts';
 import { createEVMContext, verifyEvmChains } from './support.ts';
 import { SpectrumClient } from './spectrum-client.ts';
+import { BeefyBalanceClient } from './beefy-balance-client.js';
 import { makeGasEstimator } from './gas-estimation.ts';
 
 const assertChainId = async (
@@ -109,6 +110,12 @@ export const main = async (
   console.warn('Verifying EVM chain connectivity...');
   await verifyEvmChains(evmCtx.evmProviders);
 
+  const beefyBalance = new BeefyBalanceClient({
+    evmProviders: evmCtx.evmProviders,
+    clusterName,
+    log: (...args) => console.log(...args),
+  });
+
   const gasEstimator = makeGasEstimator({
     axelarApiAddress: config.axelar.apiUrl,
     axelarChainIdMap: config.axelar.chainIdMap,
@@ -120,6 +127,7 @@ export const main = async (
     rpc,
     spectrum,
     cosmosRest,
+    beefyBalance,
     signingSmartWalletKit,
     walletStore,
     getWalletInvocationUpdate: (messageId, opts) => {


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-private/issues/461

## Description
Adds an implementation of beefy to `getCurrentBalance` so we can now perform a withdraw operation on beefy.

Something that should be kept into consideration is that while this does work to generate steps, this might not be accurate.
Beefy returns certain mooTokens when an account deposits USDC into a vault. these mooTokens do not necessarily have a 1:1 exchange rate with USDC and will vary depending on how well the vault is performing.
In order to perform a withdraw, the planner must be aware of the exchange rate between the the two tokens, in order to assess how many mooTokens we need to exchange in order to withdraw a certain amount of USDC

### Testing Considerations
Testing is limited by the fact that there are no beefy vaults on testnet.
This PR was tested by running the planner on a local machine with `CLUSTER=mainnet` and checking if the planner attempted to create steps for a portfolio that requested a beefy withdrawal

Planner logs: (failure because this mnemonic i used doesnt have a planner invitation)
```
Resolving published.ymax0.portfolios.portfolio3 in-progress flow flow2 {
  amount: {
    brand: Object [Alleged: BoardRemoteUSDC brand] {
      getBoardId: [Function: getBoardId]
    },
    value: 1500000n
  },
  type: 'withdraw'
} {
  Beefy_re7_Avalanche: {
    brand: Object [Alleged: BoardRemoteUSDC brand] {
      getBoardId: [Function: getBoardId]
    },
    value: 2456301n
  }
} {
  portfolioId: 3,
  flowId: 2,
  steps: [
    {
      src: 'Beefy_re7_Avalanche',
      dest: '@Avalanche',
      amount: [Object],
      fee: [Object]
    },
    {
      src: '@Avalanche',
      dest: '@agoric',
      amount: [Object],
      fee: [Object]
    },
    { src: '@agoric', dest: '<Cash>', amount: [Object] }
  ],
  policyVersion: 1,
  rebalanceCount: 1
} {
  code: 0,
  height: 22210766,
  txIndex: 0,
  events: [
    { type: 'coin_spent', attributes: [Array] },
    { type: 'coin_received', attributes: [Array] },
    { type: 'transfer', attributes: [Array] },
    { type: 'message', attributes: [Array] },
    { type: 'tx', attributes: [Array] },
    { type: 'tx', attributes: [Array] },
    { type: 'tx', attributes: [Array] },
    { type: 'coin_spent', attributes: [Array] },
    { type: 'coin_received', attributes: [Array] },
    { type: 'transfer', attributes: [Array] },
    { type: 'message', attributes: [Array] },
    { type: 'message', attributes: [Array] }
  ],
  rawLog: '',
  transactionHash: 'EB1CB938417C30909B932DB715C69E9B079BA9F9827C6445716A80DA7FD3C65A',
  msgResponses: [
    {
      typeUrl: '/agoric.swingset.MsgWalletSpendActionResponse',
      value: Uint8Array(0) []
    }
  ],
  gasUsed: 173342n,
  gasWanted: 19700000n
}
⚠️ Failure for published.ymax0.portfolios.portfolio3 in-progress flow flow2 resolvePlan { policyVersion: 1, rebalanceCount: 1 } [
  {
    src: 'Beefy_re7_Avalanche',
    dest: '@Avalanche',
    amount: {
      brand: [Object [Alleged: BoardRemoteUSDC brand]],
      value: 1500000n
    },
    fee: {
      brand: [Object [Alleged: BoardRemoteBLD brand]],
      value: 8283823n
    }
  },
  {
    src: '@Avalanche',
    dest: '@agoric',
    amount: {
      brand: [Object [Alleged: BoardRemoteUSDC brand]],
      value: 1500000n
    },
    fee: {
      brand: [Object [Alleged: BoardRemoteBLD brand]],
      value: 7916437n
    }
  },
  {
    src: '@agoric',
    dest: '<Cash>',
    amount: {
      brand: [Object [Alleged: BoardRemoteUSDC brand]],
      value: 1500000n
    }
  }
] (Error#1)
Error#1: resolvePlan.2025-10-24T14:43:47.936Z condition failed after 6 retries.
  at retryUntilCondition (packages/client-utils/dist/sync-tools.js:107:11)
  at async getInvocationUpdate (packages/client-utils/dist/smart-wallet-kit.js:35:76)
```
