### PR TITLE
feat(ci): add flaky test detection mechanism

### DIFF
--- a/.github/actions/post-test/action.yml
+++ b/.github/actions/post-test/action.yml
@@ -17,6 +17,10 @@ inputs:
   mergify-token:
     description: 'token for Mergify CI Insights'
     required: true
+  job-name:
+    description: 'Job name for Mergify CI Insights (use with matrix to distinguish variations)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -59,3 +63,4 @@ runs:
         flaky_test_detection: true
         token: ${{ inputs.mergify-token }}
         report_path: 'packages/*/junit.xml'
+        job_name: ${{ inputs.job-name }}

--- a/.github/actions/post-test/action.yml
+++ b/.github/actions/post-test/action.yml
@@ -14,6 +14,9 @@ inputs:
     description: 'gcp'
     required: false
     default: ''
+  mergify-token:
+    description: 'token for Mergify CI Insights'
+    required: true
 
 runs:
   using: composite
@@ -49,3 +52,10 @@ runs:
         GCP_CREDENTIALS: ${{ inputs.gcp-credentials }}
       run: |
         node .github/actions/ci-test-result.cjs ./packages/*/_testoutput.txt
+    - name: Upload test results to Mergify CI Insights
+      if: always()
+      uses: mergifyio/gha-mergify-ci@v6
+      with:
+        flaky_test_detection: true
+        token: ${{ inputs.mergify-token }}
+        report_path: 'packages/*/junit.xml'

--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -138,10 +138,33 @@ jobs:
         working-directory: ./agoric-sdk/multichain-testing
 
       - name: Run @agoric/multichain-testing E2E Tests
-        run: ${{ inputs.test_command }}
+        run: |
+          # Enable pipefail to preserve test failure exit codes while capturing TAP output with tee.
+          # TAP output is written to _testoutput.txt as it's generated, even if tests fail.
+          set -o pipefail
+          AGORIC_AVA_USE_TAP=true ${{ inputs.test_command }} 2>&1 | tee _testoutput.txt
         working-directory: ./agoric-sdk/multichain-testing
         env:
           FILE: ${{ inputs.config }}
+
+      - name: Convert TAP to JUnit
+        if: always()
+        run: |
+          if [ -f _testoutput.txt ]; then
+            ../scripts/ava-etap-to-junit.mjs _testoutput.txt > junit.xml || true
+            echo "JUnit XML generated at multichain-testing/junit.xml"
+          else
+            echo "No TAP output found, skipping JUnit conversion"
+          fi
+        working-directory: ./agoric-sdk/multichain-testing
+
+      - name: Upload test results to Mergify CI Insights
+        if: always()
+        uses: mergifyio/gha-mergify-ci@v6
+        with:
+          flaky_test_detection: true
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: 'agoric-sdk/multichain-testing/junit.xml'
 
       - name: Capture slog.slog
         if: always()

--- a/.github/workflows/multichain-e2e-template.yml
+++ b/.github/workflows/multichain-e2e-template.yml
@@ -165,6 +165,7 @@ jobs:
           flaky_test_detection: true
           token: ${{ secrets.MERGIFY_TOKEN }}
           report_path: 'agoric-sdk/multichain-testing/junit.xml'
+          job_name: 'multichain-e2e (${{ inputs.test_suite_name }})'
 
       - name: Capture slog.slog
         if: always()

--- a/.github/workflows/multichain-e2e.yml
+++ b/.github/workflows/multichain-e2e.yml
@@ -21,7 +21,7 @@ on:
   workflow_call:
   push:
     # Temporary: ws/flaky-tests added for testing before merge
-    branches: [master, ws/flaky-tests]
+    branches: [ws/flaky-tests]
   schedule:
     # Run every 3 hours for continuous flaky test detection (orchestration-queries-hermes only)
     - cron: '0 0,3,6,9,12,15,18,21 * * *'

