### PR TITLE
chore(ymax-planner): Fix lint issues

### DIFF
--- a/services/ymax-planner/src/config.ts
+++ b/services/ymax-planner/src/config.ts
@@ -7,7 +7,7 @@ import { AxelarChainIdMap } from '@aglocal/portfolio-deploy/src/axelar-configs.j
 import * as AgoricClientUtils from '@agoric/client-utils';
 import { objectMap } from '@agoric/internal';
 import type { ClusterName } from '@agoric/internal';
-import type { AxelarChain } from '@agoric/portfolio-api/src/constants';
+import type { AxelarChain } from '@agoric/portfolio-api/src/constants.js';
 import { parseGraphqlEndpoints } from './utils.ts';
 
 export const defaultAgoricNetworkSpecForCluster: Record<ClusterName, string> =

--- a/services/ymax-planner/src/gas-estimation.ts
+++ b/services/ymax-planner/src/gas-estimation.ts
@@ -4,7 +4,7 @@ import {
   EvmWalletOperationType,
   YieldProtocol,
 } from '@agoric/portfolio-api/src/constants.js';
-import type { AxelarChain } from '@agoric/portfolio-api/src/constants';
+import type { AxelarChain } from '@agoric/portfolio-api/src/constants.js';
 import {
   walletOperationGasLimitEstimates,
   walletOperationFallbackGasLimit,

--- a/services/ymax-planner/src/resolver.ts
+++ b/services/ymax-planner/src/resolver.ts
@@ -1,7 +1,7 @@
 import { type SigningSmartWalletKit } from '@agoric/client-utils';
-import type { OfferSpec } from '@agoric/smart-wallet/src/offers';
+import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
 import type { TxStatus } from '@aglocal/portfolio-contract/src/resolver/constants.js';
-import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types';
+import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types.js';
 import type { StdFee } from '@cosmjs/stargate';
 
 type ResolveTxParams = {

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -1,13 +1,13 @@
-import { ethers, type Filter, type WebSocketProvider, type Log } from 'ethers';
-import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types';
+import { ethers } from 'ethers';
+import type { Filter, WebSocketProvider, Log } from 'ethers';
+import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types.js';
 import type { CaipChainId } from '@agoric/orchestration';
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
-  type WatcherTimeoutOptions,
 } from '../support.ts';
-import type { MakeAbortController } from '../support.ts';
+import type { MakeAbortController, WatcherTimeoutOptions } from '../support.ts';
 import { TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
 import {
   deleteTxBlockLowerBound,

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -6,7 +6,7 @@ import {
   type SigningSmartWalletKit,
 } from '@agoric/client-utils';
 import type { AxelarChain } from '@agoric/portfolio-api/src/constants.js';
-import type { OfferSpec } from '@agoric/smart-wallet/src/offers';
+import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
 import { makeKVStoreFromMap } from '@agoric/internal/src/kv-store.js';
 import type { Log } from 'ethers/providers';
 import type { CosmosRestClient } from '../src/cosmos-rest-client.ts';

--- a/services/ymax-planner/tsconfig.json
+++ b/services/ymax-planner/tsconfig.json
@@ -6,5 +6,8 @@
     "test",
     "testing",
     "tools"
+  ],
+  "exclude": [
+    "**/__generated"
   ]
 }


### PR DESCRIPTION
Even after these changes, there are still three errors as mentioned at https://github.com/Agoric/agoric-sdk/pull/12213#discussion_r2544050639 , which seem to be surfacing real issues:
```console
$ yarn lint
src/pending-tx-manager.ts:294:48 - error TS2345: Argument of type '{ timeoutMs:
 number; factoryAddr: `0x${string}`; provider: WebSocketProvider; expectedAddr:
 `0x${string}`; log: (msg: any, ...args: any[]) => void; }' is not assignable to
 parameter of type 'SmartWalletWatch & WatcherTimeoutOptions'.
  Type '{ timeoutMs: number; factoryAddr: `0x${string}`; provider:
 WebSocketProvider; expectedAddr: `0x${string}`; log: (msg: any, ...args: any[])
 => void; }' is missing the following properties from type 'SmartWalletWatch':
 kvStore, txId

294       walletCreated = await watchSmartWalletTx({
                                                   ~
295         ...watchArgs,
    ~~~~~~~~~~~~~~~~~~~~~
296         timeoutMs: opts.timeoutMs,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
297       });
    ~~~~~~~

src/pending-tx-manager.ts:300:46 - error TS2345: Argument of type '{ timeoutMs:
 number; signal: AbortSignal; factoryAddr: `0x${string}`; provider:
 WebSocketProvider; expectedAddr: `0x${string}`; log: (msg: any, ...args: any[])
 => void; }' is not assignable to parameter of type 'SmartWalletWatch &
 WatcherTimeoutOptions'.
  Type '{ timeoutMs: number; signal: AbortSignal; factoryAddr: `0x${string}`;
 provider: WebSocketProvider; expectedAddr: `0x${string}`; log: (msg: any,
 ...args: any[]) => void; }' is missing the following properties from type
 'SmartWalletWatch': kvStore, txId

300       const liveResultP = watchSmartWalletTx({
                                                 ~
301         ...watchArgs,
    ~~~~~~~~~~~~~~~~~~~~~
... 
303         signal: abortController.signal,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
304       });
    ~~~~~~~

src/pending-tx-manager.ts:317:51 - error TS2345: Argument of type '{
 publishTimeMs: number; chainId: `${string}:${string}`; signal: AbortSignal;
 factoryAddr: `0x${string}`; provider: WebSocketProvider; expectedAddr:
 `0x${string}`; log: (msg: any, ...args: any[]) => void; }' is not assignable to
 parameter of type 'SmartWalletWatch & { publishTimeMs: number; chainId:
 `${string}:${string}`; signal?: AbortSignal | undefined; }'.
  Type '{ publishTimeMs: number; chainId: `${string}:${string}`; signal:
 AbortSignal; factoryAddr: `0x${string}`; provider: WebSocketProvider;
 expectedAddr: `0x${string}`; log: (msg: any, ...args: any[]) => void; }' is
 missing the following properties from type 'SmartWalletWatch': kvStore, txId

317       walletCreated = await lookBackSmartWalletTx({
                                                      ~
318         ...watchArgs,
    ~~~~~~~~~~~~~~~~~~~~~
... 
321         signal: abortController.signal,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
322       });
    ~~~~~~~


Found 3 errors in the same file, starting at: src/pending-tx-manager.ts:294
```