### PR TITLE
feat: patch `@endo/bundle-source` to `esbuild` if bundle is too big

### DIFF
--- a/.yarn/patches/@endo-bundle-source-npm-4.1.2-80da9522ea.patch
+++ b/.yarn/patches/@endo-bundle-source-npm-4.1.2-80da9522ea.patch
@@ -1,0 +1,245 @@
+diff --git a/cache.js b/cache.js
+index e61f6d5e040f95ecb49db6cc5201cbb392a5caa8..d711a8a44311fe68408cc6eddcb465fb6857ca6d 100644
+--- a/cache.js
++++ b/cache.js
+@@ -92,11 +92,13 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
+ 
+     const bundleFileName = toBundleName(targetName);
+     const bundleWr = wr.neighbor(bundleFileName);
++    const esbuildRd = wr.neighbor(jsOpts.toBundleName(`${targetName}-esbuild`)).readOnly();
++    const esbuildPath = cwd.relative(esbuildRd.absolute());
+     const metaWr = wr.neighbor(toBundleMeta(targetName));
+ 
+     const bundle = await bundleSource(
+       rootPath,
+-      { ...bundleOptions, noTransforms, elideComments, format, conditions },
++      { ...bundleOptions, esbuildPath, noTransforms, elideComments, format, conditions },
+       {
+         ...readPowers,
+         read: loggedRead,
+diff --git a/package.json b/package.json
+index d95a02f005ffd458897f006e6fc6452869e44e01..089d8ec55e5a64f015ef6ae1b71b7aa58ff3347c 100644
+--- a/package.json
++++ b/package.json
+@@ -30,6 +30,7 @@
+     "@endo/init": "^1.1.12",
+     "@endo/promise-kit": "^1.1.13",
+     "@endo/where": "^1.0.11",
++    "esbuild": "^0.25.2",
+     "ts-blank-space": "^0.4.1"
+   },
+   "devDependencies": {
+diff --git a/src/bundle-source.js b/src/bundle-source.js
+index 173387c2225b4bfe7de3922388757fa6a7b5e58b..33cbbdd4099dd4e2f6b698414e540050dff0c422 100644
+--- a/src/bundle-source.js
++++ b/src/bundle-source.js
+@@ -1,4 +1,19 @@
+ // @ts-check
++/**
++ * CometBFT RPC Node default max_body_bytes is 1,000,000 , and we hex encode the
++ * bundle before POSTing (2 hex chars per input byte), with an ample size
++ * reserved for overhead (10,000 bytes).
++ */
++export const AGORIC_MAX_BYTE_LIMIT = (1_000_000 / 2) - 10_000;
++/**
++ * We really only need externals to prune these particular dynamic imports.
++ */
++export const AGORIC_SDK_EXTERNALS = [
++  '@agoric/deploy-script-support',
++  '@agoric/internal/src/module-utils.js',
++];
++
++export const DEFAULT_OUT_DIR = 'bundles';
+ export const DEFAULT_MODULE_FORMAT = 'endoZipBase64';
+ export const SUPPORTED_FORMATS = [
+   'getExport',
+@@ -7,6 +22,121 @@ export const SUPPORTED_FORMATS = [
+   'endoScript',
+ ];
+ 
++/**
++ * @param {string} input
++ * @returns {Promise<number>} 
++ */
++const calculateUploadSize = async (input) => {
++  // Calculate the size of the input after compression.
++  const avoidBundling = 'zlib';
++  const zlib = await import(avoidBundling);
++  const compressed = zlib.gzipSync(input);
++  return compressed.length;
++};
++
++/**
++ * @param {Date} date 
++ * @returns {Promise<string>}
++ */
++const defaultEsbuildPath = async (date) => {
++  const isoTime = date.toISOString();
++  const fsFriendlyTime = isoTime.replace(/[-:]/g, '');
++  const esbuildFileName = `esbuild-bundle-${fsFriendlyTime}.js`;
++  const avoidBundling = 'path';
++  const path = await import(avoidBundling);
++  return path.join(DEFAULT_OUT_DIR, esbuildFileName);
++};
++
++/**
++ * @param {string[]} initialExternals
++ * @returns {Promise<string[]>}
++ */
++const allExternals = async (initialExternals = []) => {
++  try {
++    const avoidBundlingModule = 'module';
++    const module = await import(avoidBundlingModule);
++    const builtins = ['node:*', ...module.builtinModules];
++    return [...initialExternals, ...builtins];
++  } catch (e) {
++    // Fallback for environments without 'module' builtin
++    return initialExternals;
++  }
++};
++
++/**
++ * Ensure that the input directory has a package.json above it.
++ *
++ * @param {string} startFilename 
++ */
++const prepareInputDirectory = async (startFilename) => {
++  const avoidBundlingPath = 'path';
++  const path = await import(avoidBundlingPath);
++  const inDir = path.dirname(startFilename);
++
++  const avoidBundlingUrl = 'url';
++  const url = await import(avoidBundlingUrl);
++  const avoidBundlingModule = 'module';
++  const module = await import(avoidBundlingModule);
++  try {
++    const origPJfile = module.findPackageJSON(url.pathToFileURL(startFilename));
++    if (origPJfile) {
++      // We have a package.json, so no need to create one.
++      return;
++    }
++  } catch (_e) {
++    // continue to create one
++  }
++
++  // Create a minimal package.json
++  const avoidBundlingFs = 'fs';
++  const fsp = await import(avoidBundlingFs).then(mod => mod.promises);
++  const pjFile = path.join(inDir, 'package.json');
++  const packageJson = JSON.stringify(
++    {
++      name: '@aglocal/temp-bundle-input',
++      type: 'module',
++    },
++    null,
++    2,
++  );
++  const tmpFile = `${pjFile}.${Date.now()}`;
++  try {
++    await fsp.writeFile(
++      tmpFile,
++      `${packageJson}\n`,
++    );
++    await fsp.rename(tmpFile, pjFile);
++  } catch (e) {
++    try {
++      await fsp.unlink(tmpFile);
++    } catch (_e) {
++      // ignore
++    }
++  }
++};
++
++/**
++ * @param {string} startFilename
++ * @param {string} outfile
++ * @param {string[]} [initialExternals]
++ */
++const esbuildBundle = async (startFilename, outfile, initialExternals = []) => {
++  const avoidBundling = 'esbuild';
++  const esbuild = await import(avoidBundling);
++  const avoidBundlingModule = 'module';
++  const module = await import(avoidBundlingModule);
++
++  await esbuild.build({
++    entryPoints: [startFilename],
++    bundle: true,
++    platform: 'neutral',
++    external: await allExternals([...initialExternals, ...AGORIC_SDK_EXTERNALS]),
++    mainFields: ['main'],
++    minifyWhitespace: true,
++    outfile,
++  });
++};
++
+ /** @type {import('./types.js').BundleSource} */
+ // @ts-ignore cast
+ const bundleSource = async (
+@@ -20,17 +150,37 @@ const bundleSource = async (
+   }
+   /** @type {{ format: import('./types.js').ModuleFormat }} */
+   // @ts-expect-error cast (xxx params)
+-  const { format: moduleFormat = DEFAULT_MODULE_FORMAT } = options;
++  const { format: moduleFormat = DEFAULT_MODULE_FORMAT, byteLimit = AGORIC_MAX_BYTE_LIMIT } = options;
+ 
+   switch (moduleFormat) {
+     case 'endoZipBase64': {
+-      const { bundleZipBase64 } = await import('./zip-base64.js');
+-      return bundleZipBase64(startFilename, options, powers);
++      const avoidBundling = './zip-base64.js';
++      const { bundleZipBase64 } = await import(avoidBundling);
++      const simpleBundle = await bundleZipBase64(startFilename, options, powers);
++      if (await calculateUploadSize(simpleBundle.endoZipBase64) < byteLimit) {
++        return simpleBundle;
++      }
++
++      // When the Endo bundle is too big, fallback to esbuild-based bundling.
++      const { esbuildPath = await defaultEsbuildPath(new Date()) } = options;
++      await esbuildBundle(startFilename, esbuildPath, powers?.externals);
++
++      await prepareInputDirectory(esbuildPath);
++      const esbuilt = await bundleZipBase64(esbuildPath, options, powers);
++      if (await calculateUploadSize(esbuilt.endoZipBase64) > byteLimit) {
++        const warning = RangeError(
++          `Bundled source ${startFilename} still exceeds byteLimit of ${byteLimit} after minimizing; got ${esbuilt.endoZipBase64.length} bytes`,
++        );
++        console.warn(`⚠️  AGORIC_SDK_WARNING:`, warning);
++      }
++
++      return esbuilt;
+     }
+     case 'getExport':
+     case 'nestedEvaluate':
+     case 'endoScript': {
+-      const { bundleScript } = await import('./script.js');
++      const avoidBundling = './script.js';
++      const { bundleScript } = await import(avoidBundling);
+       return bundleScript(startFilename, moduleFormat, options, powers);
+     }
+     default:
+diff --git a/src/types.d.ts b/src/types.d.ts
+index 656f89425805ab52e3f7d16c9732a75d90d34ea8..d63a6291fcfcee05ea2a774c260b393a1deeab8f 100644
+--- a/src/types.d.ts
++++ b/src/types.d.ts
+@@ -53,6 +53,8 @@ export type BundleOptions<T extends ModuleFormat> = {
+      * exports and imports.
+      */
+     conditions?: string[] | undefined;
++    byteLimit?: number | undefined;
++    esbuildPath?: string | undefined;
+ };
+ export type ReadFn = (location: string) => Promise<Uint8Array>;
+ /**
+diff --git a/src/types.ts b/src/types.ts
+index 315e4d187b65d04b911139d150689753fa374a81..dfa7896bf99d95957e7372f6a8f069813addcaa6 100644
+--- a/src/types.ts
++++ b/src/types.ts
+@@ -92,6 +92,8 @@ export type BundleOptions<T extends ModuleFormat> = {
+    * exports and imports.
+    */
+   conditions?: string[] | undefined;
++  byteLimit?: number | undefined;
++  esbuildPath?: string | undefined;
+ };
+ 
+ export type ReadFn = (location: string) => Promise<Uint8Array>;

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -23,5 +23,8 @@
     "npm-run-all": "^4.1.5"
   },
   "packageManager": "yarn@4.9.3",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "resolutions": {
+    "@endo/bundle-source@npm:^4.0.0": "patch:@endo/bundle-source@npm%3A4.1.2#~/.yarn/patches/@endo-bundle-source-npm-4.1.2-80da9522ea.patch"
+  }
 }

--- a/a3p-integration/package.json
+++ b/a3p-integration/package.json
@@ -25,6 +25,6 @@
   "packageManager": "yarn@4.9.3",
   "license": "Apache-2.0",
   "resolutions": {
-    "@endo/bundle-source@npm:^4.0.0": "patch:@endo/bundle-source@npm%3A4.1.2#~/.yarn/patches/@endo-bundle-source-npm-4.1.2-80da9522ea.patch"
+    "@endo/bundle-source": "portal:../node_modules/@endo/bundle-source"
   }
 }

--- a/a3p-integration/yarn.lock
+++ b/a3p-integration/yarn.lock
@@ -707,9 +707,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@endo/bundle-source@npm:^4.0.0":
-  version: 4.1.2
-  resolution: "@endo/bundle-source@npm:4.1.2"
+"@endo/bundle-source@portal:../node_modules/@endo/bundle-source::locator=root-workspace-0b6124%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@endo/bundle-source@portal:../node_modules/@endo/bundle-source::locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@endo/base64": "npm:^1.0.12"
     "@endo/compartment-mapper": "npm:^1.6.3"
@@ -717,12 +717,12 @@ __metadata:
     "@endo/init": "npm:^1.1.12"
     "@endo/promise-kit": "npm:^1.1.13"
     "@endo/where": "npm:^1.0.11"
+    esbuild: "npm:^0.25.2"
     ts-blank-space: "npm:^0.4.1"
   bin:
     bundle-source: ./src/tool.js
-  checksum: 10c0/7bee180864e8340877c0979a2c773dba7e7346959a208efdc7bc6dac48964f6f4ff61f7542195d71c7bc847f81844bc81f0c302e8136aa5d730bdd0efcb113ca
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@endo/cache-map@npm:^1.1.0":
   version: 1.1.0
@@ -1011,6 +1011,188 @@ __metadata:
   version: 1.0.11
   resolution: "@endo/zip@npm:1.0.11"
   checksum: 10c0/bf1a6c092fa9805c815625bcd241dda349683e16f9b5044c8fe78991b656941e2c20d4bdf98e01ac0fa97739ac527d8127de738062ef9bfbbff0827762a9c302
+  languageName: node
+  linkType: hard
+
+"@esbuild/aix-ppc64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/aix-ppc64@npm:0.25.12"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-arm64@npm:0.25.12"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-arm@npm:0.25.12"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-x64@npm:0.25.12"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/darwin-arm64@npm:0.25.12"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/darwin-x64@npm:0.25.12"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/freebsd-arm64@npm:0.25.12"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/freebsd-x64@npm:0.25.12"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-arm64@npm:0.25.12"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-arm@npm:0.25.12"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-ia32@npm:0.25.12"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-loong64@npm:0.25.12"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-mips64el@npm:0.25.12"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-ppc64@npm:0.25.12"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-riscv64@npm:0.25.12"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-s390x@npm:0.25.12"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-x64@npm:0.25.12"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/netbsd-x64@npm:0.25.12"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openbsd-x64@npm:0.25.12"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/sunos-x64@npm:0.25.12"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-arm64@npm:0.25.12"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-ia32@npm:0.25.12"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-x64@npm:0.25.12"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2007,6 +2189,95 @@ __metadata:
     is-date-object: "npm:^1.0.5"
     is-symbol: "npm:^1.0.4"
   checksum: 10c0/c7e87467abb0b438639baa8139f701a06537d2b9bc758f23e8622c3b42fd0fdb5bde0f535686119e446dd9d5e4c0f238af4e14960f4771877cf818d023f6730b
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.25.2":
+  version: 0.25.12
+  resolution: "esbuild@npm:0.25.12"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.25.12"
+    "@esbuild/android-arm": "npm:0.25.12"
+    "@esbuild/android-arm64": "npm:0.25.12"
+    "@esbuild/android-x64": "npm:0.25.12"
+    "@esbuild/darwin-arm64": "npm:0.25.12"
+    "@esbuild/darwin-x64": "npm:0.25.12"
+    "@esbuild/freebsd-arm64": "npm:0.25.12"
+    "@esbuild/freebsd-x64": "npm:0.25.12"
+    "@esbuild/linux-arm": "npm:0.25.12"
+    "@esbuild/linux-arm64": "npm:0.25.12"
+    "@esbuild/linux-ia32": "npm:0.25.12"
+    "@esbuild/linux-loong64": "npm:0.25.12"
+    "@esbuild/linux-mips64el": "npm:0.25.12"
+    "@esbuild/linux-ppc64": "npm:0.25.12"
+    "@esbuild/linux-riscv64": "npm:0.25.12"
+    "@esbuild/linux-s390x": "npm:0.25.12"
+    "@esbuild/linux-x64": "npm:0.25.12"
+    "@esbuild/netbsd-arm64": "npm:0.25.12"
+    "@esbuild/netbsd-x64": "npm:0.25.12"
+    "@esbuild/openbsd-arm64": "npm:0.25.12"
+    "@esbuild/openbsd-x64": "npm:0.25.12"
+    "@esbuild/openharmony-arm64": "npm:0.25.12"
+    "@esbuild/sunos-x64": "npm:0.25.12"
+    "@esbuild/win32-arm64": "npm:0.25.12"
+    "@esbuild/win32-ia32": "npm:0.25.12"
+    "@esbuild/win32-x64": "npm:0.25.12"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/c205357531423220a9de8e1e6c6514242bc9b1666e762cd67ccdf8fdfdc3f1d0bd76f8d9383958b97ad4c953efdb7b6e8c1f9ca5951cd2b7c5235e8755b34a6b
   languageName: node
   linkType: hard
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -179,6 +179,7 @@ export default [
         },
       ],
 