--- a/.github/workflows/multichain-e2e.yml
+++ b/.github/workflows/multichain-e2e.yml
@@ -19,6 +19,12 @@ on:
           - swap-on-osmosis
           - ymax-hermes
   workflow_call:
+  push:
+    # Temporary: ws/flaky-tests added for testing before merge
+    branches: [master, ws/flaky-tests]
+  schedule:
+    # Run every 3 hours for continuous flaky test detection (orchestration-queries-hermes only)
+    - cron: '0 0,3,6,9,12,15,18,21 * * *'
 
 jobs:
   orchestration-api-hermes:
@@ -101,11 +107,13 @@ jobs:
 
   orchestration-queries-hermes:
     name: Orchestration Queries - Hermes
-    # Don't run on PRs or call, only on dispatch.
-    # TODO(#11788): reenable conditions once flake is understood.
+    # Run on schedule (every 3h), push to ws/flaky-tests, or manual dispatch
+    # TODO(#11788): reenable PR/call conditions once flake is understood.
     # github.event_name == 'workflow_call' ||
     # github.event_name == 'pull_request' ||
     if: |
+      github.event_name == 'schedule' ||
+      github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' && inputs.test_type == 'orchestration-queries-hermes')
     uses: ./.github/workflows/multichain-e2e-template.yml
     with:

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -8,8 +8,8 @@ on:
   push:
     branches: [master]
   schedule:
-    # We start a little earlier to give our build cache time to populate.
-    - cron: '47 5 * * *'
+    # Run every 3 hours on the main branch for continuous flaky test detection
+    - cron: '0 0,3,6,9,12,15,18,21 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -252,20 +252,16 @@ jobs:
           from: ${{ secrets.NOTIFY_EMAIL_FROM }}
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
+      # Use always() to ensure Mergify receives test results even on cancelled runs for flaky test detection.
+      # Codecov uploads use (success() || failure()) conditions inside post-test/action.yml.
       - uses: ./.github/actions/post-test
-        if: (success() || failure())
+        if: always()
         continue-on-error: true
         timeout-minutes: 4
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Upload test results to Mergify CI Insights
-        if: always()
-        uses: mergifyio/gha-mergify-ci@v6
-        with:
-          flaky_test_detection: true
-          token: ${{ secrets.MERGIFY_TOKEN }}
-          report_path: 'packages/*/junit.xml'
+          mergify-token: ${{ secrets.MERGIFY_TOKEN }}
 
   # Verify that running `yarn codegen` in any package that defines it
   # does not produce changes. Only runs on pull requests.
@@ -417,19 +413,13 @@ jobs:
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
       - uses: ./.github/actions/post-test
-        if: (success() || failure())
+        if: always()
         continue-on-error: true
         timeout-minutes: 4
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Upload test results to Mergify CI Insights
-        if: always()
-        uses: mergifyio/gha-mergify-ci@v6
-        with:
-          flaky_test_detection: true
-          token: ${{ secrets.MERGIFY_TOKEN }}
-          report_path: 'packages/*/junit.xml'
+          mergify-token: ${{ secrets.MERGIFY_TOKEN }}
 
   ##############
   # Long-running tests are executed individually.
@@ -465,19 +455,13 @@ jobs:
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
       - uses: ./.github/actions/post-test
-        if: (success() || failure())
+        if: always()
         continue-on-error: true
         timeout-minutes: 4
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Upload test results to Mergify CI Insights
-        if: always()
-        uses: mergifyio/gha-mergify-ci@v6
-        with:
-          flaky_test_detection: true
-          token: ${{ secrets.MERGIFY_TOKEN }}
-          report_path: 'packages/*/junit.xml'
+          mergify-token: ${{ secrets.MERGIFY_TOKEN }}
 
   test-governance:
     # BEGIN-TEST-BOILERPLATE
@@ -511,19 +495,13 @@ jobs:
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
       - uses: ./.github/actions/post-test
