### PR TITLE
build: update planner build for sqlite3

### DIFF
--- a/.github/scripts/deploy_vm.sh
+++ b/.github/scripts/deploy_vm.sh
@@ -17,4 +17,5 @@ echo "Deploying to $GCE_INSTANCE: $IMAGE"
 gcloud compute instances update-container "$GCE_INSTANCE" \
   --zone "$GCE_ZONE" \
   --container-env-file "$ENV_FILE" \
-  --container-image "$IMAGE"
+  --container-image "$IMAGE" \
+  --container-mount-host-path=mount-path=/db_data,host-path=/var/lib/kv-store,mode=rw

--- a/services/ymax-planner/Dockerfile
+++ b/services/ymax-planner/Dockerfile
@@ -28,6 +28,9 @@ RUN --mount=type=cache,target=/root/.yarn/berry/cache yarn install --mode=skip-b
 RUN cd packages/cosmic-proto && yarn build
 RUN cd packages/client-utils && yarn build
 RUN cd services/ymax-planner && yarn build
+# `yarn workspaces focus ... --production` builds better-sqlite3 bindings without triggering build 
+# of dependencies such as xsnap.
+RUN yarn workspaces focus @aglocal/ymax-planner --production
 RUN cd packages/portfolio-contract && yarn build
 
 # Production stage
@@ -41,6 +44,18 @@ LABEL org.opencontainers.image.title="ymax-planner" \
 
 # Copy built application from builder stage
 COPY --from=builder /build/services/ymax-planner/dist/entrypoint.js /app/entrypoint.js
+
+# Copy better-sqlite3 bindings
+# better-sqlite3 will not run without this bindings file
+COPY --from=builder /build/node_modules/better-sqlite3/build/Release /app/Release
+
+# Copy node_modules for better-sqlite3
+#
+# better-sqlite3 requires that a node_modules or packages.json file be present
+# in order to find a root directory. since we use a compressed bundle, those
+# folders arent present and must be manually added
+RUN mkdir /app/node_modules
+COPY --from=builder /build/node_modules/better-sqlite3 /app/node_modules/better-sqlite3
 
 # Copy built highs.wasm file from builder stage
 COPY --from=builder /build/node_modules/highs/build/highs.wasm /app/highs.wasm


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-private/issues/504

## Description
Updates the build scripts for ymax-planner in order to add some files that the new sqlite3 kv-store requires.
Without this the planner crashes because the `better-sqlite3` package does not find the files it expects

### better-sqlite3 requirements
- bindings file: a build file that is created by better-sqlite3 and needed independent of the final `entrypoint.js` build
- node_modules: better-sqlite3 requires package.json/node_modules to identify the root directory of the package.

### build scripts
the build script is also updated since we need to mount a directory for sqlite db in order to make it persistent across restarts

### Testing Considerations
tested out by running test containers on GCP
generated image: https://github.com/agoric/agoric-sdk/pkgs/container/agoric-sdk/577293600?tag=ymax-planner-test


### Upgrade Considerations
The build scripts have been updated in the this PR and ymax planner must not be deployed without it
