### PR TITLE
feat(ymax-planner): Run flows in sequence

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -440,17 +440,11 @@ export const processPortfolioEvents = async (
       // is pointless because acceptance of the first submission would
       // invalidate the others as stale, but we'll see them again when such
       // acceptance prompts changes to the portfolio status.
-      let hasActiveFlow = false;
       for (const [flowKey, flowDetail] of typedEntries(status.flowsRunning || {})) {
         // If vstorage has a node for this flow then we've already responded.
         if (flowKeys.has(flowKey)) {
-          hasActiveFlow ||= await isActiveFlow(portfolioKey, flowKey, readOpts);
+          if (await isActiveFlow(portfolioKey, flowKey, readOpts)) return;
           continue;
-        }
-        if (hasActiveFlow) {
-          // Another flow is already running; wait for it to finish.
-          deferrals.push(eventRecord);
-          return;
         }
         await runWithFlowTrace(
           portfolioKey, flowKey,

--- a/services/ymax-planner/src/vstorage-utils.ts
+++ b/services/ymax-planner/src/vstorage-utils.ts
@@ -115,7 +115,7 @@ harden(parseStreamCellValue);
 
 export const STALE_RESPONSE = 'STALE_RESPONSE';
 
-type ReadStorageMetaOptions<
+export type ReadStorageMetaOptions<
   MethodName extends 'children' | 'data',
   Result = MethodName extends 'children'
     ? QueryChildrenMetaResponse

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -38,7 +38,7 @@ import {
   type NatAmount,
 } from '@agoric/ertp';
 import { arrayIsLike } from '@agoric/internal/tools/ava-assertions.js';
-import type { SupportedChain } from '@agoric/portfolio-api/src/constants.js';
+import type { FlowStatus, SupportedChain } from '@agoric/portfolio-api';
 import type { InvokeStoreEntryAction } from '@agoric/smart-wallet/src/smartWallet.js';
 import type { AssetInfo } from '@agoric/vats/src/vat-bank.js';
 import type { Marshal } from '@endo/marshal';
@@ -385,6 +385,7 @@ const mockAsset = (
 
 const depositAsset = mockAsset('USDC');
 const { boardId: depositBoardId, brand: depositBrand } = depositAsset;
+const makeDeposit = (value: bigint) => AmountMath.make(depositBrand, value);
 const { boardId: feeBoardId, brand: feeBrand } = mockAsset('Fee');
 const defaultMarshallerEntries: Pick<Map<string, unknown>, 'get'> = new Map([
   [depositBoardId, depositBrand],
@@ -606,6 +607,120 @@ test.serial(
     );
     t.is(memory.snapshots?.get(`portfolio${portfolioId}`)?.repeats, 1);
     t.is(powers.portfolioKeyForDepositAddr.size, 0);
+  },
+);
+
+test.serial.failing(
+  'processPortfolioEvents runs flows in sequence',
+  async t => {
+    const kit = await fakePortfolioKit({
+      accounts: { noble: makeDeposit(0n) },
+      otherBalances: { usdn: makeDeposit(0n) },
+    });
+    const { portfolioId, portfolioPath, initialPortfolioStatus, powers } = kit;
+    const { getBridgeSends, updateBlockHeight, updateVstorage } =
+      kit.testPowers;
+
+    // Three flows, the first one actively running.
+    const flowId1: number = 5;
+    const flowId2: number = 6;
+    const flowId3: number = 7;
+    const flowPath1 = `${portfolioPath}.flows.flow${flowId1}`;
+    const portfolioStatus = {
+      ...initialPortfolioStatus,
+      rebalanceCount: 0,
+      positionKeys: ['USDN'],
+      targetAllocation: { USDN: 1n },
+      flowCount: 3,
+      flowsRunning: {
+        [`flow${flowId1}`]: {
+          type: 'deposit',
+          amount: makeDeposit(1_000_000n),
+        },
+        [`flow${flowId2}`]: {
+          type: 'deposit',
+          amount: makeDeposit(2_000_000n),
+        },
+        [`flow${flowId3}`]: {
+          type: 'deposit',
+          amount: makeDeposit(3_000_000n),
+        },
+      },
+    };
+    updateVstorage(portfolioPath, 'set', {
+      object: { ...portfolioStatus },
+      wrap: true,
+    });
+    updateVstorage(`${portfolioPath}.flows`, 'set', { string: '' });
+    updateVstorage(flowPath1, 'set', {
+      object: { state: 'run', step: 0, how: '' } satisfies FlowStatus,
+      wrap: true,
+    });
+
+    {
+      const blockHeight = updateBlockHeight();
+      const vstorageEventDetail = makeVstorageEventDetail(
+        blockHeight,
+        portfolioPath,
+        harden({ ...portfolioStatus }),
+      );
+      const memory: PortfoliosMemory = { deferrals: [] };
+      await processPortfolioEvents(
+        [vstorageEventDetail],
+        blockHeight,
+        memory,
+        powers,
+      );
+
+      t.deepEqual(
+        getBridgeSends().map(invocation => invocation.action),
+        [],
+        'a running flow blocks further invocations',
+      );
+      t.deepEqual(
+        memory.deferrals,
+        [vstorageEventDetail.eventRecord],
+        'portfolio with a running flow is deferred',
+      );
+    }
+    {
+      // Completing the first flow allows the second to start.
+      const blockHeight = updateBlockHeight();
+      updateVstorage(flowPath1, 'set', {
+        object: { state: 'done' } satisfies FlowStatus,
+        wrap: true,
+      });
+      const vstorageEventDetail = makeVstorageEventDetail(
+        blockHeight,
+        portfolioPath,
+        harden({ ...portfolioStatus }),
+      );
+      const memory: PortfoliosMemory = { deferrals: [] };
+      await processPortfolioEvents(
+        [vstorageEventDetail],
+        blockHeight,
+        memory,
+        powers,
+      );
+
+      t.deepEqual(memory.deferrals, []);
+      const bridgeActions = getBridgeSends().map(
+        invocation => invocation.action,
+      );
+      arrayIsLike(t, bridgeActions, [bridgeActions[0]]);
+      const action = bridgeActions[0] as InvokeStoreEntryAction;
+      t.like(action, {
+        method: 'invokeEntry',
+        message: { targetName: 'planner', method: 'resolvePlan' },
+      });
+      arrayIsLike(t, action.message.args, [
+        portfolioId,
+        flowId2,
+        action.message.args[2],
+        portfolioStatus.policyVersion,
+        portfolioStatus.rebalanceCount,
+      ]);
+    }
   },
 );
 

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -610,119 +610,113 @@ test.serial(
   },
 );
 
-test.serial.failing(
-  'processPortfolioEvents runs flows in sequence',
-  async t => {
-    const kit = await fakePortfolioKit({
-      accounts: { noble: makeDeposit(0n) },
-      otherBalances: { usdn: makeDeposit(0n) },
-    });
-    const { portfolioId, portfolioPath, initialPortfolioStatus, powers } = kit;
-    const { getBridgeSends, updateBlockHeight, updateVstorage } =
-      kit.testPowers;
+test.serial('processPortfolioEvents runs flows in sequence', async t => {
+  const kit = await fakePortfolioKit({
+    accounts: { noble: makeDeposit(0n) },
+    otherBalances: { usdn: makeDeposit(0n) },
+  });
+  const { portfolioId, portfolioPath, initialPortfolioStatus, powers } = kit;
+  const { getBridgeSends, updateBlockHeight, updateVstorage } = kit.testPowers;
 
-    // Three flows, the first one actively running.
-    const flowId1: number = 5;
-    const flowId2: number = 6;
-    const flowId3: number = 7;
-    const flowPath1 = `${portfolioPath}.flows.flow${flowId1}`;
-    const portfolioStatus = {
-      ...initialPortfolioStatus,
-      rebalanceCount: 0,
-      positionKeys: ['USDN'],
-      targetAllocation: { USDN: 1n },
-      flowCount: 3,
-      flowsRunning: {
-        [`flow${flowId1}`]: {
-          type: 'deposit',
-          amount: makeDeposit(1_000_000n),
-        },
-        [`flow${flowId2}`]: {
-          type: 'deposit',
-          amount: makeDeposit(2_000_000n),
-        },
-        [`flow${flowId3}`]: {
-          type: 'deposit',
-          amount: makeDeposit(3_000_000n),
-        },
+  // Three flows, the first one actively running.
+  const flowId1: number = 5;
+  const flowId2: number = 6;
+  const flowId3: number = 7;
+  const flowPath1 = `${portfolioPath}.flows.flow${flowId1}`;
+  const portfolioStatus = {
+    ...initialPortfolioStatus,
+    rebalanceCount: 0,
+    positionKeys: ['USDN'],
+    targetAllocation: { USDN: 1n },
+    flowCount: 3,
+    flowsRunning: {
+      [`flow${flowId1}`]: {
+        type: 'deposit',
+        amount: makeDeposit(1_000_000n),
       },
-    };
-    updateVstorage(portfolioPath, 'set', {
-      object: { ...portfolioStatus },
-      wrap: true,
-    });
-    updateVstorage(`${portfolioPath}.flows`, 'set', { string: '' });
+      [`flow${flowId2}`]: {
+        type: 'deposit',
+        amount: makeDeposit(2_000_000n),
+      },
+      [`flow${flowId3}`]: {
+        type: 'deposit',
+        amount: makeDeposit(3_000_000n),
+      },
+    },
+  };
+  updateVstorage(portfolioPath, 'set', {
+    object: { ...portfolioStatus },
+    wrap: true,
+  });
+  updateVstorage(`${portfolioPath}.flows`, 'set', { string: '' });
+  updateVstorage(flowPath1, 'set', {
+    object: { state: 'run', step: 0, how: '' } satisfies FlowStatus,
+    wrap: true,
+  });
+
+  {
+    const blockHeight = updateBlockHeight();
+    const vstorageEventDetail = makeVstorageEventDetail(
+      blockHeight,
+      portfolioPath,
+      harden({ ...portfolioStatus }),
+    );
+    const memory: PortfoliosMemory = { deferrals: [] };
+    await processPortfolioEvents(
+      [vstorageEventDetail],
+      blockHeight,
+      memory,
+      powers,
+    );
+
+    t.deepEqual(
+      getBridgeSends().map(invocation => invocation.action),
+      [],
+      'a running flow blocks further invocations',
+    );
+    t.deepEqual(
+      memory.deferrals,
+      [vstorageEventDetail.eventRecord],
+      'portfolio with a running flow is deferred',
+    );
+  }
+  {
+    // Completing the first flow allows the second to start.
+    const blockHeight = updateBlockHeight();
     updateVstorage(flowPath1, 'set', {
-      object: { state: 'run', step: 0, how: '' } satisfies FlowStatus,
+      object: { state: 'done' } satisfies FlowStatus,
       wrap: true,
     });
+    const vstorageEventDetail = makeVstorageEventDetail(
+      blockHeight,
+      portfolioPath,
+      harden({ ...portfolioStatus }),
+    );
+    const memory: PortfoliosMemory = { deferrals: [] };
+    await processPortfolioEvents(
+      [vstorageEventDetail],
+      blockHeight,
+      memory,
+      powers,
+    );
 
-    {
-      const blockHeight = updateBlockHeight();
-      const vstorageEventDetail = makeVstorageEventDetail(
-        blockHeight,
-        portfolioPath,
-        harden({ ...portfolioStatus }),
-      );
-      const memory: PortfoliosMemory = { deferrals: [] };
-      await processPortfolioEvents(
-        [vstorageEventDetail],
-        blockHeight,
-        memory,
-        powers,
-      );
-
-      t.deepEqual(
-        getBridgeSends().map(invocation => invocation.action),
-        [],
-        'a running flow blocks further invocations',
-      );
-      t.deepEqual(
-        memory.deferrals,
-        [vstorageEventDetail.eventRecord],
-        'portfolio with a running flow is deferred',
-      );
-    }
-    {
-      // Completing the first flow allows the second to start.
-      const blockHeight = updateBlockHeight();
-      updateVstorage(flowPath1, 'set', {
-        object: { state: 'done' } satisfies FlowStatus,
-        wrap: true,
-      });
-      const vstorageEventDetail = makeVstorageEventDetail(
-        blockHeight,
-        portfolioPath,
-        harden({ ...portfolioStatus }),
-      );
-      const memory: PortfoliosMemory = { deferrals: [] };
-      await processPortfolioEvents(
-        [vstorageEventDetail],
-        blockHeight,
-        memory,
-        powers,
-      );
-
-      t.deepEqual(memory.deferrals, []);
-      const bridgeActions = getBridgeSends().map(
-        invocation => invocation.action,
-      );
-      arrayIsLike(t, bridgeActions, [bridgeActions[0]]);
-      const action = bridgeActions[0] as InvokeStoreEntryAction;
-      t.like(action, {
-        method: 'invokeEntry',
-        message: { targetName: 'planner', method: 'resolvePlan' },
-      });
-      arrayIsLike(t, action.message.args, [
-        portfolioId,
-        flowId2,
-        action.message.args[2],
-        portfolioStatus.policyVersion,
-        portfolioStatus.rebalanceCount,
-      ]);
-    }
-  },
-);
+    t.deepEqual(memory.deferrals, []);
+    const bridgeActions = getBridgeSends().map(invocation => invocation.action);
+    arrayIsLike(t, bridgeActions, [bridgeActions[0]]);
+    const action = bridgeActions[0] as InvokeStoreEntryAction;
+    t.like(action, {
+      method: 'invokeEntry',
+      message: { targetName: 'planner', method: 'resolvePlan' },
+    });
+    arrayIsLike(t, action.message.args, [
+      portfolioId,
+      flowId2,
+      action.message.args[2],
+      portfolioStatus.policyVersion,
+      portfolioStatus.rebalanceCount,
+    ]);
+  }
+});
 
 test.serial('startFlow logs include traceId prefix', async t => {
   const kit = await fakePortfolioKit({

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -6,8 +6,6 @@ import type { DeliverTxResponse } from '@cosmjs/stargate';
 
 import { Fail, q } from '@endo/errors';
 
-import type { PortfolioPlanner } from '@aglocal/portfolio-contract/src/planner.exo.ts';
-import type { MovementDesc } from '@aglocal/portfolio-contract/src/type-guards-steps.js';
 import type {
   FlowDetail,
   StatusFor,
@@ -18,13 +16,7 @@ import {
   makeVstorageKitFromVstorage,
   reflectWalletStore,
 } from '@agoric/client-utils';
-import type {
-  QueryChildrenMetaResponse,
-  QueryDataMetaResponse,
-  SigningSmartWalletKit,
-  VStorage,
-  VstorageKit,
-} from '@agoric/client-utils';
+import type { SigningSmartWalletKit, VStorage } from '@agoric/client-utils';
 import { boardSlottingMarshaller } from '@agoric/client-utils';
 import { partialMap, typedEntries } from '@agoric/internal';
 import type { RecordFromTuple } from '@agoric/internal';
@@ -44,7 +36,6 @@ import type { AssetInfo } from '@agoric/vats/src/vat-bank.js';
 import type { Marshal } from '@endo/marshal';
 import { Far } from '@endo/pass-style';
 import type { Passable } from '@endo/pass-style';
-import type { CosmosRestClient } from '../src/cosmos-rest-client.ts';
 import {
   makeVstorageEvent,
   pickBalance,
@@ -61,8 +52,6 @@ import {
   createMockEnginePowers,
   makeNotImplemented,
   makeNotImplementedAsync,
-  makeStreamCellJsonFromText,
-  mockGasEstimator,
 } from './mocks.ts';
 
 // #region client-utils mocks

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -658,15 +658,11 @@ test.serial('processPortfolioEvents runs flows in sequence', async t => {
       powers,
     );
 
+    t.deepEqual(memory.deferrals, []);
     t.deepEqual(
       getBridgeSends().map(invocation => invocation.action),
       [],
       'a running flow blocks further invocations',
-    );
-    t.deepEqual(
-      memory.deferrals,
-      [vstorageEventDetail.eventRecord],
-      'portfolio with a running flow is deferred',
     );
   }
   {


### PR DESCRIPTION
Fixes https://github.com/Agoric/agoric-private/issues/636

## Description
Before attempting to start a flow, verify that no earlier flow is still running (i.e., has vstorage data with state "run"). If there is such an earlier flow, defer the portfolio instead.

### Security Considerations
None known.

### Scaling Considerations
The impact is expected to be negligible.

### Documentation Considerations
n/a

### Testing Considerations
Covered by the new "processPortfolioEvents runs flows in sequence" test.

### Upgrade Considerations
Safe to deploy immediately.