-        if: (success() || failure())
+        if: always()
         continue-on-error: true
         timeout-minutes: 4
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Upload test results to Mergify CI Insights
-        if: always()
-        uses: mergifyio/gha-mergify-ci@v6
-        with:
-          flaky_test_detection: true
-          token: ${{ secrets.MERGIFY_TOKEN }}
-          report_path: 'packages/*/junit.xml'
+          mergify-token: ${{ secrets.MERGIFY_TOKEN }}
 
   test-solo:
     # BEGIN-TEST-BOILERPLATE
@@ -557,19 +535,13 @@ jobs:
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
       - uses: ./.github/actions/post-test
-        if: (success() || failure())
+        if: always()
         continue-on-error: true
         timeout-minutes: 4
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Upload test results to Mergify CI Insights
-        if: always()
-        uses: mergifyio/gha-mergify-ci@v6
-        with:
-          flaky_test_detection: true
-          token: ${{ secrets.MERGIFY_TOKEN }}
-          report_path: 'packages/*/junit.xml'
+          mergify-token: ${{ secrets.MERGIFY_TOKEN }}
 
   test-cosmic-swingset:
     # BEGIN-TEST-BOILERPLATE
@@ -607,19 +579,13 @@ jobs:
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
       - uses: ./.github/actions/post-test
-        if: (success() || failure())
+        if: always()
         continue-on-error: true
         timeout-minutes: 4
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Upload test results to Mergify CI Insights
-        if: always()
-        uses: mergifyio/gha-mergify-ci@v6
-        with:
-          flaky_test_detection: true
-          token: ${{ secrets.MERGIFY_TOKEN }}
-          report_path: 'packages/*/junit.xml'
+          mergify-token: ${{ secrets.MERGIFY_TOKEN }}
 
   test-inter-protocol:
     # BEGIN-TEST-BOILERPLATE
@@ -653,19 +619,13 @@ jobs:
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
       - uses: ./.github/actions/post-test
-        if: (success() || failure())
+        if: always()
         continue-on-error: true
         timeout-minutes: 4
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Upload test results to Mergify CI Insights
-        if: always()
-        uses: mergifyio/gha-mergify-ci@v6
-        with:
-          flaky_test_detection: true
-          token: ${{ secrets.MERGIFY_TOKEN }}
-          report_path: 'packages/*/junit.xml'
+          mergify-token: ${{ secrets.MERGIFY_TOKEN }}
 
   test-boot:
     # BEGIN-TEST-BOILERPLATE
@@ -704,19 +664,13 @@ jobs:
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
       - uses: ./.github/actions/post-test
-        if: (success() || failure())
+        if: always()
         continue-on-error: true
         timeout-minutes: 4
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Upload test results to Mergify CI Insights
-        if: always()
-        uses: mergifyio/gha-mergify-ci@v6
-        with:
-          flaky_test_detection: true
-          token: ${{ secrets.MERGIFY_TOKEN }}
-          report_path: 'packages/*/junit.xml'
+          mergify-token: ${{ secrets.MERGIFY_TOKEN }}
 
   test-swingset:
     # BEGIN-TEST-BOILERPLATE
@@ -761,19 +715,13 @@ jobs:
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
       - uses: ./.github/actions/post-test
-        if: (success() || failure())
+        if: always()
         continue-on-error: true
         timeout-minutes: 4
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Upload test results to Mergify CI Insights
-        if: always()
-        uses: mergifyio/gha-mergify-ci@v6
-        with:
-          flaky_test_detection: true
-          token: ${{ secrets.MERGIFY_TOKEN }}
-          report_path: 'packages/*/junit.xml'
+          mergify-token: ${{ secrets.MERGIFY_TOKEN }}
 
   test-zoe-unit:
     # BEGIN-TEST-BOILERPLATE
@@ -810,19 +758,13 @@ jobs:
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
       - uses: ./.github/actions/post-test
