### PR TITLE
chore(portfolio-contract): Split solveRebalance into two phases

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -207,9 +207,6 @@ jobs:
       - name: yarn test (portfolio-api)
         if: (success() || failure())
         run: cd packages/portfolio-api && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
-      - name: yarn test (portfolio-contract)
-        if: (success() || failure())
-        run: cd packages/portfolio-contract && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: yarn test (portfolio-deploy)
         if: (success() || failure())
         run: cd packages/portfolio-deploy && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
@@ -480,6 +477,45 @@ jobs:
       - name: yarn test (governance)
         if: (success() || failure())
         run: cd packages/governance && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
+      - name: notify on failure
+        if: failure() && github.event_name != 'pull_request'
+        uses: ./.github/actions/notify-status
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          from: ${{ secrets.NOTIFY_EMAIL_FROM }}
+          to: ${{ secrets.NOTIFY_EMAIL_TO }}
+          password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
+      - uses: ./.github/actions/post-test
+        if: (success() || failure())
+        continue-on-error: true
+        timeout-minutes: 4
+        with:
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
+
+  test-portfolio-contract:
+    # BEGIN-TEST-BOILERPLATE
+    timeout-minutes: 30
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # test:xs is noop in portfolio-contract/package.json
+        engine: ['node-new', 'node-old']
+    steps:
+      - name: set vars
+        id: vars
+        run: |
+          echo "test=${{ matrix.engine == 'xs' && 'test:xs' || 'test' }}" >> $GITHUB_OUTPUT
+          echo "GH_ENGINE=${{ matrix.engine }}" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/restore-node
+        with:
+          node-version: ${{ matrix.engine }}
+      # END-TEST-BOILERPLATE
+      - name: yarn test (portfolio-contract)
+        if: (success() || failure())
+        run: cd packages/portfolio-contract && yarn ${{ steps.vars.outputs.test }} | $TEST_COLLECT
       - name: notify on failure
         if: failure() && github.event_name != 'pull_request'
         uses: ./.github/actions/notify-status

--- a/packages/portfolio-contract/test/network/buildGraph.test.ts
+++ b/packages/portfolio-contract/test/network/buildGraph.test.ts
@@ -21,7 +21,7 @@ test('NetworkSpec minimal validation via builder', t => {
     links: [],
     localPlaces: [],
   } as any;
-  t.notThrows(() => makeGraphForFlow(base, {}, {}, Far('B'), feeBrand));
+  t.notThrows(() => makeGraphForFlow(base, {}, {}));
 });
 
 test('makeGraphForFlow adds intra-chain edges and appends inter edges with sequential ids', t => {
@@ -52,7 +52,7 @@ test('makeGraphForFlow adds intra-chain edges and appends inter edges with seque
       },
     ],
   } as any;
-  const graph = makeGraphForFlow(net, {}, {}, brand, feeBrand);
+  const graph = makeGraphForFlow(net, {}, {});
   const leafCount = 2; // Aave_Arbitrum, Compound_Ethereum
   const expectedIntra = leafCount * 2; // bidirectional
   t.true(graph.edges.length >= expectedIntra + net.links.length);

--- a/packages/portfolio-contract/test/network/buildGraph.test.ts
+++ b/packages/portfolio-contract/test/network/buildGraph.test.ts
@@ -4,7 +4,7 @@ import { AmountMath } from '@agoric/ertp';
 
 import { gasEstimator } from '../mocks.js';
 import type { NetworkSpec } from '../../tools/network/network-spec.js';
-import { makeGraphFromDefinition } from '../../tools/network/buildGraph.js';
+import { makeGraphForFlow } from '../../tools/network/buildGraph.js';
 import { planRebalanceFlow } from '../../tools/plan-solve.js';
 
 const brand = Far('TestBrand') as any;
@@ -21,10 +21,10 @@ test('NetworkSpec minimal validation via builder', t => {
     links: [],
     localPlaces: [],
   } as any;
-  t.notThrows(() => makeGraphFromDefinition(base, {}, {}, Far('B'), feeBrand));
+  t.notThrows(() => makeGraphForFlow(base, {}, {}, Far('B'), feeBrand));
 });
 
