### PR TITLE
fix: use SDK types for REST API account responses

### DIFF
--- a/services/ymax-planner/src/cosmos-rest-client.ts
+++ b/services/ymax-planner/src/cosmos-rest-client.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import type { QueryAllBalancesResponse } from '@agoric/cosmic-proto/cosmos/bank/v1beta1/query.js';
-import type { QueryAccountResponse } from '@agoric/cosmic-proto/cosmos/auth/v1beta1/query.js';
+import type { QueryAccountResponseSDKType } from '@agoric/cosmic-proto/cosmos/auth/v1beta1/query.js';
 import type { Coin } from '@agoric/cosmic-proto/cosmos/base/v1beta1/coin.js';
 import ky, { HTTPError, type KyInstance } from 'ky';
 
@@ -216,7 +216,7 @@ export class CosmosRestClient {
   async getAccountSequence(
     chainKey: string,
     address: string,
-  ): Promise<QueryAccountResponse> {
+  ): Promise<QueryAccountResponseSDKType> {
     const chainConfig = this.chainConfigs.get(chainKey);
     if (!chainConfig) {
       throw new Error(`Chain configuration not found for: ${chainKey}`);
@@ -225,7 +225,7 @@ export class CosmosRestClient {
 
     this.log(`[CosmosRestClient] Fetching account sequence for ${address}`);
 
-    return this.makeRequest<QueryAccountResponse>(
+    return this.makeRequest<QueryAccountResponseSDKType>(
       url,
       chainConfig,
       `Account info for ${address} on ${chainConfig.name}`,

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -19,6 +19,7 @@ import {
   makeSequencingSmartWallet,
   reflectWalletStore,
 } from '@agoric/client-utils';
+import type { BaseAccountSDKType } from '@agoric/client-utils/src/codegen/cosmos/auth/v1beta1/auth.js';
 import type { SigningSmartWalletKit } from '@agoric/client-utils';
 import {
   deeplyFulfilledObject,
@@ -197,13 +198,13 @@ export const main = async (
       'agoric',
       signingSmartWalletKit.address,
     );
-    const account = response.account;
+    const account = response.account as BaseAccountSDKType;
     if (!account) {
       throw Fail`Account not found for address ${signingSmartWalletKit.address}`;
     }
     return {
       address: signingSmartWalletKit.address,
-      accountNumber: account.accountNumber,
+      accountNumber: account.account_number,
       sequence: account.sequence,
     };
   };


### PR DESCRIPTION
 <!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->
## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

Fixes type inconsistency in REST API account responses by using SDK-generated types instead of proto types. This resolves an issue where `accountNumber` was incorrectly accessed instead of `account_number`.
