### PR TITLE
invoke ymax resolver

### DIFF
--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -550,6 +550,7 @@ const main = async (
       await walletKit.readPublished('agoricNames.instance'),
     );
     await cf.deliverResolverInvitation(resolver, postalService);
+    await cf.deliverResolverServiceInvitation(resolver, postalService);
     return;
   }
 

--- a/packages/client-utils/src/signing-smart-wallet-kit.ts
+++ b/packages/client-utils/src/signing-smart-wallet-kit.ts
@@ -294,3 +294,5 @@ export const reflectWalletStore = (
     saveOfferResult,
   });
 };
+
+export type WalletStore = ReturnType<typeof reflectWalletStore>;

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -481,11 +481,22 @@ export const contract = async (
       return makePlanner();
     }, 'planner');
 
+  const makeResolverServiceInvitation = () =>
+    zcf.makeInvitation(seat => {
+      seat.exit();
+      return resolverService;
+    }, 'resolver service');
+
   const creatorFacet = zone.exo(
     'PortfolioAdmin',
     M.interface('PortfolioAdmin', {
       makeResolverInvitation: M.callWhen().returns(InvitationShape),
+      getResolverService: M.call().returns(M.remotable()),
       deliverResolverInvitation: M.callWhen(
+        M.string(),
+        M.remotable('Instance'),
+      ).returns(),
+      deliverResolverServiceInvitation: M.callWhen(
         M.string(),
         M.remotable('Instance'),
       ).returns(),
@@ -502,6 +513,9 @@ export const contract = async (
       makeResolverInvitation() {
         return makeResolverInvitation();
       },
+      getResolverService() {
+        return resolverService;
+      },
       async deliverResolverInvitation(
         address: string,
         instancePS: Instance<() => { publicFacet: PostalServiceI }>,
@@ -512,6 +526,17 @@ export const contract = async (
         trace('made resolver invitation', invitation);
         await E(pfP).deliverPayment(address, invitation);
         trace('delivered resolver invitation');
+      },
+      async deliverResolverServiceInvitation(
+        address: string,
+        instancePS: Instance<() => { publicFacet: PostalServiceI }>,
+      ) {
+        const zoe = zcf.getZoeService();
+        const pfP = E(zoe).getPublicFacet(instancePS);
+        const invitation = await makeResolverServiceInvitation();
+        trace('made resolver service invitation', invitation);
+        await E(pfP).deliverPayment(address, invitation);
+        trace('delivered resolver service invitation');
       },
       makePlannerInvitation() {
         return makePlannerInvitation();

--- a/packages/portfolio-contract/test/cctp-resolver.test.ts
+++ b/packages/portfolio-contract/test/cctp-resolver.test.ts
@@ -4,34 +4,24 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { E } from '@endo/far';
 import { mustMatch } from '@endo/patterns';
 import type { TransactionSettlementOfferArgs } from '../src/resolver/types.ts';
-import { ResolverOfferArgsShapes } from '../src/resolver/types.ts';
+import { TransactionSettlementOfferArgsShape } from '../src/resolver/types.ts';
 import { deploy } from './contract-setup.ts';
 
-test('CCTP settlement invitation - no pending transaction found', async t => {
-  const { started, zoe } = await deploy(t);
+test('CCTP settlement - no pending transaction found', async t => {
+  const { started } = await deploy(t);
   const { creatorFacet } = started;
 
-  const resolverInvitation = await E(creatorFacet).makeResolverInvitation();
-  const resolverSeat = await E(zoe).offer(resolverInvitation);
-  const resolverMakers = (await E(resolverSeat).getOfferResult())
-    .invitationMakers;
-  const confirmInvitation = await E(resolverMakers).SettleTransaction();
+  const resolverService = await E(creatorFacet).getResolverService();
 
   const offerArgs: TransactionSettlementOfferArgs = {
     status: 'success' as const,
     txId: 'tx0',
   };
-  const confirmationSeat = await E(zoe).offer(
-    confirmInvitation,
-    {},
-    undefined,
-    offerArgs,
-  );
 
-  await t.throwsAsync(E(confirmationSeat).getOfferResult());
+  await t.throwsAsync(E(resolverService).settleTransaction(offerArgs));
 });
 
-test('CCTP confirmation invitation - invalid status throws', async t => {
+test('CCTP confirmation - invalid status throws', async t => {
   await deploy(t);
 
   const invalidOfferArgs: TransactionSettlementOfferArgs = harden({
@@ -39,7 +29,7 @@ test('CCTP confirmation invitation - invalid status throws', async t => {
     txId: 'tx0',
   });
   t.throws(() =>
-    mustMatch(invalidOfferArgs, ResolverOfferArgsShapes.SettleTransaction),
+    mustMatch(invalidOfferArgs, TransactionSettlementOfferArgsShape),
   );
 });
 

--- a/packages/portfolio-contract/test/contract-setup.ts
+++ b/packages/portfolio-contract/test/contract-setup.ts
@@ -23,7 +23,10 @@ import {
   makeUSDNIBCTraffic,
   portfolio0lcaOrch,
 } from './mocks.ts';
-import { getResolverHelperKit, settleTransaction } from './resolver-helpers.ts';
+import {
+  getResolverHelperKitForInvokeService as getResolverHelperKit,
+  settleTransaction,
+} from './resolver-helpers.ts';
 import {
   chainInfoWithCCTP,
   makeIncomingEVMEvent,

--- a/packages/portfolio-contract/test/contract-setup.ts
+++ b/packages/portfolio-contract/test/contract-setup.ts
@@ -23,7 +23,7 @@ import {
   makeUSDNIBCTraffic,
   portfolio0lcaOrch,
 } from './mocks.ts';
-import { getResolverMakers, settleTransaction } from './resolver-helpers.ts';
+import { getResolverHelperKit, settleTransaction } from './resolver-helpers.ts';
 import {
   chainInfoWithCCTP,
   makeIncomingEVMEvent,
@@ -142,7 +142,10 @@ export const setupTrader = async (t, initial = 10_000) => {
     ibcBridge.addMockAck(msg, ack);
   }
 
-  const resolverMakers = await getResolverMakers(zoe, started.creatorFacet);
+  const resolverHelperKit = await getResolverHelperKit(
+    started.creatorFacet,
+    zoe,
+  );
 
   /**
    * Read pure data (CapData that has no slots) from the storage path
@@ -173,7 +176,7 @@ export const setupTrader = async (t, initial = 10_000) => {
         if (!txIds.length) break;
         for (const txId of txIds) {
           const txNum = Number(txId.replace(/^tx/, ''));
-          await settleTransaction(zoe, resolverMakers, txNum, status);
+          await settleTransaction(resolverHelperKit, txNum, status);
           done.push(txId);
         }
       }

--- a/packages/portfolio-contract/test/resolver-helpers.ts
+++ b/packages/portfolio-contract/test/resolver-helpers.ts
@@ -7,56 +7,64 @@ import type { ResolverInvitationMakers } from '../src/resolver/resolver.exo.js';
 import type { TxStatus } from '../src/resolver/constants.js';
 
 /**
- * Helper to get resolver makers from a creator facet.
+ * Helper to get a resolver kit from a creator facet's invitation makers.
  * Encapsulates the common pattern of making a resolver invitation,
  * offering it to zoe, and getting the resolver makers from the result.
  *
- * @param zoe - Zoe service instance
  * @param creatorFacet - The creator facet that has makeResolverInvitation
- * @returns {Promise<ResolverInvitationMakers>}
+ * @param zoe - Zoe service instance
  */
-export const getResolverMakers = async (
-  zoe: ZoeService,
+export const getResolverHelperKit = async (
   creatorFacet: any,
-): Promise<ResolverInvitationMakers> => {
+  zoe: ZoeService,
+): Promise<{ zoe: ZoeService; invitationMakers: ResolverInvitationMakers }> => {
   const resolverInvitation = await E(creatorFacet).makeResolverInvitation();
   const resolverSeat = (await E(zoe).offer(resolverInvitation)) as UserSeat<{
     invitationMakers: ResolverInvitationMakers;
   }>;
-  return (await E(resolverSeat).getOfferResult()).invitationMakers;
+  const { invitationMakers } = await E(resolverSeat).getOfferResult();
+  return { zoe, invitationMakers };
 };
+
+export type ResolverHelperKit = Awaited<
+  ReturnType<typeof getResolverHelperKit>
+>;
 
 /**
  * Helper to manually settle a transaction in tests.
  * This should be called when a test flow includes a transaction operation
  * to resolve the waiting promise.
  *
- * @param zoe - Zoe service instance
- * @param resolverMakers - ResolverInvitationMakers instance
+ * @param helperKit - ResolverHelperKit
  * @param txNumber - Transaction number for txId
  * @param status - Transaction status
  * @param log - Optional logging function (defaults to console.log, pass () => {} to disable)
  */
 export const settleTransaction = async (
-  zoe: ZoeService,
-  resolverMakers: ResolverInvitationMakers,
+  helperKit: ResolverHelperKit,
   txNumber: number = 0,
   status: Exclude<TxStatus, 'pending'> = 'success',
   log: (message: string, ...args: any[]) => void = console.log,
-): Promise<string> => {
+): Promise<void> => {
   await eventLoopIteration();
   await eventLoopIteration(); // XXX for some reason we need two iterations here to pass the tests
 
   log('Creating transaction settlement invitation...');
-  const settleInvitation = await E(resolverMakers).SettleTransaction();
+  const settleInvitation = await E(
+    helperKit.invitationMakers,
+  ).SettleTransaction();
   log('Got settlement invitation, making offer...');
 
-  const settlementSeat = await E(zoe).offer(settleInvitation, {}, undefined, {
-    status,
-    txId: `tx${txNumber}`,
-  });
+  const settlementSeat = await E(helperKit.zoe).offer(
+    settleInvitation,
+    {},
+    undefined,
+    {
+      status,
+      txId: `tx${txNumber}`,
+    },
+  );
 
   const result = (await E(settlementSeat).getOfferResult()) as string;
   log(`Transaction settlement got result:`, result);
-  return result;
 };

--- a/packages/portfolio-contract/test/ymax-scenario.test.ts
+++ b/packages/portfolio-contract/test/ymax-scenario.test.ts
@@ -26,7 +26,10 @@ import {
   makeUSDNIBCTraffic,
   portfolio0lcaOrch,
 } from './mocks.ts';
-import { getResolverHelperKit, settleTransaction } from './resolver-helpers.ts';
+import {
+  getResolverHelperKitForInvitationMakers as getResolverHelperKit,
+  settleTransaction,
+} from './resolver-helpers.ts';
 
 // Use an EVM chain whose axelar ID differs from its chain name
 const { sourceChain } = evmNamingDistinction;

--- a/packages/portfolio-contract/test/ymax-scenario.test.ts
+++ b/packages/portfolio-contract/test/ymax-scenario.test.ts
@@ -26,7 +26,7 @@ import {
   makeUSDNIBCTraffic,
   portfolio0lcaOrch,
 } from './mocks.ts';
-import { getResolverMakers, settleTransaction } from './resolver-helpers.ts';
+import { getResolverHelperKit, settleTransaction } from './resolver-helpers.ts';
 
 // Use an EVM chain whose axelar ID differs from its chain name
 const { sourceChain } = evmNamingDistinction;
@@ -76,7 +76,10 @@ const rebalanceScenarioMacro = test.macro({
       ? withBrand(scenarios[scenario.previous], usdc.brand)
       : undefined;
 
-    const resolverMakers = await getResolverMakers(zoe, started.creatorFacet);
+    const resolverHelperKit = await getResolverHelperKit(
+      started.creatorFacet,
+      zoe,
+    );
 
     if (description.includes('Recover')) {
       // simulate arrival of funds in the LCA via IBC from Noble
@@ -110,16 +113,16 @@ const rebalanceScenarioMacro = test.macro({
         await eventLoopIteration();
         if (move.dest === '@Arbitrum') {
           // Also confirm CCTP transaction for flows to Arbitrum
-          await settleTransaction(zoe, resolverMakers, index, 'success');
+          await settleTransaction(resolverHelperKit, index, 'success');
           index += 1;
         }
         if (move.src === '@Arbitrum') {
-          await settleTransaction(zoe, resolverMakers, index, 'success');
+          await settleTransaction(resolverHelperKit, index, 'success');
           index += 1;
           if (move.dest === '@agoric') {
             await transmitVTransferEvent('acknowledgementPacket', -1);
             // Also confirm Noble transaction for flows to Noble
-            await settleTransaction(zoe, resolverMakers, index, 'success');
+            await settleTransaction(resolverHelperKit, index, 'success');
             index += 1;
           }
         }

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -160,7 +160,10 @@ export const makeVstorageEvent = (
 };
 
 type Powers = {
-  evmCtx: Omit<EvmContext, 'signingSmartWalletKit' | 'fetch' | 'cosmosRest'>;
+  evmCtx: Omit<
+    EvmContext,
+    'signingSmartWalletKit' | 'walletStore' | 'fetch' | 'cosmosRest'
+  >;
   rpc: CosmosRPCClient;
   spectrum: SpectrumClient;
   cosmosRest: CosmosRestClient;
@@ -654,6 +657,7 @@ export const startEngine = async (
     marshaller,
     now,
     signingSmartWalletKit,
+    walletStore,
     vstoragePathPrefixes,
   });
   console.warn(`Found ${pendingTxKeys.length} pending transactions`);

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -7,8 +7,8 @@ import type { Coin } from '@cosmjs/stargate';
 
 import { Fail, X, annotateError, q } from '@endo/errors';
 import { Nat } from '@endo/nat';
-import { reflectWalletStore, getInvocationUpdate } from '@agoric/client-utils';
-import type { SigningSmartWalletKit } from '@agoric/client-utils';
+import { getInvocationUpdate } from '@agoric/client-utils';
+import type { SigningSmartWalletKit, WalletStore } from '@agoric/client-utils';
 import type { RetryOptionsAndPowers } from '@agoric/client-utils/src/sync-tools.js';
 import { AmountMath, type Brand } from '@agoric/ertp';
 import type { Bech32Address } from '@agoric/orchestration';
@@ -165,7 +165,7 @@ type Powers = {
   spectrum: SpectrumClient;
   cosmosRest: CosmosRestClient;
   signingSmartWalletKit: SigningSmartWalletKit;
-  walletStore: ReturnType<typeof reflectWalletStore>;
+  walletStore: WalletStore;
   getWalletInvocationUpdate: (
     messageId: string | number,
     retryOpts?: RetryOptionsAndPowers,

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -2,7 +2,7 @@ import type { WebSocketProvider } from 'ethers';
 
 import { Fail } from '@endo/errors';
 
-import type { SigningSmartWalletKit } from '@agoric/client-utils';
+import type { SigningSmartWalletKit, WalletStore } from '@agoric/client-utils';
 import type { CaipChainId } from '@agoric/orchestration';
 import { parseAccountId } from '@agoric/orchestration/src/utils/address.js';
 import type { AxelarChain } from '@agoric/portfolio-api/src/constants.js';
@@ -32,6 +32,7 @@ export type EvmContext = {
   usdcAddresses: UsdcAddresses['mainnet' | 'testnet'];
   evmProviders: EvmProviders;
   signingSmartWalletKit: SigningSmartWalletKit;
+  walletStore: WalletStore;
   fetch: typeof fetch;
 };
 
@@ -147,6 +148,7 @@ const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
 
     await resolvePendingTx({
       signingSmartWalletKit: ctx.signingSmartWalletKit,
+      walletStore: ctx.walletStore,
       txId,
       status: transferStatus ? TxStatus.SUCCESS : TxStatus.FAILED,
     });
@@ -229,6 +231,7 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
 
     await resolvePendingTx({
       signingSmartWalletKit: ctx.signingSmartWalletKit,
+      walletStore: ctx.walletStore,
       txId,
       status: transferStatus ? TxStatus.SUCCESS : TxStatus.FAILED,
     });

--- a/services/ymax-planner/src/resolver.ts
+++ b/services/ymax-planner/src/resolver.ts
@@ -6,7 +6,7 @@ import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types';
 type ResolveTxParams = {
   signingSmartWalletKit: SigningSmartWalletKit;
   txId: TxId;
-  status: Omit<TxStatus, 'pending'>;
+  status: Exclude<TxStatus, 'pending'>;
   proposal?: object;
 };
 

--- a/services/ymax-planner/src/resolver.ts
+++ b/services/ymax-planner/src/resolver.ts
@@ -50,6 +50,6 @@ export const resolvePendingTx = async ({
     proposal,
   });
 
-  const result = await signingSmartWalletKit.executeOffer(action);
-  return result;
+  // An offer error will result in a throw
+  await signingSmartWalletKit.executeOffer(action);
 };

--- a/services/ymax-planner/src/resolver.ts
+++ b/services/ymax-planner/src/resolver.ts
@@ -1,10 +1,11 @@
-import { type SigningSmartWalletKit } from '@agoric/client-utils';
+import type { SigningSmartWalletKit, WalletStore } from '@agoric/client-utils';
 import type { OfferSpec } from '@agoric/smart-wallet/src/offers';
 import type { TxStatus } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types';
 
 type ResolveTxParams = {
   signingSmartWalletKit: SigningSmartWalletKit;
+  walletStore: WalletStore;
   txId: TxId;
   status: Exclude<TxStatus, 'pending'>;
   proposal?: object;

--- a/services/ymax-planner/src/resolver.ts
+++ b/services/ymax-planner/src/resolver.ts
@@ -1,7 +1,9 @@
+import { Fail, q } from '@endo/errors';
 import type { SigningSmartWalletKit, WalletStore } from '@agoric/client-utils';
 import type { OfferSpec } from '@agoric/smart-wallet/src/offers';
 import type { TxStatus } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types';
+import type { ResolverKit } from '@aglocal/portfolio-contract/src/resolver/resolver.exo.js';
 
 type ResolveTxParams = {
   signingSmartWalletKit: SigningSmartWalletKit;
@@ -26,7 +28,7 @@ const getInvitationMakers = async (wallet: SigningSmartWalletKit) => {
   };
 };
 
-export const resolvePendingTx = async ({
+export const resolvePendingTxByInvitation = async ({
   signingSmartWalletKit,
   txId,
   status,
@@ -53,3 +55,24 @@ export const resolvePendingTx = async ({
   // An offer error will result in a throw
   await signingSmartWalletKit.executeOffer(action);
 };
+
+export const resolvePendingTxByInvocation = async ({
+  walletStore,
+  txId,
+  status,
+  proposal,
+}: ResolveTxParams) => {
+  !proposal || Fail`Unexpected proposal ${q(proposal)}`;
+
+  const offerArgs = {
+    status,
+    txId,
+  };
+
+  const resolver = walletStore.get<ResolverKit['service']>('resolver');
+
+  // An invocation error will result in a throw
+  await resolver.settleTransaction(offerArgs);
+};
+
+export const resolvePendingTx = resolvePendingTxByInvitation;


### PR DESCRIPTION
closes: #11966
refs: #11746, #10741

## Description
Using the continuing invitation mechanism to settle cctp transactions is expensive (see #10741 for the oracle analysis). This PR introduces a mechanism to be able to transition the resolver from continuing invitations to smart-wallet based invocations as introduced in #11746.

### Security Considerations
None, this doesn't change the model that the ability to submit settlement info is tied to capabilities held by a smart wallet.

### Scaling Considerations
Reduce overhead of submitting settlement info

### Documentation Considerations
None

### Testing Considerations
Switched the existing tests to direct invocation. Some of the tests are skipped (and outdated), but I locally verified that the changes work as far these tests did before with the invitation based mechanism.

### Upgrade Considerations
There is not a good cheap way to detect whether there is a capability saved in the smart wallet store, so while the planner includes the implementation to use the invocation mechanism, it doesn't switch to it. Switching will require a follow-on change once all deployed contracts have switched to the supporting direct resolver invocations.
