### PR TITLE
feat(portfolio-contract): Add rebalance and simpleRebalance to EVM

### DIFF
--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -636,8 +636,33 @@ export const preparePortfolioKit = (
         deposit() {
           throw Error('TODO in a later PR');
         },
+        /**
+         * Initiate a rebalance with a new target allocation.
+         *
+         * Sets the target allocation and starts a rebalance flow.
+         *
+         * @param allocation - Target allocation mapping from InstrumentId to portion
+         */
+        simpleRebalance(allocation: TargetAllocation) {
+          const { manager } = this.facets;
+          manager.setTargetAllocation(allocation);
+          const flowDetail: FlowDetail = { type: 'rebalance' };
+          const startedFlow = manager.startFlow(flowDetail);
+          return `flow${startedFlow.flowId}`;
+        },
+        /**
+         * Initiate a rebalance using the existing target allocation.
+         *
+         * The target allocation must have been previously set via
+         * `reallocate()` or when opening the portfolio.
+         */
         rebalance() {
-          throw Error('TODO in a later PR');
+          const { targetAllocation } = this.state;
+          targetAllocation ||
+            Fail`rebalance requires targetAllocation to be set (use reallocate() instead)`;
+          const flowDetail: FlowDetail = { type: 'rebalance' };
+          const startedFlow = this.facets.manager.startFlow(flowDetail);
+          return `flow${startedFlow.flowId}`;
         },
         /**
          * Initiate a withdrawal to the source EVM account.

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -654,12 +654,12 @@ export const preparePortfolioKit = (
          * Initiate a rebalance using the existing target allocation.
          *
          * The target allocation must have been previously set via
-         * `reallocate()` or when opening the portfolio.
+         * `SimpleRebalance()` or when opening the portfolio.
          */
         rebalance() {
           const { targetAllocation } = this.state;
           targetAllocation ||
-            Fail`rebalance requires targetAllocation to be set (use reallocate() instead)`;
+            Fail`rebalance requires targetAllocation to be set (use SimpleRebalance instead)`;
           const flowDetail: FlowDetail = { type: 'rebalance' };
           const startedFlow = this.facets.manager.startFlow(flowDetail);
           return `flow${startedFlow.flowId}`;

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -658,8 +658,8 @@ export const preparePortfolioKit = (
          */
         rebalance() {
           const { targetAllocation } = this.state;
-          targetAllocation ||
-            Fail`rebalance requires targetAllocation to be set (use SimpleRebalance instead)`;
+          (targetAllocation && Object.keys(targetAllocation).length > 0) ||
+            Fail`rebalance requires targetAllocation to be set`;
           const flowDetail: FlowDetail = { type: 'rebalance' };
           const startedFlow = this.facets.manager.startFlow(flowDetail);
           return `flow${startedFlow.flowId}`;

--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -895,6 +895,280 @@ test('start deposit more to same', async t => {
   );
 });
 
+test('evmHandler.simpleRebalance sets allocation and starts a rebalance flow', async t => {
+  const { common, planner1, started, readPublished, txResolver } =
+    await setupPlanner(t);
+  const { usdc, bld } = common.brands;
+
+  const inputs = {
+    fromChain: 'Arbitrum' as const,
+    depositAmount: usdc.units(1000),
+    allocations: [{ instrument: 'Aave_Arbitrum', portion: 10000n }],
+  };
+  const { fromChain: evm, depositAmount, allocations } = inputs;
+
+  type EvmHandler = Awaited<
+    ReturnType<typeof started.publicFacet.openPortfolioFromEVM>
+  >['evmHandler'];
+  let evmHandler: EvmHandler | undefined;
+
+  const traderDo = async () => {
+    const permit2Payload = {
+      permit: {
+        permitted: {
+          token: contractsMock[evm].usdc,
+          amount: depositAmount.value,
+        },
+        nonce: 1n,
+        deadline: 1n,
+      },
+      owner: '0x2222222222222222222222222222222222222222',
+      witness:
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      witnessTypeString: 'OpenPortfolioWitness',
+      signature: '0x1234',
+    } as const;
+    const permitDetails = {
+      chainId: Number(chainInfoWithCCTP[evm].reference),
+      token: contractsMock[evm].usdc,
+      amount: depositAmount.value,
+      spender: contractsMock[evm].depositFactory,
+      permit2Payload,
+    } as const;
+
+    const result = await E(started.publicFacet).openPortfolioFromEVM(
+      { allocations },
+      permitDetails,
+    );
+    evmHandler = result.evmHandler;
+    return result;
+  };
+
+  // Start traderDo first so plannerDo can wait for it
+  const traderDoP = traderDo();
+
+  /** Simulate chain inputs (acks) for makeAccount + GMP transfers. */
+  const chainDo = async () => {
+    await ackNFA(common.utils);
+    await common.utils.transmitVTransferEvent('acknowledgementPacket', -2);
+    await txResolver.drainPending();
+    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
+    await txResolver.drainPending();
+    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
+  };
+
+  const plannerDo = async () => {
+    const pId = 0;
+    // Wait for trader to open portfolio before reading status
+    await traderDoP;
+    const status = (await readPublished(
+      `portfolios.portfolio${pId}`,
+    )) as unknown as StatusFor['portfolio'];
+    const { flowsRunning = {}, policyVersion, rebalanceCount } = status;
+    const sync = [policyVersion, rebalanceCount] as const;
+    const [[flowId, detail]] = Object.entries(flowsRunning);
+    const flowNum = Number(flowId.replace('flow', ''));
+    if (detail.type !== 'deposit') throw t.fail(detail.type);
+    const planDepositAmount = AmountMath.make(usdc.brand, detail.amount.value);
+    const fee = bld.units(100);
+    const plan: FundsFlowPlan = {
+      flow: [
+        { src: `+${evm}`, dest: `@${evm}`, amount: planDepositAmount, fee },
+        {
+          src: `@${evm}`,
+          dest: 'Aave_Arbitrum',
+          amount: planDepositAmount,
+          fee,
+        },
+      ],
+    };
+    await E(planner1.stub).resolvePlan(pId, flowNum, plan, ...sync);
+    return flowNum;
+  };
+
+  await planner1.redeem();
+  await Promise.all([traderDoP, plannerDo(), chainDo()]);
+
+  // Verify portfolio is ready
+  const statusBefore = (await readPublished(
+    `portfolios.portfolio0`,
+  )) as unknown as StatusFor['portfolio'];
+  t.deepEqual(statusBefore.flowsRunning, {}, 'no flows running after deposit');
+
+  // Now test simpleRebalance via evmHandler
+  t.truthy(evmHandler, 'evmHandler is defined');
+  const newAllocation = { Aave_Arbitrum: 6000n, Compound_Arbitrum: 4000n };
+  const flowKey = await E(evmHandler!).simpleRebalance(newAllocation);
+  t.regex(flowKey, /^flow\d+$/, 'simpleRebalance returns a flow key');
+
+  // Check that a rebalance flow is now running
+  const statusAfter = (await readPublished(
+    `portfolios.portfolio0`,
+  )) as unknown as StatusFor['portfolio'];
+  const flowsRunning = statusAfter.flowsRunning ?? {};
+  t.is(keys(flowsRunning).length, 1, 'one flow running');
+
+  const [[flowId, flowDetail]] = Object.entries(flowsRunning);
+  t.is(flowId, flowKey, 'flow key matches');
+  t.is(flowDetail.type, 'rebalance', 'flow is a rebalance');
+
+  // Verify the target allocation was updated
+  t.deepEqual(
+    statusAfter.targetAllocation,
+    newAllocation,
+    'target allocation updated',
+  );
+});
+
+test('evmHandler.rebalance uses existing allocation', async t => {
+  const { common, planner1, started, readPublished, txResolver } =
+    await setupPlanner(t);
+  const { usdc, bld } = common.brands;
+
+  const initialAllocation = { Aave_Arbitrum: 10000n };
+  const inputs = {
+    fromChain: 'Arbitrum' as const,
+    depositAmount: usdc.units(1000),
+    allocations: [{ instrument: 'Aave_Arbitrum', portion: 10000n }],
+  };
+  const { fromChain: evm, depositAmount, allocations } = inputs;
+
+  type EvmHandler = Awaited<
+    ReturnType<typeof started.publicFacet.openPortfolioFromEVM>
+  >['evmHandler'];
+  let evmHandler: EvmHandler | undefined;
+
+  const traderDo = async () => {
+    const permit2Payload = {
+      permit: {
+        permitted: {
+          token: contractsMock[evm].usdc,
+          amount: depositAmount.value,
+        },
+        nonce: 1n,
+        deadline: 1n,
+      },
+      owner: '0x2222222222222222222222222222222222222222',
+      witness:
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      witnessTypeString: 'OpenPortfolioWitness',
+      signature: '0x1234',
+    } as const;
+    const permitDetails = {
+      chainId: Number(chainInfoWithCCTP[evm].reference),
+      token: contractsMock[evm].usdc,
+      amount: depositAmount.value,
+      spender: contractsMock[evm].depositFactory,
+      permit2Payload,
+    } as const;
+
+    const result = await E(started.publicFacet).openPortfolioFromEVM(
+      { allocations },
+      permitDetails,
+    );
+    evmHandler = result.evmHandler;
+    return result;
+  };
+
+  // Start traderDo first so plannerDo can wait for it
+  const traderDoP = traderDo();
+
+  /** Simulate chain inputs (acks) for makeAccount + GMP transfers. */
+  const chainDo = async () => {
+    await ackNFA(common.utils);
+    await common.utils.transmitVTransferEvent('acknowledgementPacket', -2);
+    await txResolver.drainPending();
+    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
+    await txResolver.drainPending();
+    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
+  };
+
+  const plannerDo = async () => {
+    const pId = 0;
+    // Wait for trader to open portfolio before reading status
+    await traderDoP;
+    const status = (await readPublished(
+      `portfolios.portfolio${pId}`,
+    )) as unknown as StatusFor['portfolio'];
+    const { flowsRunning = {}, policyVersion, rebalanceCount } = status;
+    const sync = [policyVersion, rebalanceCount] as const;
+    const [[flowId, detail]] = Object.entries(flowsRunning);
+    const flowNum = Number(flowId.replace('flow', ''));
+    if (detail.type !== 'deposit') throw t.fail(detail.type);
+    const planDepositAmount = AmountMath.make(usdc.brand, detail.amount.value);
+    const fee = bld.units(100);
+    const plan: FundsFlowPlan = {
+      flow: [
+        { src: `+${evm}`, dest: `@${evm}`, amount: planDepositAmount, fee },
+        {
+          src: `@${evm}`,
+          dest: 'Aave_Arbitrum',
+          amount: planDepositAmount,
+          fee,
+        },
+      ],
+    };
+    await E(planner1.stub).resolvePlan(pId, flowNum, plan, ...sync);
+    return flowNum;
+  };
+
+  await planner1.redeem();
+  await Promise.all([traderDoP, plannerDo(), chainDo()]);
+
+  // Verify portfolio is ready with initial allocation
+  const statusBefore = (await readPublished(
+    `portfolios.portfolio0`,
+  )) as unknown as StatusFor['portfolio'];
+  t.deepEqual(statusBefore.flowsRunning, {}, 'no flows running after deposit');
+  t.deepEqual(
+    statusBefore.targetAllocation,
+    initialAllocation,
+    'initial target allocation set',
+  );
+
+  // Now test rebalance (without new allocation) via evmHandler
+  t.truthy(evmHandler, 'evmHandler is defined');
+  const flowKey = await E(evmHandler!).rebalance();
+  t.regex(flowKey, /^flow\d+$/, 'rebalance returns a flow key');
+
+  // Check that a rebalance flow is now running
+  const statusAfter = (await readPublished(
+    `portfolios.portfolio0`,
+  )) as unknown as StatusFor['portfolio'];
+  const flowsRunning = statusAfter.flowsRunning ?? {};
+  t.is(keys(flowsRunning).length, 1, 'one flow running');
+
+  const [[flowId, flowDetail]] = Object.entries(flowsRunning);
+  t.is(flowId, flowKey, 'flow key matches');
+  t.is(flowDetail.type, 'rebalance', 'flow is a rebalance');
+
+  // Target allocation should remain unchanged
+  t.deepEqual(
+    statusAfter.targetAllocation,
+    initialAllocation,
+    'target allocation unchanged',
+  );
+});
+
+test('evmHandler.rebalance fails if targetAllocation not set', async t => {
+  const { trader1, common } = await setupTrader(t);
+  const { poc26 } = common.brands;
+
+  // Open portfolio via regular method with no target allocation
+  await Promise.all([
+    trader1.openPortfolio(t, { Access: poc26.make(1n) }, {}),
+    ackNFA(common.utils),
+  ]);
+
+  // Verify no target allocation is set
+  const status = await trader1.getPortfolioStatus();
+  t.is(
+    status.targetAllocation,
+    undefined,
+    'targetAllocation not set for portfolio without allocation',
+  );
+});
+
 const setupPlanner = async (
   t,
   overrides: Partial<PortfolioPrivateArgs> = {},

--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -1187,7 +1187,7 @@ test('evmHandler.rebalance fails if targetAllocation not set', async t => {
   // Try to call rebalance and expect it to throw
   await t.throwsAsync(
     () => E(evmHandler).rebalance(),
-    { message: /targetAllocation.*not set|no targetAllocation/i },
+    { message: /targetAllocation.* to be set|no targetAllocation/i },
     'rebalance should fail if targetAllocation is not set',
   );
 });

--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -1157,7 +1157,7 @@ test('evmHandler.rebalance fails if targetAllocation not set', async t => {
   const permit2Payload = {
     permit: {
       permitted: {
-        token: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+        token: contractsMock.Arbitrum.usdc,
         amount: 0n,
       },
       nonce: 1n,
@@ -1171,9 +1171,9 @@ test('evmHandler.rebalance fails if targetAllocation not set', async t => {
   };
   const permitDetails = {
     chainId: 42161,
-    token: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+    token: contractsMock.Arbitrum.usdc,
     amount: 0n,
-    spender: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+    spender: contractsMock.Arbitrum.depositFactory,
     permit2Payload,
   };
 


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description
Implement the rebalance pathway for EVM.  EIP712 doesn't support optional arguments, so we have distinct `simpleRebalance` and `rebalance` (with no args) operations.

### Security Considerations
NA

### Scaling Considerations
NA

### Documentation Considerations
NA

### Testing Considerations
Flow tests provided but not yet reviewed.

### Upgrade Considerations
NA