### PR TITLE
misc portfolio contract & api

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,5 @@
 SECURITY.md @Agoric/security
-* @Agoric/engprodexec
+
+# Disabled until we need it again (https://agoricopco.slack.com/archives/C038E5369FT/p1761730824478649?thread_ts=1761687795.856629&cid=C038E5369FT)
+
+# * @Agoric/engprodexec

--- a/packages/portfolio-api/src/main.js
+++ b/packages/portfolio-api/src/main.js
@@ -1,4 +1,6 @@
 export * from './constants.js';
 export * from './instruments.js';
 export * from './resolver.js';
-export * from './types.js';
+
+// eslint-disable-next-line import/export -- just types
+export * from './types-index.js';

--- a/packages/portfolio-api/src/types.ts
+++ b/packages/portfolio-api/src/types.ts
@@ -1,9 +1,14 @@
+/* eslint-disable @typescript-eslint/no-unused-vars -- doesn't see type usage in JSDoc */
 import type { NatAmount } from '@agoric/ertp';
 import {
   type AccountId,
   type Bech32Address,
   type CosmosChainAddress,
 } from '@agoric/orchestration';
+import type {
+  ContinuingInvitationSpec,
+  ContractInvitationSpec,
+} from '@agoric/smart-wallet/src/invitations.js';
 import type { SupportedChain, YieldProtocol } from './constants.js';
 import type { InstrumentId } from './instruments.js';
 import type { PublishedTx } from './resolver.js';
@@ -108,3 +113,20 @@ export type StatusFor = {
   flow: FlowStatus;
   flowSteps: FlowStep[];
 };
+
+/**
+ * Names suitable for use as `publicInvitationMaker` in {@link ContractInvitationSpec}.
+ */
+export type PortfolioPublicInvitationMaker = 'makeOpenPortfolioInvitation';
+
+/**
+ * Names suitable for use as `invitationMakerName` in {@link ContinuingInvitationSpec}.
+ *
+ * These continuing invitation makers are returned from portfolio creation and enable
+ * ongoing operations like rebalancing between yield protocols.
+ */
+export type PortfolioContinuingInvitationMaker =
+  | 'Deposit'
+  | 'Withdraw'
+  | 'Rebalance'
+  | 'SimpleRebalance';

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -365,12 +365,15 @@ export const contract = async (
   /**
    * Generate sequential portfolio IDs while keeping the portfolios collection private.
    * Each portfolio kit only gets access to its own state, not the full collection.
+   *
+   * NB: this assumes portfolios are never deleted; if deletion is added,
+   * a more robust ID generation strategy will be needed.
    */
   const makeNextPortfolioKit = () => {
     const portfolioId = portfolios.getSize();
-    const it = makePortfolioKit({ portfolioId });
-    portfolios.init(portfolioId, it);
-    return it;
+    const kit = makePortfolioKit({ portfolioId });
+    portfolios.init(portfolioId, kit);
+    return kit;
   };
 
   // Create openPortfolio flow with makePortfolioKit - circular dependency avoided
@@ -378,6 +381,7 @@ export const contract = async (
     { openPortfolio: flows.openPortfolio },
     {
       ...ctx1,
+      // Older name maintained for upgrade compatibility
       makePortfolioKit: makeNextPortfolioKit as any, // XXX Guest...
       inertSubscriber,
     },

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -47,6 +47,7 @@ import { makeMarshal } from '@endo/marshal';
 import type { CopyRecord } from '@endo/pass-style';
 import { M } from '@endo/patterns';
 import type { PublicSubscribers } from '@agoric/smart-wallet/src/types.ts';
+import type { PortfolioPublicInvitationMaker } from '@agoric/portfolio-api';
 import { preparePlanner } from './planner.exo.ts';
 import { preparePortfolioKit, type PortfolioKit } from './portfolio.exo.ts';
 import * as flows from './portfolio.flows.ts';
@@ -452,7 +453,7 @@ export const contract = async (
         proposalShapes.openPortfolio,
       );
     },
-  });
+  } satisfies Record<PortfolioPublicInvitationMaker, any> & ThisType<any>);
 
   const makeResolverInvitation = () => {
     trace('makeResolverInvitation');

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -25,6 +25,7 @@ import type { Zone } from '@agoric/zone';
 import { Fail, X } from '@endo/errors';
 import { E } from '@endo/far';
 import { M } from '@endo/patterns';
+import type { PortfolioContinuingInvitationMaker } from '@agoric/portfolio-api';
 import { generateNobleForwardingAddress } from './noble-fwd-calc.js';
 import { type LocalAccount, type NobleAccount } from './portfolio.flows.js';
 import { preparePosition, type Position } from './pos.exo.js';
@@ -617,7 +618,8 @@ export const preparePortfolioKit = (
             proposalShapes.rebalance,
           );
         },
