### PR TITLE
ci: disable mergify post-merge comments

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -42,6 +42,7 @@ shared:
 merge_queue:
   max_parallel_checks: 1
   queued_label: null
+  status_comments: none
 
 priority_rules:
   - name: high_priority


### PR DESCRIPTION
This change has been made by @turadg from the Mergify config editor.

To disable [these new comments](https://github.com/Agoric/agoric-sdk/pull/12257#issuecomment-3578738979) from Mergify upon merge (back to the earlier behavior like [this PR from November](https://github.com/Agoric/agoric-sdk/pull/12235) )


https://docs.mergify.com/changelog/2026-01-07-add-none-option-to-status-comments-for-merge-queue/

