### PR TITLE
chore: resolver changes to observe and resolve makeAccount transactions

### DIFF
--- a/packages/portfolio-api/src/resolver.js
+++ b/packages/portfolio-api/src/resolver.js
@@ -6,9 +6,10 @@
  * Represents a published transaction with its type, optional amount, destination, and status.
  *
  * @typedef {object} PublishedTx
- * @property {TxType} type - The type of transaction (CCTP_TO_EVM, GMP or CCTP_TO_AGORIC)
+ * @property {TxType} type - The type of transaction (CCTP_TO_EVM, GMP, CCTP_TO_AGORIC, or MAKE_ACCOUNT)
  * @property {bigint} [amount] - Optional transaction amount as a bigint
- * @property {AccountId} destinationAddress - The destination account identifier for the transaction
+ * @property {AccountId} destinationAddress - The destination account identifier for the transaction (CCTP/GMP destination, or MAKE_ACCOUNT factory address in CAIP format)
+ * @property {string} [expectedAddr] - The expected smart wallet hex address to be created (for MAKE_ACCOUNT only, format: 0x...)
  * @property {TxStatus} status - Current status of the transaction (pending, success, or failed)
  */
 
@@ -35,5 +36,6 @@ export const TxType = /** @type {const} */ ({
   CCTP_TO_EVM: 'CCTP_TO_EVM',
   GMP: 'GMP',
   CCTP_TO_AGORIC: 'CCTP_TO_AGORIC',
+  MAKE_ACCOUNT: 'MAKE_ACCOUNT',
 });
 harden(TxType);

--- a/packages/portfolio-contract/src/resolver/types.ts
+++ b/packages/portfolio-contract/src/resolver/types.ts
@@ -71,6 +71,17 @@ export const PublishedTxShape: TypedPattern<PublishedTx> = M.or(
     },
     {},
   ),
+  // MAKE_ACCOUNT requires expectedAddr (hex) and destinationAddress is factory (CAIP)
+  M.splitRecord(
+    {
+      type: M.or(TxType.MAKE_ACCOUNT),
+      destinationAddress: M.string(),
+      expectedAddr: M.string(),
+      status: TxStatus.PENDING,
+    },
+    {},
+    {},
+  ),
 );
 
 // Backwards compatibility

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -26,6 +26,10 @@ import type {
 } from './support.ts';
 import { lookBackCctp, watchCctpTransfer } from './watchers/cctp-watcher.ts';
 import { lookBackGmp, watchGmp } from './watchers/gmp-watcher.ts';
