### PR TITLE
chore: capture and report axelar scan error messages

### DIFF
--- a/services/ymax-planner/src/axelarscan-utils.ts
+++ b/services/ymax-planner/src/axelarscan-utils.ts
@@ -97,13 +97,13 @@ const findTxInAxelarScan = harden(
  * @param {TxId} txId - The transaction ID to search for
  * @param {`0x${string}`} destinationAddress - The destination address on the EVM chain
  * @param {{ axelarApiUrl: string; fetch: typeof fetch }} config - Configuration object containing Axelar API URL and fetch function
- * @returns {Promise<GMPTxStatus | undefined>} The status of the GMP transaction if found, otherwise undefined
+ * @returns {Promise<{ status: GMPTxStatus | undefined; errorMessage?: string }>} The status and optional error message of the GMP transaction
  */
 export const findTxStatusFromAxelarscan = async (
   txId: TxId,
   destinationAddress: `0x${string}`,
   config: { axelarApiUrl: string; fetch: typeof fetch },
-): Promise<GMPTxStatus | undefined> => {
+): Promise<{ status: GMPTxStatus | undefined; errorMessage?: string }> => {
   // XXX: Add a `from` timestamp to avoid fetching too much data
   const foundTxs = await findTxInAxelarScan(
     destinationAddress,
@@ -125,5 +125,9 @@ export const findTxStatusFromAxelarscan = async (
     return false;
   });
 
-  return txInAxelarScan?.status;
+  const status = txInAxelarScan?.status;
+  const errorMessage =
+    status === 'error' ? txInAxelarScan?.error?.error?.message : undefined;
+
+  return { status, errorMessage };
 };

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -188,7 +188,7 @@ test('handlePendingTx fails a pendingTx on it finds a failed tx on Axelarscan (l
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching for MulticallStatus and MulticallExecuted events for txId: ${txId} at contract: ${contractAddress}`,
     `[${txId}] ✗ No MulticallStatus or MulticallExecuted found for txId ${txId} within 0.01 minutes`,
-    `[${txId}] failed to execute on destination chain`,
+    `[${txId}] Error: Transaction execution failed`,
     `[${txId}] GMP tx resolved`,
   ]);
 });
@@ -235,6 +235,11 @@ test('handlePendingTx fails a pendingTx on it finds a failed tx on Axelarscan (l
                   ]),
                 },
               },
+              error: {
+                error: {
+                  message: 'Execution failed on destination chain',
+                },
+              },
               executed: {
                 transactionHash: '0xexecuted123',
                 receipt: {
@@ -270,7 +275,7 @@ test('handlePendingTx fails a pendingTx on it finds a failed tx on Axelarscan (l
     `[${txId}] No matching MulticallStatus or MulticallExecuted found`,
     `[${txId}] Lookback completed without finding transaction, waiting for live mode`,
     `[${txId}] ✗ No MulticallStatus or MulticallExecuted found for txId ${txId} within 0.01 minutes`,
-    `[${txId}] failed to execute on destination chain`,
+    `[${txId}] Error: Execution failed on destination chain`,
     `[${txId}] Live mode completed`,
     `[${txId}] GMP tx resolved`,
   ]);

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -421,6 +421,23 @@ const createMockAxelarScanResponse = (
     };
   }
 
+  if (status === 'error') {
+    return {
+      data: [
+        {
+          ...baseEvent,
+          error: {
+            error: {
+              message: 'Transaction execution failed',
+            },
+          },
+        },
+      ],
+      total: 1,
+      time_spent: 100,
+    };
+  }
+
   return {
     data: [baseEvent],
     total: 1,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes:
- https://github.com/Agoric/agoric-private/issues/375

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
When a GMP transaction fails on the destination EVM chain, the error message from Axelar scan is now extracted and passed as the rejection reason when the resolver tries to settle the transaction.
