### PR TITLE
fix(ymax-planner): Increase the resolver tx fee submission to 0.25 BLD

### DIFF
--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -187,7 +187,8 @@ export const main = async (
       // We should probably be adjusting fees in accordance with current
       // parameters and `(msg MsgWalletSpendAction) CheckAdmissibility`
       // (cf. ../../../golang/cosmos/x/swingset/types/msgs.go), i.e.
-      // `$beansPerInboundTx + $beansPerMessageByte * msgLen` where
+      // `$beansPerInboundTx + $beansPerMessage + $beansPerMessageByte * msgLen`
+      // where
       // * `msgLen` is `JSON.stringify(swk.marshaller.toCapData(bridgeAction)).length`
       //   (@see {@link SigningSmartWalletKit} `sendBridgeAction`)
       // * `bridgeAction` is `{ method: "invokeEntry", message }`

--- a/services/ymax-planner/src/resolver.ts
+++ b/services/ymax-planner/src/resolver.ts
@@ -12,7 +12,7 @@ type ResolveTxParams = {
 };
 
 const smartWalletFee: StdFee = {
-  amount: [{ denom: 'ubld', amount: '50000' }], // 0.05 BLD
+  amount: [{ denom: 'ubld', amount: '250000' }], // 0.25 BLD
   gas: '19700000',
 };
 


### PR DESCRIPTION
fixes: https://github.com/Agoric/agoric-private/issues/590

#12254 failed to account for the per-message fee, and even doing so we still need some buffer for computrons.