### PR TITLE
feat(orchestration): accept `upsert` option when updating chainHub

### DIFF
--- a/packages/orchestration/src/exos/chain-hub.js
+++ b/packages/orchestration/src/exos/chain-hub.js
@@ -18,6 +18,7 @@ import {
 } from '../typeGuards.js';
 import { getBech32Prefix } from '../utils/address.js';
 import { caipIdFromInfo } from '../utils/chain-info.js';
+import { makeStoreWrapper } from '../utils/store.js';
 
 /**
  * @import {NameHub} from '@agoric/vats';
@@ -28,12 +29,18 @@ import { caipIdFromInfo } from '../utils/chain-info.js';
  * @import {AccountId, CosmosChainAddress, ChainInfo, CaipChainId, Denom, DenomAmount, AccountIdArg} from '../orchestration-api.js';
  * @import {Remote, TypedPattern} from '@agoric/internal';
  * @import {Pattern} from '@endo/patterns';
- * @import {MapStore, SetStore} from '@agoric/store';
+ * @import {MapStore} from '@agoric/store';
  * @import {Brand} from '@agoric/ertp';
  */
 
 /** receiver address value for ibc transfers that involve PFM */
 export const PFM_RECEIVER = /** @type {const} */ ('pfm');
+
+/**
+ * @param {ChainHubOptions} opts
+ */
+const makeHubStoreWrapper = ({ upsert = false } = {}) =>
+  makeStoreWrapper(upsert ? 'lax' : 'strict');
 
 /**
  * If K matches a known chain, narrow the type from generic ChainInfo
@@ -211,25 +218,37 @@ export const TransferRouteShape = M.splitRecord(
   {},
 );
 
+/**
+ * @typedef {object} ChainHubOptions
+ * @property {boolean} [upsert] - if true, update or insert entries as required
+ */
+
+/** @type {TypedPattern<ChainHubOptions>} */
+const ChainHubOptionsShape = M.splitRecord({}, { upsert: M.boolean() });
+
 const ChainHubI = M.interface('ChainHub', {
-  registerChain: M.call(M.string(), ChainInfoShape).returns(),
-  updateChain: M.call(M.string(), ChainInfoShape).returns(),
+  registerChain: M.call(M.string(), ChainInfoShape)
+    .optional(ChainHubOptionsShape)
+    .returns(),
+  updateChain: M.call(M.string(), ChainInfoShape)
+    .optional(ChainHubOptionsShape)
+    .returns(),
   getChainInfo: M.call(M.string()).returns(VowShape),
   getChainInfoByChainId: M.call(M.string()).returns(ChainInfoShape),
-  registerConnection: M.call(
-    M.string(),
-    M.string(),
-    IBCConnectionInfoShape,
-  ).returns(),
-  updateConnection: M.call(
-    M.string(),
-    M.string(),
-    IBCConnectionInfoShape,
-  ).returns(),
+  registerConnection: M.call(M.string(), M.string(), IBCConnectionInfoShape)
+    .optional(ChainHubOptionsShape)
+    .returns(),
+  updateConnection: M.call(M.string(), M.string(), IBCConnectionInfoShape)
+    .optional(ChainHubOptionsShape)
+    .returns(),
   getConnectionInfo: M.call(ChainIdArgShape, ChainIdArgShape).returns(VowShape),
   getChainsAndConnection: M.call(M.string(), M.string()).returns(VowShape),
-  registerAsset: M.call(M.string(), DenomDetailShape).returns(),
-  updateAsset: M.call(M.string(), DenomDetailShape).returns(),
+  registerAsset: M.call(M.string(), DenomDetailShape)
+    .optional(ChainHubOptionsShape)
+    .returns(),
+  updateAsset: M.call(M.string(), DenomDetailShape)
+    .optional(ChainHubOptionsShape)
+    .returns(),
   getAsset: M.call(M.string(), M.string()).returns(
     M.or(DenomDetailShape, M.undefined()),
   ),
@@ -451,8 +470,13 @@ export const makeChainHub = (
      *
      * @param {string} name
      * @param {ChainInfo} chainInfo
+     * @param {ChainHubOptions} [opts]
      */
-    registerChain(name, chainInfo) {
+    registerChain(name, chainInfo, opts) {
+      if (opts?.upsert) {
+        // Register with upsert uses the same logic as update with upsert.
+        return this.updateChain(name, chainInfo, opts);
+      }
       chainInfos.init(name, chainInfo);
       chainIdToChainName.init(caipIdFromInfo(chainInfo), name);
       if (chainInfo.namespace === 'cosmos' && chainInfo.bech32Prefix) {
@@ -464,29 +488,38 @@ export const makeChainHub = (
      *
      * @param {string} chainName - Name of the chain to update
      * @param {ChainInfo} chainInfo - New chain info
+     * @param {ChainHubOptions} [opts]
      * @throws {Error} If chain not registered
      */
-    updateChain(chainName, chainInfo) {
-      if (!chainInfos.has(chainName)) {
+    updateChain(chainName, chainInfo, opts) {
+      const $ = makeHubStoreWrapper(opts);
+      const oldInfo = $(chainInfos).get(chainName);
+      try {
+        $(chainInfos).mustSet(chainName, chainInfo);
+      } catch (e) {
         throw makeError(`Chain ${q(chainName)} not registered`);
       }
-      const oldInfo = chainInfos.get(chainName);
+      const caipId = caipIdFromInfo(chainInfo);
+      const bech32Prefix = /** @type {CosmosChainInfo} */ (chainInfo)
+        .bech32Prefix;
+      $(chainIdToChainName).set(caipId, chainName);
+      if (bech32Prefix) {
+        $(bech32PrefixToChainName).set(bech32Prefix, chainName);
+      }
+      if (!oldInfo) {
+        return;
+      }
+
+      // Clean up old indexes if they changed
       // defensively check, for older versions which may not have `chainIdToChainName`
-      if (chainIdToChainName.has(caipIdFromInfo(oldInfo))) {
-        chainIdToChainName.delete(caipIdFromInfo(oldInfo));
+      const oldCaipId = caipIdFromInfo(oldInfo);
+      if (oldCaipId !== caipId) {
+        $(chainIdToChainName).delete(oldCaipId);
       }
-      if (/** @type {CosmosChainInfo} */ (oldInfo).bech32Prefix) {
-        bech32PrefixToChainName.delete(
-          /** @type {CosmosChainInfo} */ (oldInfo).bech32Prefix,
-        );
-      }
-      chainInfos.set(chainName, chainInfo);
-      chainIdToChainName.init(caipIdFromInfo(chainInfo), chainName);
-      if (/** @type {CosmosChainInfo} */ (chainInfo).bech32Prefix) {
-        bech32PrefixToChainName.init(
-          /** @type {CosmosChainInfo} */ (chainInfo).bech32Prefix,
-          chainName,
-        );
+      const oldBech32Prefix = /** @type {CosmosChainInfo} */ (oldInfo)
+        .bech32Prefix;
+      if (oldBech32Prefix && oldBech32Prefix !== bech32Prefix) {
+        $(bech32PrefixToChainName).delete(oldBech32Prefix);
       }
     },
     /**
@@ -527,8 +560,24 @@ export const makeChainHub = (
      * @param {string} primaryChainId
      * @param {string} counterpartyChainId
      * @param {IBCConnectionInfo} connectionInfo from primary to counterparty
+     * @param {ChainHubOptions} [opts]
      */
-    registerConnection(primaryChainId, counterpartyChainId, connectionInfo) {
+    registerConnection(
+      primaryChainId,
+      counterpartyChainId,
+      connectionInfo,
+      opts,
+    ) {
+      if (opts?.upsert) {
+        // Register with upsert uses the same logic as update with upsert.
+        return this.updateConnection(
+          primaryChainId,
+          counterpartyChainId,
+          connectionInfo,
+          opts,
+        );
+      }
+
       const [key, normalized] = normalizeConnectionInfo(
         primaryChainId,
         counterpartyChainId,
@@ -543,21 +592,29 @@ export const makeChainHub = (
      * @param {string} counterpartyChainId - Cosmos chainId of counterparty
      *   chain
      * @param {IBCConnectionInfo} connectionInfo - New connection info
+     * @param {ChainHubOptions} [opts]
      * @throws {Error} If connection not registered
      */
-    updateConnection(primaryChainId, counterpartyChainId, connectionInfo) {
+    updateConnection(
+      primaryChainId,
+      counterpartyChainId,
+      connectionInfo,
+      opts,
+    ) {
+      const $ = makeHubStoreWrapper(opts);
       const key = connectionKey(primaryChainId, counterpartyChainId);
-      if (!connectionInfos.has(key)) {
-        throw makeError(
-          `Connection ${q(primaryChainId)}<->${q(counterpartyChainId)} not registered`,
-        );
-      }
       const [_, normalizedInfo] = normalizeConnectionInfo(
         primaryChainId,
         counterpartyChainId,
         connectionInfo,
       );
-      connectionInfos.set(key, normalizedInfo);
+      try {
+        $(connectionInfos).mustSet(key, normalizedInfo);
+      } catch (e) {
+        throw makeError(
+          `Connection ${q(primaryChainId)}<->${q(counterpartyChainId)} not registered`,
+        );
+      }
     },
     /**
      * @param {string | { chainId: string }} primary the primary chain
@@ -602,8 +659,13 @@ export const makeChainHub = (
      * @param {Denom} denom - on the holding chain, whose name is given in
      *   `detail.chainName`
      * @param {DenomDetail} detail - chainName and baseName must be registered
+     * @param {ChainHubOptions} [opts]
      */
-    registerAsset(denom, detail) {
+    registerAsset(denom, detail, opts) {
+      if (opts?.upsert) {
+        // Register with upsert uses the same logic as update with upsert.
+        return this.updateAsset(denom, detail, opts);
+      }
       const { chainName, baseName } = detail;
       chainInfos.has(chainName) ||
         Fail`must register chain ${q(chainName)} first`;
@@ -611,9 +673,11 @@ export const makeChainHub = (
         Fail`must register chain ${q(baseName)} first`;
 
       const denomKey = makeDenomKey(denom, detail.chainName);
-      denomDetails.has(denomKey) &&
+      try {
+        denomDetails.init(denomKey, detail);
+      } catch (e) {
         Fail`already registered ${q(denom)} on ${q(chainName)}`;
-      denomDetails.init(denomKey, detail);
+      }
       if (detail.brand) {
         chainName === 'agoric' ||
           Fail`brands only registerable for agoric-held assets`;
@@ -625,15 +689,14 @@ export const makeChainHub = (
      *
      * @param {Denom} denom - Denom on the holding chain
      * @param {DenomDetail} detail - New asset details
+     * @param {ChainHubOptions} [opts]
      * @throws {Error} If asset not registered or referenced chains not
      *   registered
      */
-    updateAsset(denom, detail) {
+    updateAsset(denom, detail, opts) {
+      const $ = makeHubStoreWrapper(opts);
       const { baseName, brand, chainName } = detail;
       const denomKey = makeDenomKey(denom, chainName);
-      if (!denomDetails.has(denomKey)) {
-        throw makeError(`Asset ${q(denom)} on ${q(chainName)} not registered`);
-      }
       if (!chainInfos.has(chainName)) {
         throw makeError(`Chain ${q(chainName)} not registered`);
       }
@@ -646,14 +709,22 @@ export const makeChainHub = (
         }
       }
 
-      const oldDetail = denomDetails.get(denomKey);
-      if (oldDetail.brand) {
-        brandDenoms.delete(oldDetail.brand);
+      const oldDetail = $(denomDetails).get(denomKey);
+      try {
+        $(denomDetails).mustSet(denomKey, detail);
+      } catch (e) {
+        throw makeError(`Asset ${q(denom)} on ${q(chainName)} not registered`);
+      }
+      if (brand) {
+        $(brandDenoms).set(brand, denom);
+      }
+      if (!oldDetail) {
+        return;
       }
 
-      denomDetails.set(denomKey, detail);
-      if (brand) {
-        brandDenoms.init(brand, denom);
+      const oldBrand = oldDetail.brand;
+      if (oldBrand && oldBrand !== brand) {
+        $(brandDenoms).delete(oldBrand);
       }
     },
     /**

--- a/packages/orchestration/src/utils/store.js
+++ b/packages/orchestration/src/utils/store.js
@@ -1,0 +1,141 @@
+/**
+ * @import {MapStore, SetStore, WeakMapStore, WeakSetStore} from '@agoric/store';
+ */
+
+/**
+ * @template [K=any]
+ * @template [V=never]
+ * @typedef {object} Store
+ * @property {(key: K) => void} add
+ * @property {(key: K) => void} delete
+ * @property {(key: K) => V | undefined} get
+ * @property {(key: K) => boolean} has
+ * @property {(key: K, value: V) => void} set
+ * @property {(key: K) => void} mustAdd
+ * @property {(key: K) => void} mustDelete
+ * @property {(key: K) => V} mustGet
+ * @property {(key: K, value: V) => void} mustInit
+ * @property {(key: K, value: V) => void} mustSet
+ */
+
+/**
+ * @param {'strict' | 'lax'} [mode='strict']
+ */
+export const makeStoreWrapper =
+  (mode = 'strict') =>
+  /**
+   * @template K, V
+   * @overload
+   * @param {MapStore<K, V>} store
+   * @returns {Map<K, V> & Pick<Store<K, V>, 'mustDelete' | 'mustGet' | 'mustInit' | 'mustSet'>}
+   */
+  /**
+   * @template K
+   * @overload
+   * @param {SetStore<K>} store
+   * @returns {Set<K> & Pick<Store<K>, 'mustAdd' | 'mustDelete'>}
+   */
+  /**
+   * @template K, V
+   * @overload
+   * @param {WeakMapStore<K, V>} store
+   * @returns {WeakMap<K, V> & Pick<Store<K, V>, 'mustDelete' | 'mustGet' | 'mustInit' | 'mustSet'>}
+   */
+  /**
+   * @template K
+   * @overload
+   * @param {WeakSetStore<K>} store
+   * @returns {WeakSet<K> & Pick<Store<K>, 'mustAdd' | 'mustDelete'>}
+   */
+  /**
+   * @template K
+   * @template [V=never]
+   * @param {MapStore<K, V> | SetStore<K> | WeakMapStore<K, V> | WeakSetStore<K>} store
+   */
+  store => {
+    const {
+      add,
+      delete: del,
+      get,
+      has,
+      init,
+      set,
+    } = /** @type {MapStore<K, V> & SetStore<K>} */ (store);
+    assert(del);
+    assert(has);
+
+    /** @type {Omit<Store<K, V>, 'mustAdd' | 'mustDelete' | 'mustInit' |'mustSet'>} */
+    const maybe = {
+      add(key) {
+        has(key) || add(key);
+      },
+      delete(key) {
+        has(key) && del(key);
+      },
+      get(key) {
+        if (has(key)) {
+          return get(key);
+        }
+        return undefined;
+      },
+      has,
+      set(key, value) {
+        if (has(key)) {
+          set(key, value);
+        } else {
+          init(key, value);
+        }
+      },
+      mustGet(key) {
+        return get(key);
+      },
+    };
+
+    /** @param {Store<K, V>} methods */
+    const cull = ({
+      add: a,
+      get: g,
+      set: s,
+      mustAdd,
+      mustGet,
+      mustInit,
+      mustSet,
+      ...core
+    }) => ({
+      ...core,
+      ...('add' in store ? { add: a, mustAdd } : {}),
+      ...('get' in store ? { get: g, mustGet } : {}),
+      ...('init' in store ? { mustInit } : {}),
+      ...('set' in store ? { set: s, mustSet } : {}),
+    });
+
+    if (mode === 'lax') {
+      /** @type {Store<K, V>} */
+      const laxStore = {
+        ...maybe,
+        mustAdd: maybe.add,
+        mustDelete: maybe.delete,
+        mustInit: maybe.set,
+        mustSet: maybe.set,
+      };
+      return cull(laxStore);
+    }
+
+    /** @type {Store<K, V>} */
+    const strictStore = {
+      ...maybe,
+      mustAdd(key) {
+        return add(key);
+      },
+      mustDelete(key) {
+        return del(key);
+      },
+      mustInit(key, value) {
+        return init(key, value);
+      },
+      mustSet(key, value) {
+        return set(key, value);
+      },
+    };
+    return cull(strictStore);
+  };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX

## Description
ChainHub's `update*()` methods always threw errors when entries didn't exist, preventing idempotent chain registry initialization. This made updates to the chain registry throw when existing entries partially overlapped with the new information, leaving behind unknown state.

## Changes

**Core Enhancement:**
- Added optional `upsert` (an operation that will "**up**date existing or in**sert** missing entries" as necessary) flag to `chainHub.update*` and `chainHub.register*` methods
- Created `makeStoreWrapper()` utility supporting 'strict' (default, throws on conflicts) and 'lax' (upsert) modes
- Accepted `{ upsert: true }` option for `registerChainsAndAssets()`, enabling idempotent re-registration

```javascript
// Without `upsert`: would throw if chain exists or doesn't exist
chainHub.registerChain(name, info);  // throws if exists
chainHub.updateChain(name, info);     // throws if missing

// After: default as above, but idempotent updates/insertions can be requested via an `upsert: true` flag
chainHub.registerChain(name, info, { upsert: true });  // always works, reusing updateChain
chainHub.updateChain(name, info, { upsert: true });  // always works
```

**Store Wrapper Mechanics:**
- In 'lax' mode: `mustInit()` and `mustSet()` both perform upsert (set if exists, init if not), `mustDelete()` never throws
- In 'strict' mode: operations throw on violations (existing mustInit, missing mustSet or mustDelete)
- Properly cleans up old indexes when chain IDs or prefixes change

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Tested in CI.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
Backwards compatible. The `upsert` parameter defaults to `false`, preserving existing strict behavior.

The store wrapper does not introduce upgrade concerns.  It consists of ephemeral methods (i.e., with no internal durable state) that are called upon a separate, potentially durable collection.
