### PR TITLE
feat(portfolio-api): Extend types and shapes for EVM deposits and withdrawals

### DIFF
--- a/packages/portfolio-api/src/types.ts
+++ b/packages/portfolio-api/src/types.ts
@@ -10,7 +10,11 @@ import type {
   ContinuingInvitationSpec,
   ContractInvitationSpec,
 } from '@agoric/smart-wallet/src/invitations.js';
-import type { SupportedChain, YieldProtocol } from './constants.js';
+import type {
+  AxelarChain,
+  SupportedChain,
+  YieldProtocol,
+} from './constants.js';
 import type { InstrumentId } from './instruments.js';
 import type { PublishedTx } from './resolver.js';
 
@@ -36,11 +40,25 @@ export type SeatKeyword = 'Cash' | 'Deposit';
  */
 export type LocalChainAccountRef = '+agoric';
 
+/**
+ * Identifies the blockchain hosting an address external to ymax from which
+ * funds for a deposit must be supplied.
+ */
+export type DepositFromChainRef = `+${AxelarChain}`;
+
+/**
+ * Identifies the blockchain hosting an address external to ymax to which
+ * withdrawn funds will be sent.
+ */
+export type WithdrawToChainRef = `-${AxelarChain}`;
+
 export type InterChainAccountRef = `@${SupportedChain}`;
 
 export type AssetPlaceRef =
   | `<${SeatKeyword}>`
   | LocalChainAccountRef
+  | DepositFromChainRef
+  | WithdrawToChainRef
   | InterChainAccountRef
   | InstrumentId;
 
@@ -75,8 +93,8 @@ export type ProposalType = {
 export type TargetAllocation = Partial<Record<InstrumentId, bigint>>;
 
 export type FlowDetail =
-  | { type: 'withdraw'; amount: NatAmount }
-  | { type: 'deposit'; amount: NatAmount }
+  | { type: 'withdraw'; amount: NatAmount; toChain?: SupportedChain }
+  | { type: 'deposit'; amount: NatAmount; fromChain?: SupportedChain }
   | { type: 'rebalance' }; // aka simpleRebalance
 
 /** linked list of concurrent failures, including dependencies */

--- a/packages/portfolio-api/test/types.test-d.ts
+++ b/packages/portfolio-api/test/types.test-d.ts
@@ -89,7 +89,19 @@ expectNotAssignable<ProposalType['withdraw']>({
 
 expectAssignable<FlowDetail>({ type: 'rebalance' });
 expectAssignable<FlowDetail>({ type: 'deposit', amount: natAmount });
+expectAssignable<FlowDetail>({
+  type: 'deposit',
+  amount: natAmount,
+  fromChain: 'Ethereum',
+});
+expectAssignable<FlowDetail>({ type: 'withdraw', amount: natAmount });
+expectAssignable<FlowDetail>({
+  type: 'withdraw',
+  amount: natAmount,
+  toChain: 'Ethereum',
+});
 expectNotAssignable<FlowDetail>({ type: 'deposit' });
+expectNotAssignable<FlowDetail>({ type: 'withdraw' });
 
 expectAssignable<FlowStatus>({ state: 'run', step: 1, how: 'start' });
 expectAssignable<FlowStatus>({

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -284,15 +284,21 @@ export const portfolioIdOfPath = (path: string | string[]) => {
   );
 };
 
-export const FlowDetailShape: TypedPattern<FlowDetail> = M.or(
-  { type: 'withdraw', amount: AnyNatAmountShape },
-  { type: 'deposit', amount: AnyNatAmountShape },
-  { type: 'rebalance' },
-);
-
 /** ChainNames including those in future upgrades */
 type ChainNameExt = string;
 const ChainNameExtShape: TypedPattern<ChainNameExt> = M.string();
+
+export const FlowDetailShape: TypedPattern<FlowDetail> = M.or(
+  M.splitRecord(
+    { type: 'withdraw', amount: AnyNatAmountShape },
+    { toChain: ChainNameExtShape },
+  ),
+  M.splitRecord(
+    { type: 'deposit', amount: AnyNatAmountShape },
+    { fromChain: ChainNameExtShape },
+  ),
+  { type: 'rebalance' },
+);
 
 export const PortfolioStatusShapeExt: TypedPattern<StatusFor['portfolio']> =
   M.splitRecord(


### PR DESCRIPTION
## Description
* Extend AssetPlaceRef to include DepositFromChainRef `+${AxelarChain}` and WithdrawToChainRef `-${AxelarChain}` values, so that MovementDesc steps from ymax-planner can use the former as a deposit `src` (generalizing LocalChainAccountRef "+agoric") and the latter as a withdrawal `dest`.
* Add an optional `fromChain` field to FlowDetail with type "deposit" and an optional `toChain` field to FlowDetail with type "withdraw", so that the ymax contract can publish such data to vstorage as a signal to ymax-planner that its steps should start with a DepositFromChainRef `src` or WithdrawToChainRef `dest` (respectively).

Note that this PR does not change implementation code in either the contract or the planner; it merely updates the contract between them to unblock those changes.

### Security Considerations
None known.

### Scaling Considerations
n/a

### Documentation Considerations
I think we're already covered.

### Testing Considerations
Not really applicable, but I did update the existing packages/portfolio-api/test/types.test-d.ts.

### Upgrade Considerations
Backwards-compatible and safe to deploy immediately.