### PR TITLE
chore: Set spend-action tx fees to 0.01 BLD

### DIFF
--- a/packages/client-utils/src/signing-smart-wallet-kit.ts
+++ b/packages/client-utils/src/signing-smart-wallet-kit.ts
@@ -58,9 +58,19 @@ type WalletStoreEntryProxy<T, Recursive extends true | false = false> = {
     : never;
 };
 
+/**
+ * A reasonable default fee for transactions consisting of a single
+ * WalletSpendAction message.
+ */
 const defaultFee: StdFee = {
-  amount: [{ denom: 'ubld', amount: '500000' }], // XXX enough?
-  gas: '19700000',
+  // As of 2025-11, even a large isolated spend action transaction consumes
+  // less than 200_000 gas units, so 400_000 includes a fudge factor of over 2x.
+  gas: '400000',
+  // As of 2025-11, validators seem to still be using the Agoric
+  // `minimum-gas-prices` recommendation of 0.01ubld per gas unit:
+  // https://community.agoric.com/t/network-change-instituting-fees-on-the-agoric-chain-to-mitigate-spam-transactions/109/2
+  // So 10_000 ubld = 0.01 BLD includes a fudge factor of over 2x.
+  amount: [{ denom: 'ubld', amount: '10000' }],
 };
 
 /**

--- a/packages/client-utils/test/signing-smart-wallet-kit.test.ts
+++ b/packages/client-utils/test/signing-smart-wallet-kit.test.ts
@@ -96,7 +96,7 @@ test('sendBridgeAction handles simple action', async t => {
         },
       },
     ],
-    fee: { amount: [{ denom: 'ubld', amount: '500000' }], gas: '19700000' },
+    fee: { amount: [{ denom: 'ubld', amount: '10000' }], gas: '400000' },
   });
 });
 
@@ -174,7 +174,7 @@ test('sendBridgeAction uses explicit signing when signerData provided', async t 
         },
       },
     ],
-    fee: { amount: [{ denom: 'ubld', amount: '500000' }], gas: '19700000' },
+    fee: { amount: [{ denom: 'ubld', amount: '10000' }], gas: '400000' },
     memo: 'test memo',
     signerData,
   });

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -179,34 +179,14 @@ export const main = async (
     setTimeout,
     makeNonce: () => new Date(now()).toISOString(),
     fee: {
-      // XXX The required fee amount has an "inboundTx" fixed-size component and
-      // a "messageByte" variable component, both measured in "beans" of which
-      // there are "feeUnit" per `fee_unit_price` (all visible as swingset
-      // params via e.g.
-      // `agd --node https://main.rpc.agoric.net:443 query swingset params`).
-      // We should probably be adjusting fees in accordance with current
-      // parameters and `(msg MsgWalletSpendAction) CheckAdmissibility`
-      // (cf. ../../../golang/cosmos/x/swingset/types/msgs.go), i.e.
-      // `$beansPerInboundTx + $beansPerMessage + $beansPerMessageByte * msgLen`
-      // where
-      // * `msgLen` is `JSON.stringify(swk.marshaller.toCapData(bridgeAction)).length`
-      //   (@see {@link SigningSmartWalletKit} `sendBridgeAction`)
-      // * `bridgeAction` is `{ method: "invokeEntry", message }`
-      //   (@see {@link reflectWalletStore} `makeEntryProxy`)
-      // * `message` is `{ id, targetName, method, args, saveResult? } }`
-      //   (@see {@link reflectWalletStore} `makeEntryProxy`)
-      // * `id` is either `${method}.${makeNonce()}` or undefined
-      //   (@see {@link reflectWalletStore} `makeEntryProxy`)
-      // * `method` is e.g. "resolvePlan"
-      //   (@see {@link processPortfolioEvents} `startFlow`)
-      // But the necessary plumbing is missing, so as of 2025-11 we hard-code
-      // 0.5 BLD for parameters "inboundTx" 1000000000, "messageByte" 20000000,
-      // "feeUnit" 150000000000, `fee_unit_price` 1000000ubld and expected
-      // `spend_action` sizes like the 1470 bytes from transaction
-      // 2E1D14A1B2F92383E7BAB6FB7EC0E34F332AC8A7ED6884B7627A29D8AB194567
-      // (leaving a buffer for larger transactions).
-      amount: [{ denom: 'ubld', amount: '500000' }],
-      gas: '19700000',
+      // As of 2025-11, a planner transaction consumes 160_000 to 185_000 gas
+      // units, so 400_000 includes a fudge factor of over 2x.
+      gas: '400000',
+      // As of 2025-11, validators seem to still be using the Agoric
+      // `minimum-gas-prices` recommendation of 0.01ubld per gas unit:
+      // https://community.agoric.com/t/network-change-instituting-fees-on-the-agoric-chain-to-mitigate-spam-transactions/109/2
+      // So 10_000 ubld = 0.01 BLD includes a fudge factor of over 2x.
+      amount: [{ denom: 'ubld', amount: '10000' }],
     },
   });
 

--- a/services/ymax-planner/src/resolver.ts
+++ b/services/ymax-planner/src/resolver.ts
@@ -12,8 +12,14 @@ type ResolveTxParams = {
 };
 
 const smartWalletFee: StdFee = {
-  amount: [{ denom: 'ubld', amount: '250000' }], // 0.25 BLD
-  gas: '19700000',
+  // As of 2025-11, a resolver transaction consumes 125_000 to 160_000 gas
+  // units, so 400_000 includes a fudge factor of over 2x.
+  gas: '400000',
+  // As of 2025-11, validators seem to still be using the Agoric
+  // `minimum-gas-prices` recommendation of 0.01ubld per gas unit:
+  // https://community.agoric.com/t/network-change-instituting-fees-on-the-agoric-chain-to-mitigate-spam-transactions/109/2
+  // So 10_000 ubld = 0.01 BLD includes a fudge factor of over 2x.
+  amount: [{ denom: 'ubld', amount: '10000' }],
 };
 
 const getInvitationMakers = async (wallet: SigningSmartWalletKit) => {


### PR DESCRIPTION
refs: #12209
refs: #12254
refs: #12255
fixes: https://github.com/Agoric/agoric-private/issues/590

## Description
Previous PRs reflected a misunderstanding of Cosmos transaction fees. The [actual behavior](https://docs.cosmos.network/sdk/v0.53/learn/beginner/gas-fees) is `fees = ceil(gas * gasPrices)`, where the `gas` of a transaction must not be less than the actual count of gas units consumed by its execution but can be arbitrarily higher, the `gasPrices` of a transaction must contain at least one amount that is not less than a nonzero amount of the same denom in the receiving RPC node's `minimum-gas-prices` configuration (or equivalently [_and more relevant for `{ gas, amount }` fees sent by [@cosmjs/stargate SigningStargateClient](https://cosmos.github.io/cosmjs/latest/stargate/classes/SigningStargateClient.html) methods_] the `fees` of a transaction must contain at least one amount reflecting such an inequality) but can be arbitrarily higher, and the complete `fees` of a transaction are taken in totality with any excess w.r.t. to actual gas needed and/or node `minimum-gas-prices` being treated as increasing tx priority.

The failures observed after deploying #12209 and prompting #12254 and #12255 were therefore not caused by too-low fees as such, but rather by their amounts being too low _for the corresponding `gas` value_, which was itself over 100x the actual gas units consumed by planner/resolver transactions (as observed in respective examples [2E1D14A1B2F92383E7BAB6FB7EC0E34F332AC8A7ED6884B7627A29D8AB194567](https://www.mintscan.io/agoric/tx/2E1D14A1B2F92383E7BAB6FB7EC0E34F332AC8A7ED6884B7627A29D8AB194567?height=22723916) and [02398D15FFBF7017684FF4029602DB0B429C59A88DA28555273D4309288B8990](https://www.mintscan.io/agoric/tx/02398D15FFBF7017684FF4029602DB0B429C59A88DA28555273D4309288B8990?height=22643003)). Dropping `gas` to a reasonable value should allow for a corresponding reduction in fee amounts—0.01 BLD, even with more than doubling both the expected gas consumption and RPC node `minimum-gas-prices`.

### Security Considerations
None known.

### Scaling Considerations
Reducing planner transaction fees by 50x and resolver transaction fees by 25x will extend the capacity of each planner balance deposit accordingly.

### Documentation Considerations
Inline comments should hopefully prevent future misunderstanding of Cosmos transaction fees. 

### Testing Considerations
We'll verify via ymax0 integration before deploying to ymax1.

### Upgrade Considerations
Safe to deploy immediately.