### PR TITLE
chore(types): typeof for runtime types

### DIFF
--- a/a3p-integration/proposals/z:acceptance/test/test-lib/governance.js
+++ b/a3p-integration/proposals/z:acceptance/test/test-lib/governance.js
@@ -274,7 +274,7 @@ export const makeGovernanceDriver = async (fetch, networkConfig) => {
 /**
  *
  * @param {import('ava').ExecutionContext} t
- * @param {Awaited<ReturnType<makeGovernanceDriver>>} governanceDriver
+ * @param {Awaited<ReturnType<typeof makeGovernanceDriver>>} governanceDriver
  * @param {{
  *   instanceName: string;
  *   duration: number;

--- a/multichain-testing/tools/batchQuery.js
+++ b/multichain-testing/tools/batchQuery.js
@@ -129,7 +129,7 @@ const parseIfJSON = d => {
 };
 
 /**
- * @param {ReturnType<makeVStorage>} vstorage
+ * @param {ReturnType<typeof makeVStorage>} vstorage
  * @param {FromCapData<string>} unmarshal
  * @param {[AgoricChainStoragePathKind, string][]} paths
  */

--- a/multichain-testing/tools/e2e-tools.js
+++ b/multichain-testing/tools/e2e-tools.js
@@ -87,7 +87,7 @@ export const makeBlockTool = ({ rpc, delay }) => {
 
   return { waitForBlock };
 };
-/** @typedef {ReturnType<makeBlockTool>} BlockTool */
+/** @typedef {ReturnType<typeof makeBlockTool>} BlockTool */
 
 /**
  * @param {string} fullPath
@@ -695,4 +695,4 @@ export const makeDoOffer = wallet => {
   return doOffer;
 };
 
-/** @typedef {Awaited<ReturnType<makeE2ETools>>} E2ETools */
+/** @typedef {Awaited<ReturnType<typeof makeE2ETools>>} E2ETools */

--- a/packages/SwingSet/src/controller/bundle-handler.js
+++ b/packages/SwingSet/src/controller/bundle-handler.js
@@ -22,7 +22,7 @@ export const makeXsnapBundleData = harden(() => {
 
 /**
  * @param {import('@agoric/swing-store').BundleStore} bundleStore
- * @param {ReturnType<makeXsnapBundleData>} bundleData
+ * @param {ReturnType<typeof makeXsnapBundleData>} bundleData
  * @returns {BundleHandler}
  */
 export const makeWorkerBundleHandler = harden((bundleStore, bundleData) => {

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -141,7 +141,7 @@ function onUnhandledRejection(e, pr) {
  *   spawn?: typeof import('child_process').spawn,
  *   env?: Record<string, string | undefined>,
  *   kernelBundle?: Bundle
- *   xsnapBundleData?: ReturnType<import('./bundle-handler.js').makeXsnapBundleData>,
+ *   xsnapBundleData?: ReturnType<typeof import('./bundle-handler.js').makeXsnapBundleData>,
  *   bundleHandler?: import('./bundle-handler.js').BundleHandler,
  *   profileVats?: string[],
  *   debugVats?: string[],

--- a/packages/SwingSet/src/devices/mailbox/mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox/mailbox.js
@@ -143,7 +143,7 @@ function getOrCreatePeer(state, peer) {
 }
 
 /**
- * @param {ReturnType<exportMailboxData>} data
+ * @param {ReturnType<typeof exportMailboxData>} data
  * @returns {Map<string, Mailbox>}
  */
 export function makeEphemeralMailboxStorage(data) {

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -195,14 +195,14 @@ export default function buildKernel(
     kernelSlog,
   );
 
-  /** @type {ReturnType<makeVatWarehouse>} */
+  /** @type {ReturnType<typeof makeVatWarehouse>} */
   let vatWarehouse;
   let started = false;
 
   /**
    * @typedef {{
    *   manager: unknown,
-   *   translators: ReturnType<makeDeviceTranslators>,
+   *   translators: ReturnType<typeof makeDeviceTranslators>,
    * }} DeviceInfo
    */
   const ephemeral = {

--- a/packages/agoric-cli/src/lib/format.js
+++ b/packages/agoric-cli/src/lib/format.js
@@ -175,7 +175,7 @@ export const offerStatusTuples = (state, agoricNames) => {
 
 /**
  * @param {CurrentWalletRecord} current
- * @param {ReturnType<makeWalletStateCoalescer>['state']} coalesced
+ * @param {ReturnType<typeof makeWalletStateCoalescer>['state']} coalesced
  * @param {AgoricNamesRemotes} agoricNames
  */
 export const summarize = (current, coalesced, agoricNames) => {

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -276,7 +276,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       await rmVerbose(serverDir);
     }
 
-    /** @type {(args: string[], spawnOpts?: Parameters<typeof pspawn>[2], dockerArgs?: string[]) => ReturnType<pspawn>} */
+    /** @type {(args: string[], spawnOpts?: Parameters<typeof pspawn>[2], dockerArgs?: string[]) => ReturnType<typeof pspawn>} */
     let chainSpawn;
     if (!popts.dockerTag) {
       chainSpawn = (args, spawnOpts) =>
@@ -482,7 +482,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       await rmVerbose(serverDir);
     }
 
-    /** @type {(args: string[], spawnOpts?: Parameters<typeof pspawn>[2], dockerArgs?: string[]) => ReturnType<pspawn>} */
+    /** @type {(args: string[], spawnOpts?: Parameters<typeof pspawn>[2], dockerArgs?: string[]) => ReturnType<typeof pspawn>} */
     let soloSpawn;
     if (!popts.dockerTag) {
       soloSpawn = (args, spawnOpts) => pspawn(agSolo, args, spawnOpts);

--- a/packages/async-flow/src/async-flow.js
+++ b/packages/async-flow/src/async-flow.js
@@ -541,7 +541,7 @@ export const prepareAsyncFlowTools = (outerZone, outerOptions = {}) => {
 harden(prepareAsyncFlowTools);
 
 /**
- * @typedef {ReturnType<prepareAsyncFlowTools>} AsyncFlowTools
+ * @typedef {ReturnType<typeof prepareAsyncFlowTools>} AsyncFlowTools
  */
 
 /**

--- a/packages/async-flow/src/bijection.js
+++ b/packages/async-flow/src/bijection.js
@@ -65,7 +65,7 @@ const makeVowishStore = name => {
   });
 };
 
-/** @typedef {ReturnType<makeVowishStore>} VowishStore */
+/** @typedef {ReturnType<typeof makeVowishStore>} VowishStore */
 
 /**
  * As suggested by the name, this *mostly* represents a mathematical bijection,
@@ -203,5 +203,5 @@ export const prepareBijection = (
 harden(prepareBijection);
 
 /**
- * @typedef {ReturnType<ReturnType<prepareBijection>>} Bijection
+ * @typedef {ReturnType<ReturnType<typeof prepareBijection>>} Bijection
  */

--- a/packages/async-flow/src/endowments.js
+++ b/packages/async-flow/src/endowments.js
@@ -262,5 +262,5 @@ export const prepareEndowmentTools = (outerZone, outerOptions = {}) => {
 harden(prepareEndowmentTools);
 
 /**
- * @typedef {ReturnType<prepareEndowmentTools>} EndowmentTools
+ * @typedef {ReturnType<typeof prepareEndowmentTools>} EndowmentTools
  */

--- a/packages/async-flow/src/log-store.js
+++ b/packages/async-flow/src/log-store.js
@@ -264,5 +264,5 @@ export const prepareLogStore = zone => {
 };
 
 /**
- * @typedef {ReturnType<ReturnType<prepareLogStore>>} LogStore
+ * @typedef {ReturnType<ReturnType<typeof prepareLogStore>>} LogStore
  */

--- a/packages/async-flow/src/replay-membrane.js
+++ b/packages/async-flow/src/replay-membrane.js
@@ -714,4 +714,4 @@ export const makeReplayMembraneForTesting = ({
 };
 harden(makeReplayMembrane);
 
-/** @typedef {ReturnType<makeReplayMembrane>} ReplayMembrane */
+/** @typedef {ReturnType<typeof makeReplayMembrane>} ReplayMembrane */

--- a/packages/async-flow/test/async-flow-early-completion.test.js
+++ b/packages/async-flow/test/async-flow-early-completion.test.js
@@ -48,7 +48,7 @@ const prepareOrchestra = (zone, k = 1) =>
     },
   );
 
-/** @typedef {ReturnType<ReturnType<prepareOrchestra>>} Orchestra */
+/** @typedef {ReturnType<ReturnType<typeof prepareOrchestra>>} Orchestra */
 
 const firstLogLen = 7;
 

--- a/packages/async-flow/test/async-flow.test.js
+++ b/packages/async-flow/test/async-flow.test.js
@@ -51,7 +51,7 @@ const prepareOrchestra = (zone, k = 1) =>
     },
   );
 
-/** @typedef {ReturnType<ReturnType<prepareOrchestra>>} Orchestra */
+/** @typedef {ReturnType<ReturnType<typeof prepareOrchestra>>} Orchestra */
 
 const firstLogLen = 7;
 

--- a/packages/async-flow/test/bad-host.test.js
+++ b/packages/async-flow/test/bad-host.test.js
@@ -42,7 +42,7 @@ const prepareBadHost = zone =>
     },
   );
 
-/** @typedef {ReturnType<ReturnType<prepareBadHost>>} BadHost */
+/** @typedef {ReturnType<ReturnType<typeof prepareBadHost>>} BadHost */
 
 /**
  * @param {any} t

--- a/packages/async-flow/test/replay-membrane-eventual.test.js
+++ b/packages/async-flow/test/replay-membrane-eventual.test.js
@@ -37,7 +37,7 @@ const preparePingee = zone =>
   });
 
 /**
- * @typedef {ReturnType<ReturnType<preparePingee>>} Pingee
+ * @typedef {ReturnType<ReturnType<typeof preparePingee>>} Pingee
  */
 
 const testMode = /** @type {const} */ ({

--- a/packages/cosmic-swingset/tools/test-kit.js
+++ b/packages/cosmic-swingset/tools/test-kit.js
@@ -279,7 +279,7 @@ export const makeCosmicSwingsetTestKit = async (
     blockingSend,
     shutdown: shutdownKernel,
     internals,
-  } = /** @type {EReturn<launchAndShareInternals>} */ (launchResult);
+  } = /** @type {EReturn<typeof launchAndShareInternals>} */ (launchResult);
   /** @type {(options?: { kernelOnly?: boolean }) => Promise<void>} */
   const shutdown = async ({ kernelOnly = false } = {}) => {
     await shutdownKernel();

--- a/packages/deploy-script-support/src/getBundlerMaker.js
+++ b/packages/deploy-script-support/src/getBundlerMaker.js
@@ -13,7 +13,7 @@
 import { E } from '@endo/far';
 import url from 'url';
 
-/** @typedef {ReturnType<import('./endo-pieces-contract.js')['start']>['publicFacet']} BundleMaker */
+/** @typedef {ReturnType<typeof import('./endo-pieces-contract.js').start>['publicFacet']} BundleMaker */
 /** @typedef {ReturnType<BundleMaker['makeBundler']>} Bundler */
 
 export const makeGetBundlerMaker =

--- a/packages/fast-usdc/src/cli/bridge-action.js
+++ b/packages/fast-usdc/src/cli/bridge-action.js
@@ -7,7 +7,7 @@ import { boardSlottingMarshaller } from '@agoric/client-utils';
 
 const defaultMarshaller = boardSlottingMarshaller();
 
-/** @typedef {ReturnType<boardSlottingMarshaller>} BoardSlottingMarshaller */
+/** @typedef {ReturnType<typeof boardSlottingMarshaller>} BoardSlottingMarshaller */
 
 /**
  * @param {BridgeAction} bridgeAction

--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -163,7 +163,7 @@ const facetHelpers = (zcf, paramManager) => {
    * @param {LCF} limitedCreatorFacet
    */
   const makeVirtualGovernorFacet = limitedCreatorFacet => {
-    /** @type {FunctionsPlusContext<unknown, GovernedCreatorFacet<limitedCreatorFacet>>} */
+    /** @type {FunctionsPlusContext<unknown, GovernedCreatorFacet<typeof limitedCreatorFacet>>} */
     const governorFacet = harden({
       getParamMgrRetriever: () =>
         Far('paramRetriever', { get: () => paramManager }),

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -76,7 +76,7 @@ export {};
  *
  * @template {import('./contractGovernance/typedParamManager.js').ParamTypesMap} T Governed parameters of contract
  * @typedef {{
- *   electionManager: import('@agoric/zoe/src/zoeService/utils.js').Instance<import('./contractGovernor.js')['start']>,
+ *   electionManager: import('@agoric/zoe/src/zoeService/utils.js').Instance<typeof import('./contractGovernor.js').start>,
  *   governedParams: import('./contractGovernance/typedParamManager.js').ParamRecordsFromTypes<T & {
  *     Electorate: 'invitation'
  *   }>
@@ -691,7 +691,7 @@ export {};
  * @param {ERef<ZoeService>} zoe
  * @param {import('@agoric/zoe/src/zoeService/utils.js').Instance<(zcf: ZCF<GovernanceTerms<{}>>) => {}>} allegedGoverned
  * @param {Instance<(zcf) => {publicFacet: GovernorPublic}>} allegedGovernor
- * @param {Installation<import('@agoric/governance/src/contractGovernor.js').start>} contractGovernorInstallation
+ * @param {Installation<typeof import('@agoric/governance/src/contractGovernor.js').start>} contractGovernorInstallation
  * @returns {Promise<GovernancePair>}
  */
 
@@ -711,7 +711,7 @@ export {};
  */
 
 /**
- * @typedef {import('./contractGovernor.js')['start']} GovernorSF
+ * @typedef {typeof import('./contractGovernor.js').start} GovernorSF
  */
 
 // TODO find a way to parameterize the startInstance so the governed contract types flow

--- a/packages/governance/test/unitTests/committee.test.js
+++ b/packages/governance/test/unitTests/committee.test.js
@@ -41,8 +41,8 @@ const setupContract = async (
     bundleSource(counterRoot),
   ]);
   // install the contract
-  /** @typedef {Installation<import('../../src/committee.js')['start']>} CommitteInstallation */
-  /** @typedef {Installation<start>} CounterInstallation */
+  /** @typedef {Installation<typeof import('../../src/committee.js').start>} CommitteInstallation */
+  /** @typedef {Installation<typeof start>} CounterInstallation */
   /** @type {[CommitteInstallation, CounterInstallation] } */
   const [electorateInstallation, counterInstallation] = await Promise.all([
     E(zoe).install(electorateBundle),

--- a/packages/governance/tools/puppetGovernance.js
+++ b/packages/governance/tools/puppetGovernance.js
@@ -50,7 +50,7 @@ export const setUpGovernedContract = async (
 
   /**
    * @type {[
-   * Installation<start>,
+   * Installation<typeof start>,
    * Installation<any>,
    * Installation<T>,
    * ]}

--- a/packages/inter-protocol/src/proposals/econ-behaviors.js
+++ b/packages/inter-protocol/src/proposals/econ-behaviors.js
@@ -38,22 +38,28 @@ export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
 /**
  * @typedef {object} PSMKit
  * @property {string} label
- * @property {Instance<import('../psm/psm.js').start>} psm
+ * @property {Instance<typeof import('../psm/psm.js').start>} psm
  * @property {Instance<
- *   import('../../../governance/src/contractGovernor.js').start
+ *   typeof import('../../../governance/src/contractGovernor.js').start
  * >} psmGovernor
  * @property {Awaited<
  *   ReturnType<
  *     Awaited<
- *       ReturnType<import('../psm/psm.js')['start']>
+ *       ReturnType<typeof import('../psm/psm.js').start>
  *     >['creatorFacet']['getLimitedCreatorFacet']
  *   >
  * >} psmCreatorFacet
- * @property {GovernorCreatorFacet<import('../../src/psm/psm.js')['start']>} psmGovernorCreatorFacet
+ * @property {GovernorCreatorFacet<
+ *   typeof import('../../src/psm/psm.js').start
+ * >} psmGovernorCreatorFacet
  * @property {AdminFacet} psmAdminFacet
  */
 
-/** @typedef {GovernanceFacetKit<import('../auction/auctioneer.js').start>} AuctioneerKit */
+/**
+ * @typedef {GovernanceFacetKit<
+ *   typeof import('../auction/auctioneer.js').start
+ * >} AuctioneerKit
+ */
 
 /**
  * @typedef {WellKnownSpaces & ChainBootstrapSpace & EconomyBootstrapSpace} EconomyBootstrapPowers
@@ -73,7 +79,7 @@ export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
  *   anchorBalancePayments: MapStore<Brand, Payment<'nat'>>;
  *   econCharterKit: EconCharterStartResult;
  *   reserveKit: GovernanceFacetKit<
- *     import('../reserve/assetReserve.js')['start']
+ *     typeof import('../reserve/assetReserve.js').start
  *   >;
  *   vaultFactoryKit: GovernanceFacetKit<VFStart>;
  *   auctioneerKit: AuctioneerKit;
@@ -84,12 +90,12 @@ export const SECONDS_PER_WEEK = 7n * SECONDS_PER_DAY;
 
 /**
  * @typedef {StartedInstanceKit<
- *   import('../econCommitteeCharter.js')['start']
+ *   typeof import('../econCommitteeCharter.js').start
  * >} EconCharterStartResult
  */
 /**
  * @typedef {StartedInstanceKit<
- *   import('@agoric/governance/src/committee.js')['start']
+ *   typeof import('@agoric/governance/src/committee.js').start
  * >} CommitteeStartResult
  */
 

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -172,7 +172,9 @@ export const createPriceFeed = async (
   /**
    * @type {[
    *   [Brand<'nat'>, Brand<'nat'>],
-   *   Installation<import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js')['start]>,
+   *   Installation<
+   *     typeof import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').start
+   *   >,
    *   Timer,
    * ]}
    */

--- a/packages/inter-protocol/src/proposals/upgrade-vaults.js
+++ b/packages/inter-protocol/src/proposals/upgrade-vaults.js
@@ -60,7 +60,7 @@ export const upgradeVaults = async (
 
   await priceAuthority8400;
 
-  /** @type {Instance<start>} */
+  /** @type {Instance<typeof start>} */
   const auctionNewInstance = await auctionUpgradeNewInstance;
   auctionUpgradeNewInstanceProducer.reset();
   const publicFacet = E(zoe).getPublicFacet(auctionNewInstance);

--- a/packages/inter-protocol/src/proposals/withdraw-reserve-proposal.js
+++ b/packages/inter-protocol/src/proposals/withdraw-reserve-proposal.js
@@ -6,7 +6,7 @@ import { reserveThenDeposit } from './utils.js';
  * @param {BootstrapPowers & {
  *   consume: {
  *     reserveKit: Promise<
- *       ReturnType<import('../reserve/assetReserve.js')['start']>
+ *       ReturnType<typeof import('../reserve/assetReserve.js').start>
  *     >;
  *   };
  * }} powers

--- a/packages/inter-protocol/src/provisionPoolKit.js
+++ b/packages/inter-protocol/src/provisionPoolKit.js
@@ -63,7 +63,7 @@ const FIRST_LOWER_NEAR_KEYWORD = /^[a-z][a-zA-Z0-9_$]*$/;
  */
 
 /**
- * @typedef {Instance<psmStart>} PsmInstance
+ * @typedef {Instance<typeof psmStart>} PsmInstance
  */
 
 /**

--- a/packages/inter-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/inter-protocol/src/vaultFactory/vaultFactory.js
@@ -80,7 +80,7 @@ harden(meta);
  *   initialShortfallInvitation: Invitation;
  *   storageNode: Remote<StorageNode>;
  *   marshaller: Remote<Marshaller>;
- *   auctioneerInstance: Instance<auctioneerStart>;
+ *   auctioneerInstance: Instance<typeof auctioneerStart>;
  *   managerParams: Record<string, VaultManagerParamOverrides>;
  *   directorParamOverrides: [object];
  * }} privateArgs

--- a/packages/inter-protocol/test/auction/auctionContract.test.js
+++ b/packages/inter-protocol/test/auction/auctionContract.test.js
@@ -36,7 +36,7 @@ import {
 } from '../supports.js';
 import { setUpInstallations } from './tools.js';
 
-/** @type {TestFn<Awaited<ReturnType<makeTestContext>>>} */
+/** @type {TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
 const test = anyTest;
 
 /**
@@ -59,7 +59,9 @@ const test = anyTest;
  */
 
 /**
- * @typedef {Awaited<ReturnType<subscriptionTracker<BookDataNotification>>>} BookDataTracker
+ * @typedef {Awaited<
+ *   ReturnType<typeof subscriptionTracker<BookDataNotification>>
+ * >} BookDataTracker
  */
 
 const trace = makeTracer('Test AuctContract', false);
@@ -99,7 +101,7 @@ test.before(async t => {
 });
 
 /**
- * @param {ExecutionContext<Awaited<ReturnType<makeTestContext>>>} t
+ * @param {ExecutionContext<Awaited<ReturnType<typeof makeTestContext>>>} t
  * @param {any} params
  */
 export const setupServices = async (t, params = defaultParams) => {
@@ -141,7 +143,7 @@ export const setupServices = async (t, params = defaultParams) => {
 };
 
 /**
- * @param {ExecutionContext<Awaited<ReturnType<makeTestContext>>>} t
+ * @param {ExecutionContext<Awaited<ReturnType<typeof makeTestContext>>>} t
  * @param {any} [params]
  */
 const makeAuctionDriver = async (t, params = defaultParams) => {

--- a/packages/inter-protocol/test/auction/proportionalDist.test.js
+++ b/packages/inter-protocol/test/auction/proportionalDist.test.js
@@ -11,7 +11,7 @@ import { distributeProportionalSharesWithLimits } from '../../src/auction/auctio
  * @import {ExecutionContext} from 'ava';
  */
 
-/** @type {TestFn<Awaited<ReturnType<makeTestContext>>>} */
+/** @type {TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
 const test = anyTest;
 
 const trace = makeTracer('Test AuctContract', false);
@@ -32,7 +32,7 @@ test.before(async t => {
 });
 
 /**
- * @param {ExecutionContext<Awaited<ReturnType<makeTestContext>>>} t
+ * @param {ExecutionContext<Awaited<ReturnType<typeof makeTestContext>>>} t
  * @param {[collateralReturned: bigint, bidRaise: bigint]} amountsReturned
  * @param {{ deposit: number; goal?: number }[]} rawDeposits
  * @param {[transfers: [bigint, bigint][], leftovers: [bigint, bigint]]} rawExpected

--- a/packages/inter-protocol/test/auction/tools.js
+++ b/packages/inter-protocol/test/auction/tools.js
@@ -19,12 +19,12 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
 
 /**
  * @typedef {{
- *   autoRefund: Installation<refundStart>;
- *   auctioneer: Installation<auctioneerStart>;
+ *   autoRefund: Installation<typeof refundStart>;
+ *   auctioneer: Installation<typeof auctioneerStart>;
  *   governor: Installation<
- *     import('@agoric/governance/src/contractGovernor.js')['start']
+ *     typeof import('@agoric/governance/src/contractGovernor.js').start
  *   >;
- *   reserve: Installation<reserveStart>;
+ *   reserve: Installation<typeof reserveStart>;
  * }} AuctionTestInstallations
  */
 

--- a/packages/inter-protocol/test/provisionPool.test.js
+++ b/packages/inter-protocol/test/provisionPool.test.js
@@ -49,7 +49,7 @@ const WantMintedFeeBP = 1n;
 const GiveMintedFeeBP = 3n;
 const MINT_LIMIT = scale6(20_000_000);
 
-/** @type {TestFn<Awaited<ReturnType<makeTestContext>>>} */
+/** @type {TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
 const test = unknownTest;
 
 const makeTestContext = async () => {
@@ -66,7 +66,7 @@ const makeTestContext = async () => {
   const committeeInstall = await E(zoe).install(committeeBundle);
   const psmInstall = await E(zoe).install(psmBundle);
   const centralSupply = await E(zoe).install(centralSupplyBundle);
-  /** @type {Installation<import('../src/provisionPool.js')['start']>} */
+  /** @type {Installation<typeof import('../src/provisionPool.js').start>} */
   const policyInstall = await E(zoe).install(policyBundle);
 
   const mintLimit = AmountMath.make(mintedBrand, MINT_LIMIT);

--- a/packages/inter-protocol/test/psm/psm.test.js
+++ b/packages/inter-protocol/test/psm/psm.test.js
@@ -45,7 +45,7 @@ import { anchorAssets, chainStorageEntries } from './psm-storage-fixture.js';
  * @import {EconomyBootstrapPowers} from '../../src/proposals/econ-behaviors.js';
  */
 
-/** @type {TestFn<Awaited<ReturnType<makeTestContext>>>} */
+/** @type {TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
 const test = anyTest;
 
 const trace = makeTracer('TestPSM', false);
@@ -174,7 +174,7 @@ test.before(async t => {
 });
 
 /**
- * @param {ExecutionContext<Awaited<ReturnType<makeTestContext>>>} t
+ * @param {ExecutionContext<Awaited<ReturnType<typeof makeTestContext>>>} t
  * @param {{}} [customTerms]
  */
 async function makePsmDriver(t, customTerms) {
@@ -190,7 +190,7 @@ async function makePsmDriver(t, customTerms) {
   // Each driver needs its own to avoid state pollution between tests
   const mockChainStorage = makeMockChainStorageRoot();
 
-  /** @type {StartedInstanceKit<start>} */
+  /** @type {StartedInstanceKit<typeof start>} */
   const { creatorFacet, publicFacet } = await E(zoe).startInstance(
     psmInstall,
     harden({ AUSD: anchor.issuer }),

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -17,7 +17,7 @@ import { withAmountUtils } from '../supports.js';
 
 /**
  * @import {ExecutionContext} from 'ava';
- * @import {start as startWalletFactory} from '@agoric/smart-wallet/src/walletFactory.js';
+ * @import {start as StartWalletFactory} from '@agoric/smart-wallet/src/walletFactory.js';
  * @import {ScopedBridgeManager} from '@agoric/vats';
  * @import {NameAdmin} from '@agoric/vats';
  * @import {FluxStartFn} from '@agoric/inter-protocol/src/price/fluxAggregatorContract.js';
@@ -79,7 +79,7 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     'walletFactory',
   );
   /**
-   * @type {Promise<Installation<startWalletFactory>>}
+   * @type {Promise<Installation<StartWalletFactory>>}
    */
   const installation = E(zoe).install(bundle);
 

--- a/packages/inter-protocol/test/smartWallet/oracle-integration.test.js
+++ b/packages/inter-protocol/test/smartWallet/oracle-integration.test.js
@@ -132,7 +132,7 @@ const setupFeedWithWallets = async (t, oracleAddresses) => {
   await t.context.simpleCreatePriceFeed(oracleAddresses, 'ATOM', 'USD');
 
   /**
-   * @type {Instance<start>}
+   * @type {Instance<typeof start>}
    */
   const governedPriceAggregator = await E(agoricNames).lookup(
     'instance',
@@ -393,7 +393,7 @@ test.serial('govern oracles list', async t => {
   );
   /**
    * @type {Instance<
-   *   import('@agoric/governance/src/committee.js')['start']
+   *   typeof import('@agoric/governance/src/committee.js').start
    * >}
    */
   const economicCommittee = await E(agoricNames).lookup(

--- a/packages/inter-protocol/test/smartWallet/psm-integration.test.js
+++ b/packages/inter-protocol/test/smartWallet/psm-integration.test.js
@@ -29,7 +29,7 @@ import { headValue, sequenceCurrents, withAmountUtils } from '../supports.js';
 
 /**
  * @type {TestFn<
- *   Awaited<ReturnType<makeDefaultTestContext>> & {
+ *   Awaited<ReturnType<typeof makeDefaultTestContext>> & {
  *     consume: EconomyBootstrapPowers['consume'];
  *   }
  * >}

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -117,7 +117,7 @@ export const installPuppetGovernance = (zoe, produce) => {
 /**
  * @param {bigint} value
  * @param {{
- *   centralSupply: ERef<Installation<start>>;
+ *   centralSupply: ERef<Installation<typeof start>>;
  *   feeMintAccess: ERef<FeeMintAccess>;
  *   zoe: ERef<ZoeService>;
  * }} powers

--- a/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/fluxAggregator/bootstrap-fluxAggregator-service-upgrade.js
@@ -44,13 +44,13 @@ export const buildRootObject = async () => {
   /**
    * @type {{
    *   committee?: Installation<
-   *     import('@agoric/governance/src/committee.js')['start']
+   *     typeof import('@agoric/governance/src/committee.js').start
    *   >;
    *   fluxAggregatorV1?: Installation<
-   *     import('../../../src/price/fluxAggregatorContract.js').start
+   *     typeof import('../../../src/price/fluxAggregatorContract.js').start
    *   >;
    *   puppetContractGovernor?: Installation<
-   *     import('@agoric/governance/tools/puppetContractGovernor.js').start
+   *     typeof import('@agoric/governance/tools/puppetContractGovernor.js').start
    *   >;
    * }}
    */

--- a/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/psmUpgrade/bootstrap-psm-upgrade.js
@@ -22,7 +22,7 @@ import { scale6, withAmountUtils } from '../../supports.js';
 /**
  * @import {FeeMintAccess} from '@agoric/zoe';
  * @import {MetricsNotification} from '../../../src/psm/psm.js';
- * @import {start} from '@agoric/governance/tools/puppetContractGovernor.js';
+ * @import {start as startPeppetGovernor} from '@agoric/governance/tools/puppetContractGovernor.js';
  * @import {PuppetContractGovernorKit} from '@agoric/governance/tools/puppetContractGovernor.js';
  * @import {StartParams} from '@agoric/zoe/src/zoeService/utils.js';
  */
@@ -36,7 +36,7 @@ const anchor = withAmountUtils(makeIssuerKit('bucks'));
 const firstGive = anchor.units(21);
 const secondGive = anchor.units(3);
 
-/** @import {start as PsmSF} from '../../../src/psm/psm.js' */
+/** @import {start as startPsm} from '../../../src/psm/psm.js' */
 
 export const buildRootObject = async () => {
   const storageKit = makeFakeStorageKit('psmUpgradeTest');
@@ -75,19 +75,22 @@ export const buildRootObject = async () => {
   /**
    * @type {{
    *   committee?: Installation<
-   *     import('@agoric/governance/src/committee.js')['start']
+   *     typeof import('@agoric/governance/src/committee.js').start
    *   >;
-   *   psmV1?: Installation<PsmSF>;
-   *   puppetContractGovernor?: Installation<start>;
+   *   psmV1?: Installation<typeof startPsm>;
+   *   puppetContractGovernor?: Installation<typeof startPeppetGovernor>;
    * }}
    */
   const installations = {};
 
-  /** @type {PuppetContractGovernorKit<PsmSF>} */
+  /** @type {PuppetContractGovernorKit<typeof startPsm>} */
   let governorFacets;
 
   /**
-   * @type {Omit<StartParams<PsmSF>['terms'], 'issuers' | 'brands'>}
+   * @type {Omit<
+   *   StartParams<typeof startPsm>['terms'],
+   *   'issuers' | 'brands'
+   * >}
    */
   const psmTerms = {
     anchorBrand: anchor.brand,

--- a/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
+++ b/packages/inter-protocol/test/swingsetTests/reserve/bootstrap-assetReserve-upgrade.js
@@ -64,31 +64,33 @@ export const buildRootObject = async () => {
   /**
    * @type {{
    *   committee?: Installation<
-   *     import('@agoric/governance/src/committee.js')['start']
+   *     typeof import('@agoric/governance/src/committee.js').start
    *   >;
    *   assetReserveV1?: Installation<
-   *     import('../../../src/reserve/assetReserve.js')['start']
+   *     typeof import('../../../src/reserve/assetReserve.js').start
    *   >;
    *   puppetContractGovernor?: Installation<
-   *     import('@agoric/governance/tools/puppetContractGovernor.js')['start']
+   *     typeof import('@agoric/governance/tools/puppetContractGovernor.js').start
    *   >;
    * }}
    */
   const installations = {};
 
   /**
-   * @type {PuppetContractGovernorKit<start>}
+   * @type {PuppetContractGovernorKit<typeof start>}
    */
   let governorFacets;
   /**
    * @type {ReturnType<
-   *   Awaited<ReturnType<start>>['creatorFacet']['getLimitedCreatorFacet']
+   *   Awaited<
+   *     ReturnType<typeof start>
+   *   >['creatorFacet']['getLimitedCreatorFacet']
    * >}
    */
   let arLimitedFacet;
 
   /**
-   * @type {Omit<StartParams<start>['terms'], 'issuers' | 'brands'>}
+   * @type {Omit<StartParams<typeof start>['terms'], 'issuers' | 'brands'>}
    */
   const arTerms = {
     governedParams: {

--- a/packages/inter-protocol/test/vaultFactory/driver.js
+++ b/packages/inter-protocol/test/vaultFactory/driver.js
@@ -189,7 +189,7 @@ const getRunFromFaucet = async (t, amt) => {
     zoe,
     feeMintAccess,
   } = t.context;
-  /** @type {Promise<Installation<start>>} */
+  /** @type {Promise<Installation<typeof start>>} */
   // @ts-expect-error cast
   // On-chain, there will be pre-existing RUN. The faucet replicates that
   const { creatorFacet: faucetCreator } = await E(zoe).startInstance(

--- a/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactory.test.js
@@ -1968,7 +1968,7 @@ test('manager notifiers, with snapshot', async t => {
   });
 
   /**
-   * @type {ReturnType<makeMockChainStorageRoot>}
+   * @type {ReturnType<typeof makeMockChainStorageRoot>}
    */
   // @ts-expect-error mock
   const storage = await services.space.consume.chainStorage;

--- a/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
+++ b/packages/inter-protocol/test/vaultFactory/vaultFactoryUtils.js
@@ -169,7 +169,7 @@ export const getRunFromFaucet = async (t, amount) => {
     feeMintAccess,
     run,
   } = t.context;
-  /** @type {Promise<Installation<start>>} */
+  /** @type {Promise<Installation<typeof start>>} */
   // On-chain, there will be pre-existing RUN. The faucet replicates that
   // @ts-expect-error
   const { creatorFacet: faucetCreator } = await E(zoe).startInstance(

--- a/packages/internal/src/callback.js
+++ b/packages/internal/src/callback.js
@@ -25,7 +25,7 @@ const ownKeys =
 /**
  * @template {Methods} T
  * @typedef {(
- *   ...args: Parameters<ReturnType<prepareAttenuator>>
+ *   ...args: Parameters<ReturnType<typeof prepareAttenuator>>
  * ) => Farable<T>} MakeAttenuator
  */
 

--- a/packages/orchestration/src/exos/chain-hub-admin.js
+++ b/packages/orchestration/src/exos/chain-hub-admin.js
@@ -80,4 +80,4 @@ export const prepareChainHubAdmin = (zone, chainHub) => {
   return makeCreatorFacet;
 };
 
-/** @typedef {ReturnType<prepareChainHubAdmin>} ChainHubAdmin */
+/** @typedef {ReturnType<typeof prepareChainHubAdmin>} ChainHubAdmin */

--- a/packages/orchestration/src/proposals/start-stakeAtom.js
+++ b/packages/orchestration/src/proposals/start-stakeAtom.js
@@ -19,7 +19,7 @@ const trace = makeTracer('StartStakeAtom', true);
  * @param {BootstrapPowers & {
  *   installation: {
  *     consume: {
- *       stakeIca: Installation<start>;
+ *       stakeIca: Installation<typeof start>;
  *     };
  *   };
  * }} powers

--- a/packages/orchestration/src/proposals/start-stakeBld.js
+++ b/packages/orchestration/src/proposals/start-stakeBld.js
@@ -13,7 +13,7 @@ const trace = makeTracer('StartStakeBld', true);
  * @param {BootstrapPowers & {
  *   installation: {
  *     consume: {
- *       stakeBld: Installation<start>;
+ *       stakeBld: Installation<typeof start>;
  *     };
  *   };
  * }} powers
@@ -51,7 +51,7 @@ export const startStakeBld = async ({
   ]);
 
   /**
-   * @type {StartUpgradableOpts<start>}
+   * @type {StartUpgradableOpts<typeof start>}
    */
   const startOpts = {
     label: 'stakeBld',

--- a/packages/orchestration/src/proposals/start-stakeOsmo.js
+++ b/packages/orchestration/src/proposals/start-stakeOsmo.js
@@ -19,7 +19,7 @@ const trace = makeTracer('StartStakeOsmo', true);
  * @param {BootstrapPowers & {
  *   installation: {
  *     consume: {
- *       stakeIca: Installation<start>;
+ *       stakeIca: Installation<typeof start>;
  *     };
  *   };
  *   instance: {

--- a/packages/orchestration/src/utils/agd-lib.js
+++ b/packages/orchestration/src/utils/agd-lib.js
@@ -155,4 +155,4 @@ export const makeAgd = ({ execFileSync, log = console.log }) => {
   return make();
 };
 
-/** @typedef {ReturnType<makeAgd>} Agd */
+/** @typedef {ReturnType<typeof makeAgd>} Agd */

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -47,7 +47,7 @@ export const getCourierPK = (key, keyToCourierPK) => {
  * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} retain
  * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} redeem
  * @property {Remote<TransferProtocol>} transferProtocol
- * @property {ReturnType<prepareVowTools>['when']} when
+ * @property {ReturnType<typeof prepareVowTools>['when']} when
  * @param {Remote<Connection>} connection
  * @returns {(args: CourierArgs) => Courier}
  */

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -35,7 +35,7 @@ const TRANSFER_PROPOSAL_SHAPE = {
  * @param {ZCF} powers.zcf the Zoe Contract Facet
  * @param {Remote<BoardDepositFacet>} powers.board where to find depositFacets by boardID
  * @param {Remote<NameHub>} powers.namesByAddress where to find depositFacets by bech32
- * @param {ReturnType<prepareVowTools>['when']} powers.when
+ * @param {ReturnType<typeof prepareVowTools>['when']} powers.when
  *
  * @import {NameHub} from '@agoric/vats'
  */

--- a/packages/pola-io/src/cmd.js
+++ b/packages/pola-io/src/cmd.js
@@ -80,4 +80,4 @@ export const makeCmdRunner = (file, { execFile, defaultEnv } = {}) => {
   return make({ preArgs: [], postArgs: [], postEnv: {} });
 };
 freeze(makeCmdRunner);
-/** @typedef {ReturnType<makeCmdRunner>} CmdRunner */
+/** @typedef {ReturnType<typeof makeCmdRunner>} CmdRunner */

--- a/packages/portfolio-deploy/src/chain-info.build.js
+++ b/packages/portfolio-deploy/src/chain-info.build.js
@@ -198,7 +198,7 @@ const makeAgd = (
  *
  * @param {string} chainId of agoric chain
  * @param {string[]} peers bech32prefix:connection-12:channel-34:ustake
- * @param {{ agd: ReturnType<makeAgd> }} io
+ * @param {{ agd: ReturnType<typeof makeAgd> }} io
  * @returns {Promise<Record<string, CosmosChainInfo>>} where
  *   info.agoric.connections has a connection to each peeer
  */

--- a/packages/smart-wallet/test/addAsset.test.js
+++ b/packages/smart-wallet/test/addAsset.test.js
@@ -19,7 +19,7 @@ const importSpec = async spec =>
   new URL(importMetaResolve(spec, import.meta.url)).pathname;
 
 /**
- * @type {TestFn<Awaited<ReturnType<makeDefaultTestContext>>>}
+ * @type {TestFn<Awaited<ReturnType<typeof makeDefaultTestContext>>>}
  */
 const test = anyTest;
 
@@ -136,7 +136,9 @@ const IST_UNIT = 1_000_000n;
 const CENT = IST_UNIT / 100n;
 
 /**
- * @param {ExecutionContext<Awaited<ReturnType<makeDefaultTestContext>>>} t
+ * @param {ExecutionContext<
+ *   Awaited<ReturnType<typeof makeDefaultTestContext>>
+ * >} t
  */
 const makeScenario = t => {
   /**

--- a/packages/smart-wallet/test/contexts.js
+++ b/packages/smart-wallet/test/contexts.js
@@ -8,7 +8,7 @@ import { withAmountUtils } from './supports.js';
 
 /**
  * @import {ExecutionContext} from 'ava';
- * @import {start} from '../src/walletFactory.js';
+ * @import {start as StartWalletFactory} from '../src/walletFactory.js';
  */
 
 /**
@@ -30,7 +30,7 @@ export const makeDefaultTestContext = async (t, makeSpace) => {
     `${dirname}/../src/walletFactory.js`,
     'walletFactory',
   );
-  /** @type {Promise<Installation<start>>} */
+  /** @type {Promise<Installation<StartWalletFactory>>} */
   const installation = E(zoe).install(bundle);
   //#endregion
 

--- a/packages/smart-wallet/test/invitation1.test.js
+++ b/packages/smart-wallet/test/invitation1.test.js
@@ -28,7 +28,7 @@ import { prepareSmartWallet } from '../src/smartWallet.js';
  * @import {BridgeAction} from '../src/smartWallet.js';
  */
 
-/** @type {TestFn<Awaited<ReturnType<makeTestContext>>>} */
+/** @type {TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
 const test = anyTest;
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -86,7 +86,7 @@ const makeTestContext = async t => {
   const startAnyContract = async () => {
     const bundle = await bundleCache.load(asset.anyContract, 'automaticRefund');
     /**
-     * @type {Promise<Installation<prepare>>}
+     * @type {Promise<Installation<typeof prepare>>}
      */
     const installation = E(zoe).install(bundle);
     return E(zoe).startInstance(installation);

--- a/packages/smart-wallet/test/invoke-result.test.js
+++ b/packages/smart-wallet/test/invoke-result.test.js
@@ -16,7 +16,7 @@ import * as priceExports from './wallet-fun.contract.js';
  */
 
 /**
- * @typedef {Awaited<ReturnType<makeTestContext>>} WTestCtx
+ * @typedef {Awaited<ReturnType<typeof makeTestContext>>} WTestCtx
  */
 
 const contractName = 'walletFactory';

--- a/packages/smart-wallet/test/startWalletFactory.test.js
+++ b/packages/smart-wallet/test/startWalletFactory.test.js
@@ -9,7 +9,7 @@ import { makeMockTestSpace } from './supports.js';
 /**
  * @import {EReturn} from '@endo/far';
  * @import {TestFn} from 'ava';
- * @import {start} from '../src/walletFactory.js';
+ * @import {start as StartWalletFactory} from '../src/walletFactory.js';
  */
 
 /**
@@ -32,7 +32,7 @@ const makeTestContext = async () => {
     `${dirname}/../src/walletFactory.js`,
     'walletFactory',
   );
-  /** @type {Promise<Installation<typeof start>>} */
+  /** @type {Promise<Installation<StartWalletFactory>>} */
   const installation = E(zoe).install(bundle);
   //#endregion
 

--- a/packages/smart-wallet/test/startWalletFactory.test.js
+++ b/packages/smart-wallet/test/startWalletFactory.test.js
@@ -32,7 +32,7 @@ const makeTestContext = async () => {
     `${dirname}/../src/walletFactory.js`,
     'walletFactory',
   );
-  /** @type {Promise<Installation<start>>} */
+  /** @type {Promise<Installation<typeof start>>} */
   const installation = E(zoe).install(bundle);
   //#endregion
 

--- a/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/bootstrap-walletFactory-service-upgrade.js
+++ b/packages/smart-wallet/test/swingsetTests/upgradeWalletFactory/bootstrap-walletFactory-service-upgrade.js
@@ -14,7 +14,7 @@ import { makePromiseKit } from '@endo/promise-kit';
 /**
  * @import {AdminFacet, ContractOf, InvitationAmount, ZCFMint} from '@agoric/zoe';
  * @import {SmartWallet} from '../../../src/smartWallet.js';
- * @import {start} from '../../../src/walletFactory.js';
+ * @import {start as StartWalletFactory} from '../../../src/walletFactory.js';
  */
 
 const trace = makeTracer('BootWFUpg', false);
@@ -49,7 +49,7 @@ export const buildRootObject = async () => {
   const bank = await E(bankManager).getBankForAddress(walletAddr);
 
   // for startInstance
-  /** @type {Installation<start>} */
+  /** @type {Installation<StartWalletFactory>} */
   let installation;
   const terms = {
     agoricNames,

--- a/packages/smart-wallet/test/walletFactory.test.js
+++ b/packages/smart-wallet/test/walletFactory.test.js
@@ -17,7 +17,7 @@ import {
  */
 
 /**
- * @type {TestFn<Awaited<ReturnType<makeDefaultTestContext>>>}
+ * @type {TestFn<Awaited<ReturnType<typeof makeDefaultTestContext>>>}
  */
 const test = anyTest;
 

--- a/packages/swing-store/src/swingStore.js
+++ b/packages/swing-store/src/swingStore.js
@@ -149,10 +149,10 @@ const IN_MEMORY = ':memory:';
  * @property {SnapshotCallback} [archiveSnapshot]  Called after creation of a new heap snapshot
  * @property {TranscriptCallback} [archiveTranscript]  Called after a formerly-current transcript span is finalized
  * @property {(pendingExports: Iterable<[key: string, value: string | null]>) => void} [exportCallback]
- * @property {Replacer<ReturnType<makeKVStore>>} [wrapKvStore]
- * @property {Replacer<ReturnType<makeTranscriptStore>>} [wrapTranscriptStore]
- * @property {Replacer<ReturnType<makeSnapStore>>} [wrapSnapStore]
- * @property {Replacer<ReturnType<makeBundleStore>>} [wrapBundleStore]
+ * @property {Replacer<ReturnType<typeof makeKVStore>>} [wrapKvStore]
+ * @property {Replacer<ReturnType<typeof makeTranscriptStore>>} [wrapTranscriptStore]
+ * @property {Replacer<ReturnType<typeof makeSnapStore>>} [wrapSnapStore]
+ * @property {Replacer<ReturnType<typeof makeBundleStore>>} [wrapBundleStore]
  */
 
 /**

--- a/packages/swing-store/src/transcriptStore.js
+++ b/packages/swing-store/src/transcriptStore.js
@@ -374,7 +374,7 @@ export function makeTranscriptStore(
    * transcript.${vatID}.current export record are responsibility of the caller.
    *
    * @param {string} vatID
-   * @param {ReturnType<getCurrentSpanBounds>} bounds
+   * @param {ReturnType<typeof getCurrentSpanBounds>} bounds
    * @returns {{deferredTask: Promise<void>}}
    */
   function closeSpan(vatID, bounds) {

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -1326,7 +1326,7 @@ function build(
 
   /**
    * @param {VatDeliveryObject} delivery
-   * @returns {undefined | ReturnType<startVat>}
+   * @returns {undefined | ReturnType<typeof startVat>}
    */
   function dispatchToUserspace(delivery) {
     let result;

--- a/packages/vats/src/core/startWalletFactory.js
+++ b/packages/vats/src/core/startWalletFactory.js
@@ -17,7 +17,7 @@ import {
  * @import {EMarshaller} from '@agoric/internal/src/marshal/wrap-marshaller.js';
  * @import {EReturn} from '@endo/far';
  * @import {AdminFacet, ContractOf, InvitationAmount, ZCFMint} from '@agoric/zoe';
- * @import {start} from '@agoric/smart-wallet/src/walletFactory.js';
+ * @import {start as StartWalletFactory} from '@agoric/smart-wallet/src/walletFactory.js';
  * @import {CommitteeElectorateCreatorFacet} from '@agoric/governance/src/committee.js';
  * @import {ScopedBridgeManager} from '../types.js';
  */
@@ -26,7 +26,7 @@ const trace = makeTracer('StartWF', 'verbose');
 
 /**
  * @param {ERef<ZoeService>} zoe
- * @param {Installation<start>} inst
+ * @param {Installation<StartWalletFactory>} inst
  *
  * @typedef {EReturn<typeof startFactoryInstance>} WalletFactoryStartResult
  */
@@ -73,7 +73,7 @@ const publishRevivableWalletState = async (
  *     econCharterKit: {
  *       creatorFacet: Awaited<
  *         ReturnType<
- *           import('@agoric/inter-protocol/src/econCommitteeCharter.js')['start']
+ *           typeof import('@agoric/inter-protocol/src/econCommitteeCharter.js').start
  *         >
  *       >['creatorFacet'];
  *       adminFacet: AdminFacet;

--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -142,7 +142,7 @@ export const prepareNameHubKit = zone => {
     /** @type {Map<string, PromiseKit<unknown>>} */
     keyToAdminPK: new Map(),
   });
-  /** @type {WeakMap<any, ReturnType<init1>>} */
+  /** @type {WeakMap<any, ReturnType<typeof init1>>} */
   const ephemera = new WeakMap();
   /** @param {{}} me */
   const my = me => provideWeak(ephemera, me, init1);

--- a/packages/vats/src/vat-bank.js
+++ b/packages/vats/src/vat-bank.js
@@ -418,9 +418,9 @@ export const BankI = M.interface('Bank', {
 /**
  * @param {Zone} zone
  * @param {object} makers
- * @param {ReturnType<prepareAssetSubscription>} makers.provideAssetSubscription
- * @param {ReturnType<prepareDurablePublishKit>} makers.makePublishKit
- * @param {ReturnType<prepareVirtualPurse>} makers.makeVirtualPurse
+ * @param {ReturnType<typeof prepareAssetSubscription>} makers.provideAssetSubscription
+ * @param {ReturnType<typeof prepareDurablePublishKit>} makers.makePublishKit
+ * @param {ReturnType<typeof prepareVirtualPurse>} makers.makeVirtualPurse
  */
 const prepareBank = (
   zone,
@@ -567,11 +567,11 @@ const BankManagerI = M.interface('BankManager', {
 /**
  * @param {Zone} zone
  * @param {object} makers
- * @param {ReturnType<prepareAssetSubscription>} makers.provideAssetSubscription
- * @param {ReturnType<prepareBank>} makers.makeBank
- * @param {ReturnType<prepareDurablePublishKit>} makers.makePublishKit
- * @param {ReturnType<prepareRewardPurseController>} makers.makeRewardPurseController
- * @param {ReturnType<prepareVirtualPurse>} makers.makeVirtualPurse
+ * @param {ReturnType<typeof prepareAssetSubscription>} makers.provideAssetSubscription
+ * @param {ReturnType<typeof prepareBank>} makers.makeBank
+ * @param {ReturnType<typeof prepareDurablePublishKit>} makers.makePublishKit
+ * @param {ReturnType<typeof prepareRewardPurseController>} makers.makeRewardPurseController
+ * @param {ReturnType<typeof prepareVirtualPurse>} makers.makeVirtualPurse
  */
 const prepareBankManager = (
   zone,

--- a/packages/vats/test/boot.test.js
+++ b/packages/vats/test/boot.test.js
@@ -24,7 +24,7 @@ import {
  */
 
 //#region ambient authority limited to test set-up
-/** @typedef {ExecutionContext<ReturnType<makeTestContext>>} ECtx */
+/** @typedef {ExecutionContext<ReturnType<typeof makeTestContext>>} ECtx */
 
 const makeTestContext = () => {
   const bundleSource = bundleSourceAmbient;

--- a/packages/vats/test/bridge-target.test.js
+++ b/packages/vats/test/bridge-target.test.js
@@ -11,7 +11,7 @@ import { makeFakeTransferBridge } from '../tools/fake-bridge.js';
  * @import {TestFn} from 'ava';
  */
 
-/** @type {TestFn<Awaited<ReturnType<makeTestContext>>>} */
+/** @type {TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
 const test = anyTest;
 
 const { fakeVomKit } = reincarnate({ relaxDurabilityRules: false });

--- a/packages/vats/test/localchain.test.js
+++ b/packages/vats/test/localchain.test.js
@@ -26,7 +26,7 @@ import {
  * @import {AdditionalTransferPowers} from '../src/localchain.js';
  */
 
-/** @type {TestFn<Awaited<ReturnType<makeTestContext>>>} */
+/** @type {TestFn<Awaited<ReturnType<typeof makeTestContext>>>} */
 const test = anyTest;
 
 const { fakeVomKit } = reincarnate({ relaxDurabilityRules: false });

--- a/packages/vats/test/vpurse.test.js
+++ b/packages/vats/test/vpurse.test.js
@@ -18,7 +18,7 @@ import { prepareVirtualPurse } from '../src/virtual-purse.js';
  * @import {VirtualPurseController} from '../src/virtual-purse.js';
  */
 
-/** @type {TestFn<ReturnType<makeTestContext>>} */
+/** @type {TestFn<ReturnType<typeof makeTestContext>>} */
 const test = rawTest;
 
 const { fakeVomKit } = reincarnate({ relaxDurabilityRules: false });

--- a/packages/vow/src/E.js
+++ b/packages/vow/src/E.js
@@ -310,7 +310,7 @@ const makeE = (HandledPromise, powers = {}) => {
 
 export default makeE;
 
-/** @typedef {ReturnType<makeE>} EProxy */
+/** @typedef {ReturnType<typeof makeE>} EProxy */
 
 /**
  * `DataOnly<T>` means to return a record type `T2` consisting only of

--- a/packages/vow/src/retryable.js
+++ b/packages/vow/src/retryable.js
@@ -204,7 +204,7 @@ export const prepareRetryableTools = (outerZone, outerOptions) => {
 harden(prepareRetryableTools);
 
 /**
- * @typedef {ReturnType<prepareRetryableTools>} RetryableTools
+ * @typedef {ReturnType<typeof prepareRetryableTools>} RetryableTools
  */
 
 /**

--- a/packages/zoe/src/contracts/mintAndSellNFT.js
+++ b/packages/zoe/src/contracts/mintAndSellNFT.js
@@ -43,7 +43,7 @@ const start = zcf => {
 
   /**
    * @param {object} obj
-   * @param {Installation<sellItemStart>} obj.sellItemsInstallation
+   * @param {Installation<typeof sellItemStart>} obj.sellItemsInstallation
    * @param {*} obj.customValueProperties
    * @param {number} obj.count
    * @param {*} obj.moneyIssuer

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -116,7 +116,7 @@ harden(makeInstanceAdminStorage);
 
 /**
  * @param {Baggage} zoeBaggage
- * @param {ReturnType<makeZoeSeatAdminFactory>} makeZoeSeatAdminKit
+ * @param {ReturnType<typeof makeZoeSeatAdminFactory>} makeZoeSeatAdminKit
  */
 const makeInstanceAdminBehavior = (zoeBaggage, makeZoeSeatAdminKit) => {
   const makeSeatHandle = defineDurableHandle(zoeBaggage, 'Seat');

--- a/packages/zoe/test/unitTests/contracts/ownable-counter.test.js
+++ b/packages/zoe/test/unitTests/contracts/ownable-counter.test.js
@@ -10,7 +10,7 @@ import { makeZoeForTest } from '../../../tools/setup-zoe.js';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
 /**
- * @import {start} from './ownable-counter.js';
+ * @import {start as startOwnableCounter} from './ownable-counter.js';
  */
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);
@@ -26,7 +26,7 @@ test('zoe - ownable-counter contract', async t => {
   // Pack the contract.
   const bundle = await bundleSource(root);
   vatAdminState.installBundle('b1-ownable-counter', bundle);
-  /** @type {Installation<start>} */
+  /** @type {Installation<typeof startOwnableCounter>} */
   const installation = await E(zoe).installBundleID('b1-ownable-counter');
 
   const { creatorFacet: firstCounter, publicFacet: viewCounter } = await E(

--- a/packages/zoe/test/unitTests/contracts/priceAggregator.test.js
+++ b/packages/zoe/test/unitTests/contracts/priceAggregator.test.js
@@ -118,7 +118,7 @@ test.before('setup aggregator and oracles', async t => {
   /** @type {Installation<OracleStart>} */
   const oracleInstallation = await E(zoe).installBundleID('b1-oracle');
   vatAdminState.installBundle('b1-aggregator', aggregatorBundle);
-  /** @type {Installation<start>} */
+  /** @type {Installation<typeof start>} */
   const aggregatorInstallation = await E(zoe).installBundleID('b1-aggregator');
 
   const link = makeIssuerKit('$ATOM');

--- a/packages/zoe/test/unitTests/contracts/valueVow.test.js
+++ b/packages/zoe/test/unitTests/contracts/valueVow.test.js
@@ -73,7 +73,7 @@ test('baggage', async t => {
   });
 
   await E(zoe).startInstance(
-    /** @type {Installation<startValueVow>} */
+    /** @type {Installation<typeof startValueVow>} */
     (await bundleAndInstall(contractFile)),
   );
 

--- a/packages/zoe/test/unitTests/zoe.test.js
+++ b/packages/zoe/test/unitTests/zoe.test.js
@@ -12,7 +12,7 @@ import { setup } from './setupBasicMints.js';
 import { setupZCFTest } from './zcf/setupZcfTest.js';
 
 /**
- * @import {start} from '@agoric/zoe/src/contracts/automaticRefund.js';
+ * @import {start as startAutomaticRefund} from '@agoric/zoe/src/contracts/automaticRefund.js';
  */
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);
@@ -108,7 +108,7 @@ test(`E(zoe).getPublicFacet`, async t => {
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
   vatAdminState.installBundle('b1-refund', bundle);
-  /** @type {Installation<start>} */
+  /** @type {Installation<typeof startAutomaticRefund>} */
   const installation = await E(zoe).installBundleID('b1-refund');
   const { publicFacet, instance } = await E(zoe).startInstance(installation);
   await t.throwsAsync(() =>
@@ -230,7 +230,7 @@ test(`zoe.getTerms`, async t => {
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
   vatAdminState.installBundle('b1-refund', bundle);
-  /** @type {Installation<start>} */
+  /** @type {Installation<typeof startAutomaticRefund>} */
   const installation = await E(zoe).installBundleID('b1-refund');
   const { instance } = await E(zoe).startInstance(
     installation,


### PR DESCRIPTION
refs: #10665

## Description
Reviewing #10665 made me realize we have a lot of broken type declarations using runtime values without `typeof`. These technically resolve to `any`, but sometimes tsc is smart enough to make the `typeof` implicit. It's hard to tell since we're not running tsc in strict mode (aka with implicit any allowed).

This is mostly the result of a quick grep, and manual review, so I expect I missed some cases.

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
I expect existing tests to keep passing. I haven't checked coverage before/after.

### Upgrade Considerations
None