-test('makeGraphFromDefinition adds intra-chain edges and appends inter edges with sequential ids', t => {
+test('makeGraphForFlow adds intra-chain edges and appends inter edges with sequential ids', t => {
   const net: NetworkSpec = {
     chains: [
       { name: 'Arbitrum', control: 'axelar' },
@@ -52,7 +52,7 @@ test('makeGraphFromDefinition adds intra-chain edges and appends inter edges wit
       },
     ],
   } as any;
-  const graph = makeGraphFromDefinition(net, {}, {}, brand, feeBrand);
+  const graph = makeGraphForFlow(net, {}, {}, brand, feeBrand);
   const leafCount = 2; // Aave_Arbitrum, Compound_Ethereum
   const expectedIntra = leafCount * 2; // bidirectional
   t.true(graph.edges.length >= expectedIntra + net.links.length);

--- a/packages/portfolio-contract/test/network/prod-network.test.ts
+++ b/packages/portfolio-contract/test/network/prod-network.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@agoric/portfolio-api/src/constants.js';
 
 import {
-  makeGraphFromDefinition,
+  makeGraphForFlow,
   type RebalanceGraph,
 } from '../../tools/network/buildGraph.js';
 import PROD_NETWORK, {
@@ -72,8 +72,7 @@ const POOLS: ReadonlyArray<PoolKey> = [
 ];
 
 // Helpers
-const getGraph = () =>
-  makeGraphFromDefinition(PROD_NETWORK, {}, {}, brand, feeBrand);
+const getGraph = () => makeGraphForFlow(PROD_NETWORK, {}, {}, brand, feeBrand);
 
 const hasEdge = (
   edges: RebalanceGraph['edges'],

--- a/packages/portfolio-contract/test/network/prod-network.test.ts
+++ b/packages/portfolio-contract/test/network/prod-network.test.ts
@@ -72,7 +72,7 @@ const hasEdge = (
   via?: TransferProtocol,
 ) =>
   edges.some(
-    e => e.src === src && e.dest === dest && (via ? e.via === via : true),
+    e => e.src === src && e.dest === dest && (via ? e.transfer === via : true),
   );
 
 const isReachable = (

--- a/packages/portfolio-contract/test/network/prod-network.test.ts
+++ b/packages/portfolio-contract/test/network/prod-network.test.ts
@@ -16,8 +16,6 @@ import type {
   TransferProtocol,
 } from '../../tools/network/network-spec.js';
 
-const toSet = <T>(iter: Iterable<T>) => new Set(iter);
-
 // Shared expectations (precisely typed)
 type HubKey = `@${(typeof SupportedChain)[keyof typeof SupportedChain]}`;
 type EvmHubKey = `@${(typeof AxelarChain)[keyof typeof AxelarChain]}`;
@@ -134,13 +132,13 @@ test('PROD_NETWORK has the expected hubs', t => {
   t.is(PROD_NETWORK, NAMED_PROD);
 
   const graph = getGraph();
-  const nodes = toSet(graph.nodes.values());
+  const nodes = new Set(graph.nodes.values());
   for (const hub of HUBS) t.true(nodes.has(hub), `missing hub ${hub}`);
 });
 
 test('PROD_NETWORK has the expected pools', t => {
   const graph = getGraph();
-  const nodes = toSet(graph.nodes.values());
+  const nodes = new Set(graph.nodes.values());
   for (const p of POOLS) t.true(nodes.has(p), `missing pool ${p}`);
 });
 

--- a/packages/portfolio-contract/test/network/prod-network.test.ts
+++ b/packages/portfolio-contract/test/network/prod-network.test.ts
@@ -1,15 +1,11 @@
 import test from 'ava';
-import { Far } from '@endo/marshal';
-import type { Brand } from '@agoric/ertp/src/types.js';
 import {
   AxelarChain,
   SupportedChain,
 } from '@agoric/portfolio-api/src/constants.js';
 
-import {
-  makeGraphForFlow,
-  type RebalanceGraph,
-} from '../../tools/network/buildGraph.js';
+import { makeGraphForFlow } from '../../tools/network/buildGraph.js';
+import type { FlowGraph } from '../../tools/network/buildGraph.js';
 import PROD_NETWORK, {
   PROD_NETWORK as NAMED_PROD,
 } from '../../tools/network/network.prod.js';
@@ -19,9 +15,6 @@ import type {
   PoolKey,
   TransferProtocol,
 } from '../../tools/network/network-spec.js';
-
-const brand = Far('TestBrand') as Brand<'nat'>;
-const feeBrand = Far('TestFeeBrand') as Brand<'nat'>;
 
 const toSet = <T>(iter: Iterable<T>) => new Set(iter);
 
@@ -72,10 +65,10 @@ const POOLS: ReadonlyArray<PoolKey> = [
 ];
 
 // Helpers
-const getGraph = () => makeGraphForFlow(PROD_NETWORK, {}, {}, brand, feeBrand);
+const getGraph = () => makeGraphForFlow(PROD_NETWORK, {}, {});
 
 const hasEdge = (
-  edges: RebalanceGraph['edges'],
+  edges: FlowGraph['edges'],
   src: AssetPlaceRef,
   dest: AssetPlaceRef,
   via?: TransferProtocol,
@@ -85,7 +78,7 @@ const hasEdge = (
   );
 
 const isReachable = (
-  edges: RebalanceGraph['edges'],
+  edges: FlowGraph['edges'],
   start: AssetPlaceRef,
   goal: AssetPlaceRef,
 ) => {

--- a/packages/portfolio-contract/test/rebalance.test.ts
+++ b/packages/portfolio-contract/test/rebalance.test.ts
@@ -635,7 +635,7 @@ testWithAllModes(
   },
 );
 
-test.failing('solver differentiates cheapest vs. fastest', async t => {
+test('solver differentiates cheapest vs. fastest', async t => {
   const network: NetworkSpec = {
     debug: true,
     environment: 'test',

--- a/packages/portfolio-contract/test/rebalance.test.ts
+++ b/packages/portfolio-contract/test/rebalance.test.ts
@@ -683,9 +683,9 @@ test.failing('solver differentiates cheapest vs. fastest', async t => {
     gasEstimator,
   });
   t.like(cheapResult.flows.map(flow => flow.edge).sort(compareFlowEdges), [
-    { src: '+agoric', dest: '@agoric', via: 'local' },
-    { src: '@agoric', dest: '@External', via: 'cheap' },
-    { src: '@External', dest: 'Sink_External', via: 'local' },
+    { src: '+agoric', dest: '@agoric', transfer: 'local' },
+    { src: '@agoric', dest: '@External', transfer: 'cheap' },
+    { src: '@External', dest: 'Sink_External', transfer: 'local' },
   ]);
   await assertSteps(t, cheapResult.steps, [
     { src: '+agoric', dest: '@agoric', amount: token(100n) },
@@ -708,9 +708,9 @@ test.failing('solver differentiates cheapest vs. fastest', async t => {
     gasEstimator,
   });
   t.like(fastResult.flows.map(flow => flow.edge).sort(compareFlowEdges), [
-    { src: '+agoric', dest: '@agoric', via: 'local' },
-    { src: '@agoric', dest: '@External', via: 'fast' },
-    { src: '@External', dest: 'Sink_External', via: 'local' },
+    { src: '+agoric', dest: '@agoric', transfer: 'local' },
+    { src: '@agoric', dest: '@External', transfer: 'fast' },
+    { src: '@External', dest: 'Sink_External', transfer: 'local' },
   ]);
   await assertSteps(t, fastResult.steps, [
     { src: '+agoric', dest: '@agoric', amount: token(100n) },

--- a/packages/portfolio-contract/tools/graph-diagnose.ts
+++ b/packages/portfolio-contract/tools/graph-diagnose.ts
@@ -235,8 +235,10 @@ export const explainPath = (
   if (path.length < 2) return { ok: true };
   const nodes = graph.nodes;
   const edgeMap = new Map<string, { capacity: number }>();
-  for (const e of graph.edges)
-    edgeMap.set(`${e.src}->${e.dest}`, { capacity: e.capacity ?? Infinity });
+  for (const e of graph.edges) {
+    const capacity = Number(e.capacity ?? Infinity);
+    edgeMap.set(`${e.src}->${e.dest}`, { capacity });
+  }
   for (let i = 0; i < path.length - 1; i += 1) {
     const src = path[i];
     const dest = path[i + 1];

--- a/packages/portfolio-contract/tools/graph-diagnose.ts
+++ b/packages/portfolio-contract/tools/graph-diagnose.ts
@@ -18,7 +18,7 @@ import {
   type PoolKey,
   type PoolPlaceInfo,
 } from '../src/type-guards.js';
-import type { RebalanceGraph } from './network/buildGraph.js';
+import type { FlowGraph } from './network/buildGraph.js';
 import type { NetworkSpec } from './network/network-spec.js';
 import type { LpModel } from './plan-solve.js';
 
@@ -48,7 +48,7 @@ const bfs = <T>(start: T, adj: Map<T, T[]>): Set<T> => {
  *   - Set `debug: true` on the NetworkSpec used to build the graph.
  */
 export const diagnoseInfeasible = (
-  graph: RebalanceGraph,
+  graph: FlowGraph,
   _model: LpModel,
 ): string => {
   const nodes = [...graph.nodes];
@@ -216,7 +216,7 @@ export const preflightValidateNetworkPlan = (
  *   before validating it with `explainPath`.
  */
 export const explainPath = (
-  graph: RebalanceGraph,
+  graph: FlowGraph,
   path: string[],
 ):
   | { ok: true }
@@ -300,7 +300,7 @@ export const explainPath = (
  * Diagnose near-miss connectivity categories for each source (positive supply)
  * and sink (negative supply). Purely topological; ignores objective.
  */
-export const diagnoseNearMisses = (graph: RebalanceGraph) => {
+export const diagnoseNearMisses = (graph: FlowGraph) => {
   const nodes = [...graph.nodes];
   const supplies = graph.supplies;
   const sources = nodes.filter(n => (supplies[n] || 0) > 0);
@@ -353,7 +353,7 @@ export const diagnoseNearMisses = (graph: RebalanceGraph) => {
 
 /** Build a canonical leaf/hub -> hub/leaf path skeleton between two nodes. */
 export const canonicalPathBetween = (
-  graph: RebalanceGraph,
+  graph: FlowGraph,
   src: string,
   dest: string,
 ): string[] => {
@@ -384,7 +384,7 @@ export const canonicalPathBetween = (
 
 /** Build an example path explanation for a pair of nodes. */
 export const examplePathExplain = (
-  graph: RebalanceGraph,
+  graph: FlowGraph,
   src: string,
   dest: string,
 ) => {
@@ -398,7 +398,7 @@ export const examplePathExplain = (
  * Includes supply/reachability summary, near-miss pairs, and an example path explanation.
  */
 export const formatInfeasibleDiagnostics = (
-  graph: RebalanceGraph,
+  graph: FlowGraph,
   model: LpModel,
 ): string => {
   const diag = diagnoseInfeasible(graph, model);
@@ -438,7 +438,7 @@ export const formatInfeasibleDiagnostics = (
  * @returns Validation result with ok flag and details
  */
 export const validateSolvedFlows = (
-  graph: RebalanceGraph,
+  graph: FlowGraph,
   flows: Array<{
     edge: { src: string; dest: string; id: string };
     flow: number;

--- a/packages/portfolio-contract/tools/network/path.ts
+++ b/packages/portfolio-contract/tools/network/path.ts
@@ -3,7 +3,7 @@ import type {
   AssetPlaceRef,
   MovementDesc,
 } from '../../src/type-guards-steps.js';
-import type { RebalanceGraph, FlowEdge } from './buildGraph.js';
+import type { FlowEdge, FlowGraph } from './buildGraph.js';
 
 /** Weight selector: cheapest => variableFee, fastest => timeFixed, default 1 */
 const edgeWeight = (e: FlowEdge, mode: 'cheapest' | 'fastest') => {
@@ -14,7 +14,7 @@ const edgeWeight = (e: FlowEdge, mode: 'cheapest' | 'fastest') => {
 
 /** Find shortest(weighted) path using Dijkstra (graph small so OK). */
 export const findPath = (
-  graph: RebalanceGraph,
+  graph: FlowGraph,
   src: AssetPlaceRef,
   dest: AssetPlaceRef,
   mode: 'cheapest' | 'fastest' = 'cheapest',

--- a/packages/portfolio-contract/tools/network/path.ts
+++ b/packages/portfolio-contract/tools/network/path.ts
@@ -7,8 +7,8 @@ import type { FlowEdge, FlowGraph } from './buildGraph.js';
 
 /** Weight selector: cheapest => variableFee, fastest => timeFixed, default 1 */
 const edgeWeight = (e: FlowEdge, mode: 'cheapest' | 'fastest') => {
-  if (mode === 'cheapest') return e.variableFee ?? 0;
-  if (mode === 'fastest') return e.timeFixed ?? 0;
+  if (mode === 'cheapest') return e.variableFeeBps ?? 0;
+  if (mode === 'fastest') return e.timeSec ?? 0;
   return 1;
 };
 

--- a/packages/portfolio-contract/tools/plan-solve.ts
+++ b/packages/portfolio-contract/tools/plan-solve.ts
@@ -325,8 +325,12 @@ const prettyJsonable = (obj: unknown): string => {
   return pretty;
 };
 
-const solveLPModel = (model: LpModel, graph: FlowGraph): LpSolution => {
-  const solution = jsLPSolver.Solve(model, 1e-9);
+const solveLPModel = (
+  model: LpModel,
+  graph: FlowGraph,
+  { precision = 1e-9 } = {},
+): LpSolution => {
+  const solution = jsLPSolver.Solve(model, precision);
 
   // The 'feasible' flag can be overly strict, so we check if we got a result
   // instead. If result is undefined or there are no variable values, it's truly infeasible.
@@ -355,7 +359,7 @@ export const solveRebalance = async (
   // Then, derive a new model with minor-unit integer amount values against the
   // selected subgraph.
   // This two-step approach seems to dodge some IEEE 754 rounding issues.
-  const pickSolution = solveLPModel(model, graph);
+  const pickSolution = solveLPModel(model, graph, { precision: 1e-15 });
   const refinedModel = refineModel(model, graph, pickSolution);
   const solution = solveLPModel(refinedModel, graph);
 

--- a/packages/portfolio-contract/tools/plan-solve.ts
+++ b/packages/portfolio-contract/tools/plan-solve.ts
@@ -1,5 +1,9 @@
 import jsLPSolver from 'javascript-lp-solver';
-import type { IModel, IModelVariableConstraint } from 'javascript-lp-solver';
+import type {
+  IModel,
+  IModelVariableConstraint,
+  Solution,
+} from 'javascript-lp-solver';
 
 import { Fail, annotateError } from '@endo/errors';
 
@@ -42,6 +46,9 @@ const replaceOrInit = <K, V>(
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const trace = makeTracer('solve');
 
+/** The count of minor units per major unit (e.g., uusdc per USDC) */
+const UNIT_SCALE = 1e6;
+
 /** Mode of optimization */
 export type RebalanceMode = 'cheapest' | 'fastest';
 
@@ -54,6 +61,7 @@ export interface SolvedEdgeFlow {
 
 /** Model shape for javascript-lp-solver */
 export type LpModel = IModel<string, string>;
+export type LpSolution = Solution<string>;
 
 /**
  * Gas estimation interface:
@@ -90,145 +98,154 @@ const FLOW_EPS = 1e-6;
 
 // ------------------------------ Model Building -------------------------------
 
-type IntVar = Record<
+type FlowVar = Record<
   | `allow_${string}`
   | `through_${string}`
   | `netOut_${string}`
-  | 'magnifiedVariableFee'
+  | 'variableFeeBps'
   | 'weight',
   number
 >;
-type BinaryVar = Record<
+type PickVar = Record<
   `allow_${string}` | 'magnifiedFlatFee' | 'timeSec' | 'weight',
   number
 >;
 type WeightFns = {
-  getPrimaryWeights: (intVar: IntVar, binaryVar: BinaryVar) => number[];
-  setWeights: (intVar: IntVar, binaryVar: BinaryVar, epsilon: number) => void;
+  classifyWeights: (
+    flowVar: FlowVar,
+    pickVar: PickVar,
+  ) => { primary: number[]; other: number[] };
+  setWeights: (flowVar: FlowVar, pickVar: PickVar, epsilon: number) => void;
 };
+
+const DEFAULT_SECONDARY_WEIGHT_EPSILON = 1e-6;
 
 const modeFns = new Map(
   typedEntries({
     cheapest: {
-      getPrimaryWeights: (intVar, binaryVar) => [
-        intVar.magnifiedVariableFee,
-        binaryVar.magnifiedFlatFee,
-      ],
-      setWeights: (intVar, binaryVar, epsilon) => {
+      classifyWeights: (flowVar, pickVar) => ({
+        primary: [flowVar.variableFeeBps, pickVar.magnifiedFlatFee],
+        other: [pickVar.timeSec],
+      }),
+      setWeights: (flowVar, pickVar, epsilon) => {
         // Fees have full weight; time is weighted by epsilon.
-        intVar.weight = intVar.magnifiedVariableFee;
-        binaryVar.weight =
-          binaryVar.magnifiedFlatFee + binaryVar.timeSec * epsilon;
+        flowVar.weight = flowVar.variableFeeBps;
+        pickVar.weight = pickVar.magnifiedFlatFee + pickVar.timeSec * epsilon;
       },
     },
     fastest: {
-      getPrimaryWeights: (_intVar, binaryVar) => [binaryVar.timeSec],
-      setWeights: (intVar, binaryVar, epsilon) => {
+      classifyWeights: (flowVar, pickVar) => ({
+        primary: [pickVar.timeSec],
+        other: [flowVar.variableFeeBps, pickVar.magnifiedFlatFee],
+      }),
+      setWeights: (flowVar, pickVar, epsilon) => {
         // Fees are weighted by epsilon; time has full weight.
-        intVar.weight = intVar.magnifiedVariableFee * epsilon;
-        binaryVar.weight =
-          binaryVar.timeSec + binaryVar.magnifiedFlatFee * epsilon;
+        flowVar.weight = flowVar.variableFeeBps * epsilon;
+        pickVar.weight = pickVar.timeSec + pickVar.magnifiedFlatFee * epsilon;
       },
     },
   } as Record<RebalanceMode, WeightFns>),
 );
 
 /**
- * Build LP/MIP model for javascript-lp-solver.
+ * Build LP/MIP model for javascript-lp-solver, expressing amounts in major
+ * units with floating point values (e.g., `1.5` for 1.5 USDC from 1_500_000n
+ * uusdc).
  */
 export const buildLPModel = (
   graph: FlowGraph,
   mode: RebalanceMode,
 ): LpModel => {
-  const { getPrimaryWeights, setWeights } =
+  const { classifyWeights, setWeights } =
     modeFns.get(mode) || Fail`unknown mode ${mode}`;
 
-  const intVariables = {} as Record<`via_${string}`, IntVar>;
-  const binaryVariables = {} as Record<`pick_${string}`, BinaryVar>;
+  const flowVariables = {} as Record<`via_${string}`, FlowVar>;
+  const pickVariables = {} as Record<`pick_${string}`, PickVar>;
   const couplingConstraints = {} as Record<string, IModelVariableConstraint>;
   const throughputConstraints = {} as Record<string, IModelVariableConstraint>;
   const netFlowConstraints = {} as Record<string, IModelVariableConstraint>;
-  let minPrimaryWeight = Infinity;
+  let [minPrimaryWeight, maxSecondaryWeight] = [Infinity, -Infinity];
   for (const edge of graph.edges) {
     const { id, src, dest } = edge;
     const { capacity, min, variableFeeBps, flatFee = 0n, timeSec = 0 } = edge;
 
+    // Scale min and capacity to major units.
     throughputConstraints[`through_${id}`] = {
-      min: Number(min ?? 0n),
-      max: capacity === undefined ? undefined : Number(capacity),
+      min: min === undefined ? 0 : Number(min) / UNIT_SCALE,
+      max: capacity === undefined ? undefined : Number(capacity) / UNIT_SCALE,
     };
-
-    // The numbers in graph.supplies should use the same units as flatFee, but
-    // variableFeeBps is in basis points relative to some scaling of those other
-    // values.
-    // We also want fee attributes large enough to avoid IEEE 754 rounding
-    // issues.
-    // Assume that scaling to be 1e6 (i.e., 100 bp = 1% of supplies[key]/1e6)
-    // and scale the fee attributes accordingly such that variableFeeBps 100 will
-    // contribute a weight of 0.01 for each `via_$edge` atomic unit of payload
-    // (i.e., magnified by 1e6 if the scaling is actually 1e6) and flatFee 1
-    // will contribute a weight of 1e6 if the corresponding edge is used (i.e.,
-    // also magnified by 1e6 if the scaling is actually 1e6).
-    // The solution may be disrupted by either over- or under-weighting
-    // variableFeeBps w.r.t. flatFee, but not otherwise, and we accept the risk.
-    // TODO: Define FlowGraph['scale'] to eliminate this guesswork.
-    const magnifiedVariableFee = variableFeeBps / 10_000;
-    const magnifiedFlatFee = Number(flatFee) * 1e6;
 
     // Dynamic costs for this edge are associated with the numeric `via_${id}`
     // variable, and fixed costs are associated with the binary `pick_${id}`.
     // We couple them together with a shared `allow_${id}` attribute that has a
-    // tiny negative value for the former and an enormous positive value for the
+    // small negative value for the former and a large positive value for the
     // latter, and a constraint that the total sum be non-negative.
     // So any `via_${id}` dynamic flow requires activation of `pick_${id}`,
     // which adds enough `allow_${id}` to cover all of the flow.
     couplingConstraints[`allow_${id}`] = { min: 0 };
-    const FORCE_PICK = -1e-6;
-    const COVER_FLOW = 1e9;
+    const FORCE_PICK = -1;
+    const COVER_FLOW = 1e12;
 
-    const intVar: IntVar = {
+    const flowVar: FlowVar = {
       [`allow_${id}`]: FORCE_PICK,
       [`through_${id}`]: 1,
       [`netOut_${src}`]: 1,
       [`netOut_${dest}`]: -1,
-      magnifiedVariableFee,
+      variableFeeBps,
       weight: 0, // increased below
     };
-    intVariables[`via_${id}`] = intVar;
+    flowVariables[`via_${id}`] = flowVar;
 
-    const binaryVar = {
+    // Basing weight on unscaled variableFeeBps is an an implicit magnification
+    // by 1e4 to hundreds of minor units/thousandths of major units (e.g.,
+    // 100 bps = 1% of 1.5 USDC is actually 0.015 USDC but manifests as 150),
+    // and flatFee (which is in minor units) should follow suit such that e.g.
+    // 123 uusdc = 0.000123 USDC manifests as 1.23.
+    const magnifiedFlatFee = (Number(flatFee) * 1e4) / UNIT_SCALE;
+
+    const pickVar: PickVar = {
       [`allow_${id}`]: COVER_FLOW,
       magnifiedFlatFee,
       timeSec,
       weight: 0, // increased below
     };
-    binaryVariables[`pick_${id}`] = binaryVar;
+    pickVariables[`pick_${id}`] = pickVar;
 
-    // Keep track of the lowest non-zero primary weight for `mode`.
+    // Track the gap between primary and non-primary non-zero weights.
+    const weights = classifyWeights(flowVar, pickVar);
     minPrimaryWeight = Math.min(
       minPrimaryWeight,
-      ...getPrimaryWeights(intVar, binaryVar).map(n => n || Infinity),
+      ...weights.primary.map(n => n || Infinity),
+    );
+    maxSecondaryWeight = Math.max(
+      maxSecondaryWeight,
+      ...weights.other.map(n => n || -Infinity),
     );
   }
 
-  // Finalize the weights.
-  const epsilonWeight = Number.isFinite(minPrimaryWeight)
-    ? minPrimaryWeight / 1e6
-    : 1e-9;
+  // Finalize the weights, trying to leave 100x overhead between primary and
+  // non-primary contributions.
+  const maxExpectedFlow = Math.max(
+    ...Object.values(graph.supplies).map(x => Math.abs(x) / UNIT_SCALE),
+  );
+  const epsilonWeight =
+    Number.isFinite(minPrimaryWeight) && Number.isFinite(maxSecondaryWeight)
+      ? minPrimaryWeight / (maxSecondaryWeight * maxExpectedFlow * 100)
+      : DEFAULT_SECONDARY_WEIGHT_EPSILON;
   for (const { id } of graph.edges) {
     setWeights(
-      intVariables[`via_${id}`],
-      binaryVariables[`pick_${id}`],
+      flowVariables[`via_${id}`],
+      pickVariables[`pick_${id}`],
       epsilonWeight,
     );
     // No arc is free.
-    binaryVariables[`pick_${id}`].weight += 1;
+    pickVariables[`pick_${id}`].weight += 1;
   }
 
   // Constrain the net flow from each node.
   for (const node of graph.nodes) {
     const supply = graph.supplies[node] || 0;
-    netFlowConstraints[`netOut_${node}`] = { equal: supply };
+    netFlowConstraints[`netOut_${node}`] = { equal: supply / UNIT_SCALE };
   }
 
   return {
@@ -239,10 +256,50 @@ export const buildLPModel = (
       ...throughputConstraints,
       ...netFlowConstraints,
     },
-    binaries: objectMap(binaryVariables, () => true),
-    ints: objectMap(intVariables, () => true),
-    variables: { ...binaryVariables, ...intVariables },
+    binaries: objectMap(pickVariables, () => true),
+    ints: {},
+    variables: { ...pickVariables, ...flowVariables },
   };
+};
+
+/**
+ * Refine a coarse model of floating-point major-unit amount values and a
+ * corresponding solution into a narrow model of integer minor-unit amount
+ * values along only selected arcs.
+ */
+const refineModel = (
+  fullModel: LpModel,
+  graph: FlowGraph,
+  solution: LpSolution,
+): LpModel => {
+  const cloned = JSON.parse(JSON.stringify(fullModel));
+  cloned.binaries = {};
+  cloned.ints = {};
+  for (const edge of graph.edges) {
+    const { id, capacity, min } = edge;
+    const pickVar = `pick_${id}`;
+    const flowVar = `via_${id}`;
+    if ((solution[flowVar] ?? 0) > 0) {
+      cloned.binaries[pickVar] = true;
+      cloned.ints[flowVar] = true;
+      cloned.constraints[`through_${id}`] = {
+        min: min === undefined ? 0 : Number(min),
+        max: capacity === undefined ? undefined : Number(capacity),
+      };
+      cloned.variables[pickVar].weight =
+        (cloned.variables[pickVar].weight - 1) * UNIT_SCALE + 1;
+    } else {
+      delete cloned.variables[pickVar];
+      delete cloned.variables[flowVar];
+      delete cloned.constraints[`allow_${id}`];
+      delete cloned.constraints[`through_${id}`];
+    }
+  }
+  for (const node of graph.nodes) {
+    const supply = graph.supplies[node] || 0;
+    cloned.constraints[`netOut_${node}`] = { equal: supply };
+  }
+  return cloned;
 };
 
 /**
@@ -268,15 +325,9 @@ const prettyJsonable = (obj: unknown): string => {
   return pretty;
 };
 
-// This operation is async to allow future use of async solvers if needed
-export const solveRebalance = async (
-  model: LpModel,
-  graph: FlowGraph,
-): Promise<{ flows: SolvedEdgeFlow[]; detail?: Record<string, unknown> }> => {
-  await null;
+const solveLPModel = (model: LpModel, graph: FlowGraph): LpSolution => {
   const solution = jsLPSolver.Solve(model, 1e-9);
 
-  // jsLPSolver returns an object with variable values
   // The 'feasible' flag can be overly strict, so we check if we got a result
   // instead. If result is undefined or there are no variable values, it's truly infeasible.
   if (!(solution?.feasible || solution?.result)) {
@@ -289,6 +340,24 @@ export const solveRebalance = async (
     }
     throw Fail`No feasible solution: ${solution}`;
   }
+
+  return solution;
+};
+
+// This operation is async to allow future use of async solvers if needed
+export const solveRebalance = async (
+  model: LpModel,
+  graph: FlowGraph,
+): Promise<{ flows: SolvedEdgeFlow[]; detail?: Record<string, unknown> }> => {
+  await null;
+
+  // First, use the provided model with major-unit amount values to pick arcs.
+  // Then, derive a new model with minor-unit integer amount values against the
+  // selected subgraph.
+  // This two-step approach seems to dodge some IEEE 754 rounding issues.
+  const pickSolution = solveLPModel(model, graph);
+  const refinedModel = refineModel(model, graph, pickSolution);
+  const solution = solveLPModel(refinedModel, graph);
 
   const flows: SolvedEdgeFlow[] = [];
   for (const edge of graph.edges) {
@@ -440,7 +509,8 @@ export const rebalanceMinCostFlowSteps = async (
           // HACK of subtract 1n in order to avoid rounding errors in Noble
           // See https://github.com/Agoric/agoric-private/issues/415
           const usdnOut =
-            (BigInt(flow) * (10000n - BigInt(edge.variableFeeBps))) / 10000n - 1n;
+            (BigInt(flow) * (10000n - BigInt(edge.variableFeeBps))) / 10000n -
+            1n;
           details = { detail: { usdnOut } };
           break;
         }

--- a/packages/portfolio-contract/tools/plan-solve.ts
+++ b/packages/portfolio-contract/tools/plan-solve.ts
@@ -25,7 +25,7 @@ import {
   formatInfeasibleDiagnostics,
   validateSolvedFlows,
 } from './graph-diagnose.js';
-import { chainOf, makeGraphFromDefinition } from './network/buildGraph.js';
+import { chainOf, makeGraphForFlow } from './network/buildGraph.js';
 import type { FlowEdge, RebalanceGraph } from './network/buildGraph.js';
 import type { NetworkSpec } from './network/network-spec.js';
 
@@ -504,7 +504,7 @@ export const planRebalanceFlow = async (opts: {
     gasEstimator,
   } = opts;
   // TODO remove "automatic" values that should be static
-  const graph = makeGraphFromDefinition(
+  const graph = makeGraphForFlow(
     network,
     current,
     target,

--- a/packages/portfolio-contract/tools/plan-solve.ts
+++ b/packages/portfolio-contract/tools/plan-solve.ts
@@ -366,7 +366,8 @@ export const rebalanceMinCostFlowSteps = async (
    * Add 20% to a fee estimate in case the landscape changes between estimation
    * and execution.
    */
-  const padFeeEstimate = (estimate: bigint): bigint => (estimate * 120n) / 100n;
+  const padFeeEstimate = (estimate: bigint): bigint =>
+    estimate <= 0n ? estimate : (estimate * 120n - 1n) / 100n + 1n;
 
   /**
    * Ensure minimum gas is sent for an Axelar GMP transaction, to hopefully


### PR DESCRIPTION
 ...the first with floating-point major-unit values to select arcs,
the second with integer minor-unit values for precision

## Description
This started as a fix for https://github.com/Agoric/agoric-private/issues/538 , but investigation revealed that issue to be working as expected (withdrawing `currentBalances: {}` _should_ fail). But it does lay the foundation for a followup to trace flows through the graph in a partial order, which I'll be working on next.

### Security Considerations
None known.

### Scaling Considerations
Invoking LP solver logic twice will be slower than doing so once, but AFAICT not in a way that makes material difference.

### Documentation Considerations
Updated solver-approach-design.md.

### Testing Considerations
Fixes the previously-failing "solver differentiates cheapest vs. fastest" test.

### Upgrade Considerations
Safe for immediate deployment.