-        if: (success() || failure())
+        if: always()
         continue-on-error: true
         timeout-minutes: 4
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Upload test results to Mergify CI Insights
-        if: always()
-        uses: mergifyio/gha-mergify-ci@v6
-        with:
-          flaky_test_detection: true
-          token: ${{ secrets.MERGIFY_TOKEN }}
-          report_path: 'packages/*/junit.xml'
+          mergify-token: ${{ secrets.MERGIFY_TOKEN }}
 
   test-zoe-swingset:
     # BEGIN-TEST-BOILERPLATE
@@ -858,16 +800,10 @@ jobs:
           to: ${{ secrets.NOTIFY_EMAIL_TO }}
           password: ${{ secrets.NOTIFY_EMAIL_PASSWORD }}
       - uses: ./.github/actions/post-test
-        if: (success() || failure())
+        if: always()
         continue-on-error: true
         timeout-minutes: 4
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
-      - name: Upload test results to Mergify CI Insights
-        if: always()
-        uses: mergifyio/gha-mergify-ci@v6
-        with:
-          flaky_test_detection: true
-          token: ${{ secrets.MERGIFY_TOKEN }}
-          report_path: 'packages/*/junit.xml'
+          mergify-token: ${{ secrets.MERGIFY_TOKEN }}

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
   merge_group:
   push:
-    branches: [master]
+    # Temporary: ws/flaky-tests added for testing before merge
+    branches: [master, ws/flaky-tests]
   schedule:
     # Run every 3 hours on the main branch for continuous flaky test detection
     - cron: '0 0,3,6,9,12,15,18,21 * * *'

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -262,6 +262,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
           mergify-token: ${{ secrets.MERGIFY_TOKEN }}
+          job-name: 'test-quick (${{ matrix.engine }})'
 
   # Verify that running `yarn codegen` in any package that defines it
   # does not produce changes. Only runs on pull requests.
@@ -420,6 +421,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
           mergify-token: ${{ secrets.MERGIFY_TOKEN }}
+          job-name: 'test-quick2 (${{ matrix.engine }})'
 
   ##############
   # Long-running tests are executed individually.
@@ -462,6 +464,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
           mergify-token: ${{ secrets.MERGIFY_TOKEN }}
+          job-name: 'test-fast-usdc-deploy (${{ matrix.engine }})'
 
   test-governance:
     # BEGIN-TEST-BOILERPLATE
@@ -502,6 +505,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
           mergify-token: ${{ secrets.MERGIFY_TOKEN }}
+          job-name: 'test-governance (${{ matrix.engine }})'
 
   test-solo:
     # BEGIN-TEST-BOILERPLATE
@@ -542,6 +546,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
           mergify-token: ${{ secrets.MERGIFY_TOKEN }}
+          job-name: 'test-solo (${{ matrix.engine }})'
 
   test-cosmic-swingset:
     # BEGIN-TEST-BOILERPLATE
@@ -586,6 +591,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
           mergify-token: ${{ secrets.MERGIFY_TOKEN }}
+          job-name: 'test-cosmic-swingset (${{ matrix.engine }})'
 
   test-inter-protocol:
     # BEGIN-TEST-BOILERPLATE
@@ -626,6 +632,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
           mergify-token: ${{ secrets.MERGIFY_TOKEN }}
+          job-name: 'test-inter-protocol (${{ matrix.engine }})'
 
   test-boot:
     # BEGIN-TEST-BOILERPLATE
@@ -671,6 +678,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
           mergify-token: ${{ secrets.MERGIFY_TOKEN }}
+          job-name: 'test-boot (${{ matrix.engine }})'
 
   test-swingset:
     # BEGIN-TEST-BOILERPLATE
@@ -722,6 +730,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
           mergify-token: ${{ secrets.MERGIFY_TOKEN }}
+          job-name: 'test-swingset (${{ matrix.engine }})'
 
   test-zoe-unit:
     # BEGIN-TEST-BOILERPLATE
@@ -765,6 +774,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
           mergify-token: ${{ secrets.MERGIFY_TOKEN }}
+          job-name: 'test-zoe-unit (${{ matrix.engine }})'
 
   test-zoe-swingset:
     # BEGIN-TEST-BOILERPLATE