-      },
+      } satisfies Record<PortfolioContinuingInvitationMaker, any> &
+        ThisType<any>,
     },
     {
       stateShape: PortfolioStateShape,

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -1022,6 +1022,8 @@ export const openPortfolio = (async (
     const traceP = trace.sub(`portfolio${id}`);
     traceP('portfolio opened');
 
+    // TODO provide a way to recover if any of these provisionings fail
+    // SEE https://github.com/Agoric/agoric-private/issues/488
     // Register Noble Forwarding Account (NFA) for CCTP transfers
     {
       const sender = await ctxI.contractAccount;

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -45,7 +45,7 @@ import type {
 import { Fail } from '@endo/errors';
 import { isNat } from '@endo/nat';
 import { M } from '@endo/patterns';
-import type { EVMContractAddresses, start } from './portfolio.contract.js';
+import type { EVMContractAddresses } from './portfolio.contract.js';
 
 export type { OfferArgsFor } from './type-guards-steps.js';
 
@@ -61,27 +61,6 @@ const AnyString = <_T>() => M.string();
 export const makeNatAmountShape = (brand: Brand<'nat'>, min?: NatValue) =>
   harden({ brand, value: min ? M.gte(min) : M.nat() });
 // #endregion
-
-/**
- * Names suitable for use as `publicInvitationMaker` in {@link ContractInvitationSpec}.
- *
- * @see {@link start} for the contract implementation
- * @see {@link makeTrader.openPortfolio} for usage example
- */
-export type PortfolioPublicFacet = Awaited<
-  ReturnType<typeof start>
->['publicFacet'];
-export type { PortfolioPublicInvitationMaker as PortfolioInvitationMaker } from '@agoric/portfolio-api';
-
-/**
- * Names suitable for use as `invitationMakerName` in {@link ContinuingInvitationSpec}.
- *
- * These continuing invitation makers are returned from portfolio creation and enable
- * ongoing operations like rebalancing between yield protocols.
- *
- * @see {@link makeTrader.rebalance} for usage example
- */
-export type { PortfolioContinuingInvitationMaker } from '@agoric/portfolio-api';
 
 // #region Proposal Shapes
 

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -46,7 +46,6 @@ import { Fail } from '@endo/errors';
 import { isNat } from '@endo/nat';
 import { M } from '@endo/patterns';
 import type { EVMContractAddresses, start } from './portfolio.contract.js';
-import type { PortfolioKit } from './portfolio.exo.js';
 
 export type { OfferArgsFor } from './type-guards-steps.js';
 
@@ -72,7 +71,7 @@ export const makeNatAmountShape = (brand: Brand<'nat'>, min?: NatValue) =>
 export type PortfolioPublicFacet = Awaited<
   ReturnType<typeof start>
 >['publicFacet'];
-export type PortfolioInvitationMaker = keyof PortfolioPublicFacet;
+export type { PortfolioPublicInvitationMaker as PortfolioInvitationMaker } from '@agoric/portfolio-api';
 
 /**
  * Names suitable for use as `invitationMakerName` in {@link ContinuingInvitationSpec}.
@@ -82,8 +81,7 @@ export type PortfolioInvitationMaker = keyof PortfolioPublicFacet;
  *
  * @see {@link makeTrader.rebalance} for usage example
  */
-export type PortfolioContinuingInvitationMaker =
-  keyof PortfolioKit['invitationMakers'];
+export type { PortfolioContinuingInvitationMaker } from '@agoric/portfolio-api';
 
 // #region Proposal Shapes
 

--- a/packages/portfolio-contract/tools/portfolio-actors.ts
+++ b/packages/portfolio-contract/tools/portfolio-actors.ts
@@ -21,13 +21,15 @@ import {
   makePositionPath,
   portfolioIdOfPath,
   type OfferArgsFor,
-  type PortfolioContinuingInvitationMaker,
-  type PortfolioInvitationMaker,
   type ProposalType,
   type StatusFor,
   type PoolKey,
 } from '@aglocal/portfolio-contract/src/type-guards.js';
 import type { WalletTool } from '@aglocal/portfolio-contract/tools/wallet-offer-tools.js';
+import type {
+  PortfolioPublicInvitationMaker,
+  PortfolioContinuingInvitationMaker,
+} from '@agoric/portfolio-api';
 
 const { fromEntries } = Object;
 
@@ -108,7 +110,7 @@ export const makeTrader = (
       if (portfolioPath !== undefined) throw Error('already opened');
       if (openId) throw Error('already opening');
 
-      const publicInvitationMaker: PortfolioInvitationMaker =
+      const publicInvitationMaker: PortfolioPublicInvitationMaker =
         'makeOpenPortfolioInvitation';
 
       const invitationSpec = {


### PR DESCRIPTION
refs: #12168 

## Description
A couple commits that didn't get pushed to #12168 before merge. Also some other small fixups I've wanted to land.

- **fix: bad .ts export in portfolio-api**
- **docs: NFA failure recovery**
- **ci: disable EngProdExec auto-review**
- **feat: invitation maker names in portfolio-api**
- **refactor(types): import maker names from portfolio-api**

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
CI

### Upgrade Considerations
none