### PR TITLE
Add Rebalance and SetTargetAllocation to EVM

### DIFF
--- a/packages/orchestration/tools/contract-tests.ts
+++ b/packages/orchestration/tools/contract-tests.ts
@@ -250,6 +250,8 @@ export const setupOrchestrationTest = async ({
     );
     // let the bridge handler finish
     await eventLoopIteration();
+
+    return base;
   };
 
   /** A chainHub for Exo tests, distinct from the one a contract makes within `withOrchestration` */

--- a/packages/portfolio-api/src/evm-wallet/eip712-messages.ts
+++ b/packages/portfolio-api/src/evm-wallet/eip712-messages.ts
@@ -73,7 +73,11 @@ const PortfolioStandaloneTypeParams = [
  */
 const OperationTypes = {
   OpenPortfolio: [{ name: 'allocations', type: 'Allocation[]' }],
-  Rebalance: [{ name: 'allocations', type: 'Allocation[]' }, PortfolioIdParam],
+  Rebalance: [PortfolioIdParam],
+  SetTargetAllocation: [
+    { name: 'allocations', type: 'Allocation[]' },
+    PortfolioIdParam,
+  ],
   Deposit: [PortfolioIdParam],
   /**
    * Withdraw funds from a portfolio to the source EVM account.

--- a/packages/portfolio-api/test/eip712-messages.test.ts
+++ b/packages/portfolio-api/test/eip712-messages.test.ts
@@ -119,11 +119,7 @@ test('getYmaxStandaloneOperationData for Deposit', t => {
 });
 
 test('getYmaxStandaloneOperationData for Rebalance', t => {
-  const allocations: TargetAllocation[] = [
-    { instrument: 'Aave_Arbitrum', portion: 10000n },
-  ];
   const data = {
-    allocations,
     portfolio: 0n,
     nonce: 1n,
     deadline: 1700000000n,
@@ -139,6 +135,33 @@ test('getYmaxStandaloneOperationData for Rebalance', t => {
   t.is(result.primaryType, 'Rebalance');
   t.deepEqual(result.message, data);
   t.deepEqual(result.types.Rebalance, [
+    { name: 'portfolio', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+  ]);
+});
+
+test('getYmaxStandaloneOperationData for SetTargetAllocation', t => {
+  const allocations: TargetAllocation[] = [
+    { instrument: 'Aave_Arbitrum', portion: 10000n },
+  ];
+  const data = {
+    allocations,
+    portfolio: 0n,
+    nonce: 1n,
+    deadline: 1700000000n,
+  };
+
+  const result = getYmaxStandaloneOperationData(
+    data,
+    'SetTargetAllocation',
+    42161n,
+    MOCK_CONTRACT_ADDRESS,
+  );
+
+  t.is(result.primaryType, 'SetTargetAllocation');
+  t.deepEqual(result.message, data);
+  t.deepEqual(result.types.SetTargetAllocation, [
     { name: 'allocations', type: 'Allocation[]' },
     { name: 'portfolio', type: 'uint256' },
     { name: 'nonce', type: 'uint256' },
@@ -283,6 +306,7 @@ test('validateYmaxOperationTypeName passes for valid types', t => {
   const validTypes: OperationTypeNames[] = [
     'OpenPortfolio',
     'Rebalance',
+    'SetTargetAllocation',
     'Deposit',
     'Withdraw',
   ];
@@ -323,6 +347,13 @@ test('splitWitnessFieldType parses Rebalance witness type', t => {
   t.deepEqual(splitWitnessFieldType('YmaxV1Rebalance'), {
     domain: { name: 'Ymax', version: '1' },
     primaryType: 'Rebalance',
+  });
+});
+
+test('splitWitnessFieldType parses SetTargetAllocation witness type', t => {
+  t.deepEqual(splitWitnessFieldType('YmaxV1SetTargetAllocation'), {
+    domain: { name: 'Ymax', version: '1' },
+    primaryType: 'SetTargetAllocation',
   });
 });
 
@@ -367,10 +398,18 @@ test('YmaxOperationType types are correctly inferred', t => {
 
   // Rebalance type
   const rebalance: YmaxOperationType<'Rebalance'> = {
-    allocations: [{ instrument: 'test', portion: 100n }],
     portfolio: 0n,
   };
   t.deepEqual(rebalance, {
+    portfolio: 0n,
+  });
+
+  // SetTargetAllocation type
+  const setTargetAllocation: YmaxOperationType<'SetTargetAllocation'> = {
+    allocations: [{ instrument: 'test', portion: 100n }],
+    portfolio: 0n,
+  };
+  t.deepEqual(setTargetAllocation, {
     allocations: [{ instrument: 'test', portion: 100n }],
     portfolio: 0n,
   });

--- a/packages/portfolio-contract/src/evm-wallet-handler.ts
+++ b/packages/portfolio-contract/src/evm-wallet-handler.ts
@@ -309,12 +309,24 @@ export const prepareEVMPortfolioOperationManager = (
           case 'Rebalance': {
             const {
               data: { portfolio: portfolioId },
+              permitDetails,
             } = operationDetails;
 
             const portfolio = wallet.portfolios.get(BigInt(portfolioId));
 
-            const result =
-              E(portfolio).rebalance(/* otherData, permitDetails */);
+            const result = E(portfolio).rebalance(undefined, permitDetails);
+
+            return watch(result, BasicOutcomeWatcher);
+          }
+          case 'SetTargetAllocation': {
+            const {
+              data: { portfolio: portfolioId, allocations },
+              permitDetails,
+            } = operationDetails;
+
+            const portfolio = wallet.portfolios.get(BigInt(portfolioId));
+
+            const result = E(portfolio).rebalance(allocations, permitDetails);
 
             return watch(result, BasicOutcomeWatcher);
           }