@@ -807,3 +817,4 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
           mergify-token: ${{ secrets.MERGIFY_TOKEN }}
+          job-name: 'test-zoe-swingset (${{ matrix.engine }})'

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -258,6 +258,13 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Upload test results to Mergify CI Insights
+        if: always()
+        uses: mergifyio/gha-mergify-ci@v6
+        with:
+          flaky_test_detection: true
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: 'packages/*/junit.xml'
 
   # Verify that running `yarn codegen` in any package that defines it
   # does not produce changes. Only runs on pull requests.
@@ -415,6 +422,13 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Upload test results to Mergify CI Insights
+        if: always()
+        uses: mergifyio/gha-mergify-ci@v6
+        with:
+          flaky_test_detection: true
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: 'packages/*/junit.xml'
 
   ##############
   # Long-running tests are executed individually.
@@ -456,6 +470,13 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Upload test results to Mergify CI Insights
+        if: always()
+        uses: mergifyio/gha-mergify-ci@v6
+        with:
+          flaky_test_detection: true
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: 'packages/*/junit.xml'
 
   test-governance:
     # BEGIN-TEST-BOILERPLATE
@@ -495,6 +516,13 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Upload test results to Mergify CI Insights
+        if: always()
+        uses: mergifyio/gha-mergify-ci@v6
+        with:
+          flaky_test_detection: true
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: 'packages/*/junit.xml'
 
   test-solo:
     # BEGIN-TEST-BOILERPLATE
@@ -534,6 +562,13 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Upload test results to Mergify CI Insights
+        if: always()
+        uses: mergifyio/gha-mergify-ci@v6
+        with:
+          flaky_test_detection: true
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: 'packages/*/junit.xml'
 
   test-cosmic-swingset:
     # BEGIN-TEST-BOILERPLATE
@@ -577,6 +612,13 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Upload test results to Mergify CI Insights
+        if: always()
+        uses: mergifyio/gha-mergify-ci@v6
+        with:
+          flaky_test_detection: true
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: 'packages/*/junit.xml'
 
   test-inter-protocol:
     # BEGIN-TEST-BOILERPLATE
@@ -616,6 +658,13 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Upload test results to Mergify CI Insights
+        if: always()
+        uses: mergifyio/gha-mergify-ci@v6
+        with:
+          flaky_test_detection: true
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: 'packages/*/junit.xml'
 
   test-boot:
     # BEGIN-TEST-BOILERPLATE
@@ -660,6 +709,13 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Upload test results to Mergify CI Insights
+        if: always()
+        uses: mergifyio/gha-mergify-ci@v6
+        with:
+          flaky_test_detection: true
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: 'packages/*/junit.xml'
 
   test-swingset:
     # BEGIN-TEST-BOILERPLATE
@@ -710,6 +766,13 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Upload test results to Mergify CI Insights
+        if: always()
+        uses: mergifyio/gha-mergify-ci@v6
+        with:
+          flaky_test_detection: true
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: 'packages/*/junit.xml'
 
   test-zoe-unit:
     # BEGIN-TEST-BOILERPLATE
@@ -752,6 +815,13 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Upload test results to Mergify CI Insights
+        if: always()
+        uses: mergifyio/gha-mergify-ci@v6
+        with:
+          flaky_test_detection: true
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: 'packages/*/junit.xml'
 
   test-zoe-swingset:
     # BEGIN-TEST-BOILERPLATE
@@ -793,3 +863,10 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           gcp-credentials: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Upload test results to Mergify CI Insights
+        if: always()
+        uses: mergifyio/gha-mergify-ci@v6
+        with:
+          flaky_test_detection: true
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: 'packages/*/junit.xml'