+      'jsdoc/no-defaults': 'off',
       'no-use-before-define': 'off',
     },
   },

--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -15,6 +15,9 @@
     "test:xcs": "ava --config ava.xcs.config.js"
   },
   "packageManager": "yarn@4.9.3",
+  "dependencies": {
+    "@endo/bundle-source": "MULTICHAIN_TESTING"
+  },
   "devDependencies": {
     "@agoric/cosmic-proto": "MULTICHAIN_TESTING",
     "@agoric/fast-usdc": "MULTICHAIN_TESTING",
@@ -112,7 +115,8 @@
     "@cosmjs/math@npm:0.32.3": "npm:^0.36.0",
     "@cosmjs/proto-signing@npm:0.32.3": "npm:^0.36.0",
     "@cosmjs/stargate@npm:0.32.3": "npm:^0.36.0",
-    "@cosmjs/tendermint-rpc@npm:0.32.3": "npm:^0.36.0"
+    "@cosmjs/tendermint-rpc@npm:0.32.3": "npm:^0.36.0",
+    "@endo/bundle-source": "portal:../../agoric-sdk/node_modules/@endo/bundle-source"
   },
   "license": "Apache-2.0"
 }

--- a/multichain-testing/yarn.lock
+++ b/multichain-testing/yarn.lock
@@ -828,9 +828,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@endo/bundle-source@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "@endo/bundle-source@npm:4.1.2"
+"@endo/bundle-source@portal:../../agoric-sdk/node_modules/@endo/bundle-source::locator=root-workspace-0b6124%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@endo/bundle-source@portal:../../agoric-sdk/node_modules/@endo/bundle-source::locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@endo/base64": "npm:^1.0.12"
     "@endo/compartment-mapper": "npm:^1.6.3"
@@ -838,12 +838,12 @@ __metadata:
     "@endo/init": "npm:^1.1.12"
     "@endo/promise-kit": "npm:^1.1.13"
     "@endo/where": "npm:^1.0.11"
+    esbuild: "npm:^0.25.2"
     ts-blank-space: "npm:^0.4.1"
   bin:
     bundle-source: ./src/tool.js
-  checksum: 10c0/7bee180864e8340877c0979a2c773dba7e7346959a208efdc7bc6dac48964f6f4ff61f7542195d71c7bc847f81844bc81f0c302e8136aa5d730bdd0efcb113ca
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@endo/cache-map@npm:^1.1.0":
   version: 1.1.0
@@ -1132,6 +1132,188 @@ __metadata:
   version: 1.0.11
   resolution: "@endo/zip@npm:1.0.11"
   checksum: 10c0/bf1a6c092fa9805c815625bcd241dda349683e16f9b5044c8fe78991b656941e2c20d4bdf98e01ac0fa97739ac527d8127de738062ef9bfbbff0827762a9c302
