### PR TITLE
fix(portfolio-api): Allow extensions to MovementDescShape

### DIFF
--- a/packages/portfolio-contract/src/type-guards-steps.ts
+++ b/packages/portfolio-contract/src/type-guards-steps.ts
@@ -80,7 +80,8 @@ export const makeOfferArgsShapes = (usdcBrand: Brand<'nat'>) => {
       detail: M.recordOf(M.string(), M.nat()),
       claim: M.boolean(),
     },
-    {},
+    // Be robust in the face of additional properties
+    M.record(),
   );
 
   return {

--- a/packages/portfolio-contract/test/offer-shapes.test.ts
+++ b/packages/portfolio-contract/test/offer-shapes.test.ts
@@ -3,7 +3,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
-import { M, matches, mustMatch } from '@endo/patterns';
+import { matches, mustMatch } from '@endo/patterns';
 import { makeOfferArgsShapes } from '../src/type-guards-steps.ts';
 import {
   FlowStatusShape,

--- a/packages/portfolio-contract/test/offer-shapes.test.ts
+++ b/packages/portfolio-contract/test/offer-shapes.test.ts
@@ -131,41 +131,6 @@ test('movementDescShape allows unknown additional properties', t => {
     () => mustMatch(specimenWithExtra, movementDescShape),
     'movementDescShape should allow unknown properties',
   );
-
-  // A strict shape (with empty object {} as rest) rejects extra properties
-  const strictMovementDescShape = M.splitRecord(
-    {
-      amount: M.and(
-        M.recordOf(M.string(), M.any()),
-        M.splitRecord({ brand: USDC, value: M.gte(1n) }),
-      ),
-      src: M.string(),
-      dest: M.string(),
-    },
-    {
-      fee: M.any(),
-      detail: M.recordOf(M.string(), M.nat()),
-      claim: M.boolean(),
-    },
-    // Empty object rest - strict matching, no additional properties allowed
-    {},
-  );
-
-  t.false(
-    matches(specimenWithExtra, strictMovementDescShape),
-    'strict shape should reject unknown properties',
-  );
-
-  // Confirm the base case still works with strict shape
-  const specimenWithoutExtra = harden({
-    src: '@noble',
-    dest: '@Arbitrum',
-    amount,
-  });
-  t.true(
-    matches(specimenWithoutExtra, strictMovementDescShape),
-    'strict shape should accept valid specimen without extras',
-  );
 });
 
 test('PoolKeyExt shapes accept future pool keys', t => {


### PR DESCRIPTION
refs: 
-  https://github.com/Agoric/agoric-private/issues/559

## Description
Loosen the shape definition of MovementShapeDec to allow extensions. Currently existing components would reject additional properties like an optional `close` flag for `withdraw` operations. That would require us to delicate upgrade dance among servers, contract, and UI for essentially a backwards compatible enhancement. This is to loosen the shape now so that we can upgrade all those elements before needing enhancements here.

### Security Considerations
`MovementDesc`'s are primarily provided by the planner, so the exposure is limited. However they may also be provided in a few operations like the special `withdraw` action from clients where they provide steps. Those operations may require additional manual protection to ensure that extraneous arguments are not used to attack. Those are also required for the existing `details` property, so should not add much additional risk.

### Scaling Considerations
NA

### Documentation Considerations
NA

### Testing Considerations
A test is added to confirm that previously rejected property additions are now accepted.

### Upgrade Considerations
This is all about enabling smoother upgrades. The change here should go in as soon as convenient so that it's already deployed in the UI and secondary services before additional properties are required.
