### PR TITLE
fix(ymax-planner): add missing kvStore and txId to SmartWallet watchers

### DIFF
--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -316,6 +316,8 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
 
       walletCreated = await lookBackSmartWalletTx({
         ...watchArgs,
+        kvStore: ctx.kvStore,
+        txId,
         publishTimeMs: opts.publishTimeMs,
         chainId: caipId,
         signal: abortController.signal,

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -43,11 +43,14 @@ const parseSmartWalletCreatedLog = (log: any) => {
   };
 };
 
-type SmartWalletWatch = {
+type SmartWalletWatchBase = {
   factoryAddr: `0x${string}`;
   provider: WebSocketProvider;
   expectedAddr: `0x${string}`;
   log?: (...args: unknown[]) => void;
+};
+
+type SmartWalletWatch = SmartWalletWatchBase & {
   kvStore: KVStore;
   txId: `tx${number}`;
 };
@@ -60,7 +63,7 @@ export const watchSmartWalletTx = ({
   log = () => {},
   setTimeout = globalThis.setTimeout,
   signal,
-}: SmartWalletWatch & WatcherTimeoutOptions): Promise<boolean> => {
+}: SmartWalletWatchBase & WatcherTimeoutOptions): Promise<boolean> => {
   return new Promise(resolve => {
     if (signal?.aborted) {
       resolve(false);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: 
- https://github.com/Agoric/agoric-sdk/pull/12213#discussion_r2544050639

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Resolves TypeScript errors and enables proper block scanning persistence in `lookBackSmartWalletTx`. Refactors types to clarify which fields are required by each watcher function.