+  languageName: node
+  linkType: hard
+
+"@esbuild/aix-ppc64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/aix-ppc64@npm:0.25.12"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-arm64@npm:0.25.12"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-arm@npm:0.25.12"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-x64@npm:0.25.12"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/darwin-arm64@npm:0.25.12"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/darwin-x64@npm:0.25.12"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/freebsd-arm64@npm:0.25.12"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/freebsd-x64@npm:0.25.12"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-arm64@npm:0.25.12"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-arm@npm:0.25.12"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-ia32@npm:0.25.12"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-loong64@npm:0.25.12"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-mips64el@npm:0.25.12"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-ppc64@npm:0.25.12"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-riscv64@npm:0.25.12"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-s390x@npm:0.25.12"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-x64@npm:0.25.12"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/netbsd-x64@npm:0.25.12"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openbsd-x64@npm:0.25.12"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/sunos-x64@npm:0.25.12"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-arm64@npm:0.25.12"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-ia32@npm:0.25.12"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-x64@npm:0.25.12"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2526,6 +2708,95 @@ __metadata:
     has-tostringtag: "npm:^1.0.2"
     hasown: "npm:^2.0.2"
   checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.25.2":
+  version: 0.25.12
+  resolution: "esbuild@npm:0.25.12"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.25.12"
+    "@esbuild/android-arm": "npm:0.25.12"
+    "@esbuild/android-arm64": "npm:0.25.12"
+    "@esbuild/android-x64": "npm:0.25.12"
+    "@esbuild/darwin-arm64": "npm:0.25.12"
+    "@esbuild/darwin-x64": "npm:0.25.12"
+    "@esbuild/freebsd-arm64": "npm:0.25.12"
+    "@esbuild/freebsd-x64": "npm:0.25.12"
+    "@esbuild/linux-arm": "npm:0.25.12"
+    "@esbuild/linux-arm64": "npm:0.25.12"
+    "@esbuild/linux-ia32": "npm:0.25.12"
+    "@esbuild/linux-loong64": "npm:0.25.12"
+    "@esbuild/linux-mips64el": "npm:0.25.12"
+    "@esbuild/linux-ppc64": "npm:0.25.12"
+    "@esbuild/linux-riscv64": "npm:0.25.12"
+    "@esbuild/linux-s390x": "npm:0.25.12"
+    "@esbuild/linux-x64": "npm:0.25.12"
+    "@esbuild/netbsd-arm64": "npm:0.25.12"
+    "@esbuild/netbsd-x64": "npm:0.25.12"
+    "@esbuild/openbsd-arm64": "npm:0.25.12"
+    "@esbuild/openbsd-x64": "npm:0.25.12"
+    "@esbuild/openharmony-arm64": "npm:0.25.12"
+    "@esbuild/sunos-x64": "npm:0.25.12"
+    "@esbuild/win32-arm64": "npm:0.25.12"
+    "@esbuild/win32-ia32": "npm:0.25.12"
+    "@esbuild/win32-x64": "npm:0.25.12"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/c205357531423220a9de8e1e6c6514242bc9b1666e762cd67ccdf8fdfdc3f1d0bd76f8d9383958b97ad4c953efdb7b6e8c1f9ca5951cd2b7c5235e8755b34a6b
   languageName: node
   linkType: hard
 
@@ -4366,6 +4637,7 @@ __metadata:
     "@cosmjs/crypto": "npm:^0.36.0"
     "@cosmjs/proto-signing": "npm:^0.36.0"
     "@cosmjs/stargate": "npm:^0.36.0"
+    "@endo/bundle-source": "npm:MULTICHAIN_TESTING"
     "@endo/errors": "npm:^1.2.13"
     "@endo/far": "npm:^1.1.14"
     "@endo/nat": "npm:^5.1.3"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@cosmjs/stargate@npm:0.32.3": "npm:^0.36.0",
     "@cosmjs/tendermint-rpc@npm:0.32.3": "npm:^0.36.0",
     "@cosmology/telescope@npm:^1.12.21": "patch:@cosmology/telescope@npm%3A1.12.21#~/.yarn/patches/@cosmology-telescope-npm-1.12.21-6ca5e89f7e.patch",
+    "@endo/bundle-source": "patch:@endo/bundle-source@npm%3A4.1.2#~/.yarn/patches/@endo-bundle-source-npm-4.1.2-80da9522ea.patch",
     "@noble/hashes@npm:^1": "npm:~1.8.0",
     "@noble/hashes@npm:^1.5.0": "npm:~1.8.0",
     "ava@npm:^5.3.0": "patch:ava@npm%3A5.3.1#~/.yarn/patches/ava-npm-5.3.1-d83c0bdc77.patch",

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -52,7 +52,9 @@ const allValues = async obj => {
 };
 
 const bundleRelative = rel =>
