### PR TITLE
fix(ymax-resolver): add retry logic when reading initial pending transactions

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -821,10 +821,11 @@ export const startEngine = async (
     let streamCellJson;
     let data;
     try {
-      streamCellJson = await query.vstorage.readStorage(path, {
-        kind: 'data',
+      const metaResponse = await readStorageMeta(query.vstorage, path, 'data', {
+        retries: 4,
       });
-      const streamCell = parseStreamCell(streamCellJson.value, path);
+      streamCellJson = metaResponse.result.value;
+      const streamCell = parseStreamCell(streamCellJson, path);
       const marshalledData = parseStreamCellValue(streamCell, -1, path);
       data = marshaller.fromCapData(marshalledData);
       if (


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

Replace direct `readStorage()` call with `readStorageMeta()` to add retry logic (4 retries) when loading pending transactions at engine startup. This reduces false-positive `Failed to read old pending tx` errors caused by transient network/RPC failures.

[Slack Thread](https://agoricopco.slack.com/archives/C0A0E7QA415/p1768642236262009)

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Pending transactions resolved after making this change:
- [tx129](https://vstorage.agoric.net/?path=published.ymax0.pendingTxs.tx129&endpoint=https%3A%2F%2Fdevnet.rpc.agoric.net%3A443&height=undefined)
- [tx131](https://vstorage.agoric.net/?path=published.ymax0.pendingTxs.tx131&endpoint=https%3A%2F%2Fdevnet.rpc.agoric.net%3A443&height=undefined)

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- A new planner deployment is required for ymax0 and ymax1.