### PR TITLE
chore(ymax-planner): Improve use of `rejectPlan`

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -396,7 +396,7 @@ export const processPortfolioEvents = async (
       }
 
       // If this (portfolio, flows) data hasn't changed since our last
-      // submission, there's no point in trying again.
+      // successful submission, there's no point in trying again.
       memory.snapshots ||= new Map();
       const oldState = memory.snapshots.get(portfolioKey);
       const oldFingerprint = oldState?.fingerprint;
@@ -407,7 +407,6 @@ export const processPortfolioEvents = async (
         oldState.repeats += 1;
         return;
       }
-      memory.snapshots.set(portfolioKey, { fingerprint, repeats: 0 });
 
       // If any in-progress flows need activation (as indicated by not having
       // its own dedicated vstorage data), then find the first such flow and
@@ -422,8 +421,9 @@ export const processPortfolioEvents = async (
           portfolioKey, flowKey,
           () => startFlow(status, portfolioKey, flowKey, flowDetail),
         );
-        return;
+        break;
       }
+      memory.snapshots.set(portfolioKey, { fingerprint, repeats: 0 });
     } catch (err) {
       const age = blockHeight - eventRecord.blockHeight;
       if (err.code === STALE_RESPONSE) {

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -381,6 +381,7 @@ export const processPortfolioEvents = async (
       if (err instanceof UserInputError || err instanceof NoSolutionError) {
         try {
           await settle('rejectPlan', [...scope, err.message, ...conditions]);
+          return;
         } catch (settleErr) {
           // eslint-disable-next-line no-ex-assign
           err = AggregateError([err, settleErr]);


### PR DESCRIPTION
Ref #12274
Ref https://github.com/Agoric/agoric-sdk/pull/12235#discussion_r2550423602

## Description
* Don't treat successful `rejectPlan` as an error
* Include log output for `rejectPlan`
* Consolidate startFlow log output
* Don't update portfolio state snapshots when handlePortfolio fails

### Security Considerations
None known.

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Covered.

### Upgrade Considerations
This affects only happy-path output that AFAIK nothing specifically looks for, so should be safe to deploy immediately.