### PR TITLE
include flow key trace ID in planner logs

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -1,21 +1,20 @@
 /// <reference types="ses" />
 /* eslint-env node */
 
-import { inspect } from 'node:util';
 import type { InspectOptions } from 'node:util';
+import { inspect } from 'node:util';
 
 import type { Coin } from '@cosmjs/stargate';
 
-import { Fail, annotateError, q } from '@endo/errors';
-import { Nat } from '@endo/nat';
-import { reflectWalletStore, getInvocationUpdate } from '@agoric/client-utils';
 import type { SigningSmartWalletKit } from '@agoric/client-utils';
+import { getInvocationUpdate, reflectWalletStore } from '@agoric/client-utils';
 import type { RetryOptionsAndPowers } from '@agoric/client-utils/src/sync-tools.js';
 import { AmountMath, type Brand } from '@agoric/ertp';
 import type { Bech32Address } from '@agoric/orchestration';
 import type { AssetInfo } from '@agoric/vats/src/vat-bank.js';
+import { annotateError, Fail, q } from '@endo/errors';
+import { Nat } from '@endo/nat';
 
-import type { SupportedChain } from '@agoric/portfolio-api/src/constants.js';
 import type { PortfolioPlanner } from '@aglocal/portfolio-contract/src/planner.exo.ts';
 import {
   TxStatus,
@@ -27,16 +26,16 @@ import {
   type TxId,
 } from '@aglocal/portfolio-contract/src/resolver/types.ts';
 import type { MovementDesc } from '@aglocal/portfolio-contract/src/type-guards-steps.js';
+import type {
+  FlowDetail,
+  PoolKey as InstrumentId,
+  StatusFor,
+} from '@aglocal/portfolio-contract/src/type-guards.ts';
 import {
   flowIdFromKey,
   PoolPlaces,
   portfolioIdFromKey,
   PortfolioStatusShapeExt,
-} from '@aglocal/portfolio-contract/src/type-guards.ts';
-import type {
-  FlowDetail,
-  PoolKey as InstrumentId,
-  StatusFor,
 } from '@aglocal/portfolio-contract/src/type-guards.ts';
 import { PROD_NETWORK } from '@aglocal/portfolio-contract/tools/network/network.prod.js';
 import type { GasEstimator } from '@aglocal/portfolio-contract/tools/plan-solve.ts';
@@ -50,13 +49,16 @@ import {
 } from '@agoric/internal';
 import { fromUniqueEntries } from '@agoric/internal/src/ses-utils.js';
 import { makeWorkPool } from '@agoric/internal/src/work-pool.js';
+import type { SupportedChain } from '@agoric/portfolio-api/src/constants.js';
 
 import type { CosmosRestClient } from './cosmos-rest-client.ts';
 import type { CosmosRPCClient, SubscriptionResponse } from './cosmos-rpc.ts';
-import { handlePendingTx } from './pending-tx-manager.ts';
-import type { EvmContext, HandlePendingTxOpts } from './pending-tx-manager.ts';
 import type { Sdk as SpectrumBlockchainSdk } from './graphql/api-spectrum-blockchain/__generated/sdk.ts';
 import type { Sdk as SpectrumPoolsSdk } from './graphql/api-spectrum-pools/__generated/sdk.ts';
+import { logger, runWithFlowTrace } from './logger.ts';
+import type { EvmContext, HandlePendingTxOpts } from './pending-tx-manager.ts';
+import { handlePendingTx } from './pending-tx-manager.ts';
+import type { BalanceQueryPowers } from './plan-deposit.ts';
 import {
   getCurrentBalance,
   getNonDustBalances,
@@ -64,14 +66,13 @@ import {
   planRebalanceToAllocations,
   planWithdrawFromAllocations,
 } from './plan-deposit.ts';
-import type { BalanceQueryPowers } from './plan-deposit.ts';
 import type { SpectrumClient } from './spectrum-client.ts';
 import {
-  STALE_RESPONSE,
   parseStreamCell,
   parseStreamCellValue,
   readStorageMeta,
   readStreamCellValue,
+  STALE_RESPONSE,
   vstoragePathIsAncestorOf,
   vstoragePathIsParentOf,
 } from './vstorage-utils.ts';
@@ -322,7 +323,7 @@ export const processPortfolioEvents = async (
     };
 
     const { network: _network, ...logContext } = plannerContext;
-    console.debug(
+    logger.debug(
       `Starting ${path} in-progress flow ${flowKey}`,
       flowDetail,
       inspectForStdout(logContext),
@@ -343,7 +344,7 @@ export const processPortfolioEvents = async (
           break;
         default: {
           const msg = `⚠️  Unknown flow type ${type} for ${path} in-progress flow ${flowKey}`;
-          console.warn(msg);
+          logger.warn(msg);
           return;
         }
       }
@@ -365,7 +366,7 @@ export const processPortfolioEvents = async (
       // for at least another block.
       if (!isDryRun) {
         void getWalletInvocationUpdate(id as any).catch(err => {
-          console.warn(
+          logger.warn(
             `⚠️ Failure for ${path} in-progress flow ${flowKey} resolvePlan`,
             { policyVersion, rebalanceCount },
             steps,
@@ -373,7 +374,7 @@ export const processPortfolioEvents = async (
           );
         });
       }
-      console.log(
+      logger.info(
         `Resolving ${path} in-progress flow ${flowKey}`,
         flowDetail,
         currentBalances,
@@ -435,7 +436,10 @@ export const processPortfolioEvents = async (
       for (const [flowKey, flowDetail] of entries(status.flowsRunning || {})) {
         // If vstorage has data for this flow then we've already responded.
         if (flowKeys.has(flowKey)) continue;
-        await startFlow(status, portfolioKey, flowKey, flowDetail);
+        await runWithFlowTrace(
+          portfolioKey, flowKey,
+          () => startFlow(status, portfolioKey, flowKey, flowDetail),
+        );
         return;
       }
     } catch (err) {

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -323,11 +323,7 @@ export const processPortfolioEvents = async (
     };
 
     const { network: _network, ...logContext } = plannerContext;
-    logger.debug(
-      `Starting ${path} in-progress flow ${flowKey}`,
-      flowDetail,
-      inspectForStdout(logContext),
-    );
+    logger.debug(`Starting flow`, flowDetail, inspectForStdout(logContext));
 
     try {
       let steps: MovementDesc[];
@@ -343,8 +339,7 @@ export const processPortfolioEvents = async (
           steps = await planWithdrawFromAllocations(plannerContext);
           break;
         default: {
-          const msg = `⚠️  Unknown flow type ${type} for ${path} in-progress flow ${flowKey}`;
-          logger.warn(msg);
+          logger.warn(`⚠️  Unknown flow type ${type}`);
           return;
         }
       }
@@ -367,7 +362,7 @@ export const processPortfolioEvents = async (
       if (!isDryRun) {
         void getWalletInvocationUpdate(id as any).catch(err => {
           logger.warn(
-            `⚠️ Failure for ${path} in-progress flow ${flowKey} resolvePlan`,
+            `⚠️ Failure for resolvePlan`,
             { policyVersion, rebalanceCount },
             steps,
             err,
@@ -375,7 +370,7 @@ export const processPortfolioEvents = async (
         });
       }
       logger.info(
-        `Resolving ${path} in-progress flow ${flowKey}`,
+        `Resolving`,
         flowDetail,
         currentBalances,
         inspectForStdout({

--- a/services/ymax-planner/src/logger.ts
+++ b/services/ymax-planner/src/logger.ts
@@ -1,0 +1,59 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { Console } from 'node:console';
+
+type TraceContext = {
+  traceId?: string;
+};
+
+const traceStore = new AsyncLocalStorage<TraceContext>();
+
+const tracePrefix = () => {
+  const { traceId } = traceStore.getStore() || {};
+  return traceId ? `[${traceId}] ` : '';
+};
+
+const withPrefix = (args: any[]) => {
+  const prefix = tracePrefix();
+  return prefix ? [prefix, ...args] : args;
+};
+
+/**
+ * Run a function within a trace context so downstream async work can reuse the
+ * same traceId without needing to thread it through parameters.
+ */
+export const runWithTrace = async <T>(
+  traceId: string,
+  fn: () => Promise<T> | T,
+): Promise<T> => traceStore.run({ traceId }, fn);
+
+export const runWithFlowTrace = async <T>(
+  portfolioKey: string,
+  flowKey: string,
+  fn: () => Promise<T> | T,
+): Promise<T> => {
+  const traceId = `${portfolioKey}.${flowKey}`;
+  return runWithTrace(traceId, fn);
+};
+
+type LogTarget = Pick<Console, 'debug' | 'info' | 'log' | 'warn' | 'error'>;
+
+// Module state to allow swapping out the log target (e.g., for tests).
+let logTarget: LogTarget = console;
+
+export const setLogTarget = (target: LogTarget) => {
+  logTarget = target;
+};
+
+/**
+ * Minimal logger that mirrors console.* but prefixes logs with the current
+ * traceId from AsyncLocalStorage when present.
+ */
+export const logger = {
+  debug: (...args: any[]) => logTarget.debug(...withPrefix(args)),
+  log: (...args: any[]) => logTarget.log(...withPrefix(args)),
+  info: (...args: any[]) => logTarget.info(...withPrefix(args)),
+  warn: (...args: any[]) => logTarget.warn(...withPrefix(args)),
+  error: (...args: any[]) => logTarget.error(...withPrefix(args)),
+};
+
+export const getCurrentTraceId = () => traceStore.getStore()?.traceId;


### PR DESCRIPTION
_no issue_

## Description
We need a way to query flow activity across services. For now, `portfolioX.flowY` is in reach so let's at least use that.

This does so with a new `runWithTrace` utility we can use throughout the application. It uses [Node's AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) for which tracing is a common use.

### Security Considerations
none

### Scaling Considerations
slight new overhead

### Documentation Considerations
New logging pattern. Clear enough

### Testing Considerations
CI

### Upgrade Considerations

This changes log messages. Nothing should be depending on the string patterns. If we need to parse logs we should migrate to a structured logging library like Pino.