### PR TITLE
fix(ymax-planner): Don't resubmit steps to the same effective portfolio state

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -6,7 +6,7 @@ import type { InspectOptions } from 'node:util';
 
 import type { Coin } from '@cosmjs/stargate';
 
-import { Fail, X, annotateError, q } from '@endo/errors';
+import { Fail, annotateError, q } from '@endo/errors';
 import { Nat } from '@endo/nat';
 import { reflectWalletStore, getInvocationUpdate } from '@agoric/client-utils';
 import type { SigningSmartWalletKit } from '@agoric/client-utils';


### PR DESCRIPTION
Fixes https://github.com/Agoric/agoric-private/issues/545

## Description
Introduce per-portfolio circuit breaking to ymax-planner: before submitting steps for a portfolio's flow, check if we've previously submitted steps against effectively identical portfolio state ("effectively" in the sense that we ignore `rebalanceCount`, which can increment even if nothing actually changes).

### Security Considerations
None known.

### Scaling Considerations
This will prevent loops from draining the planner's wallet.

### Documentation Considerations
n/a

### Testing Considerations
We don't yet have a unit testing environment with enough mocking to represent this, but I manually verified that expected submissions still take place.

### Upgrade Considerations
Safe to deploy immediately.