### PR TITLE
docs(portfolio-contract): OfferArgsFor['flow']

### DIFF
--- a/packages/portfolio-contract/src/type-guards-steps.ts
+++ b/packages/portfolio-contract/src/type-guards-steps.ts
@@ -61,9 +61,22 @@ export const getKeywordOfPlaceRef = (
 };
 
 export type OfferArgsFor = {
-  deposit: { flow?: MovementDesc[] };
-  openPortfolio: { flow?: MovementDesc[]; targetAllocation?: TargetAllocation };
-  rebalance: { flow?: MovementDesc[]; targetAllocation?: TargetAllocation };
+  deposit: {
+    /** default to waiting for flow steps from planner */
+    flow?: MovementDesc[];
+  };
+  openPortfolio: {
+    /** default to waiting for flow steps from planner */
+    flow?: MovementDesc[];
+    /** initial target allocation */
+    targetAllocation?: TargetAllocation;
+  };
+  rebalance: {
+    /** default to waiting for flow steps from planner */
+    flow?: MovementDesc[];
+    /** change or re-state target allocation. */
+    targetAllocation?: TargetAllocation;
+  };
 };
 
 export const makeOfferArgsShapes = (usdcBrand: Brand<'nat'>) => {


### PR DESCRIPTION
refs:
 - https://github.com/Agoric/agoric-private/issues/506
 - #12114
 - #12091

## Description / Documentation Considerations

clarify `flow` property in `offerArgs`

Design docs on the overall "single flow" change are also in progress:

 - https://github.com/Agoric/agoric-sdk/pull/12091

### Security / Scaling Considerations

n/a

### Testing Considerations / Upgrade Considerations

The changes around #12114 could have tested the actual offer specs that the UI submits to discover that it was, in a sense, a breaking change.