### PR TITLE
chore(ymax-resolver): handle reverted make account transactions

### DIFF
--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -358,6 +358,7 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
       factoryAddr: (factoryAddr || accountAddress) as `0x${string}`,
       provider,
       expectedAddr: expectedAddr as `0x${string}`,
+      chainId: caipId,
       log: (msg, ...args) => log(logPrefix, msg, ...args),
     };
 

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -17,6 +17,11 @@ import {
   getTxBlockLowerBound,
   setTxBlockLowerBound,
 } from '../kv-store.ts';
+import {
+  fetchReceiptWithRetry,
+  DEFAULT_RETRY_OPTIONS,
+  type RetryOptions,
+} from './watcher-utils.ts';
 
 //#region Alchemy alchemy_minedTransactions subscription types
 // See https://docs.alchemy.com/reference/alchemy-minedtransactions
@@ -112,49 +117,6 @@ const extractExecuteData = (
   } catch {
     return null;
   }
-};
-
-export type RetryOptions = {
-  /** Maximum number of retry attempts */
-  limit: number;
-  /** Maximum delay between retries in milliseconds */
-  backoffLimit: number;
-};
-
-export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
-  limit: 5,
-  backoffLimit: 3000,
-};
-
-/**
- * Fetch transaction receipt with retry logic for freshly mined transactions.
- * @param provider - The WebSocket provider
- * @param txHash - Transaction hash
- * @param log - Logging function
- * @param retryOptions - Retry configuration (limit and backoffLimit)
- * @returns Transaction receipt or null if not available after retries
- */
-const fetchReceiptWithRetry = async (
-  provider: WebSocketProvider,
-  txHash: string,
-  log: (...args: unknown[]) => void,
-  retryOptions: RetryOptions = DEFAULT_RETRY_OPTIONS,
-) => {
-  const { limit, backoffLimit } = retryOptions;
-  let receipt = await provider.getTransactionReceipt(txHash);
-  if (!receipt) {
-    log(`Receipt not yet available for txHash=${txHash}, retrying...`);
-    for (let i = 0; i < limit && !receipt; i += 1) {
-      const delay = Math.min(100 * 2 ** i, backoffLimit);
-      await new Promise(resolve => setTimeout(resolve, delay));
-      receipt = await provider.getTransactionReceipt(txHash);
-    }
-
-    if (!receipt) {
-      log(`Failed to get receipt for txHash=${txHash} after ${limit} retries`);
-    }
-  }
-  return receipt;
 };
 
 export const watchGmp = ({

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -20,45 +20,9 @@ import {
 import {
   fetchReceiptWithRetry,
   DEFAULT_RETRY_OPTIONS,
+  type AlchemySubscriptionMessage,
   type RetryOptions,
 } from './watcher-utils.ts';
-
-//#region Alchemy alchemy_minedTransactions subscription types
-// See https://docs.alchemy.com/reference/alchemy-minedtransactions
-type AlchemyMinedTransaction = {
-  blockHash: string;
-  blockNumber: string;
-  hash: string;
-  from: string;
-  gas: string;
-  gasPrice: string;
-  input: string;
-  nonce: string;
-  to: string | null;
-  transactionIndex: string;
-  type: string;
-  value: string;
-  // ECDSA signature fields
-  r?: string;
-  s?: string;
-  v?: string;
-  // EIP-1559 fields
-  maxPriorityFeePerGas?: string;
-  maxFeePerGas?: string;
-};
-
-type AlchemySubscriptionMessage = {
-  jsonrpc: '2.0';
-  method: 'eth_subscription';
-  params: {
-    result: {
-      removed: boolean;
-      transaction: AlchemyMinedTransaction;
-    };
-    subscription: string;
-  };
-};
-//#endregion
 
 const MULTICALL_STATUS_SIGNATURE = ethers.id(
   'MulticallStatus(string,bool,uint256)',

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -1,7 +1,9 @@
 import type { Filter, WebSocketProvider, Log } from 'ethers';
 import { id, zeroPadValue, getAddress, AbiCoder } from 'ethers';
+import type { WebSocket } from 'ws';
 import type { CaipChainId } from '@agoric/orchestration';
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
+import { tryJsonParse } from '@agoric/internal';
 import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
@@ -14,6 +16,13 @@ import {
   setTxBlockLowerBound,
 } from '../kv-store.ts';
 import type { WatcherResult } from '../pending-tx-manager.ts';
+import {
+  fetchReceiptWithRetry,
+  handleReceiptStatus,
+  DEFAULT_RETRY_OPTIONS,
+  type AlchemySubscriptionMessage,
+  type RetryOptions,
+} from './watcher-utils.ts';
 
 // New version (3 parameters) - without sourceAddress
 export const SMART_WALLET_CREATED_SIGNATURE = id(
@@ -65,7 +74,9 @@ type SmartWalletWatchBase = {
   factoryAddr: `0x${string}`;
   provider: WebSocketProvider;
   expectedAddr: `0x${string}`;
+  chainId: CaipChainId;
   log?: (...args: unknown[]) => void;
+  retryOptions?: RetryOptions;
 };
 
 type SmartWalletWatch = SmartWalletWatchBase & {
@@ -77,87 +88,219 @@ export const watchSmartWalletTx = ({
   factoryAddr,
   provider,
   expectedAddr,
+  chainId,
   timeoutMs = TX_TIMEOUT_MS,
   log = () => {},
   setTimeout = globalThis.setTimeout,
   signal,
+  retryOptions = DEFAULT_RETRY_OPTIONS,
 }: SmartWalletWatchBase &
   WatcherTimeoutOptions &
   Partial<SmartWalletWatch>): Promise<WatcherResult> => {
-  return new Promise(resolve => {
-    if (signal?.aborted) {
-      resolve({ settled: false });
-      return;
-    }
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) return resolve({ settled: false });
 
-    const TO_TOPIC = zeroPadValue(expectedAddr.toLowerCase(), 32);
-
-    const filterV1 = {
-      address: factoryAddr,
-      topics: [SMART_WALLET_CREATED_SIGNATURE_V1, TO_TOPIC],
-    };
-    const filterV2 = {
-      address: factoryAddr,
-      topics: [SMART_WALLET_CREATED_SIGNATURE, TO_TOPIC],
-    };
-
-    log(`Watching SmartWalletCreated events emitted by ${factoryAddr}`);
-
-    let walletCreated = false;
-    let timeoutId: NodeJS.Timeout;
-    let listeners: Array<{ event: any; listener: any }> = [];
-
-    const finish = (result: WatcherResult) => {
-      resolve(result);
-      if (timeoutId) clearTimeout(timeoutId);
-      for (const { event, listener } of listeners) {
-        void provider.off(event, listener);
-      }
-      listeners = [];
-    };
-
-    signal?.addEventListener('abort', () => finish({ settled: false }));
-
-    const listenForSmartWalletCreation = async (eventLog: Log) => {
-      let eventData;
-      try {
-        eventData = parseSmartWalletCreatedLog(eventLog);
-      } catch (error: any) {
-        log(`Log parsing error:`, error.message);
-        return;
-      }
-
-      const { wallet } = eventData;
-      const normalizedWallet = wallet.toLowerCase();
-      log(`SmartWalletCreated event detected: wallet:${normalizedWallet}`);
-      if (normalizedWallet === expectedAddr) {
-        log(
-          `✓ Address matches! Expected: ${expectedAddr}, Found: ${normalizedWallet}`,
-        );
-        walletCreated = true;
-        finish({
-          settled: true,
-          txHash: eventLog.transactionHash,
-          success: true,
-        });
-        return;
-      }
-      log(
-        `Address mismatch. Expected: ${expectedAddr}, Found: ${normalizedWallet}`,
-      );
-    };
-
-    void provider.on(filterV1, listenForSmartWalletCreation);
-    void provider.on(filterV2, listenForSmartWalletCreation);
-    listeners.push(
-      { event: filterV1, listener: listenForSmartWalletCreation },
-      { event: filterV2, listener: listenForSmartWalletCreation },
+    log(
+      `Watching for wallet creation at factory ${factoryAddr} for expectedAddr ${expectedAddr}`,
     );
 
-    timeoutId = setTimeout(() => {
-      if (!walletCreated) {
+    let done = false;
+    let timeoutId: NodeJS.Timeout | undefined;
+    let subId: string | null = null;
+    const cleanups: (() => void)[] = [];
+
+    const ws = provider.websocket as WebSocket;
+
+    const finish = (res: WatcherResult) => {
+      if (done) return;
+      done = true;
+
+      if (timeoutId) clearTimeout(timeoutId);
+
+      resolve(res);
+      if (subId) {
+        void provider
+          .send('eth_unsubscribe', [subId])
+          .catch(e => log('Failed to unsubscribe:', e));
+      }
+      for (const cleanup of cleanups) cleanup();
+    };
+
+    /**
+     * Cleanup and reject with error.
+     * Used for fatal errors where we cannot continue watching.
+     */
+    const fail = (err: unknown) => {
+      if (done) return;
+      done = true;
+
+      if (timeoutId) clearTimeout(timeoutId);
+
+      reject(err);
+      if (subId) {
+        void provider
+          .send('eth_unsubscribe', [subId])
+          .catch(error =>
+            log('Failed to unsubscribe during error cleanup:', error),
+          );
+      }
+      for (const cleanup of cleanups) cleanup();
+    };
+
+    const onWsError = (e: any) => {
+      const errorMsg = e?.message || String(e);
+      log(
+        `WebSocket error during wallet watch for expectedAddr=${expectedAddr}: ${errorMsg}`,
+      );
+      fail(new Error(`WebSocket connection error: ${errorMsg}`));
+    };
+
+    const onWsClose = (code?: number, reason?: any) => {
+      if (!done) {
         log(
-          `✗ No matching SmartWalletCreated event found within ${timeoutMs / 60000} minutes`,
+          `WebSocket closed during wallet watch for expectedAddr=${expectedAddr} (code=${code}, reason=${reason})`,
+        );
+        fail(
+          new Error(`WebSocket closed unexpectedly: ${reason} (code=${code})`),
+        );
+      }
+    };
+
+    ws.on('error', onWsError);
+    cleanups.unshift(() => ws.off('error', onWsError));
+
+    ws.on('close', onWsClose);
+    cleanups.unshift(() => ws.off('close', onWsClose));
+
+    if (signal) {
+      const onAbort = () => finish({ settled: false });
+      signal.addEventListener('abort', onAbort);
+      cleanups.unshift(() => {
+        signal.removeEventListener('abort', onAbort);
+      });
+    }
+
+    const messageHandler = async (data: any) => {
+      await null;
+      if (done) return;
+
+      try {
+        const msg = tryJsonParse(
+          data.toString(),
+          'alchemy_minedTransactions subscription response',
+        ) as AlchemySubscriptionMessage;
+
+        if (msg.method !== 'eth_subscription') return;
+
+        const tx = msg.params?.result?.transaction;
+        const removed = msg.params?.result?.removed;
+        if (!tx) return;
+
+        // Ignore transactions that have been removed from canonical chain (reorged)
+        if (removed === true) {
+          log(
+            `⚠️  REORG: expectedAddr=${expectedAddr} txHash=${tx.hash} was removed from chain - ignoring`,
+          );
+          return;
+        }
+
+        const txHash = tx.hash;
+        if (!txHash) return;
+
+        // Fetch receipt to check for SmartWalletCreated event
+        const receipt = await fetchReceiptWithRetry(
+          provider,
+          txHash,
+          log,
+          retryOptions,
+        );
+        if (!receipt) {
+          log(`Transaction ${txHash} not confirmed after waiting`);
+          return;
+        }
+
+        // Look for SmartWalletCreated event in logs with matching expectedAddr
+        const matchingLog = receipt.logs.find(l => {
+          // Check for either v1 or v2 signature
+          if (
+            l.topics?.[0] !== SMART_WALLET_CREATED_SIGNATURE_V1 &&
+            l.topics?.[0] !== SMART_WALLET_CREATED_SIGNATURE
+          ) {
+            return false;
+          }
+
+          // Check if wallet address matches
+          try {
+            const eventData = parseSmartWalletCreatedLog(l);
+            return eventData.wallet.toLowerCase() === expectedAddr;
+          } catch {
+            return false;
+          }
+        });
+
+        if (!matchingLog) {
+          // This transaction to the factory doesn't create our expected wallet
+          return;
+        }
+
+        log(
+          `✓ Found SmartWalletCreated event for expectedAddr=${expectedAddr} in txHash=${txHash}`,
+        );
+
+        /**
+         * Transaction status check: We found the SmartWalletCreated event in the logs.
+         * Now check if the transaction succeeded or reverted.
+         */
+        const result = await handleReceiptStatus(
+          receipt,
+          txHash,
+          `expectedAddr=${expectedAddr}`,
+          chainId,
+          provider,
+          log,
+        );
+        if (result) {
+          return finish(result);
+        }
+      } catch (e) {
+        log(
+          `Error processing WebSocket message for expectedAddr=${expectedAddr}:`,
+          e instanceof Error ? e.message : String(e),
+        );
+      }
+    };
+
+    const subscribe = async () => {
+      // Verify liveness.
+      await provider.getNetwork();
+
+      // Attach message handler before subscribing to avoid race condition
+      ws.on('message', messageHandler);
+      cleanups.unshift(() => ws.off('message', messageHandler));
+
+      subId = await provider.send('eth_subscribe', [
+        'alchemy_minedTransactions',
+        {
+          addresses: [{ to: factoryAddr }],
+          includeRemoved: true, // Receive reorg notifications
+          hashesOnly: false,
+        },
+      ]);
+    };
+
+    if (ws.readyState === 1) {
+      subscribe().catch(fail);
+    } else {
+      ws.once('open', () => subscribe().catch(fail));
+    }
+
+    // Intentional: does not resolve/reject; only logs on timeout
+    timeoutId = setTimeout(() => {
+      if (!done) {
+        log(
+          `✗ No wallet creation found for expectedAddr ${expectedAddr} within ${
+            timeoutMs / 60000
+          } minutes`,
         );
       }
     }, timeoutMs);

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -1,0 +1,44 @@
+import type { WebSocketProvider } from 'ethers';
+
+export type RetryOptions = {
+  /** Maximum number of retry attempts */
+  limit: number;
+  /** Maximum delay between retries in milliseconds */
+  backoffLimit: number;
+};
+
+export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
+  limit: 5,
+  backoffLimit: 3000,
+};
+
+/**
+ * Fetch transaction receipt with retry logic for freshly mined transactions.
+ * @param provider - The WebSocket provider
+ * @param txHash - Transaction hash
+ * @param log - Logging function
+ * @param retryOptions - Retry configuration (limit and backoffLimit)
+ * @returns Transaction receipt or null if not available after retries
+ */
+export const fetchReceiptWithRetry = async (
+  provider: WebSocketProvider,
+  txHash: string,
+  log: (...args: unknown[]) => void,
+  retryOptions: RetryOptions = DEFAULT_RETRY_OPTIONS,
+) => {
+  const { limit, backoffLimit } = retryOptions;
+  let receipt = await provider.getTransactionReceipt(txHash);
+  if (!receipt) {
+    log(`Receipt not yet available for txHash=${txHash}, retrying...`);
+    for (let i = 0; i < limit && !receipt; i += 1) {
+      const delay = Math.min(100 * 2 ** i, backoffLimit);
+      await new Promise(resolve => setTimeout(resolve, delay));
+      receipt = await provider.getTransactionReceipt(txHash);
+    }
+
+    if (!receipt) {
+      log(`Failed to get receipt for txHash=${txHash} after ${limit} retries`);
+    }
+  }
+  return receipt;
+};

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -1,5 +1,42 @@
 import type { WebSocketProvider } from 'ethers';
 
+//#region Alchemy alchemy_minedTransactions subscription types
+// See https://docs.alchemy.com/reference/alchemy-minedtransactions
+export type AlchemyMinedTransaction = {
+  blockHash: string;
+  blockNumber: string;
+  hash: string;
+  from: string;
+  gas: string;
+  gasPrice: string;
+  input: string;
+  nonce: string;
+  to: string | null;
+  transactionIndex: string;
+  type: string;
+  value: string;
+  // ECDSA signature fields
+  r?: string;
+  s?: string;
+  v?: string;
+  // EIP-1559 fields
+  maxPriorityFeePerGas?: string;
+  maxFeePerGas?: string;
+};
+
+export type AlchemySubscriptionMessage = {
+  jsonrpc: '2.0';
+  method: 'eth_subscription';
+  params: {
+    result: {
+      removed: boolean;
+      transaction: AlchemyMinedTransaction;
+    };
+    subscription: string;
+  };
+};
+//#endregion
+
 export type RetryOptions = {
   /** Maximum number of retry attempts */
   limit: number;

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -12,7 +12,6 @@ import type { PendingTx } from '@aglocal/portfolio-contract/src/resolver/types.t
 import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import { createMockPendingTxOpts, mockFetch } from './mocks.ts';
 import { handlePendingTx } from '../src/pending-tx-manager.ts';
-import { getConfirmationsRequired } from '../src/support.ts';
 
 test('handlePendingTx processes GMP transaction successfully', async t => {
   const opts = createMockPendingTxOpts();

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -14,6 +14,8 @@ const abiCoder = new AbiCoder();
 const factoryAddress = '0x51e589D94b51d01B75442AE1504cD8c50d6127C9';
 // address posted on vstorage is in lowercase
 const expectedWalletAddr = '0x8cb4b25e77844fc0632aca14f1f9b23bdd654ebf';
+const walletOwner = 'agoric1test';
+const sourceAddress = `cosmos:agoric-3:${walletOwner}`;
 
 const createSmartWalletCreatedLog = (
   walletAddr: string,
@@ -69,15 +71,19 @@ test('handlePendingTx processes MAKE_ACCOUNT transaction successfully', async t 
     destinationAddress: `${chain}:${factoryAddress}`,
     expectedAddr: expectedWalletAddr,
     factoryAddr: factoryAddress,
+    sourceAddress,
   };
 
-  setTimeout(() => {
-    const mockLog = createSmartWalletCreatedLog(
-      expectedWalletAddr,
-      'agoric1owner123',
-      'agoric-3',
-    );
+  // Create mockLog outside setTimeout so we can reference it in assertions
+  const mockLog = createSmartWalletCreatedLog(
+    expectedWalletAddr,
+    walletOwner,
+    'agoric-3',
+  );
+  // Add metadata for mock WebSocket simulation
+  (mockLog as any).expectedWalletAddress = expectedWalletAddr;
 
+  setTimeout(() => {
     const filter = {
       address: factoryAddress,
       topics: [
@@ -99,9 +105,8 @@ test('handlePendingTx processes MAKE_ACCOUNT transaction successfully', async t 
 
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
-    `[${txId}] Watching SmartWalletCreated events emitted by ${factoryAddress}`,
-    `[${txId}] SmartWalletCreated event detected: wallet:${expectedWalletAddr}`,
-    `[${txId}] ✓ Address matches! Expected: ${expectedWalletAddr}, Found: ${expectedWalletAddr}`,
+    `[${txId}] Watching for wallet creation at factory ${factoryAddress} for expectedAddr ${expectedWalletAddr}`,
+    `[${txId}] ✅ SUCCESS: expectedAddr=${expectedWalletAddr} txHash=${mockLog.transactionHash} block=${mockLog.blockNumber}`,
     `[${txId}] MAKE_ACCOUNT tx resolved`,
   ]);
 });
@@ -123,14 +128,17 @@ test('handlePendingTx logs timeout on MAKE_ACCOUNT transaction with no matching 
     destinationAddress: `${chain}:${factoryAddress}`,
     expectedAddr: expectedWalletAddr,
     factoryAddr: factoryAddress,
+    sourceAddress,
   };
 
   setTimeout(() => {
     const mockLog = createSmartWalletCreatedLog(
       expectedWalletAddr,
-      'agoric1owner123',
+      walletOwner,
       'agoric-3',
     );
+    // Add metadata for mock WebSocket simulation (though this arrives after timeout)
+    (mockLog as any).expectedWalletAddress = expectedWalletAddr;
 
     const filter = {
       address: factoryAddress,
@@ -153,10 +161,9 @@ test('handlePendingTx logs timeout on MAKE_ACCOUNT transaction with no matching 
 
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
-    `[${txId}] Watching SmartWalletCreated events emitted by ${factoryAddress}`,
-    `[${txId}] ✗ No matching SmartWalletCreated event found within 0.05 minutes`,
-    `[${txId}] SmartWalletCreated event detected: wallet:${expectedWalletAddr}`,
-    `[${txId}] ✓ Address matches! Expected: ${expectedWalletAddr}, Found: ${expectedWalletAddr}`,
+    `[${txId}] Watching for wallet creation at factory ${factoryAddress} for expectedAddr ${expectedWalletAddr}`,
+    `[${txId}] ✗ No wallet creation found for expectedAddr ${expectedWalletAddr} within 0.05 minutes`,
+    `[${txId}] ✅ SUCCESS: expectedAddr=${expectedWalletAddr} txHash=0x123abc block=18500000`,
     `[${txId}] MAKE_ACCOUNT tx resolved`,
   ]);
 });
@@ -170,7 +177,7 @@ test('handlePendingTx ignores non-matching wallet addresses', async t => {
 
   // Use a different address - getAddress normalizes it to checksummed format
   const wrongWalletAddrChecksummed =
-    '0x742d35cc6635c0532925a3b8d9deb1c9e5eb2b64';
+    '0x742d35cC6635C0532925a3b8D9deB1c9E5eb2B64';
 
   const logMessages: string[] = [];
   const logger = (...args: any[]) => logMessages.push(args.join(' '));
@@ -182,21 +189,24 @@ test('handlePendingTx ignores non-matching wallet addresses', async t => {
     destinationAddress: `${chain}:${factoryAddress}`,
     expectedAddr: expectedWalletAddr,
     factoryAddr: factoryAddress,
+    sourceAddress,
   };
 
   // Emit wrong address first
   setTimeout(() => {
     const mockLog = createSmartWalletCreatedLog(
       wrongWalletAddrChecksummed,
-      'agoric1owner123',
+      walletOwner,
       'agoric-3',
     );
+    // Add metadata for mock WebSocket simulation with wrong expected address
+    (mockLog as any).expectedWalletAddress = wrongWalletAddrChecksummed;
 
     const filter = {
       address: factoryAddress,
       topics: [
         SMART_WALLET_CREATED_SIGNATURE,
-        zeroPadValue(expectedWalletAddr, 32),
+        zeroPadValue(wrongWalletAddrChecksummed, 32),
       ],
     };
 
@@ -206,9 +216,11 @@ test('handlePendingTx ignores non-matching wallet addresses', async t => {
   setTimeout(() => {
     const mockLog = createSmartWalletCreatedLog(
       expectedWalletAddr,
-      'agoric1owner123',
+      walletOwner,
       'agoric-3',
     );
+    // Add metadata for mock WebSocket simulation with correct expected address
+    (mockLog as any).expectedWalletAddress = expectedWalletAddr;
 
     const filter = {
       address: factoryAddress,
@@ -229,13 +241,12 @@ test('handlePendingTx ignores non-matching wallet addresses', async t => {
     });
   });
 
+  const correctTxHash = '0x123abc'; // Both use the same hash from createSmartWalletCreatedLog
+
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
-    `[${txId}] Watching SmartWalletCreated events emitted by ${factoryAddress}`,
-    `[${txId}] SmartWalletCreated event detected: wallet:${wrongWalletAddrChecksummed}`,
-    `[${txId}] Address mismatch. Expected: ${expectedWalletAddr}, Found: ${wrongWalletAddrChecksummed}`,
-    `[${txId}] SmartWalletCreated event detected: wallet:${expectedWalletAddr}`,
-    `[${txId}] ✓ Address matches! Expected: ${expectedWalletAddr}, Found: ${expectedWalletAddr}`,
+    `[${txId}] Watching for wallet creation at factory ${factoryAddress} for expectedAddr ${expectedWalletAddr}`,
+    `[${txId}] ✅ SUCCESS: expectedAddr=${expectedWalletAddr} txHash=${correctTxHash} block=18500000`,
     `[${txId}] MAKE_ACCOUNT tx resolved`,
   ]);
 });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes:
- https://github.com/Agoric/agoric-private/issues/714

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
- Adds reverted transaction handling with differential finality protection for `MAKE_ACCOUNT` transactions.
- Common utilities extraction (DRY principle)
- Source address validation for security

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
E2E testing in progress.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New deployment of `ymax0` and `ymax1` planner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time WebSocket wallet monitoring; public watch APIs now accept expected source-address, chain ID, optional retry controls, and a public timeout parameter.

* **Bug Fixes**
  * More reliable receipt handling with retry/backoff, finality protection and reorg-aware revert handling; improved timeout, unsubscribe and cleanup behavior.

* **Refactor**
  * Consolidated watcher utilities and unified execute-data and receipt processing.

* **Tests**
  * Updated tests and mocks to cover source-address propagation and new watch flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->