### PR TITLE
prefer objectMap

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -194,7 +194,16 @@ export default [
     ],
 
     rules: {
-      'no-restricted-syntax': ['error', ...deprecatedTerminology.all],
+      'no-restricted-syntax': [
+        'error',
+        ...deprecatedTerminology.all,
+        {
+          selector:
+            'CallExpression[callee.object.name="Object"][callee.property.name="fromEntries"] > CallExpression.arguments[callee.object.name="Object"][callee.property.name="entries"]',
+          message:
+            'Prefer objectMap over Object.fromEntries(Object.entries(...))',
+        },
+      ],
     },
   },
   {

--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -182,12 +182,10 @@ async function replay(transcriptFile) {
 
   const fakeKernelKeeper = /** @type {KernelKeeper} */ ({
     provideVatKeeper: _vatID =>
-      /** @type {VatKeeper} */ (
-        /** @type {Partial<import('../src/types-external.js').VatKeeper>} */ ({
-          addToTranscript: () => {},
-          getSnapshotInfo: () => loadSnapshotID && { hash: loadSnapshotID },
-        })
-      ),
+      /** @type {Partial<VatKeeper>} */ ({
+        addToTranscript: () => {},
+        getSnapshotInfo: () => loadSnapshotID && { hash: loadSnapshotID },
+      }),
     getRelaxDurabilityRules: () => false,
   });
 
@@ -205,7 +203,7 @@ async function replay(transcriptFile) {
   });
 
   const kernelSlog = /** @type {KernelSlog} */ (
-    /** @type {Partial<import('../src/types-external.js').KernelSlog>} */ ({
+    /** @type {Partial<KernelSlog>} */ ({
       write() {},
       delivery: () => () => undefined,
       syscall: () => () => undefined,
@@ -278,7 +276,7 @@ async function replay(transcriptFile) {
     meterControl,
   });
   const allVatPowers = /** @type {VatPowers} */ (
-    /** @type {Partial<import('../src/types-external.js').VatPowers>} */ ({
+    /** @type {Partial<VatPowers>} */ ({
       testLog,
     })
   );
@@ -436,7 +434,7 @@ async function replay(transcriptFile) {
     updateWorkersSynced();
     const currentBundleIDs = await bundleHandler.getCurrentBundleIDs();
     const managerOptions = /** @type {ManagerOptions} */ (
-      /** @type {Partial<import('../src/types-internal.js').ManagerOptions>} */ ({
+      /** @type {Partial<ManagerOptions>} */ ({
         sourcedConsole: console,
         vatParameters,
         useTranscript: true,
@@ -591,7 +589,7 @@ async function replay(transcriptFile) {
     },
   );
 
-  /** @type {import('stream').Readable} */
+  /** @type {Readable} */
   let transcriptF = fs.createReadStream(transcriptFile);
   if (transcriptFile.endsWith('.gz')) {
     transcriptF = transcriptF.pipe(zlib.createGunzip());

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -1,4 +1,3 @@
-/* eslint-disable @agoric/no-typedef-import -- it's the only way to re-export with JSDoc */
 export {};
 
 /**
@@ -18,6 +17,14 @@ export {};
  * @import {KernelKeeper} from './kernel/state/kernelKeeper.js';
  * @import {xsnap} from '@agoric/xsnap';
  * @import { KVStore } from '@agoric/internal/src/kv-store.js';
+ * @import {SnapStore} from '@agoric/swing-store';
+ * @import {SnapshotResult} from '@agoric/swing-store';
+ * @import {TranscriptStore} from '@agoric/swing-store';
+ * @import {SwingStore} from '@agoric/swing-store';
+ * @import {SwingStoreKernelStorage} from '@agoric/swing-store';
+ * @import {SwingStoreHostStorage} from '@agoric/swing-store';
+ * @import {Mailbox} from './devices/mailbox/mailbox.js';
+ * @import {MailboxExport} from './devices/mailbox/mailbox.js';
  */
 
 /* This file defines types that part of the external API of swingset. That
@@ -241,12 +248,12 @@ export {};
  */
 /**
  * @typedef { KVStore } KVStore
- * @typedef { import('@agoric/swing-store').SnapStore } SnapStore
- * @typedef { import('@agoric/swing-store').SnapshotResult } SnapshotResult
- * @typedef { import('@agoric/swing-store').TranscriptStore } TranscriptStore
- * @typedef { import('@agoric/swing-store').SwingStore } SwingStore
- * @typedef { import('@agoric/swing-store').SwingStoreKernelStorage } SwingStoreKernelStorage
- * @typedef { import('@agoric/swing-store').SwingStoreHostStorage } SwingStoreHostStorage
+ * @typedef { SnapStore } SnapStore
+ * @typedef { SnapshotResult } SnapshotResult
+ * @typedef { TranscriptStore } TranscriptStore
+ * @typedef { SwingStore } SwingStore
+ * @typedef { SwingStoreKernelStorage } SwingStoreKernelStorage
+ * @typedef { SwingStoreHostStorage } SwingStoreHostStorage
  */
 
 /**
@@ -316,10 +323,10 @@ export {};
  */
 
 /**
- * @typedef { import('./devices/mailbox/mailbox.js').Mailbox } Mailbox
+ * @typedef { Mailbox } Mailbox
  */
 /**
- * @typedef { import('./devices/mailbox/mailbox.js').MailboxExport } MailboxExport
+ * @typedef { MailboxExport } MailboxExport
  */
 
 /**

--- a/packages/base-zone/tools/greeter.js
+++ b/packages/base-zone/tools/greeter.js
@@ -1,22 +1,17 @@
-import { M, getInterfaceGuardPayload } from '@endo/patterns';
+import { M, getInterfaceGuardPayload, objectMap } from '@endo/patterns';
 
 /**
  * @import {Zone} from '../src/types.js';
  */
 
 /**
- * @template {{}} T
+ * @template {Record<string, Function>} T
  * @param {T} obj
  * @param {unknown} that
  * @returns {T}
  */
 export const bindAllMethodsTo = (obj, that = obj) =>
-  /** @type {T} */
-  (
-    Object.fromEntries(
-      Object.entries(obj).map(([name, fn]) => [name, fn.bind(that)]),
-    )
-  );
+  objectMap(obj, fn => fn.bind(that));
 
 export const GreeterI = M.interface('Greeter', {
   greet: M.call().optional(M.string()).returns(M.string()),

--- a/packages/deploy-script-support/src/getBundlerMaker.js
+++ b/packages/deploy-script-support/src/getBundlerMaker.js
@@ -13,7 +13,11 @@
 import { E } from '@endo/far';
 import url from 'url';
 
-/** @typedef {ReturnType<typeof import('./endo-pieces-contract.js').start>['publicFacet']} BundleMaker */
+/**
+ * @import {start} from './endo-pieces-contract.js';
+ */
+
+/** @typedef {ReturnType<typeof start>['publicFacet']} BundleMaker */
 /** @typedef {ReturnType<BundleMaker['makeBundler']>} Bundler */
 
 export const makeGetBundlerMaker =

--- a/packages/deploy-script-support/src/startInstance.js
+++ b/packages/deploy-script-support/src/startInstance.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { objectMap } from '@agoric/internal';
 import { assert } from '@endo/errors';
 import { E, passStyleOf } from '@endo/far';
 
@@ -36,13 +37,8 @@ export const makeStartInstance = (
   zoeInvitationPurse,
 ) => {
   const makeIssuerKeywordRecord = issuerPetnameKeywordRecord => {
-    return Object.fromEntries(
-      Object.entries(issuerPetnameKeywordRecord).map(
-        ([keyword, issuerPetname]) => {
-          const issuerP = E(issuerManager).get(issuerPetname);
-          return [keyword, issuerP];
-        },
-      ),
+    return objectMap(issuerPetnameKeywordRecord, issuerPetname =>
+      E(issuerManager).get(issuerPetname),
     );
   };
 

--- a/packages/governance/test/unitTests/committee.test.js
+++ b/packages/governance/test/unitTests/committee.test.js
@@ -21,6 +21,7 @@ import { remoteNullMarshaller } from '../swingsetTests/utils.js';
 /**
  * @import {SimpleIssue} from '../../src/types.js';
  * @import {start} from '../../src/binaryVoteCounter.js';
+ * @import {CommitteeStartResult} from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
  */
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);
@@ -41,13 +42,13 @@ const setupContract = async (
     bundleSource(counterRoot),
   ]);
   // install the contract
-  /** @typedef {Installation<typeof import('../../src/committee.js').start>} CommitteInstallation */
   /** @typedef {Installation<typeof start>} CounterInstallation */
-  /** @type {[CommitteInstallation, CounterInstallation] } */
+  /** @type {[any, CounterInstallation] } */
   const [electorateInstallation, counterInstallation] = await Promise.all([
     E(zoe).install(electorateBundle),
     E(zoe).install(counterBundle),
   ]);
+  /** @type {CommitteeStartResult} */
   const electorateStartResult = await E(zoe).startInstance(
     electorateInstallation,
     {},

--- a/packages/inter-protocol/src/proposals/price-feed-proposal.js
+++ b/packages/inter-protocol/src/proposals/price-feed-proposal.js
@@ -16,6 +16,7 @@ import {
 /**
  * @import {ChainlinkConfig} from '@agoric/inter-protocol/src/price/fluxAggregatorKit.js';
  * @import {EconomyBootstrapPowers} from './econ-behaviors.js';
+ * @import {start} from '@agoric/inter-protocol/src/price/fluxAggregatorContract.js';
  */
 
 // backwards compatibility
@@ -173,7 +174,7 @@ export const createPriceFeed = async (
    * @type {[
    *   [Brand<'nat'>, Brand<'nat'>],
    *   Installation<
-   *     typeof import('@agoric/inter-protocol/src/price/fluxAggregatorContract.js').start
+   *     typeof start
    *   >,
    *   Timer,
    * ]}

--- a/packages/inter-protocol/src/proposals/withdraw-reserve-proposal.js
+++ b/packages/inter-protocol/src/proposals/withdraw-reserve-proposal.js
@@ -3,10 +3,14 @@ import { makeTracer } from '@agoric/internal/src/debug.js';
 import { reserveThenDeposit } from './utils.js';
 
 /**
+ * @import {start} from '../reserve/assetReserve.js';
+ */
+
+/**
  * @param {BootstrapPowers & {
  *   consume: {
  *     reserveKit: Promise<
- *       ReturnType<typeof import('../reserve/assetReserve.js').start>
+ *       ReturnType<typeof start>
  *     >;
  *   };
  * }} powers

--- a/packages/inter-protocol/test/clientSupport.test.js
+++ b/packages/inter-protocol/test/clientSupport.test.js
@@ -4,6 +4,10 @@ import { makeIssuerKit } from '@agoric/ertp';
 import { Offers } from '../src/clientSupport.js';
 import { withAmountUtils } from './supports.js';
 
+/**
+ * @import {AgoricNamesRemotes} from '@agoric/vats/tools/board-utils.js';
+ */
+
 const ist = withAmountUtils(makeIssuerKit('IST'));
 const atom = withAmountUtils(makeIssuerKit('ATOM'));
 const stAtom = withAmountUtils(makeIssuerKit('stATOM'));
@@ -11,7 +15,7 @@ const stAtom = withAmountUtils(makeIssuerKit('stATOM'));
 // uses actual Brand objects instead of BoardRemote to make the test output more legible
 /**
  * @satisfies {Partial<
- *   import('@agoric/vats/tools/board-utils.js').AgoricNamesRemotes
+ *   AgoricNamesRemotes
  * >}
  */
 const agoricNames = {

--- a/packages/inter-protocol/test/provisionPool.test.js
+++ b/packages/inter-protocol/test/provisionPool.test.js
@@ -34,6 +34,7 @@ import {
  * @import {WalletReviver} from '@agoric/smart-wallet/src/walletFactory.js'
  * @import {TestFn} from 'ava';
  * @import {WalletFactoryStartResult} from '@agoric/vats/src/core/startWalletFactory.js';
+ * @import {start} from '../src/provisionPool.js';
  */
 
 const pathname = new URL(import.meta.url).pathname;
@@ -66,7 +67,7 @@ const makeTestContext = async () => {
   const committeeInstall = await E(zoe).install(committeeBundle);
   const psmInstall = await E(zoe).install(psmBundle);
   const centralSupply = await E(zoe).install(centralSupplyBundle);
-  /** @type {Installation<typeof import('../src/provisionPool.js').start>} */
+  /** @type {Installation<typeof start>} */
   const policyInstall = await E(zoe).install(policyBundle);
 
   const mintLimit = AmountMath.make(mintedBrand, MINT_LIMIT);

--- a/packages/inter-protocol/test/smartWallet/oracle-integration.test.js
+++ b/packages/inter-protocol/test/smartWallet/oracle-integration.test.js
@@ -32,6 +32,8 @@ import {
  * @import {SmartWallet} from '@agoric/smart-wallet/src/smartWallet.js';
  * @import {PriceRound} from '@agoric/inter-protocol/src/price/roundsManager.js';
  * @import {ContinuingInvitationSpec} from '@agoric/smart-wallet/src/invitations.js';
+ * @import {CurrentWalletRecord} from '@agoric/smart-wallet/src/smartWallet.js';
+ * @import {start as CommitteeStart} from '@agoric/governance/src/committee.js';
  */
 
 /**
@@ -253,7 +255,7 @@ test.serial('invitations', async t => {
   });
 
   const currentSub = E(wallet).getCurrentSubscriber();
-  /** @type {import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord} */
+  /** @type {CurrentWalletRecord} */
   const currentState = await headValue(currentSub);
   t.deepEqual(
     currentState.offerToUsedInvitation.map(([k, _]) => k),
@@ -392,9 +394,7 @@ test.serial('govern oracles list', async t => {
     'econCommitteeCharter',
   );
   /**
-   * @type {Instance<
-   *   typeof import('@agoric/governance/src/committee.js').start
-   * >}
+   * @type {Instance<CommitteeStart>}
    */
   const economicCommittee = await E(agoricNames).lookup(
     'instance',
@@ -452,7 +452,7 @@ test.serial('govern oracles list', async t => {
       proposal: {},
     });
 
-    /** @type {import('@agoric/smart-wallet/src/smartWallet.js').CurrentWalletRecord} */
+    /** @type {CurrentWalletRecord} */
     let currentState = await headValue(currentSub);
     t.is(
       // @ts-expect-error cast amount kind
@@ -502,7 +502,7 @@ test.serial('govern oracles list', async t => {
 
   // Call for a vote to addOracles ////////////////////////////////
   {
-    /** @type {import('@agoric/smart-wallet/src/invitations.js').ContinuingInvitationSpec} */
+    /** @type {ContinuingInvitationSpec} */
     const proposeInvitationSpec = {
       source: 'continuing',
       previousOffer: 'acceptEcInvitationOID',
@@ -558,7 +558,7 @@ test.serial('govern oracles list', async t => {
 
   // Call for a vote to removeOracles ////////////////////////////////
   {
-    /** @type {import('@agoric/smart-wallet/src/invitations.js').ContinuingInvitationSpec} */
+    /** @type {ContinuingInvitationSpec} */
     const proposeInvitationSpec = {
       source: 'continuing',
       previousOffer: 'acceptEcInvitationOID',

--- a/packages/orchestration/src/facade.js
+++ b/packages/orchestration/src/facade.js
@@ -1,5 +1,5 @@
 /** @file Orchestration facade */
-import { assertAllDefined, deepMapObject } from '@agoric/internal';
+import { assertAllDefined, deepMapObject, objectMap } from '@agoric/internal';
 
 /**
  * @import {AsyncFlowTools, GuestInterface, HostArgs} from '@agoric/async-flow';
@@ -122,11 +122,8 @@ export const makeOrchestrationFacade = ({
     );
 
     const orcFns = /** @type {{ [N in keyof GFM]: HostForGuest<GFM[N]> }} */ (
-      Object.fromEntries(
-        Object.entries(guestFns).map(([name, guestFn]) => [
-          name,
-          orchestrate(name, mappedContext, guestFn),
-        ]),
+      objectMap(guestFns, (guestFn, name) =>
+        orchestrate(String(name), mappedContext, guestFn),
       )
     );
 

--- a/packages/portfolio-deploy/src/portfolio-start.core.js
+++ b/packages/portfolio-deploy/src/portfolio-start.core.js
@@ -1,5 +1,5 @@
 import { makeTracer } from '@agoric/internal';
-import { M } from '@endo/patterns';
+import { M, objectMap } from '@endo/patterns';
 import { E } from '@endo/far';
 import {
   lookupInterchainInfo,
@@ -75,12 +75,7 @@ export const makePrivateArgs = async (
 
   const chainInfo = {
     ...cosmosChainInfo,
-    ...Object.fromEntries(
-      Object.entries(axelarConfig).map(([chain, info]) => [
-        chain,
-        info.chainInfo,
-      ]),
-    ),
+    ...objectMap(axelarConfig, info => info.chainInfo),
   };
 
   /** @type {AxelarId} */

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -16,11 +16,19 @@ import { assert, q, Fail } from '@endo/errors';
 import { getDebugLockdownBundle } from '@agoric/xsnap-lockdown';
 import { xsnap } from './xsnap.js';
 
+/**
+ * @import {promises} from 'fs';
+ * @import {BundleSource} from '@endo/bundle-source';
+ * @import {dirname} from 'path';
+ * @import {basename} from 'path';
+ * @import {resolve} from 'path';
+ */
+
 // scripts for use in xsnap subprocesses
 const avaAssert = `./avaAssertXS.js`;
 const avaHandler = `./avaHandler.cjs`;
 
-/** @type { (ref: string, readFile: typeof import('fs').promises.readFile ) => Promise<string> } */
+/** @type { (ref: string, readFile: typeof promises.readFile ) => Promise<string> } */
 const asset = (ref, readFile) =>
   readFile(fileURLToPath(new URL(ref, import.meta.url)), 'utf8');
 
@@ -82,16 +90,16 @@ function isMatch(specimen, pattern) {
  * @param {{ verbose?: boolean, titleMatch?: string }} options
  * @param {{
  *   spawnXSnap: (opts: object) => XSnap,
- *   bundleSource: import('@endo/bundle-source').BundleSource,
+ *   bundleSource: BundleSource,
  *   resolve: ResolveFn,
- *   dirname: typeof import('path').dirname,
- *   basename: typeof import('path').basename,
+ *   dirname: typeof dirname,
+ *   basename: typeof basename,
  * }} io
  * @returns {Promise<TestResults>}
  *
  * @typedef {{ total: number, pass: number, fail: { filename: string, name: string }[] }} TestResults
  * @typedef { 'ok' | 'not ok' | 'SKIP' } Status
- * @typedef {ReturnType<typeof import('./xsnap.js').xsnap>} XSnap
+ * @typedef {ReturnType<typeof xsnap>} XSnap
  */
 async function runTestScript(
   filename,
@@ -118,7 +126,7 @@ async function runTestScript(
     /**
      * See also send() in avaHandler.cjs
      *
-     * @type { TapMessage | { testNames: string[] } | { bundleSource: Parameters<import('@endo/bundle-source').BundleSource> } | Summary }
+     * @type { TapMessage | { testNames: string[] } | { bundleSource: Parameters<BundleSource> } | Summary }
      */
     const msg = JSON.parse(decoder.decode(message));
     // console.log(input, msg, qty, byStatus);
@@ -215,7 +223,7 @@ async function runTestScript(
  * @param {object} options
  * @param {string} [options.packageFilename]
  * @param {{
- *   readFile: typeof import('fs').promises.readFile,
+ *   readFile: typeof promises.readFile,
  *   glob: typeof import('glob')
  * }} io
  * @returns {Promise<AvaXSConfig>}
@@ -301,13 +309,13 @@ async function avaConfig(args, options, { glob, readFile }) {
 /**
  * @param {string[]} args - CLI args (excluding node interpreter, script name)
  * @param {{
- *   bundleSource: import('@endo/bundle-source').BundleSource,
+ *   bundleSource: BundleSource,
  *   spawn: typeof import('child_process')['spawn'],
  *   osType: typeof import('os')['type'],
  *   readFile: typeof import('fs')['promises']['readFile'],
- *   resolve: typeof import('path').resolve,
- *   dirname: typeof import('path').dirname,
- *   basename: typeof import('path').basename,
+ *   resolve: typeof resolve,
+ *   dirname: typeof dirname,
+ *   basename: typeof basename,
  *   glob: typeof import('glob'),
  * }} io
  */
@@ -405,7 +413,7 @@ export async function main(
  *
  * @param {typeof import('path')} path
  * @returns {ResolveFn}
- * @typedef {typeof import('path').resolve } ResolveFn
+ * @typedef {typeof resolve } ResolveFn
  */
 export function makeBundleResolve(path) {
   const bundleRoots = [

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -5,6 +5,12 @@ import { fileURLToPath } from 'url';
 import fsTop from 'fs';
 import osTop from 'os';
 
+/**
+ * @import {spawn} from 'child_process';
+ * @import {ChildProcess} from 'child_process';
+ * @import {promises} from 'fs';
+ */
+
 const { freeze } = Object;
 
 /** @param {string} path */
@@ -36,11 +42,11 @@ const ModdableSDK = {
  *
  * @param {string} command
  * @param {{
- *   spawn: typeof import('child_process').spawn,
+ *   spawn: typeof spawn,
  * }} io
  */
 function makeCLI(command, { spawn }) {
-  /** @param {import('child_process').ChildProcess} child */
+  /** @param {ChildProcess} child */
   const wait = child =>
     new Promise((resolve, reject) => {
       child.on('close', () => {
@@ -228,7 +234,7 @@ const updateSubmodules = async (submodules, { fs, git }) => {
  * @param {boolean} force
  * @param {{
  *   fs: Pick<typeof import('fs'), 'existsSync'> &
- *     Pick<typeof import('fs').promises, 'readFile' | 'writeFile'>,
+ *     Pick<typeof promises, 'readFile' | 'writeFile'>,
  *   make: ReturnType<typeof makeCLI>,
  * }} io
  */
@@ -275,9 +281,9 @@ const buildXsnap = async (platform, force, { fs, make }) => {
  * @param {{
  *   env: Record<string, string | undefined>,
  *   stdout: typeof process.stdout,
- *   spawn: typeof import('child_process').spawn,
+ *   spawn: typeof spawn,
  *   fs: Pick<typeof import('fs'), 'existsSync' | 'rmdirSync'> &
- *     Pick<typeof import('fs').promises, 'readFile' | 'writeFile'>,
+ *     Pick<typeof promises, 'readFile' | 'writeFile'>,
  *   os: Pick<typeof import('os'), 'type'>,
  * }} io
  */

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -30,7 +30,7 @@ const filenameFromDescription = description =>
 
 /**
  * @param {string} path
- * @param {{ writeFileSync: typeof import('fs').writeFileSync }} io
+ * @param {{ writeFileSync: typeof writeFileSync }} io
  */
 function makeSyncStorage(path, { writeFileSync }) {
   const base = new URL(path, 'file://');
@@ -55,8 +55,8 @@ function makeSyncStorage(path, { writeFileSync }) {
 /**
  * @param {string} path
  * @param {{
- *   readdirSync: typeof import('fs').readdirSync,
- *   readFileSync: typeof import('fs').readFileSync,
+ *   readdirSync: typeof readdirSync,
+ *   readFileSync: typeof readFileSync,
  * }} io
  */
 function makeSyncAccess(path, { readdirSync, readFileSync }) {
@@ -78,6 +78,12 @@ function makeSyncAccess(path, { readdirSync, readFileSync }) {
 }
 
 /**
+ * @import {writeFileSync} from 'fs';
+ * @import {spawn} from 'child_process';
+ * @import {type} from 'os';
+ */
+
+/**
  * Start an xsnap subprocess controller that records data
  * flowing to it for replay.
  *
@@ -91,12 +97,14 @@ function makeSyncAccess(path, { readdirSync, readFileSync }) {
  *        00002-issueCommand.dat
  *        00003-reply.dat
  * @param {{
- *   writeFileSync: typeof import('fs').writeFileSync,
+ *   writeFileSync: typeof writeFileSync,
  * }} io
  * @returns {XSnap}
  *
- * @typedef {ReturnType <typeof import('./xsnap.js').xsnap>} XSnap
+ * @typedef {ReturnType <typeof xsnap>} XSnap
  * @import {XSnapOptions} from './xsnap.js';
+ * @import {readdirSync} from 'fs';
+ * @import {readFileSync} from 'fs';
  */
 export async function recordXSnap(options, folderPath, { writeFileSync }) {
   const folder = makeSyncStorage(folderPath, { writeFileSync });
@@ -186,8 +194,8 @@ export async function recordXSnap(options, folderPath, { writeFileSync }) {
  * @param {XSnapOptions} opts
  * @param {string[]} folders
  * @param {{
- *   readdirSync: typeof import('fs').readdirSync,
- *   readFileSync: typeof import('fs').readFileSync,
+ *   readdirSync: typeof readdirSync,
+ *   readFileSync: typeof readFileSync,
  * }} io
  */
 export async function replayXSnap(
@@ -299,12 +307,12 @@ export async function replayXSnap(
  *
  * @param {string[]} argv
  * @param {{
- *   spawn: typeof import('child_process').spawn,
- *   fs: Omit<import('./xsnap.js').XSnapOptions['fs'], 'tmpName'>,
+ *   spawn: typeof spawn,
+ *   fs: Omit<XSnapOptions['fs'], 'tmpName'>,
  *   tmpName: import('tmp')['tmpName'],
- *   osType: typeof import('os').type,
- *   readdirSync: typeof import('fs').readdirSync,
- *   readFileSync: typeof import('fs').readFileSync,
+ *   osType: typeof type,
+ *   readdirSync: typeof readdirSync,
+ *   readFileSync: typeof readFileSync,
  * }} io
  */
 export async function main(
@@ -315,7 +323,7 @@ export async function main(
   if (!folders) {
     throw Error(`usage: replay folder...`);
   }
-  /** @type { import('./xsnap.js').XSnapOptions } */
+  /** @type { XSnapOptions } */
   const options = {
     spawn,
     fs: { ...fs, tmpName },

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -12,10 +12,14 @@ import { makePromiseKit, racePromises } from '@endo/promise-kit';
 import { forever } from '@agoric/internal';
 import { ErrorCode, ErrorSignal, ErrorMessage, METER_TYPE } from '../api.js';
 
-/** @import {PromiseKit} from '@endo/promise-kit' */
+/**
+ * @import {PromiseKit} from '@endo/promise-kit'
+ * @import {spawn} from 'child_process';
+ * @import {TmpNameOptions} from 'tmp';
+ */
 
 /**
- * @typedef {typeof import('child_process').spawn} Spawn
+ * @typedef {typeof spawn} Spawn
  * @import {Writable} from 'stream'
  */
 
@@ -67,7 +71,7 @@ const safeHintFromDescription = description =>
  * @callback MakeSnapshotLoader
  * @param {AsyncIterable<Uint8Array>} sourceBytes
  * @param {string} description
- * @param {{fs: Pick<typeof import('fs/promises'), 'open' | 'unlink'>, ptmpName: (opts: import('tmp').TmpNameOptions) => Promise<string>}} ioPowers
+ * @param {{fs: Pick<typeof import('fs/promises'), 'open' | 'unlink'>, ptmpName: (opts: TmpNameOptions) => Promise<string>}} ioPowers
  * @returns {Promise<SnapshotLoader>}
  */
 
@@ -189,7 +193,7 @@ export async function xsnap(options) {
 
   assert(!/^-/.test(name), `name '${name}' cannot start with hyphen`);
 
-  /** @type {(opts: import('tmp').TmpNameOptions) => Promise<string>} */
+  /** @type {(opts: TmpNameOptions) => Promise<string>} */
   const ptmpName = fs.tmpName && promisify(fs.tmpName);
   const makeSnapshotLoader = snapshotUseFs
     ? makeSnapshotLoaderWithFS
@@ -432,7 +436,7 @@ export async function xsnap(options) {
 
   /**
    * @param {string} description
-   * @param {import('@endo/promise-kit').PromiseKit<void>} batonKit
+   * @param {PromiseKit<void>} batonKit
    * @returns {AsyncGenerator<Uint8Array, void, undefined>}
    */
   async function* makeSnapshotInternal(description, batonKit) {

--- a/packages/xsnap/test/leakiness.test.js
+++ b/packages/xsnap/test/leakiness.test.js
@@ -10,10 +10,13 @@ import { waitUntilQuiescent } from '@agoric/internal/src/lib-nodejs/waitUntilQui
 
 import { spawnRetentiveVatSequence } from './leakiness.mjs';
 
-/** @import {XSnapOptions} from '@agoric/xsnap/src/xsnap.js' */
+/**
+ * @import {XSnapOptions} from '@agoric/xsnap/src/xsnap.js'
+ * @import {ExecutionContext} from 'ava';
+ */
 
 /**
- * @param {import('ava').ExecutionContext} t
+ * @param {ExecutionContext} t
  * @param {Partial<XSnapOptions>} xsnapOptions
  */
 const testRetention = async (t, xsnapOptions) => {

--- a/packages/xsnap/test/message-tools.js
+++ b/packages/xsnap/test/message-tools.js
@@ -1,5 +1,11 @@
 const { freeze } = Object;
 
+/**
+ * @import {promises} from 'fs';
+ * @import {spawn} from 'child_process';
+ * @import {XSnapOptions} from '../src/xsnap.js';
+ */
+
 // a TextDecoder has mutable state; only export the (pure) decode function
 /** @type { TextDecoder['decode'] } */
 export const decode = (decoder => decoder.decode.bind(decoder))(
@@ -13,7 +19,7 @@ export const encode = (encoder => encoder.encode.bind(encoder))(
 
 /**
  * @param {string} url
- * @param {typeof import('fs').promises.readFile} [readFile]
+ * @param {typeof promises.readFile} [readFile]
  */
 export function loader(url, readFile = undefined) {
   /** @param {string} ref */
@@ -28,12 +34,12 @@ export function loader(url, readFile = undefined) {
 
 /**
  * @param {{
- *   spawn: typeof import('child_process').spawn,
+ *   spawn: typeof spawn,
  *   os: string,
  *   fs: import('fs'),
  *   tmpName: import('tmp')['tmpName'],
  * }} io
- * @returns {import('../src/xsnap.js').XSnapOptions & { messages: string[]}}
+ * @returns {XSnapOptions & { messages: string[]}}
  */
 export function options({ spawn, os, fs, tmpName }) {
   const messages = [];


### PR DESCRIPTION
_incidental_

## Description
I noticed an adoption of `objectMap` in https://github.com/Agoric/agoric-sdk/pull/12171/files/79509e438b61f8e0413ea7b3bda9d72e2c141ba1..0e896c07d277ec4384cbe306b50d2c33d4457e2b and figured it was worth linting.

This adds a `no-restricted-syntax` rule for it with an instruction to use `objectMap` instead. Then it makes the codebase conform.

This also sneaks in a `lint-fix` for group-jsdoc-imports.

### Security Considerations
n/a

### Scaling Considerations
n/a

### Documentation Considerations

Self-documenting

### Testing Considerations
CI

### Upgrade Considerations
n/a
