### PR TITLE
fix(ymax-planner): Exclude GraphQL operation description strings in outbound messages

### DIFF
--- a/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.2.2-1dfc1601b5.patch
+++ b/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.2.2-1dfc1601b5.patch
@@ -1,0 +1,200 @@
+diff --git a/cjs/client-side-base-visitor.js b/cjs/client-side-base-visitor.js
+index 42e50f507ef4feb4f156db7192c6b9be9c7524c6..d55feace207507dc5c330517dcf69fbdf95f6d9c 100644
+--- a/cjs/client-side-base-visitor.js
++++ b/cjs/client-side-base-visitor.js
+@@ -22,7 +22,7 @@ var DocumentMode;
+     DocumentMode["external"] = "external";
+     DocumentMode["string"] = "string";
+ })(DocumentMode || (exports.DocumentMode = DocumentMode = {}));
+-const EXTENSIONS_TO_REMOVE = ['.ts', '.tsx', '.js', '.jsx'];
++const EXTENSIONS_TO_REMOVE = [];
+ class ClientSideBaseVisitor extends base_visitor_js_1.BaseVisitor {
+     _schema;
+     _collectedOperations = [];
+@@ -112,9 +112,12 @@ class ClientSideBaseVisitor extends base_visitor_js_1.BaseVisitor {
+         const includeNestedFragments = this.config.documentMode === DocumentMode.documentNode || this.config.documentMode === DocumentMode.string;
+         const fragmentNames = this._extractFragments(node, includeNestedFragments);
+         const fragments = this._transformFragments(fragmentNames);
++        // Re-escape escaped values in GraphQL syntax.
++        const docLiteralContents = (0, graphql_1.print)(node).split('\\').join('\\\\');
++        const fragmentsLiteralContents = this._includeFragments(fragments);
+         const doc = this._prepareDocument(`
+-    ${(0, graphql_1.print)(node).split('\\').join('\\\\') /* Re-escape escaped values in GraphQL syntax */}
+-    ${this._includeFragments(fragments)}`);
++    ${docLiteralContents}
++    ${fragmentsLiteralContents}`);
+         if (this.config.documentMode === DocumentMode.documentNode) {
+             let gqlObj = (0, graphql_tag_1.default)([doc]);
+             if (this.config.optimizeDocumentNode) {
+@@ -158,9 +161,13 @@ class ClientSideBaseVisitor extends base_visitor_js_1.BaseVisitor {
+             return `{${metaString}"kind":"${graphql_1.Kind.DOCUMENT}","definitions":${jsonStringify(definitions)}}`;
+         }
+         if (this.config.documentMode === DocumentMode.string) {
++            const optimizedDoc = this.config.optimizeDocumentNode
++              ? (0, graphql_1.print)((0, optimize_1.optimizeDocumentNode)((0, graphql_tag_1.default)([doc])))
++              : doc;
++            const escapedLiteralContents = (0, utils_js_1.asTemplateLiteral)(optimizedDoc).slice(1, -1);
+             if (node.kind === graphql_1.Kind.FRAGMENT_DEFINITION) {
+                 const meta = this._getGraphQLCodegenMetadata(node, (0, graphql_tag_1.default)([doc]).definitions);
+-                return `new TypedDocumentString(\`${doc}\`, ${JSON.stringify({ fragmentName: node.name.value, ...meta })})`;
++                return `new TypedDocumentString(\`${escapedLiteralContents}\`, ${JSON.stringify({ fragmentName: node.name.value, ...meta })})`;
+             }
+             if (this._onExecutableDocumentNode && node.kind === graphql_1.Kind.OPERATION_DEFINITION) {
+                 const meta = this._getGraphQLCodegenMetadata(node, (0, graphql_tag_1.default)([doc]).definitions);
+@@ -168,13 +175,20 @@ class ClientSideBaseVisitor extends base_visitor_js_1.BaseVisitor {
+                     if (this._omitDefinitions === true) {
+                         return `{${`"__meta__":${JSON.stringify(meta)},`.slice(0, -1)}}`;
+                     }
+-                    return `new TypedDocumentString(\`${doc}\`, ${JSON.stringify(meta)})`;
++                    return `new TypedDocumentString(\`${escapedLiteralContents}\`, ${JSON.stringify(meta)})`;
+                 }
+             }
+-            return `new TypedDocumentString(\`${doc}\`)`;
++            return `new TypedDocumentString(\`${escapedLiteralContents}\`)`;
+         }
++        const optimizedDocPrefix = this.config.optimizeDocumentNode
++          ? (0, graphql_1.print)((0, optimize_1.optimizeDocumentNode)((0, graphql_tag_1.default)([docLiteralContents])))
++          : docLiteralContents;
++        const escapedLiteralContentsPrefix = (0, utils_js_1.asTemplateLiteral)(optimizedDocPrefix).slice(1, -1);
++        const escapedDoc = this._prepareDocument(`
++    ${escapedLiteralContentsPrefix}
++    ${fragmentsLiteralContents}`);
+         const gqlImport = this._parseImport(this.config.gqlImport || 'graphql-tag');
+-        return (gqlImport.propName || 'gql') + '`' + doc + '`';
++        return (gqlImport.propName || 'gql') + '`' + escapedDoc + '`';
+     }
+     _getGraphQLCodegenMetadata(node, definitions) {
+         let meta;
+diff --git a/cjs/utils.js b/cjs/utils.js
+index a9fc2074f8fdcd9090588571eec7cf40d335b602..01df2b0e88728310549577ad327ef4dc31f064ae 100644
+--- a/cjs/utils.js
++++ b/cjs/utils.js
+@@ -1,6 +1,6 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
+-exports.getFieldNames = exports.getFieldNodeNameValue = exports.REQUIRE_FIELDS_TYPE = exports.OMIT_TYPE = exports.DeclarationBlock = exports.getConfigValue = void 0;
++exports.getFieldNames = exports.getFieldNodeNameValue = exports.REQUIRE_FIELDS_TYPE = exports.OMIT_TYPE = exports.DeclarationBlock = exports.getConfigValue = exports.asTemplateLiteral = void 0;
+ exports.quoteIfNeeded = quoteIfNeeded;
+ exports.block = block;
+ exports.wrapWithSingleQuotes = wrapWithSingleQuotes;
+@@ -29,6 +29,8 @@ exports.unique = unique;
+ const graphql_1 = require("graphql");
+ const mappers_js_1 = require("./mappers.js");
+ const scalars_js_1 = require("./scalars.js");
++const asTemplateLiteral = str => '`' + str.replace(/[`$\\]/g, '\\$&') + '`';
++exports.asTemplateLiteral = asTemplateLiteral;
+ const getConfigValue = (value, defaultValue) => {
+     if (value === null || value === undefined) {
+         return defaultValue;
+diff --git a/esm/client-side-base-visitor.js b/esm/client-side-base-visitor.js
+index 8541f60fc546d668c663881f3aca3e0f417df64a..514dbe41153c1577959bca5f07124cc25a4da508 100644
+--- a/esm/client-side-base-visitor.js
++++ b/esm/client-side-base-visitor.js
+@@ -7,7 +7,7 @@ import { DepGraph } from 'dependency-graph';
+ import { Kind, print, } from 'graphql';
+ import gqlTag from 'graphql-tag';
+ import { BaseVisitor } from './base-visitor.js';
+-import { buildScalarsFromConfig, unique, flatten, getConfigValue, groupBy } from './utils.js';
++import { asTemplateLiteral, buildScalarsFromConfig, unique, flatten, getConfigValue, groupBy } from './utils.js';
+ import { generateFragmentImportStatement } from './imports.js';
+ gqlTag.enableExperimentalFragmentVariables();
+ export var DocumentMode;
+@@ -18,7 +18,7 @@ export var DocumentMode;
+     DocumentMode["external"] = "external";
+     DocumentMode["string"] = "string";
+ })(DocumentMode || (DocumentMode = {}));
+-const EXTENSIONS_TO_REMOVE = ['.ts', '.tsx', '.js', '.jsx'];
++const EXTENSIONS_TO_REMOVE = [];
+ export class ClientSideBaseVisitor extends BaseVisitor {
+     _schema;
+     _collectedOperations = [];
+@@ -108,9 +108,12 @@ export class ClientSideBaseVisitor extends BaseVisitor {
+         const includeNestedFragments = this.config.documentMode === DocumentMode.documentNode || this.config.documentMode === DocumentMode.string;
+         const fragmentNames = this._extractFragments(node, includeNestedFragments);
+         const fragments = this._transformFragments(fragmentNames);
++        // Re-escape escaped values in GraphQL syntax.
++        const docLiteralContents = print(node).split('\\').join('\\\\');
++        const fragmentsLiteralContents = this._includeFragments(fragments);
+         const doc = this._prepareDocument(`
+-    ${print(node).split('\\').join('\\\\') /* Re-escape escaped values in GraphQL syntax */}
+-    ${this._includeFragments(fragments)}`);
++    ${docLiteralContents}
++    ${fragmentsLiteralContents}`);
+         if (this.config.documentMode === DocumentMode.documentNode) {
+             let gqlObj = gqlTag([doc]);
+             if (this.config.optimizeDocumentNode) {
+@@ -154,9 +157,13 @@ export class ClientSideBaseVisitor extends BaseVisitor {
+             return `{${metaString}"kind":"${Kind.DOCUMENT}","definitions":${jsonStringify(definitions)}}`;
+         }
+         if (this.config.documentMode === DocumentMode.string) {
++            const optimizedDoc = this.config.optimizeDocumentNode
++              ? print(optimizeDocumentNode(gqlTag([doc])))
++              : doc;
++            const escapedLiteralContents = asTemplateLiteral(optimizedDoc).slice(1, -1);
+             if (node.kind === Kind.FRAGMENT_DEFINITION) {
+                 const meta = this._getGraphQLCodegenMetadata(node, gqlTag([doc]).definitions);
+-                return `new TypedDocumentString(\`${doc}\`, ${JSON.stringify({ fragmentName: node.name.value, ...meta })})`;
++                return `new TypedDocumentString(\`${escapedLiteralContents}\`, ${JSON.stringify({ fragmentName: node.name.value, ...meta })})`;
+             }
+             if (this._onExecutableDocumentNode && node.kind === Kind.OPERATION_DEFINITION) {
+                 const meta = this._getGraphQLCodegenMetadata(node, gqlTag([doc]).definitions);
+@@ -164,13 +171,20 @@ export class ClientSideBaseVisitor extends BaseVisitor {
+                     if (this._omitDefinitions === true) {
+                         return `{${`"__meta__":${JSON.stringify(meta)},`.slice(0, -1)}}`;
+                     }
+-                    return `new TypedDocumentString(\`${doc}\`, ${JSON.stringify(meta)})`;
++                    return `new TypedDocumentString(\`${escapedLiteralContents}\`, ${JSON.stringify(meta)})`;
+                 }
+             }
+-            return `new TypedDocumentString(\`${doc}\`)`;
++            return `new TypedDocumentString(\`${escapedLiteralContents}\`)`;
+         }
++        const optimizedDocPrefix = this.config.optimizeDocumentNode
++          ? print(optimizeDocumentNode(gqlTag([docLiteralContents])))
++          : docLiteralContents;
++        const escapedLiteralContentsPrefix = asTemplateLiteral(optimizedDocPrefix).slice(1, -1);
++        const escapedDoc = this._prepareDocument(`
++    ${escapedLiteralContentsPrefix}
++    ${fragmentsLiteralContents}`);
+         const gqlImport = this._parseImport(this.config.gqlImport || 'graphql-tag');
+-        return (gqlImport.propName || 'gql') + '`' + doc + '`';
++        return (gqlImport.propName || 'gql') + '`' + escapedDoc + '`';
+     }
+     _getGraphQLCodegenMetadata(node, definitions) {
+         let meta;
+diff --git a/esm/utils.js b/esm/utils.js
+index d363794e5779bb4e76ae0edfe8c978b24f5f7395..ca9544c1d0b245c8b6fa57daf6a35c5a16a9b73d 100644
+--- a/esm/utils.js
++++ b/esm/utils.js
+@@ -1,6 +1,7 @@
+ import { isAbstractType, isInputObjectType, isListType, isNonNullType, isObjectType, isScalarType, Kind, } from 'graphql';
+ import { parseMapper } from './mappers.js';
+ import { DEFAULT_SCALARS } from './scalars.js';
++export const asTemplateLiteral = str => '`' + str.replace(/[`$\\]/g, '\\$&') + '`';
+ export const getConfigValue = (value, defaultValue) => {
+     if (value === null || value === undefined) {
+         return defaultValue;
+diff --git a/typings/utils.d.cts b/typings/utils.d.cts
+index e2bb1a4a7854bbc714ccab2609841587ac261ad5..7a2aa10308f8895d50e1aba805e0d3f137136c9e 100644
+--- a/typings/utils.d.cts
++++ b/typings/utils.d.cts
+@@ -1,6 +1,7 @@
+ import { FieldNode, FragmentSpreadNode, GraphQLInputObjectType, GraphQLNamedType, GraphQLObjectType, GraphQLOutputType, GraphQLSchema, InlineFragmentNode, NamedTypeNode, NameNode, SelectionNode, SelectionSetNode, StringValueNode, TypeNode, DirectiveNode } from 'graphql';
+ import { RawConfig } from './base-visitor.cjs';
+ import { NormalizedScalarsMap, ParsedScalarsMap, ScalarsMap, FragmentDirectives, LoadedFragment } from './types.cjs';
++export declare const asTemplateLiteral: (str: string) => string;
+ export declare const getConfigValue: <T = any>(value: T, defaultValue: T) => T;
+ export declare function quoteIfNeeded(array: string[], joinWith?: string): string;
+ export declare function block(array: any): string;
+diff --git a/typings/utils.d.ts b/typings/utils.d.ts
+index f743d230405c81339d59ccd6dcebc04e32ca522b..86644bb8a4443af52147b66c2f57a8cc5e96085b 100644
+--- a/typings/utils.d.ts
++++ b/typings/utils.d.ts
+@@ -1,6 +1,7 @@
+ import { FieldNode, FragmentSpreadNode, GraphQLInputObjectType, GraphQLNamedType, GraphQLObjectType, GraphQLOutputType, GraphQLSchema, InlineFragmentNode, NamedTypeNode, NameNode, SelectionNode, SelectionSetNode, StringValueNode, TypeNode, DirectiveNode } from 'graphql';
+ import { RawConfig } from './base-visitor.js';
+ import { NormalizedScalarsMap, ParsedScalarsMap, ScalarsMap, FragmentDirectives, LoadedFragment } from './types.js';
++export declare const asTemplateLiteral: (str: string) => string;
+ export declare const getConfigValue: <T = any>(value: T, defaultValue: T) => T;
+ export declare function quoteIfNeeded(array: string[], joinWith?: string): string;
+ export declare function block(array: any): string;

--- a/package.json
+++ b/package.json
@@ -91,10 +91,12 @@
     "@endo/pass-style@npm:^1.6.3": "patch:@endo/pass-style@patch%3A@endo/pass-style@npm%253A1.6.3%23~/.yarn/patches/@endo-pass-style-npm-1.6.3-139d4e4c47.patch%3A%3Aversion=1.6.3&hash=1f61c8#~/.yarn/patches/@endo-pass-style-patch-fd208907c7.patch",
     "@endo/patterns@npm:^1.7.0": "patch:@endo/patterns@npm%3A1.7.0#~/.yarn/patches/@endo-patterns-npm-1.7.0-70bb963d8a.patch",
     "@endo/marshal@npm:^1.8.0": "patch:@endo/marshal@npm%3A1.8.0#~/.yarn/patches/@endo-marshal-npm-1.8.0-c73c5363a1.patch",
-    "@graphql-codegen/visitor-plugin-common@npm:2.13.8": "patch:@graphql-codegen/visitor-plugin-common@npm%3A6.1.0#~/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.1.0-c6f558d634.patch",
+    "@graphql-codegen/visitor-plugin-common@npm:2.13.8": "patch:@graphql-codegen/visitor-plugin-common@npm%3A6.2.2#~/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.2.2-1dfc1601b5.patch",
     "@graphql-codegen/visitor-plugin-common@npm:^6.1.0": "patch:@graphql-codegen/visitor-plugin-common@npm%3A6.1.0#~/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.1.0-c6f558d634.patch",
     "@graphql-codegen/visitor-plugin-common@npm:6.1.0": "patch:@graphql-codegen/visitor-plugin-common@npm%3A6.1.0#~/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.1.0-c6f558d634.patch",
-    "@graphql-tools/optimize@npm:^2.0.0": "patch:@graphql-tools/optimize@npm%3A2.0.0#~/.yarn/patches/@graphql-tools-optimize-npm-2.0.0-710bf461f3.patch"
+    "@graphql-tools/optimize@npm:^2.0.0": "patch:@graphql-tools/optimize@npm%3A2.0.0#~/.yarn/patches/@graphql-tools-optimize-npm-2.0.0-710bf461f3.patch",
+    "@graphql-codegen/visitor-plugin-common@npm:^6.2.2": "patch:@graphql-codegen/visitor-plugin-common@npm%3A6.2.2#~/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.2.2-1dfc1601b5.patch",
+    "@graphql-codegen/visitor-plugin-common@npm:6.2.2": "patch:@graphql-codegen/visitor-plugin-common@npm%3A6.2.2#~/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.2.2-1dfc1601b5.patch"
   },
   "dependenciesMeta": {
     "better-sqlite3@10.1.0": {

--- a/services/ymax-planner/src/graphql/api-spectrum-blockchain/__generated/graphql.ts
+++ b/services/ymax-planner/src/graphql/api-spectrum-blockchain/__generated/graphql.ts
@@ -513,26 +513,12 @@ export class TypedDocumentString<TResult, TVariables>
   }
 }
 
-export const GetBalancesDocument = new TypedDocumentString(`
-    """
-Get the balances for an arbitrary number of accounts.
-
-Each account is identified by a blockchain (for EVM chains, a
-'0x<upaddedLowercaseHexDigits>' representation of their EIP-155 CHAIN_ID [cf.
-https://chainlist.org/ ]), address, and token (for EVM chains, a
-'0x<hexDigits>' representation of its contract address, visible on e.g.
-https://coinmarketcap.com/ ).
-
-Note that the output 'balance' is a decimal string representing a floating-point
-token balance (e.g., each unit of which is 1e6 micro-units).
-"""
-query getBalances($accounts: [ChainAddressTokenInput!]!) {
-  balances: getAddressBalance(input: $accounts) {
+export const GetBalancesDocument = new TypedDocumentString(`query getBalances(\$accounts: [ChainAddressTokenInput!]!) {
+  balances: getAddressBalance(input: \$accounts) {
     chain
     address
     token
     balance
     error
   }
-}
-    `) as unknown as TypedDocumentString<GetBalancesQuery, GetBalancesQueryVariables>;
+}`) as unknown as TypedDocumentString<GetBalancesQuery, GetBalancesQueryVariables>;

--- a/services/ymax-planner/src/graphql/api-spectrum-pools/__generated/graphql.ts
+++ b/services/ymax-planner/src/graphql/api-spectrum-pools/__generated/graphql.ts
@@ -182,27 +182,12 @@ export class TypedDocumentString<TResult, TVariables>
   }
 }
 
-export const GetBalancesDocument = new TypedDocumentString(`
-    """
-Get the balances for an arbitrary number of deployed pool positions.
-
-Each position is identified by a blockchain (for EVM chains, a
-'0x<upaddedLowercaseHexDigits>' representation of their EIP-155 CHAIN_ID [cf.
-https://chainlist.org/ ]), protocol, pool within that protocol (corresponding
-with e.g. an associated token, cf.
-https://spectrumnodes.gitbook.io/docs/developer-guides/apis/pools-api/supported-pools
-), and address.
-
-Note that the output 'balance' is an object, from which you probably want the
-"USDC" property (a floating-point number, each unit of which is 1e6 uudc).
-"""
-query getBalances($positions: [ProtocolPoolUserBalanceInput!]!) {
-  balances: getProtocolPoolUserBalance(input: $positions) {
+export const GetBalancesDocument = new TypedDocumentString(`query getBalances(\$positions: [ProtocolPoolUserBalanceInput!]!) {
+  balances: getProtocolPoolUserBalance(input: \$positions) {
     chain
     protocol
     pool
     balance
     error
   }
-}
-    `) as unknown as TypedDocumentString<GetBalancesQuery, GetBalancesQueryVariables>;
+}`) as unknown as TypedDocumentString<GetBalancesQuery, GetBalancesQueryVariables>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4865,27 +4865,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-codegen/visitor-plugin-common@npm:6.1.0":
-  version: 6.1.0
-  resolution: "@graphql-codegen/visitor-plugin-common@npm:6.1.0"
-  dependencies:
-    "@graphql-codegen/plugin-helpers": "npm:^6.0.0"
-    "@graphql-tools/optimize": "npm:^2.0.0"
-    "@graphql-tools/relay-operation-optimizer": "npm:^7.0.0"
-    "@graphql-tools/utils": "npm:^10.0.0"
-    auto-bind: "npm:~4.0.0"
-    change-case-all: "npm:1.0.15"
-    dependency-graph: "npm:^1.0.0"
-    graphql-tag: "npm:^2.11.0"
-    parse-filepath: "npm:^1.0.2"
-    tslib: "npm:~2.6.0"
-  peerDependencies:
-    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: 10c0/120c1a0ad82d179c2ccd16dd6b556d93b658355d80b8fcf2efb55711466705d7fe8401ae020eef33ba57629a39affbf3d7fb84659de7191c07b79b182050126f
-  languageName: node
-  linkType: hard
-
-"@graphql-codegen/visitor-plugin-common@npm:6.2.2, @graphql-codegen/visitor-plugin-common@npm:^6.2.2":
+"@graphql-codegen/visitor-plugin-common@npm:6.2.2":
   version: 6.2.2
   resolution: "@graphql-codegen/visitor-plugin-common@npm:6.2.2"
   dependencies:
@@ -4905,11 +4885,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-codegen/visitor-plugin-common@patch:@graphql-codegen/visitor-plugin-common@npm%3A6.1.0#~/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.1.0-c6f558d634.patch":
-  version: 6.1.0
-  resolution: "@graphql-codegen/visitor-plugin-common@patch:@graphql-codegen/visitor-plugin-common@npm%3A6.1.0#~/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.1.0-c6f558d634.patch::version=6.1.0&hash=b01142"
+"@graphql-codegen/visitor-plugin-common@patch:@graphql-codegen/visitor-plugin-common@npm%3A6.2.2#~/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.2.2-1dfc1601b5.patch":
+  version: 6.2.2
+  resolution: "@graphql-codegen/visitor-plugin-common@patch:@graphql-codegen/visitor-plugin-common@npm%3A6.2.2#~/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.2.2-1dfc1601b5.patch::version=6.2.2&hash=ab1a17"
   dependencies:
-    "@graphql-codegen/plugin-helpers": "npm:^6.0.0"
+    "@graphql-codegen/plugin-helpers": "npm:^6.1.0"
     "@graphql-tools/optimize": "npm:^2.0.0"
     "@graphql-tools/relay-operation-optimizer": "npm:^7.0.0"
     "@graphql-tools/utils": "npm:^10.0.0"
@@ -4921,7 +4901,7 @@ __metadata:
     tslib: "npm:~2.6.0"
   peerDependencies:
     graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: 10c0/efaa776ab2614d8435ffa264f78c56857fdf2cd81c828c09146f453897037dbbe84fd06f9369c828bdd98c0cd8d54131e0c463da9639fd991f06e0ce3ea6b6ec
+  checksum: 10c0/6d30a4a9c73beee10cfef222ff0e1ca406ed7600336ed16d1c76eb41aa7f8634a6a47e0e675213fbfe851bc0fe07d1753d57421aa4e1b5c6bbb63656dd84309d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ref #12332

## Description
Restore and update [@graphql-codegen/visitor-plugin-common](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common) patch code from https://github.com/Agoric/agoric-sdk/pull/12185#discussion_r2496682951 , mostly for using `optimizeDocumentNode` with `documentMode` "string".

### Security Considerations
None known.

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
No known special requirements.

### Upgrade Considerations
Safe for immediate deployment.