### PR TITLE
chore: update planner to not timeout pending txs

### DIFF
--- a/services/ymax-planner/src/watchers/cctp-watcher.ts
+++ b/services/ymax-planner/src/watchers/cctp-watcher.ts
@@ -137,7 +137,6 @@ export const watchCctpTransfer = ({
     timeoutId = setTimeout(() => {
       if (!transferFound) {
         log(`✗ No matching transfer found within ${timeoutMs / 60000} minutes`);
-        finish(false);
       }
     }, timeoutMs);
   });

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -110,7 +110,6 @@ export const watchGmp = ({
         log(
           `✗ No MulticallStatus or MulticallExecuted found for txId ${txId} within ${timeoutMs / 60000} minutes`,
         );
-        finish(false);
       }
     }, timeoutMs);
   });


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-private/issues/483

## Description
when waiting for the completion of a gmp/cctp tx, the gmp/cctp watcher does not kill itself after a timeout, instead it keeps continuing

### Documentation Considerations
we need an alert in slack channels when the following log is detected: 
```
[txXX] ✗ No matching transfer found within XXX minutes
```
follow up task: https://github.com/Agoric/agoric-private/issues/485

### Testing Considerations
update tested on devent. even after the timeout was hit, the resolver was able to detect a tx (note: timeoutMs was reduced during testing):
```
[tx4] Watching for ERC-20 transfers to: 0x4162c8872587c9f3E9211628f02e96b56cFBd6e1 with amount: 1000000
{ portfolioEvents: [], pendingTxEvents: [] }
[tx4] ✗ No matching transfer found within 0.16666666666666666 minutes
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
{ portfolioEvents: [], pendingTxEvents: [] }
[tx4] Transfer detected: token=0x5425890298aed601595a70AB815c96711a31Bc65 from=0x2b8654b7B03cf2c38fcBf436b665e8e6Dff87a18 to=0x4162c8872587c9f3E9211628f02e96b56cFBd6e1 amount=1000000 tx=0x01b405e39bf0a01e86ce947fe874710ca7ce5c6b0f2c7b8b0b98e50428b111d5
[tx4] ✓ Amount matches! Expected: 1000000, Received: 1000000
```
