### PR TITLE
chore: add finality protection for GMP transactions with chain-specific confirmations

### DIFF
--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -236,6 +236,7 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
       contractAddress: accountAddress as `0x${string}`,
       txId,
       expectedSourceAddress: lcaAddress,
+      chainId: caipId,
       log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
     };
 

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -221,6 +221,47 @@ export const getBlockTimeMs = (chainId: CaipChainId): number => {
 };
 
 /**
+ * Number of block confirmations required before marking a transaction as final.
+ * Higher values provide stronger finality guarantees but increase latency.
+ *
+ * Values are informed by Circle’s blockchain confirmation guidance, which is based
+ * on historical reorg behavior and network architecture.
+ *
+ * Note: For Ethereum and Avalanche, these values directly match Circle’s documented
+ * confirmation requirements. For EVM L2 chains (Arbitrum, Base, Optimism), Circle
+ * expresses finality in terms of Ethereum L1 confirmations ("12 ETH blocks").
+ * Since this watcher only observes L2 chains and does not verify L1 batch inclusion
+ * or Ethereum finality, the L2 values below represent a conservative same-chain
+ * confirmation depth chosen to mitigate typical sequencer reorg risk, rather than
+ * a full implementation of Circle’s L1-anchored finality.
+ *
+ * @see https://developers.circle.com/w3s/blockchain-confirmations
+ */
+
+const blockConfirmationsRequired: Record<CaipChainId, number> = harden({
+  // ========= Mainnet =========
+  'eip155:1': 12, // Ethereum Mainnet
+  'eip155:42161': 20, // Arbitrum One
+  'eip155:43114': 1, // Avalanche C-Chain
+  'eip155:8453': 10, // Base
+  'eip155:10': 10, // Optimism
+
+  // ========= Testnet =========
+  'eip155:11155111': 12, // Ethereum Sepolia
+  'eip155:421614': 20, // Arbitrum Sepolia
+  'eip155:43113': 1, // Avalanche Fuji
+  'eip155:84532': 10, // Base Sepolia
+  'eip155:11155420': 10, // Optimism Sepolia
+});
+
+/**
+ * Get the number of confirmations required for a given chain ID.
+ */
+export const getConfirmationsRequired = (chainId: CaipChainId): number => {
+  return blockConfirmationsRequired[chainId];
+};
+
+/**
  * @deprecated should come from e.g. @agoric/portfolio-api/src/constants.js
  *   or @agoric/orchestration
  */

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -224,34 +224,35 @@ export const getBlockTimeMs = (chainId: CaipChainId): number => {
  * Number of block confirmations required before marking a transaction as final.
  * Higher values provide stronger finality guarantees but increase latency.
  *
- * Values are informed by Circle’s blockchain confirmation guidance, which is based
- * on historical reorg behavior and network architecture.
+ * Note: We use 25 confirmations for all chains as a conservative, uniform approach
+ * that maximizes safety. Since confirmation waits only apply to transaction failures
+ * (success cases return immediately with 0 confirmations), the latency impact is
+ * acceptable and limited to rare failure scenarios.
  *
- * Note: For Ethereum and Avalanche, these values directly match Circle’s documented
- * confirmation requirements. For EVM L2 chains (Arbitrum, Base, Optimism), Circle
- * expresses finality in terms of Ethereum L1 confirmations ("12 ETH blocks").
- * Since this watcher only observes L2 chains and does not verify L1 batch inclusion
- * or Ethereum finality, the L2 values below represent a conservative same-chain
- * confirmation depth chosen to mitigate typical sequencer reorg risk, rather than
- * a full implementation of Circle’s L1-anchored finality.
+ * This value can be reconfigured on a per-chain basis if specific networks require
+ * different confirmation depths based on their consensus mechanisms or reorg risk.
+ *
+ * Background: Circle's blockchain confirmation guidance recommends 12 for Ethereum,
+ * 20 for Arbitrum, 1 for Avalanche, and 10 for Base/Optimism. Our choice of 25
+ * provides additional safety margin beyond these recommendations.
  *
  * @see https://developers.circle.com/w3s/blockchain-confirmations
  */
 
 const blockConfirmationsRequired: Record<CaipChainId, number> = harden({
   // ========= Mainnet =========
-  'eip155:1': 12, // Ethereum Mainnet
-  'eip155:42161': 20, // Arbitrum One
-  'eip155:43114': 1, // Avalanche C-Chain
-  'eip155:8453': 10, // Base
-  'eip155:10': 10, // Optimism
+  'eip155:1': 25, // Ethereum Mainnet
+  'eip155:42161': 25, // Arbitrum One
+  'eip155:43114': 25, // Avalanche C-Chain
+  'eip155:8453': 25, // Base
+  'eip155:10': 25, // Optimism
 
   // ========= Testnet =========
-  'eip155:11155111': 12, // Ethereum Sepolia
-  'eip155:421614': 20, // Arbitrum Sepolia
-  'eip155:43113': 1, // Avalanche Fuji
-  'eip155:84532': 10, // Base Sepolia
-  'eip155:11155420': 10, // Optimism Sepolia
+  'eip155:11155111': 25, // Ethereum Sepolia
+  'eip155:421614': 25, // Arbitrum Sepolia
+  'eip155:43113': 25, // Avalanche Fuji
+  'eip155:84532': 25, // Base Sepolia
+  'eip155:11155420': 25, // Optimism Sepolia
 });
 
 /**

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -220,7 +220,16 @@ export const watchGmp = ({
         if (msg.method !== 'eth_subscription') return;
 
         const tx = msg.params?.result?.transaction;
+        const removed = msg.params?.result?.removed;
         if (!tx) return;
+
+        // Ignore transactions that have been removed from canonical chain (reorged)
+        if (removed === true) {
+          log(
+            `⚠️  REORG: txId=${txId} txHash=${tx.hash} was removed from chain - ignoring`,
+          );
+          return;
+        }
 
         const txHash = tx.hash;
         const txData = tx.input;
@@ -295,7 +304,7 @@ export const watchGmp = ({
         'alchemy_minedTransactions',
         {
           addresses: [{ to: contractAddress }],
-          includeRemoved: false,
+          includeRemoved: true, // Receive reorg notifications
           hashesOnly: false,
         },
       ]);

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -7,6 +7,7 @@ import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import { tryJsonParse } from '@agoric/internal';
 import {
   getBlockNumberBeforeRealTime,
+  getConfirmationsRequired,
   scanEvmLogsInChunks,
 } from '../support.ts';
 import type { MakeAbortController, WatcherTimeoutOptions } from '../support.ts';
@@ -63,6 +64,7 @@ type WatchGmp = {
   contractAddress: `0x${string}`;
   txId: TxId;
   expectedSourceAddress: string;
+  chainId: CaipChainId;
   log: (...args: unknown[]) => void;
   kvStore: KVStore;
   makeAbortController: MakeAbortController;
@@ -116,6 +118,7 @@ export const watchGmp = ({
   contractAddress,
   txId,
   expectedSourceAddress,
+  chainId,
   timeoutMs = TX_TIMEOUT_MS,
   log = () => {},
   setTimeout = globalThis.setTimeout,
@@ -246,7 +249,7 @@ export const watchGmp = ({
         }
 
         // Wait for confirmations to ensure finality and prevent reorg issues
-        const confirmations = 5;
+        const confirmations = getConfirmationsRequired(chainId);
         const receipt = await provider.waitForTransaction(
           txHash,
           confirmations,

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -67,7 +67,7 @@ test('handlePendingTx processes GMP transaction successfully', async t => {
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching transaction status for txId: ${txId} at contract: ${contractAddress}`,
-    `[${txId}] ✅ SUCCESS: txId=${txId} txHash=0x123abc block=18500000`,
+    `[${txId}] ✅ SUCCESS (5 confirmations): txId=${txId} txHash=0x123abc block=18500000`,
     `[${txId}] GMP tx resolved`,
   ]);
 });
@@ -130,7 +130,7 @@ test('handlePendingTx logs a time out on a GMP transaction with no matching even
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching transaction status for txId: ${txId} at contract: ${contractAddress}`,
     `[${txId}] ✗ No transaction status found for txId ${txId} within 0.01 minutes`,
-    `[${txId}] ✅ SUCCESS: txId=${txId} txHash=0x123abc block=18500000`,
+    `[${txId}] ✅ SUCCESS (5 confirmations): txId=${txId} txHash=0x123abc block=18500000`,
     `[${txId}] GMP tx resolved`,
   ]);
 });

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -12,6 +12,7 @@ import type { PendingTx } from '@aglocal/portfolio-contract/src/resolver/types.t
 import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import { createMockPendingTxOpts, mockFetch } from './mocks.ts';
 import { handlePendingTx } from '../src/pending-tx-manager.ts';
+import { getConfirmationsRequired } from '../src/support.ts';
 
 test('handlePendingTx processes GMP transaction successfully', async t => {
   const opts = createMockPendingTxOpts();
@@ -64,10 +65,11 @@ test('handlePendingTx processes GMP transaction successfully', async t => {
     });
   });
 
+  const requiredConfirmations = getConfirmationsRequired(chain);
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching transaction status for txId: ${txId} at contract: ${contractAddress}`,
-    `[${txId}] ✅ SUCCESS (5 confirmations): txId=${txId} txHash=0x123abc block=18500000`,
+    `[${txId}] ✅ SUCCESS (${requiredConfirmations} confirmations): txId=${txId} txHash=0x123abc block=18500000`,
     `[${txId}] GMP tx resolved`,
   ]);
 });
@@ -126,11 +128,12 @@ test('handlePendingTx logs a time out on a GMP transaction with no matching even
     });
   });
 
+  const requiredConfirmations = getConfirmationsRequired(chain);
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching transaction status for txId: ${txId} at contract: ${contractAddress}`,
     `[${txId}] ✗ No transaction status found for txId ${txId} within 0.01 minutes`,
-    `[${txId}] ✅ SUCCESS (5 confirmations): txId=${txId} txHash=0x123abc block=18500000`,
+    `[${txId}] ✅ SUCCESS (${requiredConfirmations} confirmations): txId=${txId} txHash=0x123abc block=18500000`,
     `[${txId}] GMP tx resolved`,
   ]);
 });

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -65,11 +65,10 @@ test('handlePendingTx processes GMP transaction successfully', async t => {
     });
   });
 
-  const requiredConfirmations = getConfirmationsRequired(chain);
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching transaction status for txId: ${txId} at contract: ${contractAddress}`,
-    `[${txId}] ✅ SUCCESS (${requiredConfirmations} confirmations): txId=${txId} txHash=0x123abc block=18500000`,
+    `[${txId}] ✅ SUCCESS: txId=${txId} txHash=0x123abc block=18500000`,
     `[${txId}] GMP tx resolved`,
   ]);
 });
@@ -128,12 +127,11 @@ test('handlePendingTx logs a time out on a GMP transaction with no matching even
     });
   });
 
-  const requiredConfirmations = getConfirmationsRequired(chain);
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching transaction status for txId: ${txId} at contract: ${contractAddress}`,
     `[${txId}] ✗ No transaction status found for txId ${txId} within 0.01 minutes`,
-    `[${txId}] ✅ SUCCESS (${requiredConfirmations} confirmations): txId=${txId} txHash=0x123abc block=18500000`,
+    `[${txId}] ✅ SUCCESS: txId=${txId} txHash=0x123abc block=18500000`,
     `[${txId}] GMP tx resolved`,
   ]);
 });

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -282,6 +282,7 @@ export const createMockProvider = (
             method: 'eth_subscription',
             params: {
               result: {
+                removed: false,
                 transaction: {
                   hash: log.transactionHash,
                   input: mockCalldata,

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -354,15 +354,8 @@ export const createMockProvider = (
       confirmations?: number,
       _timeout?: number,
     ) {
-      // Wait for receipt to be available - use getTransactionReceipt to respect test overrides
-      let receipt = await this.getTransactionReceipt(txHash);
-      if (!receipt) {
-        // Poll for receipt (max 10 attempts)
-        for (let i = 0; i < 10 && !receipt; i++) {
-          await new Promise(resolve => setTimeout(resolve, 10));
-          receipt = await this.getTransactionReceipt(txHash);
-        }
-      }
+      // Get receipt - use getTransactionReceipt to respect test overrides
+      const receipt = await this.getTransactionReceipt(txHash);
 
       if (!receipt) return null;
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs:
- https://github.com/Agoric/agoric-private/issues/729

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Adds finality protection by waiting for chain-specific block confirmations before marking GMP transactions as settled, preventing premature status marking if transactions get re-orged.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
- E2E tested on devnet

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- A new planner deployment for `ymax0` and `ymax1`.