--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -1648,8 +1648,7 @@ test('Withdraw from an ERC4626 position', async t => {
 });
 
 test('open portfolio from Arbitrum, 1000 USDC deposit', async t => {
-  const { common, planner1, readPublished, txResolver, evmTrader } =
-    await setupPlanner(t);
+  const { common, planner1, txResolver, evmTrader } = await setupPlanner(t);
   const { usdc, bld } = common.brands;
 
   const inputs = {
@@ -1663,44 +1662,29 @@ test('open portfolio from Arbitrum, 1000 USDC deposit', async t => {
   const { fromChain: evm, depositAmount, allocations } = inputs;
 
   const expected = {
+    portfolioId: 0,
     storagePath: `${ROOT_STORAGE_PATH}.portfolios.portfolio0`,
     positions: { Aave: usdc.units(600), Compound: usdc.units(400) },
   };
 
-  const traderDo = async () => {
-    const { storagePath } = await evmTrader
+  await planner1.redeem();
+
+  const openResult = await (async () => {
+    const result = await evmTrader
       .forChain(evm)
       .openPortfolio(allocations, depositAmount.value);
-    t.is(storagePath, expected.storagePath);
-  };
-
-  /** Simulate chain inputs (acks) for makeAccount + GMP transfers. */
-  const chainDo = async () => {
+    t.is(result.storagePath, expected.storagePath);
+    t.is(result.portfolioId, expected.portfolioId);
     await ackNFA(common.utils);
-    // Ack the makeAccount transfer before settling pending txs.
-    await common.utils.transmitVTransferEvent('acknowledgementPacket', -2);
-    await txResolver.drainPending();
-    // Ack the GMP contract call once pending txs are resolved.
-    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
-    await txResolver.drainPending();
-    // Ack the second GMP call for the second position.
-    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
-    await txResolver.drainPending();
-    // Ack the third GMP call for the third position.
-    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
-  };
+    return result;
+  })();
 
-  const plannerDo = async () => {
-    const pId = 0;
-    await traderDo;
-    // XXX refactor flow-context extraction (see other planner tests in this file).
-    const status = (await readPublished(
-      `portfolios.portfolio${pId}`,
-    )) as unknown as StatusFor['portfolio'];
+  const flowNum = await (async () => {
+    const status = await evmTrader.getPortfolioStatus();
     const { flowsRunning = {}, policyVersion, rebalanceCount } = status;
     const sync = [policyVersion, rebalanceCount] as const;
-    const [[flowId, detail]] = Object.entries(flowsRunning);
-    const flowNum = Number(flowId.replace('flow', ''));
+    const [[flowKey, detail]] = Object.entries(flowsRunning);
+    const flowId = Number(flowKey.replace('flow', ''));
     if (detail.type !== 'deposit') throw t.fail(detail.type);
     t.is(detail.amount.value, depositAmount.value);
     const planDepositAmount = AmountMath.make(usdc.brand, detail.amount.value);
@@ -1713,16 +1697,27 @@ test('open portfolio from Arbitrum, 1000 USDC deposit', async t => {
         { src: `@${evm}`, dest: 'Compound_Arbitrum', amount: Compound, fee },
       ],
     };
-    await E(planner1.stub).resolvePlan(pId, flowNum, plan, ...sync);
-    return flowNum;
-  };
+    await E(planner1.stub).resolvePlan(
+      openResult.portfolioId,
+      flowId,
+      plan,
+      ...sync,
+    );
 
-  await planner1.redeem();
-  const [, flowNum] = await Promise.all([traderDo(), plannerDo(), chainDo()]);
+    // Ack makeAccount (no fee transfer for createAndDeposit)
+    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
+    await txResolver.drainPending();
+    // Ack the second GMP call for Aave.
+    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
+    await txResolver.drainPending();
+    // Ack the third GMP call for Compound.
+    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
+    await txResolver.drainPending();
 
-  const status = (await readPublished(
-    `portfolios.portfolio0`,
-  )) as unknown as StatusFor['portfolio'];
+    return flowId;
+  })();
+
+  const status = await evmTrader.getPortfolioStatus();
 
   const { contents } = getPortfolioInfo(
     expected.storagePath,
@@ -1767,8 +1762,7 @@ test('open portfolio from Arbitrum, 1000 USDC deposit', async t => {
 });
 
 test('evmHandler.withdraw starts a withdraw flow', async t => {
-  const { common, planner1, readPublished, txResolver, evmTrader } =
-    await setupPlanner(t);
+  const { common, planner1, txResolver, evmTrader } = await setupPlanner(t);
   const { usdc, bld } = common.brands;
 
   const inputs = {
@@ -1778,35 +1772,23 @@ test('evmHandler.withdraw starts a withdraw flow', async t => {
   };
   const { fromChain: evm, depositAmount, allocations } = inputs;
 
-  const traderDo = async () => {
+  await planner1.redeem();
+
+  const openResult = await (async () => {
     const result = await evmTrader
       .forChain(evm)
       .openPortfolio(allocations, depositAmount.value);
-    return result;
-  };
-
-  // Start traderDo first so plannerDo can wait for it
-  const traderDoP = traderDo();
-
-  /** Simulate chain inputs (acks) for makeAccount + GMP transfers. */
-  const chainDo = async () => {
     await ackNFA(common.utils);
-    await common.utils.transmitVTransferEvent('acknowledgementPacket', -2);
-    await txResolver.drainPending();
-    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
-    await txResolver.drainPending();
-    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
-  };
+    return result;
+  })();
 
-  const plannerDo = async () => {
-    const { portfolioId: pId } = await traderDoP;
-    const status = (await readPublished(
-      `portfolios.portfolio${pId}`,
-    )) as unknown as StatusFor['portfolio'];
+  await (async () => {
+    const { portfolioId: pId } = openResult;
+    const status = await evmTrader.getPortfolioStatus();
     const { flowsRunning = {}, policyVersion, rebalanceCount } = status;
     const sync = [policyVersion, rebalanceCount] as const;
-    const [[flowId, detail]] = Object.entries(flowsRunning);
-    const flowNum = Number(flowId.replace('flow', ''));
+    const [[flowKey, detail]] = Object.entries(flowsRunning);
+    const flowId = Number(flowKey.replace('flow', ''));
     if (detail.type !== 'deposit') throw t.fail(detail.type);
     const planDepositAmount = AmountMath.make(usdc.brand, detail.amount.value);
     const fee = bld.units(100);
@@ -1821,46 +1803,40 @@ test('evmHandler.withdraw starts a withdraw flow', async t => {
         },
       ],
     };
-    await E(planner1.stub).resolvePlan(pId, flowNum, plan, ...sync);
-    return flowNum;
-  };
+    await E(planner1.stub).resolvePlan(pId, flowId, plan, ...sync);
 
-  await planner1.redeem();
-  await Promise.all([traderDoP, plannerDo(), chainDo()]);
+    // Ack the makeAccount (no fee transfer for createAndDeposit)
+    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
+    await txResolver.drainPending();
+    // Aave deposit instruction to Arbitrum
+    await common.utils.transmitVTransferEvent('acknowledgementPacket', -1);
+    await txResolver.drainPending();
+
+    return flowId;
+  })();
 
   // Verify portfolio is ready
-  const statusBefore = (await readPublished(
-    `portfolios.portfolio0`,
-  )) as unknown as StatusFor['portfolio'];
+  const statusBefore = await evmTrader.getPortfolioStatus();
   t.deepEqual(statusBefore.flowsRunning, {}, 'no flows running after deposit');
   t.truthy(statusBefore.sourceAccountId, 'sourceAccountId is set');
 
-  // Now test the withdraw via evmHandler
+  // Now test the withdraw
   const withdrawDetails = { token: contractsMock[evm].usdc, amount: 500n };
   const flowKey = await evmTrader.forChain(evm).withdraw(withdrawDetails);
-  if (typeof flowKey !== 'string') {
-    throw t.fail('withdraw did not return a flow key');
-  }
-  const flowKeyStr = flowKey;
-  t.regex(flowKeyStr, /^flow\d+$/, 'withdraw returns a flow key');
+  t.regex(flowKey, /^flow\d+$/, 'withdraw returns a flow key');
 
   // Check that a withdraw flow is now running
-  const statusAfter = (await readPublished(
-    `portfolios.portfolio0`,
-  )) as unknown as StatusFor['portfolio'];
-  const flowsRunning = statusAfter.flowsRunning ?? {};
-  t.is(keys(flowsRunning).length, 1, 'one flow running');
-
-  const [[flowId, flowDetail]] = Object.entries(flowsRunning);
-  t.is(flowId, flowKeyStr, 'flow key matches');
-  t.is(flowDetail.type, 'withdraw', 'flow is a withdraw');
-  if (flowDetail.type === 'withdraw') {
-    t.is(
-      flowDetail.amount.value,
-      withdrawDetails.amount,
-      'withdraw amount matches',
-    );
-  }
+  const statusAfter = await evmTrader.getPortfolioStatus();
+  t.like(
+    statusAfter.flowsRunning,
+    {
+      [flowKey]: {
+        type: 'withdraw',
+        amount: { value: withdrawDetails.amount },
+      },
+    },
+    'withdraw flow is running',
+  );
 });
 
 test.todo('evmHandler.withdraw fails if sourceAccountId not set');

--- a/packages/portfolio-contract/test/portfolio.exo.test.ts
+++ b/packages/portfolio-contract/test/portfolio.exo.test.ts
@@ -237,3 +237,21 @@ test.todo('evmHandler withdraw uses chainId from domain');
 test.todo('evmHandler withdraw defaults to source chainId if domain missing');
 
 test.todo('evmHandler withdraw check token address is USDC contract');
+
+test.todo('evmHandler rebalance requires source account');
+
+test.todo('evmHandler rebalance does not yet support deposit');
+
+test.todo('evmHandler rebalance with allocations sets new target allocation');
+
+test.todo(
+  'evmHandler rebalance with allocations requires non-empty allocations',
+);
+
+test.todo(
+  'evmHandler rebalance without allocations uses current target allocation',
+);
+
+test.todo(
+  'evmHandler rebalance without allocations fails without current target allocation',
+);

--- a/packages/portfolio-contract/tools/portfolio-actors.ts
+++ b/packages/portfolio-contract/tools/portfolio-actors.ts
@@ -442,6 +442,41 @@ export const makeEvmTrader = ({
           await submitMessage(message);
           return getMessageResult(expectedNonce, deadline) as Promise<string>;
         },
+        async rebalance() {
+          const currentPortfolioId = self.getPortfolioId();
+          const deadline = await getDeadline();
+          const message = getYmaxStandaloneOperationData(
+            {
+              portfolio: BigInt(currentPortfolioId),
+              nonce: (nonce += 1n),
+              deadline,
+            },
+            'Rebalance',
+            chainId,
+            depositFactory,
+          );
+          const expectedNonce = nonce;
+          await submitMessage(message);
+          return getMessageResult(expectedNonce, deadline) as Promise<string>;
+        },
+        async setTargetAllocation(allocations: TargetAllocation[]) {
+          const currentPortfolioId = self.getPortfolioId();
+          const deadline = await getDeadline();
+          const message = getYmaxStandaloneOperationData(
+            {
+              allocations,
+              portfolio: BigInt(currentPortfolioId),
+              nonce: (nonce += 1n),
+              deadline,
+            },
+            'SetTargetAllocation',
+            chainId,
+            depositFactory,
+          );
+          const expectedNonce = nonce;
+          await submitMessage(message);
+          return getMessageResult(expectedNonce, deadline) as Promise<string>;
+        },
       });
     },
     getPortfolioPath: () => portfolioPath || assert.fail('no portfolio'),

--- a/packages/portfolio-contract/tools/portfolio-actors.ts
+++ b/packages/portfolio-contract/tools/portfolio-actors.ts
@@ -391,10 +391,10 @@ export const makeEvmTrader = ({
 
           const expectedNonce = nonce;
           await submitMessage(permitMessage);
-          const result = await getMessageResult(expectedNonce, deadline);
-          if (typeof result !== 'string') {
-            assert.fail('missing portfolio result');
-          }
+          const result = (await getMessageResult(
+            expectedNonce,
+            deadline,
+          )) as string;
           const parsedId = Number(result.replace(/^portfolio/, ''));
           Number.isInteger(parsedId) ||
             assert.fail('invalid portfolio id result');
@@ -422,7 +422,7 @@ export const makeEvmTrader = ({
           );
           const expectedNonce = nonce;
           await submitMessage(permitMessage);
-          return getMessageResult(expectedNonce, deadline);
+          return getMessageResult(expectedNonce, deadline) as Promise<string>;
         },
         async withdraw(withdrawDetails: TokenPermissions) {
           const currentPortfolioId = self.getPortfolioId();
@@ -440,7 +440,7 @@ export const makeEvmTrader = ({
           );
           const expectedNonce = nonce;
           await submitMessage(message);
-          return getMessageResult(expectedNonce, deadline);
+          return getMessageResult(expectedNonce, deadline) as Promise<string>;
         },
       });
     },


### PR DESCRIPTION
closes: #12338

## Description
Implement the rebalance pathway for EVM. Our EIP-712 helpers don't support optional fields, so we have distinct `SetTargetAllocation` and `Rebalance` (with no args) operations. While the `SetTargetAllocation` name does not mirror the Zoe invitation (`SimpleRebalance`), this is user visible so prefer a meaningful name.

Rewrite of #12338

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
TBD

### Testing Considerations
This PR cleans up some of the existing EVM tests and adds a contract level test for each of Rebalance and SetTargetAllocation.

TODO: Exo level tests

### Upgrade Considerations
This changes the signature of the Rebalance operation and adds the SetTargetAllocationoperation. The UI will need to pick up the new version of the dev package.
