### PR TITLE
fix(internal): use a plain Map as the backing cache for wrapped marshaller

### DIFF
--- a/packages/internal/src/marshal/wrap-marshaller.js
+++ b/packages/internal/src/marshal/wrap-marshaller.js
@@ -94,11 +94,13 @@ const capacityOfDefaultCache = 50;
  * @template V
  * @param {boolean} [weakKey]
  */
-// eslint-disable-next-line no-unused-vars
 const makeDefaultCacheMap = weakKey =>
   /** @type {WeakMapAPI<K, V>} */ (
     makeCacheMapKit(capacityOfDefaultCache, {
-      makeMap: Map,
+      // We use a Map even for weakKey as the assumption is that we run under
+      // liveslots which virtualizes WeakMap, and since the mapping is
+      // bidirectional by default, the key would be pinned anyway.
+      makeMap: weakKey ? Map : Map,
     }).cache
   );
 

--- a/packages/internal/src/marshal/wrap-marshaller.js
+++ b/packages/internal/src/marshal/wrap-marshaller.js
@@ -94,6 +94,7 @@ const capacityOfDefaultCache = 50;
  * @template V
  * @param {boolean} [weakKey]
  */
+// eslint-disable-next-line no-unused-vars
 const makeDefaultCacheMap = weakKey =>
   /** @type {WeakMapAPI<K, V>} */ (
     makeCacheMapKit(capacityOfDefaultCache, {

--- a/packages/internal/src/marshal/wrap-marshaller.js
+++ b/packages/internal/src/marshal/wrap-marshaller.js
@@ -89,8 +89,6 @@ const { slotToWrapper, wrapperToSlot } = (() => {
 
 const capacityOfDefaultCache = 50;
 
-// TODO(https://github.com/Agoric/agoric-sdk/issues/12111)
-// Check cost of using virtual-aware WeakMap in liveslots
 /**
  * @template K
  * @template V
@@ -99,7 +97,7 @@ const capacityOfDefaultCache = 50;
 const makeDefaultCacheMap = weakKey =>
   /** @type {WeakMapAPI<K, V>} */ (
     makeCacheMapKit(capacityOfDefaultCache, {
-      makeMap: weakKey ? WeakMap : Map,
+      makeMap: Map,
     }).cache
   );
 


### PR DESCRIPTION
closes: #12111

## Description
Avoid the virtual aware WeakMap overhead

I did not change the capacity and kept 50, a number I pulled out of my hat. Open to bikeshed it.

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
I didn't end up re-testing the performance impact of this, but conceptually this has much less overhead.

### Upgrade Considerations
Will be picked up by any future vat bundle being deployed