-  bundleSource(new URL(rel, import.meta.url).pathname);
+  bundleSource(new URL(rel, import.meta.url).pathname, {
+    byteLimit: Infinity,
+  });
 
 /**
  * Build the source bundles for the kernel. makeSwingsetController()
@@ -445,7 +447,14 @@ export async function initializeSwingset(
   const bundleCache = await (config.bundleCachePath
     ? provideBundleCache(
         config.bundleCachePath,
-        { dev: config.includeDevDependencies, format: config.bundleFormat },
+        {
+          dev: config.includeDevDependencies,
+          format: config.bundleFormat,
+          // Disable bundle size limits for kernel-generated bundles which may
+          // be large, but do not travel through RPC and we still want to be
+          // legible.
+          byteLimit: Infinity,
+        },
         s => import(s),
       )
     : null);
@@ -487,6 +496,9 @@ export async function initializeSwingset(
       return bundleSource(desc.sourceSpec, {
         dev: config.includeDevDependencies,
         format: config.bundleFormat,
+        // Disable bundle size limits for kernel-generated bundles which may be
+        // large, but do not travel through RPC and we still want to be legible.
+        byteLimit: Infinity,
       });
     } else if ('bundleName' in desc) {
       if (!nameToBundle) {

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -31,7 +31,11 @@ const providedCaches = new Map();
  * destination, return it.
  *
  * @param {string} dest
- * @param {{ format?: string, dev?: boolean }} options
+ * @param {object} options
+ * @param {string} [options.format]
+ * @param {boolean} [options.dev]
+ * @param {number} [options.byteLimit=490_000] - Maximum bundle size in bytes before
+ *   falling back to optimizations that may reduce legibility.
  * @param {(id: string) => Promise<any>} loadModule
  * @param {number} [pid]
  * @returns {Promise<BundleCache>}

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -1086,7 +1086,12 @@ export async function launchAndShareInternals({
           const { bundles, codeSteps: coreEvalCodeSteps } =
             await extractCoreProposalBundles(coreProposals, myFilename, {
               handleToBundleSpec: async (handle, source, _sequence, _piece) => {
-                const bundle = await bundleSource(source);
+                const bundle = await bundleSource(source, {
+                  // Disable bundle size limits for chain initialization/upgrade
+                  // bundles which may be large, but do not travel through RPC
+                  // and we still want to be legible.
+                  byteLimit: Infinity,
+                });
                 const { endoZipBase64Sha512: hash } = bundle;
                 const bundleID = `b1-${hash}`;
                 handle.bundleID = bundleID;

--- a/packages/orchestration/test/utils/zcf-tools.test.ts
+++ b/packages/orchestration/test/utils/zcf-tools.test.ts
@@ -24,8 +24,11 @@ const makeTestContext = async () => {
   const bundleCache = await makeNodeBundleCache('bundles', {}, s => import(s));
   const contractBundle = await bundleCache.load(contractEntry);
 
-  fakeVatAdmin.vatAdminState.installBundle('b1-contract', contractBundle);
-  const installation = await E(zoe).installBundleID('b1-contract');
+  const bid = fakeVatAdmin.vatAdminState.registerBundle(
+    'b1-contract',
+    contractBundle,
+  );
+  const installation = await E(zoe).installBundleID(bid);
 
   const stuff = makeIssuerKit('Stuff');
   await E(zoe).startInstance(installation, { Stuff: stuff.issuer });

--- a/packages/zoe/test/unitTests/blockedOffers.test.js
+++ b/packages/zoe/test/unitTests/blockedOffers.test.js
@@ -33,9 +33,9 @@ const setupContract = async (moolaIssuer, bucksIssuer) => {
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);
-  vatAdminState.installBundle('b1-contract', bundle);
+  const b1contract = vatAdminState.registerBundle('b1-contract', bundle);
   // install the contract
-  const installation = await E(zoe).installBundleID('b1-contract');
+  const installation = await E(zoe).installBundleID(b1contract);
 
   // Alice creates an instance
   const issuerKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/contractSupport/depositTo.test.js
+++ b/packages/zoe/test/unitTests/contractSupport/depositTo.test.js
@@ -26,10 +26,13 @@ async function setupContract(moolaIssuer, bucksIssuer) {
 
   // pack the contract
   const contractBundle = await bundleSource(contractRoot);
-  fakeVatAdmin.vatAdminState.installBundle('b1-contract', contractBundle);
+  const b1contract = fakeVatAdmin.vatAdminState.registerBundle(
+    'b1-contract',
+    contractBundle,
+  );
 
   // install the contract
-  const installation = await E(zoe).installBundleID('b1-contract');
+  const installation = await E(zoe).installBundleID(b1contract);
 
   // Alice creates an instance
   const issuerKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/contractSupport/offerTo.test.js
+++ b/packages/zoe/test/unitTests/contractSupport/offerTo.test.js
@@ -25,9 +25,12 @@ const setupContract = async (moolaIssuer, bucksIssuer) => {
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);
-  fakeVatAdmin.vatAdminState.installBundle('b1-contract', bundle);
+  const b1contract = fakeVatAdmin.vatAdminState.registerBundle(
+    'b1-contract',
+    bundle,
+  );
   // install the contract
-  const installation = await E(zoe).installBundleID('b1-contract');
+  const installation = await E(zoe).installBundleID(b1contract);
 
   // Create TWO instances of the zcfTesterContract which have
   // different keywords

--- a/packages/zoe/test/unitTests/contractSupport/withdrawFrom.test.js
+++ b/packages/zoe/test/unitTests/contractSupport/withdrawFrom.test.js
@@ -30,9 +30,12 @@ async function setupContract(moolaIssuer, bucksIssuer) {
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);
-  fakeVatAdmin.vatAdminState.installBundle('b1-contract', bundle);
+  const b1contract = fakeVatAdmin.vatAdminState.registerBundle(
+    'b1-contract',
+    bundle,
+  );
   // install the contract
-  const installation = await E(zoe).installBundleID('b1-contract');
+  const installation = await E(zoe).installBundleID(b1contract);
 
   // Alice creates an instance
   const issuerKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/contracts/atomicSwap.test.js
+++ b/packages/zoe/test/unitTests/contracts/atomicSwap.test.js
@@ -28,8 +28,11 @@ test('zoe - atomicSwap', async t => {
         // pack the contract
         const bundle = await bundleSource(atomicSwapRoot);
         // install the contract
-        vatAdminState.installBundle('b1-atomicswap', bundle);
-        const installationP = E(zoe).installBundleID('b1-atomicswap');
+        const b1atomicswap = vatAdminState.registerBundle(
+          'b1-atomicswap',
+          bundle,
+        );
+        const installationP = E(zoe).installBundleID(b1atomicswap);
         return installationP;
       },
       startInstance: async installation => {
@@ -195,8 +198,11 @@ test('zoe - non-fungible atomicSwap', async t => {
         // pack the contract
         const bundle = await bundleSource(atomicSwapRoot);
         // install the contract
-        vatAdminState.installBundle('b1-atomicswap', bundle);
-        const installationP = E(zoe).installBundleID('b1-atomicswap');
+        const b1atomicswap = vatAdminState.registerBundle(
+          'b1-atomicswap',
+          bundle,
+        );
+        const installationP = E(zoe).installBundleID(b1atomicswap);
         return installationP;
       },
       startInstance: async installation => {
@@ -353,8 +359,8 @@ test('zoe - atomicSwap like-for-like', async t => {
   // pack the contract
   const bundle = await bundleSource(atomicSwapRoot);
   // install the contract
-  vatAdminState.installBundle('b1-atomicswap', bundle);
-  const installation = await E(zoe).installBundleID('b1-atomicswap');
+  const b1atomicswap = vatAdminState.registerBundle('b1-atomicswap', bundle);
+  const installation = await E(zoe).installBundleID(b1atomicswap);
 
   // Setup Alice
   const aliceMoolaPayment = moolaMint.mintPayment(moola(3n));

--- a/packages/zoe/test/unitTests/contracts/auction.test.js
+++ b/packages/zoe/test/unitTests/contracts/auction.test.js
@@ -29,8 +29,11 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
         // pack the contract
         const bundle = await bundleSource(auctionRoot);
         // install the contract
-        vatAdminState.installBundle('b1-auctioneer', bundle);
-        const installationP = E(zoe).installBundleID('b1-auctioneer');
+        const b1auctioneer = vatAdminState.registerBundle(
+          'b1-auctioneer',
+          bundle,
+        );
+        const installationP = E(zoe).installBundleID(b1auctioneer);
         return installationP;
       },
       startInstance: async installation => {
@@ -271,8 +274,8 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
   // Pack the contract.
   const bundle = await bundleSource(auctionRoot);
 
-  vatAdminState.installBundle('b1-auctioneer', bundle);
-  const installation = await E(zoe).installBundleID('b1-auctioneer');
+  const b1auctioneer = vatAdminState.registerBundle('b1-auctioneer', bundle);
+  const installation = await E(zoe).installBundleID(b1auctioneer);
   const issuerKeywordRecord = harden({
     Asset: moolaKit.issuer,
     Ask: simoleanKit.issuer,
@@ -422,8 +425,8 @@ test('zoe - secondPriceAuction - all bidders try to exit', async t => {
 
   // Pack the contract.
   const bundle = await bundleSource(auctionRoot);
-  vatAdminState.installBundle('b1-auctioneer', bundle);
-  const installation = await E(zoe).installBundleID('b1-auctioneer');
+  const b1auctioneer = vatAdminState.registerBundle('b1-auctioneer', bundle);
+  const installation = await E(zoe).installBundleID(b1auctioneer);
   const issuerKeywordRecord = harden({
     Asset: moolaKit.issuer,
     Ask: simoleanKit.issuer,
@@ -566,8 +569,8 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
   // Pack the contract.
   const bundle = await bundleSource(auctionRoot);
-  vatAdminState.installBundle('b1-auctioneer', bundle);
-  const installation = await E(zoe).installBundleID('b1-auctioneer');
+  const b1auctioneer = vatAdminState.registerBundle('b1-auctioneer', bundle);
+  const installation = await E(zoe).installBundleID(b1auctioneer);
   const issuerKeywordRecord = harden({
     Asset: ccIssuer,
     Ask: moolaIssuer,
@@ -852,8 +855,11 @@ test('zoe - firstPriceAuction w/ 3 bids', async t => {
         // pack the contract
         const bundle = await bundleSource(auctionRoot);
         // install the contract
-        vatAdminState.installBundle('b1-auctioneer', bundle);
-        const installationP = E(zoe).installBundleID('b1-auctioneer');
+        const b1auctioneer = vatAdminState.registerBundle(
+          'b1-auctioneer',
+          bundle,
+        );
+        const installationP = E(zoe).installBundleID(b1auctioneer);
         return installationP;
       },
       startInstance: async installation => {

--- a/packages/zoe/test/unitTests/contracts/automaticRefund.test.js
+++ b/packages/zoe/test/unitTests/contracts/automaticRefund.test.js
@@ -18,8 +18,11 @@ test('zoe - simplest automaticRefund', async t => {
   const { moolaKit, moola, zoe, vatAdminState } = setup();
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
-  vatAdminState.installBundle('b1-automaticRefund', bundle);
-  const installation = await E(zoe).installBundleID('b1-automaticRefund');
+  const b1automaticRefund = vatAdminState.registerBundle(
+    'b1-automaticRefund',
+    bundle,
+  );
+  const installation = await E(zoe).installBundleID(b1automaticRefund);
 
   // Setup Alice
   const aliceMoolaPayment = moolaKit.mint.mintPayment(moola(3n));
@@ -58,8 +61,11 @@ test('zoe - automaticRefund same issuer', async t => {
   const { moolaKit, moola, zoe, vatAdminState } = setup();
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
-  vatAdminState.installBundle('b1-automaticRefund', bundle);
-  const installation = await E(zoe).installBundleID('b1-automaticRefund');
+  const b1automaticRefund = vatAdminState.registerBundle(
+    'b1-automaticRefund',
+    bundle,
+  );
+  const installation = await E(zoe).installBundleID(b1automaticRefund);
 
   // Setup Alice
   const aliceMoolaPayment = moolaKit.mint.mintPayment(moola(9n));
@@ -116,8 +122,11 @@ test('zoe with automaticRefund', async t => {
   const bundle = await bundleSource(automaticRefundRoot);
 
   // 1: Alice creates an automatic refund instance
-  vatAdminState.installBundle('b1-automaticRefund', bundle);
-  const installation = await E(zoe).installBundleID('b1-automaticRefund');
+  const b1automaticRefund = vatAdminState.registerBundle(
+    'b1-automaticRefund',
+    bundle,
+  );
+  const installation = await E(zoe).installBundleID(b1automaticRefund);
   const issuerKeywordRecord = harden({
     Contribution1: moolaKit.issuer,
     Contribution2: simoleanKit.issuer,
@@ -250,8 +259,11 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
 
-  vatAdminState.installBundle('b1-automaticRefund', bundle);
-  const installation = await E(zoe).installBundleID('b1-automaticRefund');
+  const b1automaticRefund = vatAdminState.registerBundle(
+    'b1-automaticRefund',
+    bundle,
+  );
+  const installation = await E(zoe).installBundleID(b1automaticRefund);
   const issuerKeywordRecord = harden({
     ContributionA: moolaKit.issuer,
     ContributionB: simoleanKit.issuer,
@@ -325,8 +337,11 @@ test('zoe - alice tries to complete after completion has already occurred', asyn
 
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
-  vatAdminState.installBundle('b1-automaticRefund', bundle);
-  const installation = await E(zoe).installBundleID('b1-automaticRefund');
+  const b1automaticRefund = vatAdminState.registerBundle(
+    'b1-automaticRefund',
+    bundle,
+  );
+  const installation = await E(zoe).installBundleID(b1automaticRefund);
   const issuerKeywordRecord = harden({
     ContributionA: moolaKit.issuer,
     ContributionB: simoleanKit.issuer,
@@ -387,8 +402,11 @@ test('zoe - automaticRefund non-fungible', async t => {
 
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
-  vatAdminState.installBundle('b1-automaticRefund', bundle);
-  const installation = await E(zoe).installBundleID('b1-automaticRefund');
+  const b1automaticRefund = vatAdminState.registerBundle(
+    'b1-automaticRefund',
+    bundle,
+  );
+  const installation = await E(zoe).installBundleID(b1automaticRefund);
 
   // Setup Alice
   const aliceCcPayment = ccMint.mintPayment(cryptoCats(harden(['tigger'])));

--- a/packages/zoe/test/unitTests/contracts/brokenContract.test.js
+++ b/packages/zoe/test/unitTests/contracts/brokenContract.test.js
@@ -21,8 +21,11 @@ test('zoe - brokenAutomaticRefund', async t => {
   const zoe = makeZoeForTest(fakeVatAdmin);
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
-  vatAdminState.installBundle('b1-brokenAutomaticRefund', bundle);
-  const installation = await E(zoe).installBundleID('b1-brokenAutomaticRefund');
+  const b1brokenAutomaticRefund = vatAdminState.registerBundle(
+    'b1-brokenAutomaticRefund',
+    bundle,
+  );
+  const installation = await E(zoe).installBundleID(b1brokenAutomaticRefund);
 
   const issuerKeywordRecord = harden({ Contribution: moolaKit.issuer });
 

--- a/packages/zoe/test/unitTests/contracts/coveredCall-want-pattern.test.js
+++ b/packages/zoe/test/unitTests/contracts/coveredCall-want-pattern.test.js
@@ -39,13 +39,18 @@ test('zoe - coveredCall with swap for invitation', async t => {
   // Pack the contract.
   const coveredCallBundle = await bundleSource(coveredCallRoot);
 
-  vatAdminState.installBundle('b1-coveredcall', coveredCallBundle);
-  const coveredCallInstallation =
-    await E(zoe).installBundleID('b1-coveredcall');
+  const b1coveredcall = vatAdminState.registerBundle(
+    'b1-coveredcall',
+    coveredCallBundle,
+  );
+  const coveredCallInstallation = await E(zoe).installBundleID(b1coveredcall);
   const atomicSwapBundle = await bundleSource(atomicSwapRoot);
 
-  vatAdminState.installBundle('b1-atomicswap', atomicSwapBundle);
-  const swapInstallationId = await E(zoe).installBundleID('b1-atomicswap');
+  const b1atomicswap = vatAdminState.registerBundle(
+    'b1-atomicswap',
+    atomicSwapBundle,
+  );
+  const swapInstallationId = await E(zoe).installBundleID(b1atomicswap);
 
   // Setup Alice
   // Alice starts with 3 moola

--- a/packages/zoe/test/unitTests/contracts/coveredCall.test.js
+++ b/packages/zoe/test/unitTests/contracts/coveredCall.test.js
@@ -49,8 +49,11 @@ test('zoe - coveredCall', async t => {
         // pack the contract
         const bundle = await bundleSource(coveredCallRoot);
         // install the contract
-        vatAdminState.installBundle('b1-coveredcall', bundle);
-        const installationP = E(zoe).installBundleID('b1-coveredcall');
+        const b1coveredcall = vatAdminState.registerBundle(
+          'b1-coveredcall',
+          bundle,
+        );
+        const installationP = E(zoe).installBundleID(b1coveredcall);
         return installationP;
       },
       startInstance: async installation => {
@@ -238,9 +241,8 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
     setup();
   // Pack the contract.
   const bundle = await bundleSource(coveredCallRoot);
-  vatAdminState.installBundle('b1-coveredcall', bundle);
-  const coveredCallInstallation =
-    await E(zoe).installBundleID('b1-coveredcall');
+  const b1coveredcall = vatAdminState.registerBundle('b1-coveredcall', bundle);
+  const coveredCallInstallation = await E(zoe).installBundleID(b1coveredcall);
   const timer = buildManualTimer(t.log);
   const toTS = ts => TimeMath.coerceTimestampRecord(ts, timer.getTimerBrand());
 
@@ -379,13 +381,18 @@ test('zoe - coveredCall with swap for invitation', async t => {
   // Pack the contract.
   const coveredCallBundle = await bundleSource(coveredCallRoot);
 
-  vatAdminState.installBundle('b1-coveredcall', coveredCallBundle);
-  const coveredCallInstallation =
-    await E(zoe).installBundleID('b1-coveredcall');
+  const b1coveredcall = vatAdminState.registerBundle(
+    'b1-coveredcall',
+    coveredCallBundle,
+  );
+  const coveredCallInstallation = await E(zoe).installBundleID(b1coveredcall);
   const atomicSwapBundle = await bundleSource(atomicSwapRoot);
 
-  vatAdminState.installBundle('b1-atomicswap', atomicSwapBundle);
-  const swapInstallationId = await E(zoe).installBundleID('b1-atomicswap');
+  const b1atomicswap = vatAdminState.registerBundle(
+    'b1-atomicswap',
+    atomicSwapBundle,
+  );
+  const swapInstallationId = await E(zoe).installBundleID(b1atomicswap);
 
   // Setup Alice
   // Alice starts with 3 moola
@@ -650,9 +657,8 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   // Pack the contract.
   const bundle = await bundleSource(coveredCallRoot);
 
-  vatAdminState.installBundle('b1-coveredcall', bundle);
-  const coveredCallInstallation =
-    await E(zoe).installBundleID('b1-coveredcall');
+  const b1coveredcall = vatAdminState.registerBundle('b1-coveredcall', bundle);
+  const coveredCallInstallation = await E(zoe).installBundleID(b1coveredcall);
 
   // Setup Alice
   // Alice starts with 3 moola
@@ -939,10 +945,9 @@ test('zoe - coveredCall non-fungible', async t => {
 
   // install the contract.
   const bundle = await bundleSource(coveredCallRoot);
-  vatAdminState.installBundle('b1-coveredcall', bundle);
+  const b1coveredcall = vatAdminState.registerBundle('b1-coveredcall', bundle);
 
-  const coveredCallInstallation =
-    await E(zoe).installBundleID('b1-coveredcall');
+  const coveredCallInstallation = await E(zoe).installBundleID(b1coveredcall);
   const timer = buildManualTimer(t.log);
   const toTS = ts => TimeMath.coerceTimestampRecord(ts, timer.getTimerBrand());
 
@@ -1082,9 +1087,8 @@ test('zoe - coveredCall - bad proposal shape', async t => {
 
   // Bundle and install the contract.
   const bundle = await bundleSource(coveredCallRoot);
-  vatAdminState.installBundle('b1-coveredcall', bundle);
-  const coveredCallInstallation =
-    await E(zoe).installBundleID('b1-coveredcall');
+  const b1coveredcall = vatAdminState.registerBundle('b1-coveredcall', bundle);
+  const coveredCallInstallation = await E(zoe).installBundleID(b1coveredcall);
 
   // Start an instance.
   const issuerKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.test.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.test.js
@@ -22,8 +22,11 @@ test('zoe - escrowToVote', async t => {
   // pack the contract
   const bundle = await bundleSource(contractRoot);
   // install the contract
-  vatAdminState.installBundle('b1-escrowtovote', bundle);
-  const installation = await E(zoe).installBundleID('b1-escrowtovote');
+  const b1escrowtovote = vatAdminState.registerBundle(
+    'b1-escrowtovote',
+    bundle,
+  );
+  const installation = await E(zoe).installBundleID(b1escrowtovote);
 
   // Alice creates an instance and acts as the Secretary
   const issuerKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/contracts/invitation-details.test.js
+++ b/packages/zoe/test/unitTests/contracts/invitation-details.test.js
@@ -20,8 +20,11 @@ test('plural invitation details', async t => {
 
   // Pack the contract.
   const bundle = await bundleSource(root);
-  vatAdminState.installBundle('a1-two-invitations', bundle);
-  const installation = await E(zoe).installBundleID('a1-two-invitations');
+  const a1twoinvitations = vatAdminState.registerBundle(
+    'a1-two-invitations',
+    bundle,
+  );
+  const installation = await E(zoe).installBundleID(a1twoinvitations);
 
   const { creatorFacet: twoInvitations } = await E(zoe).startInstance(
     installation,

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -202,8 +202,11 @@ export const makeAutoswapInstance = async (
 
   // Create autoswap installation and instance
   const autoswapBundle = await bundleSource(autoswapRoot);
-  vatAdminState.installBundle('b1-autoswap', autoswapBundle);
-  const autoswapInstallation = await E(zoe).installBundleID('b1-autoswap');
+  const b1autoswap = vatAdminState.registerBundle(
+    'b1-autoswap',
+    autoswapBundle,
+  );
+  const autoswapInstallation = await E(zoe).installBundleID(b1autoswap);
 
   const { instance: autoswapInstance, publicFacet } = await E(
     zoe,

--- a/packages/zoe/test/unitTests/contracts/loan/loan-e2e.test.js
+++ b/packages/zoe/test/unitTests/contracts/loan/loan-e2e.test.js
@@ -36,13 +36,16 @@ test('loan - lend - exit before borrow', async t => {
     vatAdminState,
   } = setup();
   const bundle = await bundleSource(loanRoot);
-  vatAdminState.installBundle('b1-loan', bundle);
-  const installation = await E(zoe).installBundleID('b1-loan');
+  const b1loan = vatAdminState.registerBundle('b1-loan', bundle);
+  const installation = await E(zoe).installBundleID(b1loan);
 
   // Create autoswap installation and instance
   const autoswapBundle = await bundleSource(autoswapRoot);
-  vatAdminState.installBundle('b1-autoswap', autoswapBundle);
-  const autoswapInstallation = await E(zoe).installBundleID('b1-autoswap');
+  const b1autoswap = vatAdminState.registerBundle(
+    'b1-autoswap',
+    autoswapBundle,
+  );
+  const autoswapInstallation = await E(zoe).installBundleID(b1autoswap);
 
   const { instance: autoswapInstance } = await E(zoe).startInstance(
     autoswapInstallation,

--- a/packages/zoe/test/unitTests/contracts/mintPayments.test.js
+++ b/packages/zoe/test/unitTests/contracts/mintPayments.test.js
@@ -26,8 +26,11 @@ test('zoe - mint payments', async t => {
         // pack the contract
         const bundle = await bundleSource(mintPaymentsRoot);
         // install the contract
-        vatAdminState.installBundle('b1-mintpayments', bundle);
-        const installationP = E(zoe).installBundleID('b1-mintpayments');
+        const b1mintpayments = vatAdminState.registerBundle(
+          'b1-mintpayments',
+          bundle,
+        );
+        const installationP = E(zoe).installBundleID(b1mintpayments);
         return installationP;
       },
       startInstance: async installation => {
@@ -102,8 +105,11 @@ test('zoe - mint payments with unrelated give and want', async t => {
         // pack the contract
         const bundle = await bundleSource(mintPaymentsRoot);
         // install the contract
-        vatAdminState.installBundle('b1-mintpayments', bundle);
-        const installationP = E(zoe).installBundleID('b1-mintpayments');
+        const b1mintpayments = vatAdminState.registerBundle(
+          'b1-mintpayments',
+          bundle,
+        );
+        const installationP = E(zoe).installBundleID(b1mintpayments);
         return installationP;
       },
       startInstance: async installation => {

--- a/packages/zoe/test/unitTests/contracts/oracle.test.js
+++ b/packages/zoe/test/unitTests/contracts/oracle.test.js
@@ -42,7 +42,7 @@ test.before(
 
     // Pack the contract.
     const contractBundle = await bundleSource(contractPath);
-    vatAdminState.installBundle('b1-oracle', contractBundle);
+    const b1oracle = vatAdminState.registerBundle('b1-oracle', contractBundle);
 
     const link = makeIssuerKit('$LINK', AssetKind.NAT);
 
@@ -52,7 +52,7 @@ test.before(
     // else, and they can use it to create a new contract instance
     // using the same code.
     /** @type {Installation<OracleStart>} */
