### PR TITLE
docs(portfolio-contract): add a diagram for withdraw for evm-wallet

### DIFF
--- a/packages/portfolio-contract/docs-design/evm-wallet.md
+++ b/packages/portfolio-contract/docs-design/evm-wallet.md
@@ -212,7 +212,7 @@ sequenceDiagram
   end
   participant A as Arbitrum
   %% Notation: ->> for initial message, -->> for consequences
-  U->>D: withdraw(500$USDC, Arbitrum)
+  U->>D: withdraw(500 USDC, Arbitrum)
   D-->>D: allocate nonce543
   note right of MM: EIP-712 signTypedData
   D->>MM: Withdraw712(500 USDC,“Arbitrum”,nonce543,deadline)

--- a/packages/portfolio-contract/docs-design/evm-wallet.md
+++ b/packages/portfolio-contract/docs-design/evm-wallet.md
@@ -234,7 +234,7 @@ sequenceDiagram
   note over YC: NOT SHOWN:<br/>Orchestration<br/>to @Arbitrum
   YC->> A: @Arbitrum.transfer(500, `+Arbitrum`)
   YC-->> D: flow2 done
-  D -->> U: deposit done
+  D -->> U: withdrawal complete
 ```
 
 ## Early Validation


### PR DESCRIPTION
drive-by

## Description
Add a sequence diagram for withdraw

### Security Considerations
N/A

### Scaling Considerations
N/A

### Documentation Considerations
This adds sequence diagram to documentation

### Testing Considerations
N/A

### Upgrade Considerations
N/A