### PR TITLE
Verify eip712 message

### DIFF
--- a/packages/portfolio-api/package.json
+++ b/packages/portfolio-api/package.json
@@ -30,6 +30,7 @@
     "@agoric/internal": "workspace:*",
     "@agoric/orchestration": "workspace:*",
     "@endo/common": "^1.2.13",
+    "@endo/errors": "^1.2.13",
     "@endo/patterns": "^1.7.0"
   },
   "devDependencies": {

--- a/packages/portfolio-api/src/evm-wallet/message-handler-helpers.ts
+++ b/packages/portfolio-api/src/evm-wallet/message-handler-helpers.ts
@@ -99,11 +99,12 @@ export const makeEVMHandlerUtils = (viemUtils: {
     T extends OperationTypeNames,
   >(
     data: YmaxStandaloneOperationData<T>,
+    validContractAddresses?: Record<number | string, Address>,
   ): YmaxOperationDetails<T> => {
     // @ts-expect-error generic/union type compatibility
     const standaloneData: YmaxStandaloneOperationData = data;
 
-    validateYmaxDomain(standaloneData.domain);
+    validateYmaxDomain(standaloneData.domain, validContractAddresses);
     validateYmaxOperationTypeName<T>(standaloneData.primaryType);
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -218,6 +219,7 @@ export const makeEVMHandlerUtils = (viemUtils: {
     signedData: WithSignature<
       YmaxPermitWitnessTransferFromData<T> | YmaxStandaloneOperationData<T>
     >,
+    validStandaloneContractAddresses?: Record<number | string, Address>,
   ): Promise<FullMessageDetails<T>> => {
     const tokenOwner = await recoverTypedDataAddress(
       signedData as RecoverTypedDataAddressParameters,
@@ -250,8 +252,10 @@ export const makeEVMHandlerUtils = (viemUtils: {
     } else {
       const standaloneData =
         signedData as unknown as YmaxStandaloneOperationData<T>;
-      const operationDetails =
-        extractOperationDetailsFromStandaloneData(standaloneData);
+      const operationDetails = extractOperationDetailsFromStandaloneData(
+        standaloneData,
+        validStandaloneContractAddresses,
+      );
 
       return {
         ...operationDetails,

--- a/packages/portfolio-contract/src/evm-wallet-handler.ts
+++ b/packages/portfolio-contract/src/evm-wallet-handler.ts
@@ -319,12 +319,14 @@ export const prepareEVMWalletHandlerKit = (
     timerService,
     portfolioContractPublicFacet,
     publishStatus,
+    validStandaloneContractAddresses,
   }: {
     storageNode: ERemote<StorageNode>;
     vowTools: Pick<VowTools, 'asVow' | 'watch' | 'when'>;
     timerService: ERemote<TimerService>;
     portfolioContractPublicFacet: ERemote<PortfolioContractPublicFacet>;
     publishStatus: PublishStatus;
+    validStandaloneContractAddresses: Record<number | string, Address>;
   },
 ) => {
   const { extractOperationDetailsFromSignedData } = makeEVMHandlerUtils({
@@ -378,8 +380,10 @@ export const prepareEVMWalletHandlerKit = (
           trace('handleMessage', messageData);
 
           // Resolves immediately on-chain since all deps are bundled
-          const details =
-            await extractOperationDetailsFromSignedData(messageData);
+          const details = await extractOperationDetailsFromSignedData(
+            messageData,
+            validStandaloneContractAddresses,
+          );
 
           trace('extracted details', details);
 

--- a/packages/portfolio-contract/src/evm-wallet-handler.ts
+++ b/packages/portfolio-contract/src/evm-wallet-handler.ts
@@ -117,7 +117,7 @@ export const makeNonceManager = (zone: Zone) => {
   const removeExpiredNonces = (currentTime: bigint): void => {
     for (const encodedKey of noncesByDeadline.keys()) {
       const key = decodeKeyByDeadline(encodedKey);
-      if (key.deadline > currentTime) {
+      if (currentTime <= key.deadline) {
         break;
       }
 
@@ -390,6 +390,12 @@ export const prepareEVMWalletHandlerKit = (
           const { absValue: localChainTime } =
             await E(timerService).getCurrentTimestamp();
           removeExpiredNonces(localChainTime);
+
+          if (localChainTime > deadline) {
+            throw Fail`Deadline has already passed: ${q(deadline)} vs ${q(
+              localChainTime,
+            )}`;
+          }
 
           deadline < localChainTime + MAX_DEADLINE_OFFSET ||
             Fail`Deadline too far in the future: ${q(deadline)} vs ${q(localChainTime)}`;

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -77,7 +77,7 @@ import {
 } from './type-guards.ts';
 
 const trace = makeTracer('PortC');
-const { fromEntries, keys } = Object;
+const { entries, fromEntries, keys } = Object;
 
 const makeTransferChannels = (chainInfo: PortfolioPrivateArgs['chainInfo']) => {
   const { agoric, axelar, noble } = chainInfo as Record<
@@ -666,6 +666,12 @@ export const contract = async (
       timerService,
       portfolioContractPublicFacet: publicFacet,
       publishStatus,
+      validStandaloneContractAddresses: fromEntries(
+        entries(eip155ChainIdToAxelarChain).map(
+          ([chainId, chainName]) =>
+            [chainId, contracts[chainName].depositFactory] as const,
+        ),
+      ),
     },
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,6 +978,7 @@ __metadata:
     "@agoric/internal": "workspace:*"
     "@agoric/orchestration": "workspace:*"
     "@endo/common": "npm:^1.2.13"
+    "@endo/errors": "npm:^1.2.13"
     "@endo/patterns": "npm:^1.7.0"
     "@types/js-yaml": "npm:^4"
     ajv: "npm:^6.12.6"


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-private/issues/666

## Description
- Check that deadline hasn't passed
- Expand standalone EIP-712 message domain to include the depositFactory address as verifyingContract

### Security Considerations
This changes enforces that EIP-712 messages cannot be replayed between contracts and chains by always rooting the EIP-712 message signature in an agoric LCA address (transitively through owned EVM contracts)

### Scaling Considerations
None

### Documentation Considerations
TODO: Update design doc

### Testing Considerations
TODO

### Upgrade Considerations
TBD