-    const installation = await E(zoe).installBundleID('b1-oracle');
+    const installation = await E(zoe).installBundleID(b1oracle);
 
     const feeAmount = AmountMath.make(link.brand, 1000n);
     /**

--- a/packages/zoe/test/unitTests/contracts/otcDesk.test.js
+++ b/packages/zoe/test/unitTests/contracts/otcDesk.test.js
@@ -19,8 +19,8 @@ let vatAdminState;
 
 const installCode = async zoe => {
   const bundle = await bundleSource(root);
-  vatAdminState.installBundle('b1-otcdesk', bundle);
-  const installation = await E(zoe).installBundleID('b1-otcdesk');
+  const b1otcdesk = vatAdminState.registerBundle('b1-otcdesk', bundle);
+  const installation = await E(zoe).installBundleID(b1otcdesk);
   return installation;
 };
 
@@ -28,8 +28,8 @@ const installCoveredCall = async zoe => {
   const bundle = await bundleSource(
     `${dirname}/../../../src/contracts/coveredCall`,
   );
-  vatAdminState.installBundle('b1-coveredcall', bundle);
-  const installation = await E(zoe).installBundleID('b1-coveredcall');
+  const b1coveredcall = vatAdminState.registerBundle('b1-coveredcall', bundle);
+  const installation = await E(zoe).installBundleID(b1coveredcall);
   return installation;
 };
 

--- a/packages/zoe/test/unitTests/contracts/ownable-counter.test.js
+++ b/packages/zoe/test/unitTests/contracts/ownable-counter.test.js
@@ -25,9 +25,12 @@ test('zoe - ownable-counter contract', async t => {
 
   // Pack the contract.
   const bundle = await bundleSource(root);
-  vatAdminState.installBundle('b1-ownable-counter', bundle);
+  const b1ownablecounter = vatAdminState.registerBundle(
+    'b1-ownable-counter',
+    bundle,
+  );
   /** @type {Installation<typeof startOwnableCounter>} */