+import {
+  watchSmartWalletTx,
+  lookBackSmartWalletTx,
+} from './watchers/wallet-watcher.ts';
 
 export type EvmChain = keyof typeof AxelarChain;
 

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -47,6 +47,7 @@ export type GmpTransfer = {
 
 type CctpTx = PendingTx & { type: typeof TxType.CCTP_TO_EVM; amount: bigint };
 type GmpTx = PendingTx & { type: typeof TxType.GMP };
+type MakeAccountTx = PendingTx & { type: typeof TxType.MAKE_ACCOUNT };
 
 type LiveWatchOpts = { mode: 'live'; timeoutMs: number };
 type LookBackWatchOpts = {
@@ -71,6 +72,7 @@ export type PendingTxMonitor<
 type MonitorRegistry = {
   [TxType.CCTP_TO_EVM]: PendingTxMonitor<CctpTx, EvmContext>;
   [TxType.GMP]: PendingTxMonitor<GmpTx, EvmContext>;
+  [TxType.MAKE_ACCOUNT]: PendingTxMonitor<MakeAccountTx, EvmContext>;
 };
 
 const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -24,6 +24,12 @@ type ROPartial<K extends string, V> = Readonly<Partial<Record<K, V>>>;
 
 type HexAddress = `0x${string}`;
 
+export type WatcherTimeoutOptions = {
+  timeoutMs?: number;
+  setTimeout?: typeof globalThis.setTimeout;
+  signal?: AbortSignal;
+};
+
 /**
  * @deprecated should come from e.g. @agoric/portfolio-api/src/constants.js
  *   or @agoric/orchestration

--- a/services/ymax-planner/src/watchers/cctp-watcher.ts
+++ b/services/ymax-planner/src/watchers/cctp-watcher.ts
@@ -210,10 +210,12 @@ export const lookBackCctp = async ({
       },
     );
 
-    if (!matchingEvent) log(`No matching transfer found`);
+    if (!matchingEvent) {
+      log(`No matching transfer found`);
+      return false;
+    }
     deleteTxBlockLowerBound(kvStore, txId);
-
-    return !!matchingEvent;
+    return true;
   } catch (error) {
     log(`Error:`, error);
     return false;

--- a/services/ymax-planner/src/watchers/cctp-watcher.ts
+++ b/services/ymax-planner/src/watchers/cctp-watcher.ts
@@ -5,6 +5,7 @@ import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
+  type WatcherTimeoutOptions,
 } from '../support.ts';
 import { TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
 import {
@@ -76,11 +77,7 @@ export const watchCctpTransfer = ({
   log = () => {},
   setTimeout = globalThis.setTimeout,
   signal,
-}: CctpWatch & {
-  timeoutMs?: number;
-  setTimeout?: typeof globalThis.setTimeout;
-  signal?: AbortSignal;
-}): Promise<boolean> => {
+}: CctpWatch & WatcherTimeoutOptions): Promise<boolean> => {
   return new Promise(resolve => {
     if (signal?.aborted) {
       resolve(false);

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -5,6 +5,7 @@ import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
+  type WatcherTimeoutOptions,
 } from '../support.ts';
 import type { MakeAbortController } from '../support.ts';
 import { TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
@@ -39,11 +40,7 @@ export const watchGmp = ({
   log = () => {},
   setTimeout = globalThis.setTimeout,
   signal,
-}: WatchGmp & {
-  timeoutMs?: number;
-  setTimeout?: typeof globalThis.setTimeout;
-  signal?: AbortSignal;
-}): Promise<boolean> => {
+}: WatchGmp & WatcherTimeoutOptions): Promise<boolean> => {
   return new Promise(resolve => {
     if (signal?.aborted) {
       resolve(false);

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -65,7 +65,7 @@ export const watchSmartWalletTx = ({
     const TO_TOPIC = zeroPadValue(expectedAddr.toLowerCase(), 32);
     const filter = {
       address: factoryAddr,
-      topics: [SMART_WALLET_CREATED_SIGNATURE, null, TO_TOPIC],
+      topics: [SMART_WALLET_CREATED_SIGNATURE, TO_TOPIC],
     };
 
     log(`Watching SmartWalletCreated events emitted by ${factoryAddr}`);
@@ -148,7 +148,7 @@ export const lookBackSmartWalletTx = async ({
     const toTopic = zeroPadValue(expectedAddr.toLowerCase(), 32);
     const baseFilter: Filter = {
       address: factoryAddr,
-      topics: [SMART_WALLET_CREATED_SIGNATURE, null, toTopic],
+      topics: [SMART_WALLET_CREATED_SIGNATURE, toTopic],
     };
 
     const matchingEvent = await scanEvmLogsInChunks(

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -7,7 +7,7 @@ import {
 } from '../support.ts';
 import { TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
 
-const SMART_WALLET_CREATED_SIGNATURE = id(
+export const SMART_WALLET_CREATED_SIGNATURE = id(
   'SmartWalletCreated(address,string,string,string)',
 );
 const abiCoder = new AbiCoder();

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -5,6 +5,7 @@ import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
+  type WatcherTimeoutOptions,
 } from '../support.ts';
 import { TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
 import {
@@ -59,11 +60,7 @@ export const watchSmartWalletTx = ({
   log = () => {},
   setTimeout = globalThis.setTimeout,
   signal,
-}: SmartWalletWatch & {
-  timeoutMs?: number;
-  setTimeout?: typeof globalThis.setTimeout;
-  signal?: AbortSignal;
-}): Promise<boolean> => {
+}: SmartWalletWatch & WatcherTimeoutOptions): Promise<boolean> => {
   return new Promise(resolve => {
     if (signal?.aborted) {
       resolve(false);
@@ -188,10 +185,12 @@ export const lookBackSmartWalletTx = async ({
       },
     );
 
-    if (!matchingEvent) log(`No matching SmartWalletCreated event found`);
+    if (!matchingEvent) {
+      log(`No matching SmartWalletCreated event found`);
+      return false;
+    }
     deleteTxBlockLowerBound(kvStore, txId);
-
-    return !!matchingEvent;
+    return true;
   } catch (error) {
     log(`Error:`, error);
     return false;

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -1,0 +1,174 @@
+import type { Filter, WebSocketProvider, Log } from 'ethers';
+import { id, zeroPadValue, getAddress, AbiCoder } from 'ethers';
+import type { CaipChainId } from '@agoric/orchestration';
+import {
+  getBlockNumberBeforeRealTime,
+  scanEvmLogsInChunks,
+} from '../support.ts';
+import { TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
+
+const SMART_WALLET_CREATED_SIGNATURE = id(
+  'SmartWalletCreated(address,string,string,string)',
+);
+const abiCoder = new AbiCoder();
+
+const extractAddress = topic => {
+  return getAddress(`0x${topic.slice(-40)}`);
+};
+
+const parseSmartWalletCreatedLog = (log: any) => {
+  if (!log.topics || !log.data) {
+    throw new Error('Malformed SmartWalletCreated log');
+  }
+
+  const wallet = extractAddress(log.topics[1]);
+
+  const [owner, sourceChain, sourceAddress] = abiCoder.decode(
+    ['string', 'string', 'string'],
+    log.data,
+  );
+
+  return {
+    wallet,
+    owner,
+    sourceChain,
+    sourceAddress,
+  };
+};
+
+type SmartWalletWatch = {
+  factoryAddr: `0x${string}`;
+  provider: WebSocketProvider;
+  expectedAddr: `0x${string}`;
+  log?: (...args: unknown[]) => void;
+};
+
+export const watchSmartWalletTx = ({
+  factoryAddr,
+  provider,
+  expectedAddr,
+  timeoutMs = TX_TIMEOUT_MS,
+  log = () => {},
+  setTimeout = globalThis.setTimeout,
+  signal,
+}: SmartWalletWatch & {
+  timeoutMs?: number;
+  setTimeout?: typeof globalThis.setTimeout;
+  signal?: AbortSignal;
+}): Promise<boolean> => {
+  return new Promise(resolve => {
+    if (signal?.aborted) {
+      resolve(false);
+      return;
+    }
+
+    const TO_TOPIC = zeroPadValue(expectedAddr.toLowerCase(), 32);
+    const filter = {
+      address: factoryAddr,
+      topics: [SMART_WALLET_CREATED_SIGNATURE, null, TO_TOPIC],
+    };
+
+    log(`Watching SmartWalletCreated events emitted by ${factoryAddr}`);
+
+    let walletCreated = false;
+    let timeoutId: NodeJS.Timeout;
+    let listeners: Array<{ event: any; listener: any }> = [];
+
+    const finish = (result: boolean) => {
+      resolve(result);
+      if (timeoutId) clearTimeout(timeoutId);
+      for (const { event, listener } of listeners) {
+        void provider.off(event, listener);
+      }
+      listeners = [];
+    };
+
+    signal?.addEventListener('abort', () => finish(false));
+
+    const listenForSmartWalletCreation = (eventLog: Log) => {
+      let eventData;
+      try {
+        eventData = parseSmartWalletCreatedLog(eventLog);
+      } catch (error: any) {
+        log(`Log parsing error:`, error.message);
+        return;
+      }
+
+      const { wallet } = eventData;
+
+      log(`SmartWalletCreated event detected: wallet:${wallet}`);
+
+      if (wallet === expectedAddr) {
+        log(`✓ Address matches! Expected: ${expectedAddr}, Found: ${wallet}`);
+        walletCreated = true;
+        finish(true);
+        return;
+      }
+      log(`Address mismatch. Expected: ${expectedAddr}, Found: ${wallet}`);
+    };
+
+    void provider.on(filter, listenForSmartWalletCreation);
+    listeners.push({ event: filter, listener: listenForSmartWalletCreation });
+
+    timeoutId = setTimeout(() => {
+      if (!walletCreated) {
+        log(
+          `✗ No matching SmartWalletCreated event found within ${timeoutMs / 60000} minutes`,
+        );
+      }
+    }, timeoutMs);
+  });
+};
+
+export const lookBackSmartWalletTx = async ({
+  factoryAddr,
+  provider,
+  expectedAddr,
+  publishTimeMs,
+  chainId,
+  log = () => {},
+  signal,
+}: SmartWalletWatch & {
+  publishTimeMs: number;
+  chainId: CaipChainId;
+  signal?: AbortSignal;
+}): Promise<boolean> => {
+  await null;
+  try {
+    const fromBlock = await getBlockNumberBeforeRealTime(
+      provider,
+      publishTimeMs,
+    );
+    const toBlock = await provider.getBlockNumber();
+
+    log(
+      `Searching blocks ${fromBlock} → ${toBlock} for SmartWalletCreated events emitted by ${factoryAddr}`,
+    );
+
+    const toTopic = zeroPadValue(expectedAddr.toLowerCase(), 32);
+    const baseFilter: Filter = {
+      address: factoryAddr,
+      topics: [SMART_WALLET_CREATED_SIGNATURE, null, toTopic],
+    };
+
+    const matchingEvent = await scanEvmLogsInChunks(
+      { provider, baseFilter, fromBlock, toBlock, chainId, log, signal },
+      ev => {
+        try {
+          const t = parseSmartWalletCreatedLog(ev);
+          log(`Check: addresss=${t.wallet}`);
+          return t.wallet === expectedAddr;
+        } catch (e) {
+          log(`Parse error:`, e);
+          return false;
+        }
+      },
+    );
+
+    if (!matchingEvent) log(`No matching SmartWalletCreated event found`);
+    return !!matchingEvent;
+  } catch (error) {
+    log(`Error:`, error);
+    return false;
+  }
+};

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -1,0 +1,227 @@
+import test from 'ava';
+import { id, zeroPadValue, AbiCoder, getAddress } from 'ethers';
+import { createMockPendingTxOpts } from './mocks.ts';
+import { handlePendingTx } from '../src/pending-tx-manager.ts';
+import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
+import type { PendingTx } from '@aglocal/portfolio-contract/src/resolver/types.ts';
+
+const SMART_WALLET_CREATED_SIGNATURE = id(
+  'SmartWalletCreated(address,string,string,string)',
+);
+const abiCoder = new AbiCoder();
+
+const factoryAddress = '0x51e589D94b51d01B75442AE1504cD8c50d6127C9';
+const expectedWalletAddr = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+
+const createSmartWalletCreatedLog = (
+  walletAddr: string,
+  owner: string,
+  sourceChain: string,
+  sourceAddress: string,
+) => {
+  const data = abiCoder.encode(
+    ['string', 'string', 'string'],
+    [owner, sourceChain, sourceAddress],
+  );
+
+  return {
+    address: factoryAddress,
+    topics: [
+      SMART_WALLET_CREATED_SIGNATURE,
+      zeroPadValue(walletAddr.toLowerCase(), 32),
+    ],
+    data,
+    transactionHash: '0x123abc',
+    blockNumber: 18500000,
+  };
+};
+
+test('handlePendingTx processes MAKE_ACCOUNT transaction successfully', async t => {
+  const opts = createMockPendingTxOpts();
+  const txId = 'tx1';
+  const chain = 'eip155:42161'; // Arbitrum
+  const provider = opts.evmProviders[chain];
+  const type = TxType.MAKE_ACCOUNT;
+
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  const makeAccountTx: PendingTx = {
+    txId,
+    type,
+    status: 'pending',
+    destinationAddress: `${chain}:${factoryAddress}`,
+    expectedAddr: expectedWalletAddr,
+  };
+
+  setTimeout(() => {
+    const mockLog = createSmartWalletCreatedLog(
+      expectedWalletAddr,
+      'agoric1owner123',
+      'agoric-3',
+      'agoric1source456',
+    );
+
+    const filter = {
+      address: factoryAddress,
+      topics: [
+        SMART_WALLET_CREATED_SIGNATURE,
+        zeroPadValue(expectedWalletAddr.toLowerCase(), 32),
+      ],
+    };
+
+    (provider as any).emit(filter, mockLog);
+  }, 50);
+
+  await t.notThrowsAsync(async () => {
+    await handlePendingTx(makeAccountTx, {
+      ...opts,
+      log: logger,
+      timeoutMs: 3000,
+    });
+  });
+
+  t.deepEqual(logMessages, [
+    `[${txId}] handling ${type} tx`,
+    `[${txId}] Watching SmartWalletCreated events emitted by ${factoryAddress}`,
+    `[${txId}] SmartWalletCreated event detected: wallet:${expectedWalletAddr}`,
+    `[${txId}] ✓ Address matches! Expected: ${expectedWalletAddr}, Found: ${expectedWalletAddr}`,
+    `[${txId}] MAKE_ACCOUNT tx resolved`,
+  ]);
+});
+
+test('handlePendingTx logs timeout on MAKE_ACCOUNT transaction with no matching event', async t => {
+  const opts = createMockPendingTxOpts();
+  const txId = 'tx2';
+  const chain = 'eip155:42161'; // Arbitrum
+  const provider = opts.evmProviders[chain];
+  const type = TxType.MAKE_ACCOUNT;
+
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  const makeAccountTx: PendingTx = {
+    txId,
+    type,
+    status: 'pending',
+    destinationAddress: `${chain}:${factoryAddress}`,
+    expectedAddr: expectedWalletAddr,
+  };
+
+  setTimeout(() => {
+    const mockLog = createSmartWalletCreatedLog(
+      expectedWalletAddr,
+      'agoric1owner123',
+      'agoric-3',
+      'agoric1source456',
+    );
+
+    const filter = {
+      address: factoryAddress,
+      topics: [
+        SMART_WALLET_CREATED_SIGNATURE,
+        zeroPadValue(expectedWalletAddr.toLowerCase(), 32),
+      ],
+    };
+
+    (provider as any).emit(filter, mockLog);
+  }, 3010);
+
+  await t.notThrowsAsync(async () => {
+    await handlePendingTx(makeAccountTx, {
+      ...opts,
+      log: logger,
+      timeoutMs: 3000,
+    });
+  });
+
+  t.deepEqual(logMessages, [
+    `[${txId}] handling ${type} tx`,
+    `[${txId}] Watching SmartWalletCreated events emitted by ${factoryAddress}`,
+    `[${txId}] ✗ No matching SmartWalletCreated event found within 0.05 minutes`,
+    `[${txId}] SmartWalletCreated event detected: wallet:${expectedWalletAddr}`,
+    `[${txId}] ✓ Address matches! Expected: ${expectedWalletAddr}, Found: ${expectedWalletAddr}`,
+    `[${txId}] MAKE_ACCOUNT tx resolved`,
+  ]);
+});
+
+test('handlePendingTx ignores non-matching wallet addresses', async t => {
+  const opts = createMockPendingTxOpts();
+  const txId = 'tx3';
+  const chain = 'eip155:42161'; // Arbitrum
+  const provider = opts.evmProviders[chain];
+  const type = TxType.MAKE_ACCOUNT;
+
+  // Use a different address - getAddress normalizes it to checksummed format
+  const wrongWalletAddrChecksummed = getAddress(
+    '0x742d35cc6635c0532925a3b8d9deb1c9e5eb2b64',
+  );
+
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  const makeAccountTx: PendingTx = {
+    txId,
+    type,
+    status: 'pending',
+    destinationAddress: `${chain}:${factoryAddress}`,
+    expectedAddr: expectedWalletAddr,
+  };
+
+  // Emit wrong address first
+  setTimeout(() => {
+    const mockLog = createSmartWalletCreatedLog(
+      wrongWalletAddrChecksummed,
+      'agoric1owner123',
+      'agoric-3',
+      'agoric1source456',
+    );
+
+    const filter = {
+      address: factoryAddress,
+      topics: [
+        SMART_WALLET_CREATED_SIGNATURE,
+        zeroPadValue(expectedWalletAddr.toLowerCase(), 32),
+      ],
+    };
+
+    (provider as any).emit(filter, mockLog);
+  }, 30);
+
+  setTimeout(() => {
+    const mockLog = createSmartWalletCreatedLog(
+      expectedWalletAddr,
+      'agoric1owner123',
+      'agoric-3',
+      'agoric1source456',
+    );
+
+    const filter = {
+      address: factoryAddress,
+      topics: [
+        SMART_WALLET_CREATED_SIGNATURE,
+        zeroPadValue(expectedWalletAddr.toLowerCase(), 32),
+      ],
+    };
+
+    (provider as any).emit(filter, mockLog);
+  }, 60);
+
+  await t.notThrowsAsync(async () => {
+    await handlePendingTx(makeAccountTx, {
+      ...opts,
+      log: logger,
+      timeoutMs: 3000,
+    });
+  });
+
+  t.deepEqual(logMessages, [
+    `[${txId}] handling ${type} tx`,
+    `[${txId}] Watching SmartWalletCreated events emitted by ${factoryAddress}`,
+    `[${txId}] SmartWalletCreated event detected: wallet:${wrongWalletAddrChecksummed}`,
+    `[${txId}] Address mismatch. Expected: ${expectedWalletAddr}, Found: ${wrongWalletAddrChecksummed}`,
+    `[${txId}] SmartWalletCreated event detected: wallet:${expectedWalletAddr}`,
+    `[${txId}] ✓ Address matches! Expected: ${expectedWalletAddr}, Found: ${expectedWalletAddr}`,
+    `[${txId}] MAKE_ACCOUNT tx resolved`,
+  ]);
+});

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -4,10 +4,8 @@ import { createMockPendingTxOpts } from './mocks.ts';
 import { handlePendingTx } from '../src/pending-tx-manager.ts';
 import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import type { PendingTx } from '@aglocal/portfolio-contract/src/resolver/types.ts';
+import { SMART_WALLET_CREATED_SIGNATURE } from '../src/watchers/wallet-watcher.ts';
 
-const SMART_WALLET_CREATED_SIGNATURE = id(
-  'SmartWalletCreated(address,string,string,string)',
-);
 const abiCoder = new AbiCoder();
 
 const factoryAddress = '0x51e589D94b51d01B75442AE1504cD8c50d6127C9';


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs:
- https://github.com/Agoric/agoric-private/issues/546

closes:
- https://github.com/Agoric/agoric-private/issues/564

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Extends the planner/resolver to listen and resolve for makeAccount transactions on EVM chains. 

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
New tests have been added for the logic to resolve makeAccount transactions.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
This is a breaking change. For these changes to work, we need to ensure:
- Factory contract based on the changes in **[45](https://github.com/agoric-labs/agoric-to-axelar-local/pull/45)** is deployed on the EVM chains. 
- The ymax-contract is publishing data on vstorage related to pending makeAccount transactions at `published.ymax1.pendingTxs`.
- The ymax-contract is capable to pre-computing EVM remote account addresses.