### PR TITLE
chore(ymax-resolver): stop watchers on manual transaction resolution

### DIFF
--- a/services/ymax-planner/scripts/process-tx-lib.ts
+++ b/services/ymax-planner/scripts/process-tx-lib.ts
@@ -189,6 +189,7 @@ export const processTx = async (
         signingSmartWalletKit,
         vstoragePathPrefixes,
         axelarApiUrl: config.axelar.apiUrl,
+        pendingTxAbortControllers: new Map(),
       });
 
       // Get the block timestamp for lookback mode

--- a/services/ymax-planner/scripts/process-tx-lib.ts
+++ b/services/ymax-planner/scripts/process-tx-lib.ts
@@ -204,8 +204,7 @@ export const processTx = async (
       );
 
       // Process the transaction with lookback mode
-      const abortController = new AbortController();
-      await handlePendingTx(tx, txPowers, timestampMs, abortController.signal);
+      await handlePendingTx(tx, { ...txPowers, txTimestampMs: timestampMs });
 
       console.log(`\n✅ Transaction ${txId} processing complete!\n`);
     } catch (err) {

--- a/services/ymax-planner/scripts/process-tx-lib.ts
+++ b/services/ymax-planner/scripts/process-tx-lib.ts
@@ -204,7 +204,8 @@ export const processTx = async (
       );
 
       // Process the transaction with lookback mode
-      await handlePendingTx(tx, txPowers, timestampMs);
+      const abortController = new AbortController();
+      await handlePendingTx(tx, txPowers, timestampMs, abortController.signal);
 
       console.log(`\n✅ Transaction ${txId} processing complete!\n`);
     } catch (err) {

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -523,11 +523,14 @@ export const processPendingTxEvents = async (
       pendingTxAbortControllers.set(txId, abortController);
 
       // Tx resolution is non-blocking.
-      void handlePendingTxFn(tx, txPowers, undefined, abortController.signal)
-        .catch(err => error(errLabel, err))
-        .finally(() => {
-          pendingTxAbortControllers.delete(txId);
-        });
+      void handlePendingTxFn(
+        tx,
+        txPowers,
+        undefined,
+        abortController.signal,
+      ).finally(() => {
+        pendingTxAbortControllers.delete(txId);
+      });
     } catch (err) {
       error(errLabel, data, err);
     }
@@ -587,7 +590,6 @@ export const processInitialPendingTransactions = async (
 
     if (timestampMs === undefined) return;
 
-    const errLabel = `🚨 Failed to process pending tx ${tx.txId} with lookback`;
     log(`Processing pending tx ${tx.txId} with lookback`);
 
     const abortController = txPowers.makeAbortController();
@@ -595,11 +597,14 @@ export const processInitialPendingTransactions = async (
 
     // TODO: Optimize blockchain scanning by reusing state across transactions.
     // For details, see: https://github.com/Agoric/agoric-sdk/issues/11945
-    void handlePendingTxFn(tx, txPowers, timestampMs, abortController.signal)
-      .catch(err => error(errLabel, err))
-      .finally(() => {
-        pendingTxAbortControllers.delete(tx.txId);
-      });
+    void handlePendingTxFn(
+      tx,
+      txPowers,
+      timestampMs,
+      abortController.signal,
+    ).finally(() => {
+      pendingTxAbortControllers.delete(tx.txId);
+    });
   }).done;
 };
 

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -526,12 +526,10 @@ export const processPendingTxEvents = async (
       );
 
       // Tx resolution is non-blocking.