-  const installation = await E(zoe).installBundleID('b1-ownable-counter');
+  const installation = await E(zoe).installBundleID(b1ownablecounter);
 
   const { creatorFacet: firstCounter, publicFacet: viewCounter } = await E(
     zoe,

--- a/packages/zoe/test/unitTests/contracts/priceAggregator.test.js
+++ b/packages/zoe/test/unitTests/contracts/priceAggregator.test.js
@@ -117,12 +117,15 @@ test.before('setup aggregator and oracles', async t => {
   // of tests, we can also send the installation to someone
   // else, and they can use it to create a new contract instance
   // using the same code.
-  vatAdminState.installBundle('b1-oracle', oracleBundle);
+  const b1oracle = vatAdminState.registerBundle('b1-oracle', oracleBundle);
   /** @type {Installation<OracleStart>} */
-  const oracleInstallation = await E(zoe).installBundleID('b1-oracle');
-  vatAdminState.installBundle('b1-aggregator', aggregatorBundle);
+  const oracleInstallation = await E(zoe).installBundleID(b1oracle);
+  const b1aggregator = vatAdminState.registerBundle(
+    'b1-aggregator',
+    aggregatorBundle,
+  );
   /** @type {Installation<typeof start>} */
-  const aggregatorInstallation = await E(zoe).installBundleID('b1-aggregator');
+  const aggregatorInstallation = await E(zoe).installBundleID(b1aggregator);
 
   const link = makeIssuerKit('$ATOM');
   const { brand: atomBrand } = makeIssuerKit('$ATOM');

--- a/packages/zoe/test/unitTests/contracts/scaledPriceAuthority.test.js
+++ b/packages/zoe/test/unitTests/contracts/scaledPriceAuthority.test.js
@@ -51,9 +51,12 @@ test.before('setup scaled price authority', async ot => {
   // of tests, we can also send the installation to someone
   // else, and they can use it to create a new contract instance
   // using the same code.
-  vatAdminState.installBundle('b1-scaled-price-authority', scaledPriceBundle);
-  const scaledPriceInstallation = await E(zoe).installBundleID(
+  const b1scaledpriceauthority = vatAdminState.registerBundle(
     'b1-scaled-price-authority',
+    scaledPriceBundle,
+  );
+  const scaledPriceInstallation = await E(zoe).installBundleID(
+    b1scaledpriceauthority,
   );
 
   // Pick some weird decimal places.

--- a/packages/zoe/test/unitTests/contracts/sellTickets.test.js
+++ b/packages/zoe/test/unitTests/contracts/sellTickets.test.js
@@ -24,12 +24,15 @@ test(`mint and sell tickets for multiple shows`, async t => {
   const zoe = makeZoeForTest(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
-  vatAdminState.installBundle('b1-nft', mintAndSellNFTBundle);
-  const mintAndSellNFTInstallation = await E(zoe).installBundleID('b1-nft');
+  const b1nft = vatAdminState.registerBundle('b1-nft', mintAndSellNFTBundle);
+  const mintAndSellNFTInstallation = await E(zoe).installBundleID(b1nft);
 
   const sellItemsBundle = await bundleSource(sellItemsRoot);
-  vatAdminState.installBundle('b1-sell-items', sellItemsBundle);
-  const sellItemsInstallation = await E(zoe).installBundleID('b1-sell-items');
+  const b1sellitems = vatAdminState.registerBundle(
+    'b1-sell-items',
+    sellItemsBundle,
+  );
+  const sellItemsInstallation = await E(zoe).installBundleID(b1sellitems);
 
   const { issuer: moolaIssuer, brand: moolaBrand } = makeIssuerKit('moola');
 
@@ -152,12 +155,15 @@ test(`mint and sell opera tickets`, async t => {
   const zoe = makeZoeForTest(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
-  vatAdminState.installBundle('b1-nft', mintAndSellNFTBundle);
-  const mintAndSellNFTInstallation = await E(zoe).installBundleID('b1-nft');
+  const b1nft = vatAdminState.registerBundle('b1-nft', mintAndSellNFTBundle);
+  const mintAndSellNFTInstallation = await E(zoe).installBundleID(b1nft);
 
   const sellItemsBundle = await bundleSource(sellItemsRoot);
-  vatAdminState.installBundle('b1-sell-items', sellItemsBundle);
-  const sellItemsInstallation = await E(zoe).installBundleID('b1-sell-items');
+  const b1sellitems = vatAdminState.registerBundle(
+    'b1-sell-items',
+    sellItemsBundle,
+  );
+  const sellItemsInstallation = await E(zoe).installBundleID(b1sellitems);
 
   // === Initial Opera de Bordeaux part ===
 
@@ -560,12 +566,15 @@ test('Testing publicFacet.getAvailableItemsNotifier()', async t => {
   const zoe = makeZoeForTest(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
-  vatAdminState.installBundle('b1-nft', mintAndSellNFTBundle);
-  const mintAndSellNFTInstallation = await E(zoe).installBundleID('b1-nft');
+  const b1nft = vatAdminState.registerBundle('b1-nft', mintAndSellNFTBundle);
+  const mintAndSellNFTInstallation = await E(zoe).installBundleID(b1nft);
 
   const sellItemsBundle = await bundleSource(sellItemsRoot);
-  vatAdminState.installBundle('b1-sell-items', sellItemsBundle);
-  const sellItemsInstallation = await E(zoe).installBundleID('b1-sell-items');
+  const b1sellitems = vatAdminState.registerBundle(
+    'b1-sell-items',
+    sellItemsBundle,
+  );
+  const sellItemsInstallation = await E(zoe).installBundleID(b1sellitems);
 
   const { issuer: moolaIssuer, brand: moolaBrand } = makeIssuerKit('moola');
 

--- a/packages/zoe/test/unitTests/contracts/throwInOfferHandler.test.js
+++ b/packages/zoe/test/unitTests/contracts/throwInOfferHandler.test.js
@@ -19,8 +19,8 @@ test('throw in offerHandler', async t => {
   // pack the contract
   const bundle = await bundleSource(contractRoot);
   // install the contract
-  vatAdminState.installBundle('b1-throw', bundle);
-  const installation = await E(zoe).installBundleID('b1-throw');
+  const b1throw = vatAdminState.registerBundle('b1-throw', bundle);
+  const installation = await E(zoe).installBundleID(b1throw);
 
   const { creatorFacet } = await E(zoe).startInstance(installation);
 

--- a/packages/zoe/test/unitTests/contracts/useObj.test.js
+++ b/packages/zoe/test/unitTests/contracts/useObj.test.js
@@ -22,8 +22,8 @@ test('zoe - useObj', async t => {
   // pack the contract
   const bundle = await bundleSource(contractRoot);
   // install the contract
-  vatAdminState.installBundle('b1-use-obj', bundle);
-  const installation = await E(zoe).installBundleID('b1-use-obj');
+  const b1useobj = vatAdminState.registerBundle('b1-use-obj', bundle);
+  const installation = await E(zoe).installBundleID(b1useobj);
 
   // Setup Alice
   const aliceMoolaPayment = moolaMint.mintPayment(moola(3n));

--- a/packages/zoe/test/unitTests/makeKind.test.js
+++ b/packages/zoe/test/unitTests/makeKind.test.js
@@ -19,8 +19,8 @@ test('defineKind non-swingset', async t => {
   const bundle = await bundleSource(root);
   const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const zoe = makeZoeForTest(fakeVatAdmin);
-  vatAdminState.installBundle('b1-minimal', bundle);
-  const installation = await E(zoe).installBundleID('b1-minimal');
+  const b1minimal = vatAdminState.registerBundle('b1-minimal', bundle);
+  const installation = await E(zoe).installBundleID(b1minimal);
   t.notThrows(() => VatData.defineKind('x', () => {}, {}));
   t.notThrows(() => VatData.defineKindMulti('x', () => {}, { x: {}, y: {} }));
   t.notThrows(() => VatData.makeKindHandle('tag'));

--- a/packages/zoe/test/unitTests/scriptedOracle.test.js
+++ b/packages/zoe/test/unitTests/scriptedOracle.test.js
@@ -53,10 +53,16 @@ test.before(
 
     // Install the contracts on Zoe, getting installations. We use these
     // installations to instantiate the contracts.
-    vatAdminState.installBundle('b1-oracle', oracleContractBundle);
-    const oracleInstallation = await E(zoe).installBundleID('b1-oracle');
-    vatAdminState.installBundle('b1-bounty', bountyContractBundle);
-    const bountyInstallation = await E(zoe).installBundleID('b1-bounty');
+    const b1oracle = vatAdminState.registerBundle(
+      'b1-oracle',
+      oracleContractBundle,
+    );
+    const oracleInstallation = await E(zoe).installBundleID(b1oracle);
+    const b1bounty = vatAdminState.registerBundle(
+      'b1-bounty',
+      bountyContractBundle,
+    );
+    const bountyInstallation = await E(zoe).installBundleID(b1bounty);
     const { moolaIssuer, moolaMint, moola } = setup();
 
     ot.context.zoe = zoe;

--- a/packages/zoe/test/unitTests/zcf/feeMintAccess.test.js
+++ b/packages/zoe/test/unitTests/zcf/feeMintAccess.test.js
@@ -18,8 +18,8 @@ test(`feeMintAccess`, async t => {
   const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe, feeMintAccess } = makeZoeKitForTest(fakeVatAdmin);
   const bundle = await bundleSource(contractRoot);
-  vatAdminState.installBundle('b1-registerfee', bundle);
-  const installation = await E(zoe).installBundleID('b1-registerfee');
+  const b1registerfee = vatAdminState.registerBundle('b1-registerfee', bundle);
+  const installation = await E(zoe).installBundleID(b1registerfee);
   const { creatorFacet } = await E(zoe).startInstance(
     installation,
     undefined,

--- a/packages/zoe/test/unitTests/zcf/offer-proposalShape.test.js
+++ b/packages/zoe/test/unitTests/zcf/offer-proposalShape.test.js
@@ -32,8 +32,8 @@ test(`ProposalShapes mismatch`, async t => {
   // pack the contract
   const bundle = await bundleSource(contractRoot);
   // install the contract
-  vatAdminState.installBundle('b1-zcftester', bundle);
-  const installation = await E(zoe).installBundleID('b1-zcftester');
+  const b1zcftester = vatAdminState.registerBundle('b1-zcftester', bundle);
+  const installation = await E(zoe).installBundleID(b1zcftester);
 
   // Alice creates an instance
   const issuerKeywordRecord = harden({
@@ -101,8 +101,8 @@ test(`ProposalShapes matched`, async t => {
   // pack the contract
   const bundle = await bundleSource(contractRoot);
   // install the contract
-  vatAdminState.installBundle('b1-zcftester', bundle);
-  const installation = await E(zoe).installBundleID('b1-zcftester');
+  const b1zcftester = vatAdminState.registerBundle('b1-zcftester', bundle);
+  const installation = await E(zoe).installBundleID(b1zcftester);
 
   // Alice creates an instance
   const issuerKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -33,8 +33,11 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
     fakeVatAdmin.admin,
   );
   const bundle = await bundleSource(contractRoot);
-  fakeVatAdmin.vatAdminState.installBundle('b1-contract', bundle);
-  const installation = await E(zoe).installBundleID('b1-contract');
+  const b1contract = fakeVatAdmin.vatAdminState.registerBundle(
+    'b1-contract',
+    bundle,
+  );
+  const installation = await E(zoe).installBundleID(b1contract);
   const startInstanceResult = await E(zoe).startInstance(
     installation,
     issuerKeywordRecord,

--- a/packages/zoe/test/unitTests/zcf/zcfSeat-exit.test.js
+++ b/packages/zoe/test/unitTests/zcf/zcfSeat-exit.test.js
@@ -29,8 +29,8 @@ test(`zoe - wrongly throw zcfSeat.exit()`, async t => {
   // pack the contract
   const bundle = await bundleSource(contractRoot);
   // install the contract
-  vatAdminState.installBundle('b1-zcftester', bundle);
-  const installation = await E(zoe).installBundleID('b1-zcftester');
+  const b1zcftester = vatAdminState.registerBundle('b1-zcftester', bundle);
+  const installation = await E(zoe).installBundleID(b1zcftester);
 
   // Alice creates an instance
   const issuerKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/zcf/zcfSeat.test.js
+++ b/packages/zoe/test/unitTests/zcf/zcfSeat.test.js
@@ -29,8 +29,8 @@ test(`zoe - zcfSeat.fail() doesn't throw`, async t => {
   // pack the contract
   const bundle = await bundleSource(contractRoot);
   // install the contract
-  vatAdminState.installBundle('b1-zcftester', bundle);
-  const installation = await E(zoe).installBundleID('b1-zcftester');
+  const b1zcftester = vatAdminState.registerBundle('b1-zcftester', bundle);
+  const installation = await E(zoe).installBundleID(b1zcftester);
 
   // Alice creates an instance
   const issuerKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/zoe.test.js
+++ b/packages/zoe/test/unitTests/zoe.test.js
@@ -71,14 +71,10 @@ test(`E(zoe).installBundleID(bundleID)`, async t => {
   const { zoe, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/atomicSwap`;
   const bundle = await bundleSource(contractPath);
-  vatAdminState.installBundle('b1-atomic', bundle);
-  const installation = await E(zoe).installBundleID('b1-atomic');
-  // TODO Check the integrity of the installation by its hash.
-  // https://github.com/Agoric/agoric-sdk/issues/3859
-  // const hash = await E(installation).getHash();
-  // assert.is(hash, 'XXX');
-  // NOTE: the bundle ID is now the hash
-  t.is(await E(zoe).getBundleIDFromInstallation(installation), 'b1-atomic');
+  const b1atomic = vatAdminState.registerBundle('b1-atomic', bundle);
+  const installation = await E(zoe).installBundleID(b1atomic);
+  // NOTE: the bundle ID now contains the hash
+  t.is(await E(zoe).getBundleIDFromInstallation(installation), b1atomic);
 });
 
 test(`E(zoe).offer`, async t => {
@@ -107,9 +103,9 @@ test(`E(zoe).getPublicFacet`, async t => {
   const { zoe, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  vatAdminState.installBundle('b1-refund', bundle);
+  const b1refund = vatAdminState.registerBundle('b1-refund', bundle);
   /** @type {Installation<typeof startAutomaticRefund>} */
-  const installation = await E(zoe).installBundleID('b1-refund');
+  const installation = await E(zoe).installBundleID(b1refund);
   const { publicFacet, instance } = await E(zoe).startInstance(installation);
   await t.throwsAsync(() =>
     // @ts-expect-error not on public facet
@@ -124,8 +120,8 @@ test(`E(zoe).getPublicFacet promise for instance`, async t => {
   const { zoe, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  vatAdminState.installBundle('b1-refund', bundle);
-  const installationP = E(zoe).installBundleID('b1-refund');
+  const b1refund = vatAdminState.registerBundle('b1-refund', bundle);
+  const installationP = E(zoe).installBundleID(b1refund);
   // Note that E.get does not currently pipeline
   const { publicFacet: publicFacetP, instance: instanceP } = E.get(
     E(zoe).startInstance(installationP),
@@ -154,8 +150,8 @@ test(`zoe.getIssuers`, async t => {
   const { zoe, moolaKit, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  vatAdminState.installBundle('b1-refund', bundle);
-  const installation = await E(zoe).installBundleID('b1-refund');
+  const b1refund = vatAdminState.registerBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID(b1refund);
   const { instance } = await E(zoe).startInstance(installation, {
     Moola: moolaKit.issuer,
   });
@@ -166,8 +162,8 @@ test(`zoe.getIssuers - none`, async t => {
   const { zoe, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  vatAdminState.installBundle('b1-refund', bundle);
-  const installation = await E(zoe).installBundleID('b1-refund');
+  const b1refund = vatAdminState.registerBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID(b1refund);
   const { instance } = await E(zoe).startInstance(installation);
   t.deepEqual(await E(zoe).getIssuers(instance), {});
 });
@@ -185,8 +181,8 @@ test(`zoe.getBrands`, async t => {
   const { zoe, moolaKit, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  vatAdminState.installBundle('b1-refund', bundle);
-  const installation = await E(zoe).installBundleID('b1-refund');
+  const b1refund = vatAdminState.registerBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID(b1refund);
   const { instance } = await E(zoe).startInstance(installation, {
     Moola: moolaKit.issuer,
   });
@@ -197,8 +193,8 @@ test(`zoe.getBrands - none`, async t => {
   const { zoe, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  vatAdminState.installBundle('b1-refund', bundle);
-  const installation = await E(zoe).installBundleID('b1-refund');
+  const b1refund = vatAdminState.registerBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID(b1refund);
   const { instance } = await E(zoe).startInstance(installation);
   t.deepEqual(await E(zoe).getBrands(instance), {});
 });
@@ -216,8 +212,8 @@ test(`zoe.getTerms - none`, async t => {
   const { zoe, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  vatAdminState.installBundle('b1-refund', bundle);
-  const installation = await E(zoe).installBundleID('b1-refund');
+  const b1refund = vatAdminState.registerBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID(b1refund);
   const { instance } = await E(zoe).startInstance(installation);
   t.deepEqual(await E(zoe).getTerms(instance), {
     brands: {},
@@ -229,9 +225,9 @@ test(`zoe.getTerms`, async t => {
   const { zoe, moolaKit, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  vatAdminState.installBundle('b1-refund', bundle);
+  const b1refund = vatAdminState.registerBundle('b1-refund', bundle);
   /** @type {Installation<typeof startAutomaticRefund>} */
-  const installation = await E(zoe).installBundleID('b1-refund');
+  const installation = await E(zoe).installBundleID(b1refund);
   const { instance } = await E(zoe).startInstance(
     installation,
     {
@@ -272,8 +268,8 @@ test(`zoe.getInstallationForInstance`, async t => {
   const { zoe, moolaKit, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  vatAdminState.installBundle('b1-refund', bundle);
-  const installation = await E(zoe).installBundleID('b1-refund');
+  const b1refund = vatAdminState.registerBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID(b1refund);
   const { instance } = await E(zoe).startInstance(
     installation,
     {

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -139,6 +139,28 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
     getHasExited: () => hasExited,
     getExitWithFailure: () => exitWithFailure,
     /**
+     * @param {string} base
+     * @param {EndoZipBase64Bundle | TestBundle} bundle
+     */
+    getBundleID: (base, bundle) => {
+      if (bundle.moduleFormat !== 'endoZipBase64') {
+        return base;
+      }
+      if (base === `b1-${bundle.endoZipBase64Sha512}`) {
+        return base;
+      }
+      return `${base}-${bundle.endoZipBase64Sha512}`;
+    },
+    /**
+     * @param {string} base
+     * @param {EndoZipBase64Bundle | TestBundle} bundle
+     */
+    registerBundle: (base, bundle) => {
+      const bid = vatAdminState.getBundleID(base, bundle);
+      vatAdminState.installBundle(bid, bundle);
+      return bid;
+    },
+    /**
      * @param {string} id
      * @param {EndoZipBase64Bundle | TestBundle} bundle
      */
@@ -150,7 +172,14 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
         if (extant.moduleFormat === 'endoZipBase64') {
           // Narrow bundle.moduleFormat now that extant.moduleFormat is narrowed
           assert.equal(bundle.moduleFormat, extant.moduleFormat);
-          assert.equal(bundle.endoZipBase64, extant.endoZipBase64);
+          // Make the error message managable by only showing the length,
+          // beginning and end of the huge base64 strings.
+          const summarize = s =>
+            `${s.length} chars (${s.slice(0, 10)}...${s.slice(-10)})`;
+          assert(
+            bundle.endoZipBase64 === extant.endoZipBase64,
+            `bundle ${id} ${summarize(bundle.endoZipBase64)} differs from extant ${summarize(extant.endoZipBase64)}`,
+          );
         }
         return idToBundleCap.get(id);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3681,7 +3681,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@endo/bundle-source@npm:^4.1.2":
+"@endo/bundle-source@npm:4.1.2":
   version: 4.1.2
   resolution: "@endo/bundle-source@npm:4.1.2"
   dependencies:
@@ -3695,6 +3695,23 @@ __metadata:
   bin:
     bundle-source: ./src/tool.js
   checksum: 10c0/7bee180864e8340877c0979a2c773dba7e7346959a208efdc7bc6dac48964f6f4ff61f7542195d71c7bc847f81844bc81f0c302e8136aa5d730bdd0efcb113ca
+  languageName: node
+  linkType: hard
+
+"@endo/bundle-source@patch:@endo/bundle-source@npm%3A4.1.2#~/.yarn/patches/@endo-bundle-source-npm-4.1.2-80da9522ea.patch":
+  version: 4.1.2
+  resolution: "@endo/bundle-source@patch:@endo/bundle-source@npm%3A4.1.2#~/.yarn/patches/@endo-bundle-source-npm-4.1.2-80da9522ea.patch::version=4.1.2&hash=c46a8c"
+  dependencies:
+    "@endo/base64": "npm:^1.0.12"
+    "@endo/compartment-mapper": "npm:^1.6.3"
+    "@endo/evasive-transform": "npm:^2.0.2"
+    "@endo/init": "npm:^1.1.12"
+    "@endo/promise-kit": "npm:^1.1.13"
+    "@endo/where": "npm:^1.0.11"
+    ts-blank-space: "npm:^0.4.1"
+  bin:
+    bundle-source: ./src/tool.js
+  checksum: 10c0/c6b4838640c3afa9fa827db84058bf5df4dc330a560812aafdfed1a2bab116574da37ee215b2c4f33d2eab837be29af6abc745dc3649722f02e2ed0a7aaf5f6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes: #12193

[Best reviewed commit-by-commit.]

## Description

Patches `@endo/bundle-source` to automatically retry with esbuild minimisation when bundles exceed 500KB, helping to prevent RPC node `max_body_bytes` rejections until bundle chunking is available.

**Patch implementation** (`.yarn/patches/@endo-bundle-source-npm-4.1.2-*.patch`):
- Adds `byteLimit` option (default 500kB) and `esbuildPath` option
- On overflow, invokes `esbuild --bundle --minify-whitespace` and re-bundles the output
- Creates a temporary `package.json` if needed for `@endo/compartment-mapper`'s module resolution

**Prevent esbuild from bundling dynamic import expressions**:
- Portable pattern: `const mod = '@pkg/name'; await import(mod)` prevents bundlers from traversing `@pkg/name`
- Originally applied to all dynamic imports (which `@endo/bundle-source` already tolerates)
- Reworked to avoid changes to agoric-sdk source files, instead using `external` option to denylist Node.js builtin modules and known problematic modules (`@agoric/deploy-script-support`, `@agoric/internal/source/module-utils.js`)

**Kernel bundle exemption**:
- Set `byteLimit: Infinity` in SwingSet bundling paths (kernel bundles don't transit RPC)

**Test fidelity**:
- `fakeVatAdmin.registerBundle()` now generates bundleIDs containing the bundle hash
- Ensures test bundleIDs don't unnecessarily collide with different content for `endoZipBase64` bundles

### Security Considerations

Introduces esbuild as a dependency for minimisation. Only activated when standard Endo bundles exceed 500KB.

### Scaling Considerations

Raises the effective contract size ceiling without requiring on-chain changes (even though this PR has kernel changes, they only need to be deployed during the next coordinated chain software update). Bundles under 500KB are unchanged; larger bundles trade legibility for deployability.

### Documentation Considerations

Known issues with `.yarn/patches/@endo-bundle-source-npm-4.1.2-*.patch`:
- `AGORIC_SDK_EXTERNALS` explicit denylist to prevents bundling of certain dynamic imports, which may need adjustment as agoric-sdk code evolves.

### Testing Considerations

Existing tests pass. Enhanced bundleID generation improves test realism without causing behaviour regressions.

### Upgrade Considerations

The patch itself is temporary and may be removable once bundle chunking ships. No migration needed—`byteLimit` is optional and backward-compatible.