--- a/scripts/ava-etap-to-junit.mjs
+++ b/scripts/ava-etap-to-junit.mjs
@@ -1,0 +1,154 @@
+#! /usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import process from 'node:process';
+
+const resultFile = process.argv[2] || 'results.txt';
+const resultsBody = fs.readFileSync(resultFile, 'utf-8');
+
+const packageTestRegex = new RegExp(`> (.+?)@(.+?) test$`, 'gms');
+
+const tapResultRegex = new RegExp(
+  `(^(?<status>not )?ok (?<num>[0-9]+) - (?<name>.+?)(?: %ava-dur=(?<duration>[0-9]+)ms)?(?:# (?<comments>.+?))?$(?<output>(\n^#.+?$)*)(?<failure>(\n^(?:(?!(?:not|ok) )).+?$)*))`,
+  'gms',
+);
+console.log(`<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>`);
+
+const lines = resultsBody.split(/\n/);
+let buffer = [];
+let currentSuite = null;
+
+function runtimeProp() {
+  console.log(`<properties>`);
+  if (process.env.GH_ENGINE) {
+    console.log(
+      `  <property name="dd_tags[runtime.name]" value="${process.env.GH_ENGINE}"></property>`,
+    );
+    if (process.env.GH_ENGINE !== 'xs') {
+      console.log(
+        `  <property name="dd_tags[runtime.version]" value="${process.version}"></property>`,
+      );
+    }
+  }
+
+  if (typeof os.machine === 'function') {
+    console.log(
+      `  <property name="dd_tags[runtime.architecture]" value="${os.machine()}"></property>`,
+    );
+  }
+  if (typeof os.platform === 'function') {
+    console.log(
+      `  <property name="dd_tags[os.platform]" value="${os.platform()}"></property>`,
+    );
+  }
+  if (typeof os.release === 'function') {
+    console.log(
+      `  <property name="dd_tags[os.version]" value="${os.release()}"></property>`,
+    );
+  }
+  console.log(`</properties>`);
+}
+
+function processTAP(tapbody) {
+  let m;
+  // eslint-disable-next-line no-cond-assign
+  while ((m = tapResultRegex.exec(tapbody))) {
+    if (m.groups.name) {
+      const testCaseName = `${m.groups.name}`.replace(/["<>]/g, '').trim();
+
+      console.log(
+        `<testcase name="${testCaseName}"`.concat(
+          m.groups.duration
+            ? ` time="${parseInt(m.groups.duration, 10) / 1000.0}"`
+            : '',
+          '>',
+        ),
+      );
+
+      let skipped = false;
+      let succeeded = true;
+      let todo = false;
+      if (m.groups.status) {
+        succeeded = false;
+      }
+      if (m.groups.comments) {
+        if (m.groups.comments.match(/SKIP/gi)) {
+          skipped = true;
+        }
+        if (m.groups.comments.match(/TODO/gi)) {
+          todo = true;
+          skipped = true;
+          succeeded = true;
+        }
+      }
+
+      if (!succeeded) {
+        if (m.groups.failure) {
+          console.log(`<failure>`);
+          console.log(`<![CDATA[`);
+          console.log(m.groups.failure.trim());
+          console.log(`]]>`);
+          console.log(`</failure>`);
+        } else {
+          console.log(`<failure />`);
+        }
+      }
+
+      if (skipped) {
+        const why = todo ? 'todo' : '';
+        console.log(`<skipped message="${why}" />`);
+      }
+
+      if (m.groups.output !== undefined && m.groups.output.length > 0) {
+        const output = m.groups.output.replace(/"/g, '');
+        console.log(`<system-out>`);
+        console.log(`<![CDATA[`);
+        console.log(
+          output
+            .trim()
+            .split(`\n`)
+            .map(item => item.replace(/^# {3}/g, ''))
+            .join(`\n`),
+        );
+        console.log(`]]>`);
+
+        console.log(`</system-out>`);
+      }
+      console.log('</testcase>');
+    }
+  }
+}
+
+for (let i = 0; i < lines.length; i += 1) {
+  const suiteName = packageTestRegex.exec(lines[i]);
+  if (suiteName !== null) {
+    if (buffer.length > 0) {
+      processTAP(buffer.join(`\n`));
+    }
+    if (currentSuite !== null) {
+      console.log('</testsuite>');
+    }
+    buffer = [];
+    currentSuite = suiteName[1].replace(/@/g, '');
+    console.log(`<testsuite name="${currentSuite}">`);
+    runtimeProp();
+    i += 1;
+    continue;
+  }
+  buffer.push(lines[i]);
+}
+
+if (currentSuite === null) {
+  // try to get package name from input path
+  currentSuite = `agoric.${resultFile.split(path.sep).slice(-2, -1)[0]}`;
+  console.log(`<testsuite name="${currentSuite}">`);
+  runtimeProp();
+}
+
+if (buffer.length > 0) {
+  processTAP(buffer.join(`\n`));
+}
+
+console.log('</testsuite></testsuites>');

--- a/scripts/ci/collect-testruns.sh
+++ b/scripts/ci/collect-testruns.sh
@@ -2,6 +2,18 @@
 set -o xtrace
 SCRIPT_DIR=$(cd ${0%/*} && pwd -P)
 
+# Convert TAP to JUnit for each package
+for pkg in ./packages/*/_testoutput.txt; do
+  # skip if unable to expand if there are no test files
+  if [[ $pkg != "./packages/*/_testoutput.txt" ]]; then
+    echo "processing $pkg"
+    junit=$(dirname "$pkg")/junit.xml
+    echo "dest $junit"
+    $SCRIPT_DIR/../ava-etap-to-junit.mjs $pkg > $junit
+  fi
+done
+
+# Generate coverage reports
 for cov in ./packages/**/coverage; do
   # skip if unable to expand if there are no test files
   if [[ $cov != "./packages/**/coverage" ]]; then

--- a/scripts/ci/collect-testruns.sh
+++ b/scripts/ci/collect-testruns.sh
@@ -9,7 +9,7 @@ for pkg in ./packages/*/_testoutput.txt; do
     echo "processing $pkg"
     junit=$(dirname "$pkg")/junit.xml
     echo "dest $junit"
-    $SCRIPT_DIR/../ava-etap-to-junit.mjs $pkg > $junit
+    $SCRIPT_DIR/../ava-etap-to-junit.mjs $pkg > $junit || true
   fi
 done
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX 
refs: https://github.com/Agoric/agoric-sdk/issues/11788, http://github.com/Agoric/agoric-sdk/issues/11175, https://github.com/Agoric/agoric-sdk/issues/11789, https://github.com/Agoric/agoric-sdk/issues/10173, https://github.com/Agoric/agoric-sdk/issues/3981, https://github.com/Agoric/agoric-sdk/issues/5951, https://github.com/Agoric/agoric-sdk/issues/10142, https://github.com/Agoric/agoric-sdk/issues/9934, https://github.com/Agoric/agoric-sdk/issues/5575, https://github.com/Agoric/agoric-sdk/issues/9392, https://github.com/Agoric/agoric-3-proposals/issues/54, https://github.com/Agoric/agoric-sdk/issues/9188

## Description
This PR enhances the CI pipeline with continuous flaky test detection by adding scheduled runs and Mergify CI Insights integration. It restores the TAP to JUnit XML conversion that was previously removed during DataDog cleanup, ensuring test results are properly formatted for Mergify analysis. The ws/flaky-tests branch is temporarily added to triggers for testing purposes and will be removed before merging to master.

### Security Considerations
No new security assumptions or authorities introduced. This PR requires MERGIFY_TOKEN secret to be configured with scoped permissions for uploading test results to Mergify CI Insights.

### Scaling Considerations
No impact on CPU, RAM, on-chain storage, or runtime message exchanges as changes are CI-only.

### Documentation Considerations
No documentation updates required for downstream users.

### Testing Considerations
This PR establishes the flaky test detection infrastructure itself. 

### Upgrade Considerations
No upgrade steps required for live production systems. 
Verification: confirm scheduled workflow runs appear in GitHub Actions after merge to master, and check Mergify CI Insights dashboard populates with test results within 24 hours.