-      void handlePendingTxFn(
-        tx,
-        txPowers,
-        undefined,
-        abortController.signal,
-      ).finally(() => {
+      void handlePendingTxFn(tx, {
+        ...txPowers,
+        signal: abortController.signal,
+      }).finally(() => {
         pendingTxAbortControllers.delete(txId);
       });
     } catch (err) {
@@ -603,12 +601,11 @@ export const processInitialPendingTransactions = async (
 
     // TODO: Optimize blockchain scanning by reusing state across transactions.
     // For details, see: https://github.com/Agoric/agoric-sdk/issues/11945
-    void handlePendingTxFn(
-      tx,
-      txPowers,
-      timestampMs,
-      abortController.signal,
-    ).finally(() => {
+    void handlePendingTxFn(tx, {
+      ...txPowers,
+      txTimestampMs: timestampMs,
+      signal: abortController.signal,
+    }).finally(() => {
       pendingTxAbortControllers.delete(tx.txId);
     });
   }).done;

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -519,8 +519,11 @@ export const processPendingTxEvents = async (
       const tx = { txId, ...data } as PendingTx;
       log('New pending tx', tx);
 
-      const abortController = txPowers.makeAbortController();
-      pendingTxAbortControllers.set(txId, abortController);
+      const abortController = provideLazyMap(
+        pendingTxAbortControllers,
+        txId,
+        () => txPowers.makeAbortController(),
+      );
 
       // Tx resolution is non-blocking.
       void handlePendingTxFn(
@@ -592,8 +595,11 @@ export const processInitialPendingTransactions = async (
 
     log(`Processing pending tx ${tx.txId} with lookback`);
 
-    const abortController = txPowers.makeAbortController();
-    pendingTxAbortControllers.set(tx.txId, abortController);
+    const abortController = provideLazyMap(
+      pendingTxAbortControllers,
+      tx.txId,
+      () => txPowers.makeAbortController(),
+    );
 
     // TODO: Optimize blockchain scanning by reusing state across transactions.
     // For details, see: https://github.com/Agoric/agoric-sdk/issues/11945

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -124,7 +124,7 @@ const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
     } else {
       // Lookback mode with concurrent live watching
       // Start live mode now in case the txId has not yet appeared
-      const abortController = new AbortController();
+      const abortController = ctx.makeAbortController();
 
       // If external signal is aborted, abort internal controller
       const handleExternalAbort = () => {
@@ -245,7 +245,7 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
       // Strategy: Run both live and lookback concurrently. Whichever finds the
       // transaction first aborts the other. This ensures we don't miss the
       // transaction (lookback covers history, live covers new events).
-      const abortController = new AbortController();
+      const abortController = ctx.makeAbortController();
 
       // If external signal is aborted, abort internal controller
       const handleExternalAbort = () => {
@@ -384,7 +384,7 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
         signal: opts.signal,
       });
     } else {
-      const abortController = new AbortController();
+      const abortController = ctx.makeAbortController();
 
       // If external signal is aborted, abort internal controller
       const handleExternalAbort = () => {

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -179,6 +179,10 @@ const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
       }
     }
 
+    if (opts.signal.aborted) {
+      return;
+    }
+
     await resolvePendingTx({
       signingSmartWalletKit: ctx.signingSmartWalletKit,
       txId,
@@ -301,6 +305,10 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
       }
     }
 
+    if (opts.signal.aborted) {
+      return;
+    }
+
     await resolvePendingTx({
       signingSmartWalletKit: ctx.signingSmartWalletKit,
       txId,
@@ -405,6 +413,10 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
       } finally {
         opts.signal.removeEventListener('abort', handleExternalAbort);
       }
+    }
+
+    if (opts.signal.aborted) {
+      return;
     }
 
     await resolvePendingTx({

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -58,12 +58,12 @@ type CctpTx = PendingTx & { type: typeof TxType.CCTP_TO_EVM; amount: bigint };
 type GmpTx = PendingTx & { type: typeof TxType.GMP };
 type MakeAccountTx = PendingTx & { type: typeof TxType.MAKE_ACCOUNT };
 
-type LiveWatchOpts = { mode: 'live'; timeoutMs: number; signal?: AbortSignal };
+type LiveWatchOpts = { mode: 'live'; timeoutMs: number; signal: AbortSignal };
 type LookBackWatchOpts = {
   mode: 'lookback';
   publishTimeMs: number;
   timeoutMs: number;
-  signal?: AbortSignal;
+  signal: AbortSignal;
 };
 type WatchOpts = LiveWatchOpts | LookBackWatchOpts;
 
@@ -86,7 +86,7 @@ const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
     const { txId, destinationAddress, amount } = tx;
     const logPrefix = `[${txId}]`;
 
-    if (opts.signal?.aborted) {
+    if (opts.signal.aborted) {
       log(`${logPrefix} CCTP watch aborted before starting`);
       return;
     }
@@ -127,12 +127,10 @@ const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
       const abortController = new AbortController();
 
       // If external signal is aborted, abort internal controller
-      if (opts.signal) {
-        opts.signal.addEventListener('abort', () => {
-          log(`${logPrefix} External abort signal received`);
-          abortController.abort();
-        });
-      }
+      opts.signal.addEventListener('abort', () => {
+        log(`${logPrefix} External abort signal received`);
+        abortController.abort();
+      });
 
       const liveResultP = watchCctpTransfer({
         ...watchArgs,
@@ -193,7 +191,7 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
     const { txId, destinationAddress } = tx;
     const logPrefix = `[${txId}]`;
 
-    if (opts.signal?.aborted) {
+    if (opts.signal.aborted) {
       log(`${logPrefix} GMP watch aborted before starting`);
       return;
     }
@@ -234,12 +232,10 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
       const abortController = new AbortController();
 
       // If external signal is aborted, abort internal controller
-      if (opts.signal) {
-        opts.signal.addEventListener('abort', () => {
-          log(`${logPrefix} External abort signal received`);
-          abortController.abort();
-        });
-      }
+      opts.signal.addEventListener('abort', () => {
+        log(`${logPrefix} External abort signal received`);
+        abortController.abort();
+      });
 
       const liveResultP = watchGmp({
         ...watchArgs,
@@ -317,7 +313,7 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
     const { txId, expectedAddr, destinationAddress } = tx;
     const logPrefix = `[${txId}]`;
 
-    if (opts.signal?.aborted) {
+    if (opts.signal.aborted) {
       log(`${logPrefix} MAKE_ACCOUNT watch aborted before starting`);
       return;
     }
@@ -356,12 +352,10 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
       const abortController = new AbortController();
 
       // If external signal is aborted, abort internal controller
-      if (opts.signal) {
-        opts.signal.addEventListener('abort', () => {
-          log(`${logPrefix} External abort signal received`);
-          abortController.abort();
-        });
-      }
+      opts.signal.addEventListener('abort', () => {
+        log(`${logPrefix} External abort signal received`);
+        abortController.abort();
+      });
 
       const liveResultP = watchSmartWalletTx({
         ...watchArgs,
@@ -432,14 +426,14 @@ export const TX_TIMEOUT_MS = 30 * 60 * 1000; // 30 min
 export const handlePendingTx = async (
   tx: PendingTx,
   { log = () => {}, timeoutMs = TX_TIMEOUT_MS, ...evmCtx }: HandlePendingTxOpts,
-  txTimestampMs?: number,
-  signal?: AbortSignal,
+  txTimestampMs: number | undefined,
+  signal: AbortSignal,
 ) => {
   await null;
   const logPrefix = `[${tx.txId}]`;
   log(`${logPrefix} handling ${tx.type} tx`);
 
-  if (signal?.aborted) {
+  if (signal.aborted) {
     log(`${logPrefix} watch aborted before starting`);
     return;
   }

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -459,20 +459,16 @@ export const handlePendingTx = async (
     MONITORS.get(tx.type) ||
     Fail`${logPrefix} No monitor registered for tx type: ${tx.type}`;
 
+  const watchOpts: Omit<WatchOpts, 'mode'> = { timeoutMs, signal };
   try {
     if (txTimestampMs) {
       await monitor.watch(evmCtx, tx, log, {
         mode: 'lookback',
         publishTimeMs: txTimestampMs,
-        timeoutMs,
-        signal,
+        ...watchOpts,
       });
     } else {
-      await monitor.watch(evmCtx, tx, log, {
-        mode: 'live',
-        timeoutMs,
-        signal,
-      });
+      await monitor.watch(evmCtx, tx, log, { mode: 'live', ...watchOpts });
     }
   } catch (err) {
     const mode = txTimestampMs ? 'with lookback' : 'in live mode';

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -41,6 +41,14 @@ type AxelarScanOptions = {
   axelarApiUrl: string;
 };
 
+/** Watches for GMP transaction completion in live mode by listening to MulticallStatus
+ * and MulticallExecuted events. On timeout, queries Axelarscan to detect failures.
+ *
+ * NOTE: This watcher has a different API than other watchers (watchCctpTransfer,
+ * watchSmartWalletTx) because it tracks both success AND failure(via AxelarScan) states.
+ * Other watchers only detect success events. The Axelarscan dependency has been unreliable
+ * and this watcher will be refactored/removed in the future to align with other watchers.
+ */
 export const watchGmp = ({
   provider,
   contractAddress,

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -41,7 +41,8 @@ type AxelarScanOptions = {
   axelarApiUrl: string;
 };
 
-/** Watches for GMP transaction completion in live mode by listening to MulticallStatus
+/**
+ * Watches for GMP transaction completion in live mode by listening to MulticallStatus
  * and MulticallExecuted events. On timeout, queries Axelarscan to detect failures.
  *
  * NOTE: This watcher has a different API than other watchers (watchCctpTransfer,

--- a/services/ymax-planner/test/abort-signal.test.ts
+++ b/services/ymax-planner/test/abort-signal.test.ts
@@ -1,0 +1,321 @@
+import test from 'ava';
+import { handlePendingTx } from '../src/pending-tx-manager.ts';
+import { createMockPendingTxOpts } from './mocks.ts';
+import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
+import { createMockPendingTxData } from '@aglocal/portfolio-contract/tools/mocks.ts';
+
+test('handlePendingTx aborts CCTP watcher in live mode when signal is aborted', async t => {
+  const logs: string[] = [];
+  const mockLog = (...args: unknown[]) => logs.push(args.join(' '));
+
+  const txId = 'tx1';
+  const txAmount = 1_000_000n;
+  const recipientAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const destinationAddress = `eip155:42161:${recipientAddress}`;
+  const chainId = 'eip155:42161';
+
+  const cctpTx = createMockPendingTxData({
+    type: TxType.CCTP_TO_EVM,
+    amount: txAmount,
+    destinationAddress,
+  });
+
+  const opts = createMockPendingTxOpts();
+  const mockProvider = opts.evmProviders[chainId] as any;
+
+  mockProvider.getLogs = async () => [];
+
+  const abortController = new AbortController();
+
+  const watchPromise = handlePendingTx(
+    { txId, ...cctpTx },
+    {
+      ...opts,
+      log: mockLog,
+      timeoutMs: 5000,
+    },
+    undefined,
+    abortController.signal,
+  );
+
+  setTimeout(() => {
+    mockLog('[TEST] Aborting signal');
+    abortController.abort();
+  }, 100);
+
+  await watchPromise;
+
+  t.deepEqual(logs, [
+    `[${txId}] handling ${TxType.CCTP_TO_EVM} tx`,
+    `[${txId}] Watching for ERC-20 transfers to: ${recipientAddress} with amount: ${txAmount}`,
+    '[TEST] Aborting signal',
+  ]);
+});
+
+test('handlePendingTx aborts GMP watcher in live mode when signal is aborted', async t => {
+  const logs: string[] = [];
+  const mockLog = (...args: unknown[]) => logs.push(args.join(' '));
+
+  const contractAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const destinationAddress = `eip155:42161:${contractAddress}`;
+  const txId = 'tx2' as `tx${number}`;
+
+  const gmpTx = createMockPendingTxData({
+    type: TxType.GMP,
+    destinationAddress,
+  });
+
+  const chainId = 'eip155:42161';
+  const opts = createMockPendingTxOpts();
+  const mockProvider = opts.evmProviders[chainId] as any;
+
+  mockProvider.getLogs = async () => [];
+
+  const ctxWithFetch = harden({
+    ...opts,
+    fetch: async (url: string) => {
+      return {
+        ok: true,
+        json: async () => ({
+          data: [],
+        }),
+      } as Response;
+    },
+  });
+
+  const abortController = new AbortController();
+
+  const watchPromise = handlePendingTx(
+    { txId, ...gmpTx },
+    {
+      ...ctxWithFetch,
+      log: mockLog,
+      timeoutMs: 5000,
+    },
+    undefined,
+    abortController.signal,
+  ).catch(err => {
+    // GMP watcher can throw WATCH_GMP_ABORTED when aborted, which is expected
+    if (err !== 'WATCH_GMP_ABORTED') {
+      throw err;
+    }
+  });
+
+  setTimeout(() => {
+    mockLog('[TEST] Aborting signal');
+    abortController.abort();
+  }, 100);
+
+  await watchPromise;
+
+  t.deepEqual(logs, [
+    `[${txId}] handling ${TxType.GMP} tx`,
+    `[${txId}] Watching for MulticallStatus and MulticallExecuted events for txId: ${txId} at contract: ${contractAddress}`,
+    '[TEST] Aborting signal',
+  ]);
+});
+
+test('handlePendingTx exits early if signal is already aborted before starting', async t => {
+  const logs: string[] = [];
+  const mockLog = (...args: unknown[]) => logs.push(args.join(' '));
+
+  const txId = 'tx1';
+  const txAmount = 1_000_000n;
+  const recipientAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const destinationAddress = `eip155:42161:${recipientAddress}`;
+
+  const cctpTx = createMockPendingTxData({
+    type: TxType.CCTP_TO_EVM,
+    amount: txAmount,
+    destinationAddress,
+  });
+
+  const opts = createMockPendingTxOpts();
+  const abortController = new AbortController();
+
+  // Abort BEFORE starting the watcher
+  abortController.abort();
+
+  await handlePendingTx(
+    { txId, ...cctpTx },
+    {
+      ...opts,
+      log: mockLog,
+      timeoutMs: 3000,
+    },
+    undefined,
+    abortController.signal,
+  );
+
+  // Should log that it's handling the tx and then abort immediately
+  t.deepEqual(logs, [
+    `[${txId}] handling ${TxType.CCTP_TO_EVM} tx`,
+    `[${txId}] watch aborted before starting`,
+  ]);
+});
+
+test('handlePendingTx aborts CCTP watcher in lookback mode when signal is aborted', async t => {
+  const logs: string[] = [];
+  const mockLog = (...args: unknown[]) => logs.push(args.join(' '));
+
+  const txId = 'tx1';
+  const txAmount = 1_000_000n;
+  const recipientAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const destinationAddress = `eip155:42161:${recipientAddress}`;
+  const chainId = 'eip155:42161';
+
+  const cctpTx = createMockPendingTxData({
+    type: TxType.CCTP_TO_EVM,
+    amount: txAmount,
+    destinationAddress,
+  });
+
+  const opts = createMockPendingTxOpts();
+  const mockProvider = opts.evmProviders[chainId] as any;
+
+  const currentTimeMs = 1700000000;
+  const txTimestampMs = currentTimeMs - 31 * 60 * 1000; // 31 min ago
+  const avgBlockTimeMs = 300;
+  const latestBlock = 1_450_031;
+
+  mockProvider.getBlockNumber = async () => latestBlock;
+  mockProvider.getBlock = async (blockNumber: number) => {
+    const blocksAgo = latestBlock - blockNumber;
+    const ts = currentTimeMs - blocksAgo * avgBlockTimeMs;
+    return { timestamp: Math.floor(ts / 1000) };
+  };
+
+  // Make getLogs take a long time to simulate scanning many blocks
+  mockProvider.getLogs = async () => {
+    await new Promise(resolve => setTimeout(resolve, 200));
+    return [];
+  };
+
+  setTimeout(() => mockProvider.emit('block', latestBlock + 1), 10);
+
+  const abortController = new AbortController();
+
+  const watchPromise = handlePendingTx(
+    { txId, ...cctpTx },
+    {
+      ...opts,
+      log: mockLog,
+      timeoutMs: 10000,
+    },
+    txTimestampMs,
+    abortController.signal,
+  );
+
+  // Abort after 150ms - should interrupt the lookback scan
+  setTimeout(() => {
+    mockLog('[TEST] Aborting signal');
+    abortController.abort();
+  }, 150);
+
+  await watchPromise;
+
+  const fromBlock = 1442834;
+  const toBlock = latestBlock;
+
+  t.deepEqual(logs, [
+    `[${txId}] handling ${TxType.CCTP_TO_EVM} tx`,
+    `[${txId}] Watching for ERC-20 transfers to: ${recipientAddress} with amount: ${txAmount}`,
+    `[${txId}] Searching blocks ${fromBlock} → ${toBlock} for Transfer to ${recipientAddress} with amount ${txAmount}`,
+    `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${fromBlock + 9}`,
+    '[TEST] Aborting signal',
+    `[${txId}] External abort signal received`,
+    `[${txId}] [LogScan] Aborted`,
+    `[${txId}] No matching transfer found`,
+    `[${txId}] Lookback completed without finding transaction, waiting for live mode`,
+  ]);
+});
+
+test('handlePendingTx aborts GMP watcher in lookback mode when signal is aborted', async t => {
+  const logs: string[] = [];
+  const mockLog = (...args: unknown[]) => logs.push(args.join(' '));
+
+  const contractAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const destinationAddress = `eip155:42161:${contractAddress}`;
+  const txId = 'tx2' as `tx${number}`;
+
+  const gmpTx = createMockPendingTxData({
+    type: TxType.GMP,
+    destinationAddress,
+  });
+
+  const chainId = 'eip155:42161';
+  const opts = createMockPendingTxOpts();
+  const mockProvider = opts.evmProviders[chainId] as any;
+
+  const currentTimeMs = 1700000000;
+  const txTimestampMs = currentTimeMs - 10 * 1000; // 10 seconds ago
+  const avgBlockTimeMs = 300;
+  const latestBlock = 1_450_031;
+
+  mockProvider.getBlockNumber = async () => latestBlock;
+  mockProvider.getBlock = async (blockNumber: number) => {
+    const blocksAgo = latestBlock - blockNumber;
+    const ts = currentTimeMs - blocksAgo * avgBlockTimeMs;
+    return { timestamp: Math.floor(ts / 1000) };
+  };
+
+  mockProvider.getLogs = async () => {
+    await new Promise(resolve => setTimeout(resolve, 200));
+    return [];
+  };
+
+  setTimeout(() => mockProvider.emit('block', latestBlock + 1), 10);
+
+  const ctxWithFetch = harden({
+    ...opts,
+    fetch: async (url: string) => {
+      return {
+        ok: true,
+        json: async () => ({
+          data: [],
+        }),
+      } as Response;
+    },
+  });
+
+  const abortController = new AbortController();
+
+  const watchPromise = handlePendingTx(
+    { txId, ...gmpTx },
+    {
+      ...ctxWithFetch,
+      log: mockLog,
+      timeoutMs: 10000,
+    },
+    txTimestampMs,
+    abortController.signal,
+  ).catch(err => {
+    // GMP watcher can throw WATCH_GMP_ABORTED when aborted, which is expected
+    if (err !== 'WATCH_GMP_ABORTED') {
+      throw err;
+    }
+  });
+
+  setTimeout(() => {
+    mockLog('[TEST] Aborting signal');
+    abortController.abort();
+  }, 150);
+
+  await watchPromise;
+
+  const fromBlock = 1449000;
+  const toBlock = latestBlock;
+
+  t.deepEqual(logs, [
+    `[${txId}] handling ${TxType.GMP} tx`,
+    `[${txId}] Watching for MulticallStatus and MulticallExecuted events for txId: ${txId} at contract: ${contractAddress}`,
+    `[${txId}] Searching blocks ${fromBlock}/${fromBlock} → ${toBlock} for MulticallStatus or MulticallExecuted with txId ${txId} at ${contractAddress}`,
+    `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${fromBlock + 9}`,
+    `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${fromBlock + 9}`,
+    '[TEST] Aborting signal',
+    `[${txId}] External abort signal received`,
+    `[${txId}] [LogScan] Aborted`,
+    `[${txId}] No matching MulticallStatus or MulticallExecuted found`,
+    `[${txId}] Lookback completed without finding transaction, waiting for live mode`,
+  ]);
+});

--- a/services/ymax-planner/test/abort-signal.test.ts
+++ b/services/ymax-planner/test/abort-signal.test.ts
@@ -49,9 +49,8 @@ test('handlePendingTx aborts CCTP watcher in live mode when signal is aborted', 
       ...opts,
       log: mockLog,
       timeoutMs: 5000,
+      signal: abortController.signal,
     },
-    undefined,
-    abortController.signal,
   );
 
   setTimeout(() => {
@@ -126,9 +125,8 @@ test('handlePendingTx aborts GMP watcher in live mode when signal is aborted', a
       ...ctxWithFetch,
       log: mockLog,
       timeoutMs: 5000,
+      signal: abortController.signal,
     },
-    undefined,
-    abortController.signal,
   ).catch(err => {
     // GMP watcher can throw WATCH_GMP_ABORTED when aborted, which is expected
     if (err !== 'WATCH_GMP_ABORTED') {
@@ -185,15 +183,14 @@ test('handlePendingTx exits early if signal is already aborted before starting',
       ...opts,
       log: mockLog,
       timeoutMs: 3000,
+      signal: abortController.signal,
     },
-    undefined,
-    abortController.signal,
   );
 
   // Should log that it's handling the tx and then abort immediately
   t.deepEqual(logs, [
     `[${txId}] handling ${TxType.CCTP_TO_EVM} tx`,
-    `[${txId}] watch aborted before starting`,
+    `[${txId}] CCTP watch aborted before starting`,
   ]);
 });
 
@@ -244,9 +241,9 @@ test('handlePendingTx aborts CCTP watcher in lookback mode when signal is aborte
       ...opts,
       log: mockLog,
       timeoutMs: 10000,
+      txTimestampMs,
+      signal: abortController.signal,
     },
-    txTimestampMs,
-    abortController.signal,
   );
 
   // Abort after 150ms - should interrupt the lookback scan
@@ -266,7 +263,6 @@ test('handlePendingTx aborts CCTP watcher in lookback mode when signal is aborte
     `[${txId}] Searching blocks ${fromBlock} → ${toBlock} for Transfer to ${recipientAddress} with amount ${txAmount}`,
     `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${fromBlock + 9}`,
     '[TEST] Aborting signal',
-    `[${txId}] External abort signal received`,
     `[${txId}] [LogScan] Aborted`,
     `[${txId}] No matching transfer found`,
     `[${txId}] Lookback completed without finding transaction, waiting for live mode`,
@@ -329,9 +325,9 @@ test('handlePendingTx aborts GMP watcher in lookback mode when signal is aborted
       ...ctxWithFetch,
       log: mockLog,
       timeoutMs: 10000,
+      txTimestampMs,
+      signal: abortController.signal,
     },
-    txTimestampMs,
-    abortController.signal,
   ).catch(err => {
     // GMP watcher can throw WATCH_GMP_ABORTED when aborted, which is expected
     if (err !== 'WATCH_GMP_ABORTED') {
@@ -356,7 +352,6 @@ test('handlePendingTx aborts GMP watcher in lookback mode when signal is aborted
     `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${fromBlock + 9}`,
     `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${fromBlock + 9}`,
     '[TEST] Aborting signal',
-    `[${txId}] External abort signal received`,
     `[${txId}] [LogScan] Aborted`,
     `[${txId}] No matching MulticallStatus or MulticallExecuted found`,
     `[${txId}] Lookback completed without finding transaction, waiting for live mode`,

--- a/services/ymax-planner/test/cctp-watcher.test.ts
+++ b/services/ymax-planner/test/cctp-watcher.test.ts
@@ -64,16 +64,11 @@ test('handlePendingTx processes CCTP transaction successfully', async t => {
   }, 50);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(
-      cctpTx,
-      {
-        ...opts,
-        log: logger,
-        timeoutMs: 3000,
-      },
-      undefined,
-      new AbortController().signal,
-    );
+    await handlePendingTx(cctpTx, {
+      ...opts,
+      log: logger,
+      timeoutMs: 3000,
+    });
   });
 
   t.deepEqual(logMessages, [
@@ -157,16 +152,11 @@ test('handlePendingTx keeps tx pending on amount mismatch until timeout and then
   }, 3010);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(
-      cctpTx,
-      {
-        ...opts,
-        log: logger,
-        timeoutMs: 3000,
-      },
-      undefined,
-      new AbortController().signal,
-    );
+    await handlePendingTx(cctpTx, {
+      ...opts,
+      log: logger,
+      timeoutMs: 3000,
+    });
   });
 
   t.deepEqual(logMessages, [

--- a/services/ymax-planner/test/cctp-watcher.test.ts
+++ b/services/ymax-planner/test/cctp-watcher.test.ts
@@ -64,11 +64,16 @@ test('handlePendingTx processes CCTP transaction successfully', async t => {
   }, 50);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(cctpTx, {
-      ...opts,
-      log: logger,
-      timeoutMs: 3000,
-    });
+    await handlePendingTx(
+      cctpTx,
+      {
+        ...opts,
+        log: logger,
+        timeoutMs: 3000,
+      },
+      undefined,
+      new AbortController().signal,
+    );
   });
 
   t.deepEqual(logMessages, [
@@ -152,11 +157,16 @@ test('handlePendingTx keeps tx pending on amount mismatch until timeout and then
   }, 3010);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(cctpTx, {
-      ...opts,
-      log: logger,
-      timeoutMs: 3000,
-    });
+    await handlePendingTx(
+      cctpTx,
+      {
+        ...opts,
+        log: logger,
+        timeoutMs: 3000,
+      },
+      undefined,
+      new AbortController().signal,
+    );
   });
 
   t.deepEqual(logMessages, [

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -54,11 +54,16 @@ test('handlePendingTx processes GMP transaction successfully', async t => {
   }, 50);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(gmpTx, {
-      ...opts,
-      log: logger,
-      timeoutMs: 3000,
-    });
+    await handlePendingTx(
+      gmpTx,
+      {
+        ...opts,
+        log: logger,
+        timeoutMs: 3000,
+      },
+      undefined,
+      new AbortController().signal,
+    );
   });
 
   t.deepEqual(logMessages, [
@@ -115,11 +120,16 @@ test('handlePendingTx logs a time out on a GMP transaction with no matching even
   }, 700);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(gmpTx, {
-      ...opts,
-      log: logger,
-      timeoutMs: 600,
-    });
+    await handlePendingTx(
+      gmpTx,
+      {
+        ...opts,
+        log: logger,
+        timeoutMs: 600,
+      },
+      undefined,
+      new AbortController().signal,
+    );
   });
 
   t.deepEqual(logMessages, [
@@ -177,11 +187,16 @@ test('handlePendingTx fails a pendingTx on it finds a failed tx on Axelarscan (l
   }, 700);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(gmpTx, {
-      ...opts,
-      log: logger,
-      timeoutMs: 600,
-    });
+    await handlePendingTx(
+      gmpTx,
+      {
+        ...opts,
+        log: logger,
+        timeoutMs: 600,
+      },
+      undefined,
+      new AbortController().signal,
+    );
   });
 
   t.deepEqual(logMessages, [
@@ -261,6 +276,7 @@ test('handlePendingTx fails a pendingTx on it finds a failed tx on Axelarscan (l
       timeoutMs: 600,
     },
     txTimestampMs,
+    new AbortController().signal,
   );
 
   const fromBlock = 0;

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -54,16 +54,11 @@ test('handlePendingTx processes GMP transaction successfully', async t => {
   }, 50);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(
-      gmpTx,
-      {
-        ...opts,
-        log: logger,
-        timeoutMs: 3000,
-      },
-      undefined,
-      new AbortController().signal,
-    );
+    await handlePendingTx(gmpTx, {
+      ...opts,
+      log: logger,
+      timeoutMs: 3000,
+    });
   });
 
   t.deepEqual(logMessages, [
@@ -120,16 +115,11 @@ test('handlePendingTx logs a time out on a GMP transaction with no matching even
   }, 700);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(
-      gmpTx,
-      {
-        ...opts,
-        log: logger,
-        timeoutMs: 600,
-      },
-      undefined,
-      new AbortController().signal,
-    );
+    await handlePendingTx(gmpTx, {
+      ...opts,
+      log: logger,
+      timeoutMs: 600,
+    });
   });
 
   t.deepEqual(logMessages, [
@@ -187,16 +177,11 @@ test('handlePendingTx fails a pendingTx on it finds a failed tx on Axelarscan (l
   }, 700);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(
-      gmpTx,
-      {
-        ...opts,
-        log: logger,
-        timeoutMs: 600,
-      },
-      undefined,
-      new AbortController().signal,
-    );
+    await handlePendingTx(gmpTx, {
+      ...opts,
+      log: logger,
+      timeoutMs: 600,
+    });
   });
 
   t.deepEqual(logMessages, [
@@ -274,9 +259,8 @@ test('handlePendingTx fails a pendingTx on it finds a failed tx on Axelarscan (l
       ...ctxWithFetch,
       log: mockLog,
       timeoutMs: 600,
+      txTimestampMs,
     },
-    txTimestampMs,
-    new AbortController().signal,
   );
 
   const fromBlock = 0;

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -278,6 +278,7 @@ export const createMockPendingTxOpts = (
   kvStore: makeKVStoreFromMap(new Map()),
   makeAbortController,
   axelarApiUrl: mockAxelarApiAddress,
+  pendingTxAbortControllers: new Map(),
 });
 
 export const createMockPendingTxEvent = (

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -45,6 +45,7 @@ test('processPendingTxEvents handles valid single transaction event', async t =>
     events,
     mockHandlePendingTx,
     createMockPendingTxOpts(),
+    new Map(),
   );
 
   t.is(handledTxs.length, 1);
@@ -81,6 +82,7 @@ test('processPendingTxEvents handles multiple transaction events', async t => {
     events,
     mockHandlePendingTx,
     createMockPendingTxOpts(),
+    new Map(),
   );
 
   t.is(handledTxs.length, 2);
@@ -123,10 +125,15 @@ test('processPendingTxEvents errors do not disrupt processing valid transactions
   ];
 
   const errorLog = [] as Array<any[]>;
-  await processPendingTxEvents(events, mockHandlePendingTx, {
-    ...createMockPendingTxOpts(),
-    error: (...args) => errorLog.push(args),
-  });
+  await processPendingTxEvents(
+    events,
+    mockHandlePendingTx,
+    {
+      ...createMockPendingTxOpts(),
+      error: (...args) => errorLog.push(args),
+    },
+    new Map(),
+  );
   if (errorLog.length !== 2) {
     t.log(errorLog);
   }
@@ -164,6 +171,7 @@ test('processPendingTxEvents handles only pending transactions', async t => {
     events,
     mockHandlePendingTx,
     createMockPendingTxOpts(),
+    new Map(),
   );
 
   t.is(handledTxs.length, 1);
@@ -184,10 +192,15 @@ test('handlePendingTx throws error for unsupported transaction type', async t =>
 
   await t.throwsAsync(
     () =>
-      handlePendingTx(unsupportedTx, {
-        ...createMockPendingTxOpts(),
-        log: mockLog,
-      }),
+      handlePendingTx(
+        unsupportedTx,
+        {
+          ...createMockPendingTxOpts(),
+          log: mockLog,
+        },
+        undefined,
+        new AbortController().signal,
+      ),
     { message: /No monitor registered for tx type: "cctpV2"/ },
   );
 });
@@ -241,6 +254,7 @@ test('resolves a 31 min old pending CCTP transaction in lookback mode', async t 
       log: mockLog,
     },
     txTimestampMs,
+    new AbortController().signal,
   );
 
   const currentBlock = await mockProvider.getBlockNumber();
@@ -309,6 +323,7 @@ test('resolves a 28 min old pending CCTP transaction in lookback mode', async t 
       log: mockLog,
     },
     txTimestampMs,
+    new AbortController().signal,
   );
 
   const currentBlock = await mockProvider.getBlockNumber();
@@ -377,6 +392,7 @@ test('resolves a transaction published at current time in lookback mode', async 
       log: mockLog,
     },
     txTimestampMs,
+    new AbortController().signal,
   );
 
   const currentBlock = await mockProvider.getBlockNumber();
@@ -445,6 +461,7 @@ test('resolves a 10 second old pending CCTP transaction in lookback mode', async
       log: mockLog,
     },
     txTimestampMs,
+    new AbortController().signal,
   );
 
   const currentBlock = await mockProvider.getBlockNumber();
@@ -535,6 +552,7 @@ test('resolves a 10 second old pending GMP transaction in lookback mode', async 
       log: mockLog,
     },
     txTimestampMs,
+    new AbortController().signal,
   );
 
   const currentBlock = await mockProvider.getBlockNumber();
@@ -609,6 +627,7 @@ test('processInitialPendingTransactions handles transactions with lookback', asy
   await processInitialPendingTransactions(
     pendingTxRecords,
     txPowers,
+    new Map(),
     mockHandlePendingTx,
   );
 
@@ -673,6 +692,7 @@ test('processInitialPendingTransactions handles transactions with age < 20min in
   await processInitialPendingTransactions(
     pendingTxRecords,
     txPowers,
+    new Map(),
     mockHandlePendingTx,
   );
 

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -46,7 +46,6 @@ test('processPendingTxEvents handles valid single transaction event', async t =>
     events,
     mockHandlePendingTx,
     createMockPendingTxOpts(),
-    new Map(),
   );
 
   t.is(handledTxs.length, 1);
@@ -83,7 +82,6 @@ test('processPendingTxEvents handles multiple transaction events', async t => {
     events,
     mockHandlePendingTx,
     createMockPendingTxOpts(),
-    new Map(),
   );
 
   t.is(handledTxs.length, 2);
@@ -126,15 +124,10 @@ test('processPendingTxEvents errors do not disrupt processing valid transactions
   ];
 
   const errorLog = [] as Array<any[]>;
-  await processPendingTxEvents(
-    events,
-    mockHandlePendingTx,
-    {
-      ...createMockPendingTxOpts(),
-      error: (...args) => errorLog.push(args),
-    },
-    new Map(),
-  );
+  await processPendingTxEvents(events, mockHandlePendingTx, {
+    ...createMockPendingTxOpts(),
+    error: (...args) => errorLog.push(args),
+  });
   if (errorLog.length !== 2) {
     t.log(errorLog);
   }
@@ -172,7 +165,6 @@ test('processPendingTxEvents handles only pending transactions', async t => {
     events,
     mockHandlePendingTx,
     createMockPendingTxOpts(),
-    new Map(),
   );
 
   t.is(handledTxs.length, 1);
@@ -614,7 +606,6 @@ test('processInitialPendingTransactions handles transactions with lookback', asy
   await processInitialPendingTransactions(
     pendingTxRecords,
     txPowers,
-    new Map(),
     mockHandlePendingTx,
   );
 
@@ -675,7 +666,6 @@ test('processInitialPendingTransactions handles transactions with age < 20min in
   await processInitialPendingTransactions(
     pendingTxRecords,
     txPowers,
-    new Map(),
     mockHandlePendingTx,
   );
 

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -193,15 +193,10 @@ test('handlePendingTx throws error for unsupported transaction type', async t =>
 
   await t.throwsAsync(
     () =>
-      handlePendingTx(
-        unsupportedTx,
-        {
-          ...createMockPendingTxOpts(),
-          log: mockLog,
-        },
-        undefined,
-        new AbortController().signal,
-      ),
+      handlePendingTx(unsupportedTx, {
+        ...createMockPendingTxOpts(),
+        log: mockLog,
+      }),
     { message: /No monitor registered for tx type: "cctpV2"/ },
   );
 });
@@ -253,9 +248,8 @@ test('resolves a 31 min old pending CCTP transaction in lookback mode', async t 
     {
       ...opts,
       log: mockLog,
+      txTimestampMs,
     },
-    txTimestampMs,
-    new AbortController().signal,
   );
 
   const currentBlock = await mockProvider.getBlockNumber();
@@ -322,9 +316,8 @@ test('resolves a 28 min old pending CCTP transaction in lookback mode', async t 
     {
       ...opts,
       log: mockLog,
+      txTimestampMs,
     },
-    txTimestampMs,
-    new AbortController().signal,
   );
 
   const currentBlock = await mockProvider.getBlockNumber();
@@ -391,9 +384,8 @@ test('resolves a transaction published at current time in lookback mode', async 
     {
       ...opts,
       log: mockLog,
+      txTimestampMs,
     },
-    txTimestampMs,
-    new AbortController().signal,
   );
 
   const currentBlock = await mockProvider.getBlockNumber();
@@ -460,9 +452,8 @@ test('resolves a 10 second old pending CCTP transaction in lookback mode', async
     {
       ...opts,
       log: mockLog,
+      txTimestampMs,
     },
-    txTimestampMs,
-    new AbortController().signal,
   );
 
   const currentBlock = await mockProvider.getBlockNumber();
@@ -551,9 +542,8 @@ test('resolves a 10 second old pending GMP transaction in lookback mode', async 
     {
       ...ctxWithFetch,
       log: mockLog,
+      txTimestampMs,
     },
-    txTimestampMs,
-    new AbortController().signal,
   );
 
   const currentBlock = await mockProvider.getBlockNumber();
@@ -581,13 +571,9 @@ test('processInitialPendingTransactions handles transactions with lookback', asy
   const handledCalls: Array<{ tx: any; opts: any }> = [];
   const txId: TxId = 'tx1';
 
-  const mockHandlePendingTx = async (
-    tx: any,
-    opts: any,
-    timeStamp: number | undefined,
-  ) => {
+  const mockHandlePendingTx = async (tx: any, opts: any) => {
     handledCalls.push({ tx, opts });
-    if (timeStamp) {
+    if (opts.txTimestampMs) {
       logs.push('Processing old tx');
     }
   };
@@ -648,13 +634,9 @@ test('processInitialPendingTransactions handles transactions with age < 20min in
   const txId: TxId = 'tx2';
   const logs: string[] = [];
 
-  const mockHandlePendingTx = async (
-    tx: any,
-    opts: any,
-    timeStamp: number | undefined,
-  ) => {
+  const mockHandlePendingTx = async (tx: any, opts: any) => {
     handledCalls.push({ tx, opts });
-    if (timeStamp) {
+    if (opts.txTimestampMs) {
       logs.push('Processing old tx');
     }
   };
@@ -792,9 +774,8 @@ test('GMP monitor does not resolve transaction twice when live mode completes be
       ...ctxWithFetch,
       log: mockLog,
       timeoutMs: 5000,
+      txTimestampMs,
     },
-    txTimestampMs,
-    new AbortController().signal,
   );
 
   // Regression test: Ensure transaction is resolved exactly once, not twice.

--- a/services/ymax-planner/test/tx-block-lower-bound.test.ts
+++ b/services/ymax-planner/test/tx-block-lower-bound.test.ts
@@ -93,9 +93,8 @@ test('updates lower bound when a pending tx is being searched', async t => {
     {
       ...ctx,
       log: mockLog,
+      txTimestampMs,
     },
-    txTimestampMs,
-    new AbortController().signal,
   );
 
   const finalExecutedBlockSaved = await getTxBlockLowerBound(
@@ -147,9 +146,8 @@ test('begins searching from the lower bound block number stored in kv store', as
     {
       ...ctx,
       log: mockLog,
+      txTimestampMs,
     },
-    txTimestampMs,
-    new AbortController().signal,
   );
 
   const finalExecutedBlockSaved = await getTxBlockLowerBound(

--- a/services/ymax-planner/test/tx-block-lower-bound.test.ts
+++ b/services/ymax-planner/test/tx-block-lower-bound.test.ts
@@ -95,6 +95,7 @@ test('updates lower bound when a pending tx is being searched', async t => {
       log: mockLog,
     },
     txTimestampMs,
+    new AbortController().signal,
   );
 
   const finalExecutedBlockSaved = await getTxBlockLowerBound(
@@ -148,6 +149,7 @@ test('begins searching from the lower bound block number stored in kv store', as
       log: mockLog,
     },
     txTimestampMs,
+    new AbortController().signal,
   );
 
   const finalExecutedBlockSaved = await getTxBlockLowerBound(

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { id, zeroPadValue, AbiCoder, getAddress } from 'ethers';
+import { id, zeroPadValue, AbiCoder } from 'ethers';
 import { createMockPendingTxOpts } from './mocks.ts';
 import { handlePendingTx } from '../src/pending-tx-manager.ts';
 import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
@@ -73,11 +73,16 @@ test('handlePendingTx processes MAKE_ACCOUNT transaction successfully', async t 
   }, 50);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(makeAccountTx, {
-      ...opts,
-      log: logger,
-      timeoutMs: 3000,
-    });
+    await handlePendingTx(
+      makeAccountTx,
+      {
+        ...opts,
+        log: logger,
+        timeoutMs: 3000,
+      },
+      undefined,
+      new AbortController().signal,
+    );
   });
 
   t.deepEqual(logMessages, [
@@ -127,11 +132,16 @@ test('handlePendingTx logs timeout on MAKE_ACCOUNT transaction with no matching 
   }, 3010);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(makeAccountTx, {
-      ...opts,
-      log: logger,
-      timeoutMs: 3000,
-    });
+    await handlePendingTx(
+      makeAccountTx,
+      {
+        ...opts,
+        log: logger,
+        timeoutMs: 3000,
+      },
+      undefined,
+      new AbortController().signal,
+    );
   });
 
   t.deepEqual(logMessages, [
@@ -206,11 +216,16 @@ test('handlePendingTx ignores non-matching wallet addresses', async t => {
   }, 60);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(makeAccountTx, {
-      ...opts,
-      log: logger,
-      timeoutMs: 3000,
-    });
+    await handlePendingTx(
+      makeAccountTx,
+      {
+        ...opts,
+        log: logger,
+        timeoutMs: 3000,
+      },
+      undefined,
+      new AbortController().signal,
+    );
   });
 
   t.deepEqual(logMessages, [

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -73,16 +73,11 @@ test('handlePendingTx processes MAKE_ACCOUNT transaction successfully', async t 
   }, 50);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(
-      makeAccountTx,
-      {
-        ...opts,
-        log: logger,
-        timeoutMs: 3000,
-      },
-      undefined,
-      new AbortController().signal,
-    );
+    await handlePendingTx(makeAccountTx, {
+      ...opts,
+      log: logger,
+      timeoutMs: 3000,
+    });
   });
 
   t.deepEqual(logMessages, [
@@ -132,16 +127,11 @@ test('handlePendingTx logs timeout on MAKE_ACCOUNT transaction with no matching 
   }, 3010);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(
-      makeAccountTx,
-      {
-        ...opts,
-        log: logger,
-        timeoutMs: 3000,
-      },
-      undefined,
-      new AbortController().signal,
-    );
+    await handlePendingTx(makeAccountTx, {
+      ...opts,
+      log: logger,
+      timeoutMs: 3000,
+    });
   });
 
   t.deepEqual(logMessages, [
@@ -216,16 +206,11 @@ test('handlePendingTx ignores non-matching wallet addresses', async t => {
   }, 60);
 
   await t.notThrowsAsync(async () => {
-    await handlePendingTx(
-      makeAccountTx,
-      {
-        ...opts,
-        log: logger,
-        timeoutMs: 3000,
-      },
-      undefined,
-      new AbortController().signal,
-    );
+    await handlePendingTx(makeAccountTx, {
+      ...opts,
+      log: logger,
+      timeoutMs: 3000,
+    });
   });
 
   t.deepEqual(logMessages, [


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes:
- https://github.com/Agoric/agoric-private/issues/625
- https://github.com/Agoric/agoric-private/issues/657

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
This PR adds AbortSignal support to transaction watchers, allowing them to be gracefully cancelled when transactions are manually resolved, preventing unnecessary resource usage. 

It also fixes a critical race condition in the GMP monitor that could cause transactions to be resolved twice when the live watcher completed before the lookback scanner.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
 Unit tests have been added for these scenarios:
  - Abort signal handling in live mode (CCTP, GMP)
  - Abort signal handling in lookback mode (CCTP, GMP)
  - Early abort before watcher starts
  - GMP double resolution race condition regression test

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
This change requires redeploying the `ymax-planner` for mainnet and testnet - no other components are affected.