### PR TITLE
fix(portfolio-contract): rework the `pendingTx` shapes

### DIFF
--- a/.yarn/patches/@endo-pass-style-patch-613c0f4a7a.patch
+++ b/.yarn/patches/@endo-pass-style-patch-613c0f4a7a.patch
@@ -1,0 +1,80 @@
+diff --git a/src/types.d.ts b/src/types.d.ts
+index 76e50e129f3c2407765b7d974058fcb307018a53..6051a3d918e349d66c753e8d17b362238a43381f 100644
+--- a/src/types.d.ts
++++ b/src/types.d.ts
+@@ -75,7 +75,7 @@ export type PassStyled<S extends PassStyleMarker, I extends InterfaceSpec> = {
+ 
+ export type ExtractStyle<P extends PassStyled<any, any>> = P[typeof PASS_STYLE];
+ 
+-export type PassByCopy = Atom | Error | CopyArray | CopyRecord | CopyTagged;
++export type PassByCopy = Atom | Error | CopyArray | CopyReadonlyArray | CopyRecord | CopyTagged;
+ 
+ export type PassByRef =
+   | RemotableObject
+@@ -114,13 +114,16 @@ export type Passable<
+ 
+ export type Container<PC extends PassableCap, E extends Error> =
+   | CopyArrayInterface<PC, E>
++  | CopyReadonlyArrayInterface<PC, E>
+   | CopyRecordInterface<PC, E>
+   | CopyTaggedInterface<PC, E>;
+-interface CopyArrayInterface<PC extends PassableCap, E extends Error>
++export interface CopyArrayInterface<PC extends PassableCap, E extends Error>
+   extends CopyArray<Passable<PC, E>> {}
+-interface CopyRecordInterface<PC extends PassableCap, E extends Error>
++export interface CopyReadonlyArrayInterface<PC extends PassableCap, E extends Error>
++  extends CopyReadonlyArray<Passable<PC, E>> {}
++export interface CopyRecordInterface<PC extends PassableCap, E extends Error>
+   extends CopyRecord<Passable<PC, E>> {}
+-interface CopyTaggedInterface<PC extends PassableCap, E extends Error>
++export interface CopyTaggedInterface<PC extends PassableCap, E extends Error>
+   extends CopyTagged<string, Passable<PC, E>> {}
+ 
+ export type PassStyleOf = {
+@@ -134,7 +137,7 @@ export type PassStyleOf = {
+   (p: Promise<any>): 'promise';
+   (p: Error): 'error';
+   (p: CopyTagged): 'tagged';
+-  (p: any[]): 'copyArray';
++  (p: readonly any[]): 'copyArray';
+   (p: Iterable<any>): 'remotable';
+   (p: Iterator<any, any, undefined>): 'remotable';
+   <T extends PassStyled<PassStyleMarker, any>>(p: T): ExtractStyle<T>;
+@@ -204,6 +207,11 @@ export type PassableCap =
+  */
+ export type CopyArray<T extends Passable = any> = Array<T>;
+ 
++/**
++ * A Passable and Readonly sequence of Passable values.
++ */
++export type CopyReadonlyArray<T extends Passable = any> = ReadonlyArray<T>;
++
+ /**
+  * A hardened immutable ArrayBuffer.
+  */
+@@ -236,22 +244,7 @@ export type CopyTagged<
+ export type InterfaceSpec = string;
+ 
+ /**
+- * Internal to a useful pattern for writing checking logic
+- * (a "checkFoo" function) that can be used to implement a predicate
+- * (an "isFoo" function) or a validator (an "assertFoo" function).
+- *
+- *  * A predicate ideally only returns `true` or `false` and rarely throws.
+- *  * A validator throws an informative diagnostic when the predicate
+- *    would have returned `false`, and simply returns `undefined` normally
+- *    when the predicate would have returned `true`.
+- *  * The internal checking function that they share is parameterized by a
+- *    `Checker` that determines how to proceed with a failure condition.
+- *    Predicates pass in an identity function as checker. Validators
+- *    pass in `assertChecker` which is a trivial wrapper around `assert`.
+- *
+- * See the various uses for good examples.
++ * Consider this export deprecated.
++ * Import `Checker` directly from `'@endo/common/ident-checker.js'` instead.
+  */
+-export type Checker = (
+-  cond: boolean,
+-  details?: import('ses').Details | undefined,
+-) => boolean;
++export type { Checker } from '@endo/common/ident-checker.js';

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@endo/eventual-send@npm:^1.3.4": "patch:@endo/eventual-send@npm%3A1.3.4#~/.yarn/patches/@endo-eventual-send-npm-1.3.4-12411c5a98.patch",
     "@endo/far@npm:^1.1.14": "patch:@endo/far@npm%3A1.1.14#~/.yarn/patches/@endo-far-npm-1.1.14-ef03a62612.patch",
     "@endo/far@npm:^1.0.0": "patch:@endo/far@npm%3A1.1.14#~/.yarn/patches/@endo-far-npm-1.1.14-ef03a62612.patch",
-    "@endo/pass-style@npm:^1.6.3": "patch:@endo/pass-style@patch%3A@endo/pass-style@npm%253A1.6.3%23~/.yarn/patches/@endo-pass-style-npm-1.6.3-139d4e4c47.patch%3A%3Aversion=1.6.3&hash=1f61c8#~/.yarn/patches/@endo-pass-style-patch-fd208907c7.patch",
+    "@endo/pass-style@npm:^1.6.3": "patch:@endo/pass-style@patch%3A@endo/pass-style@patch%253A@endo/pass-style@npm%25253A1.6.3%2523~/.yarn/patches/@endo-pass-style-npm-1.6.3-139d4e4c47.patch%253A%253Aversion=1.6.3&hash=1f61c8%23~/.yarn/patches/@endo-pass-style-patch-fd208907c7.patch%3A%3Aversion=1.6.3&hash=f6a444#~/.yarn/patches/@endo-pass-style-patch-613c0f4a7a.patch",
     "@endo/patterns@npm:^1.7.0": "patch:@endo/patterns@npm%3A1.7.0#~/.yarn/patches/@endo-patterns-npm-1.7.0-70bb963d8a.patch",
     "@endo/marshal@npm:^1.8.0": "patch:@endo/marshal@npm%3A1.8.0#~/.yarn/patches/@endo-marshal-npm-1.8.0-c73c5363a1.patch",
     "@graphql-codegen/visitor-plugin-common@npm:2.13.8": "patch:@graphql-codegen/visitor-plugin-common@npm%3A6.2.2#~/.yarn/patches/@graphql-codegen-visitor-plugin-common-npm-6.2.2-1dfc1601b5.patch",

--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -105,6 +105,11 @@ export type CaipChainId = `${string}:${string}`;
 export type AccountId = `${CaipChainId}:${string}`;
 
 /**
+ * Rough approximation for `/0x([0-9a-fA-F]{2})+/`
+ */
+export type HexAddress = `0x${string}`;
+
+/**
  * Specific to Cosmos chains
  * @see {AccountId} for universal account identifier
  */

--- a/packages/orchestration/src/utils/orchestrationAccount.js
+++ b/packages/orchestration/src/utils/orchestrationAccount.js
@@ -160,20 +160,20 @@ const finishIbcICA = (
 
   entry.src.length === 1 || Fail`expected source length 1 in ICA traffic entry`;
   entry.src[0] === 'ibc' || Fail`expected ibc source in ICA traffic entry`;
-  const src = [
+  const src = /** @type {const} */ ([
     ...entry.src,
     ['chain', srcChain],
     ['port', srcEndpoint.portID],
     ['channel', srcEndpoint.channelID],
-  ];
+  ]);
 
   entry.dst.length === 2 || Fail`expected dest length 2 in ICA traffic entry`;
   entry.dst[0] === 'ibc' || Fail`expected ibc dest in ICA traffic entry`;
-  const dst = [
+  const dst = /** @type {const} */ ([
     ...entry.dst,
     ['port', dstEndpoint.portID],
     ['channel', dstEndpoint.channelID],
-  ];
+  ]);
   return [
     attachGenericSequence(
       /** @type {TrafficEntry<'ibc'>} */ ({

--- a/packages/portfolio-api/src/resolver.js
+++ b/packages/portfolio-api/src/resolver.js
@@ -1,27 +1,13 @@
 import { keyMirror } from '@agoric/internal';
 
 /**
- * @import {AccountId} from '@agoric/orchestration';
+ * @import {AccountId, HexAddress, TrafficEntry} from '@agoric/orchestration';
  * @import {TxId} from './types.js';
  */
 
 /**
- * Represents a published transaction with its type, optional amount, destination, and status.
- *
- * @typedef {object} PublishedTx
- * @property {TxType} type - The type of transaction (CCTP_TO_EVM, GMP, CCTP_TO_AGORIC, or MAKE_ACCOUNT)
- * @property {bigint} [amount] - Optional transaction amount as a bigint
- * @property {AccountId} [destinationAddress] - The destination account identifier for the transaction
- * @property {AccountId} [sourceAddress] - The source LCA address initiating the transaction (required for GMP and MAKE_ACCOUNT transactions)
- * @property {string} [expectedAddr] - The expected smart wallet hex address to be created (for MAKE_ACCOUNT only, format: 0x...)
- * @property {string} [factoryAddr] - The smart wallet factory address (for MAKE_ACCOUNT only, format: 0x...)
- * @property {TxStatus} status - Current status of the transaction (pending, success, or failed)
- * @property {string} [rejectionReason] - Optional reason for failure (only present when status is 'failed')
- * @property {TxId} [nextTxId] - Optional ID of the next transaction in operation
- */
-
-/**
- * Tx statuses for published transactions. Exhaustive state machine flows:
+ * Statuses for published transactions. Exhaustive state machine transitions:
+ *   - setup -> pending (when transaction information is assembled and sent)
  *   - pending -> success (when cross-chain operation completes successfully)
  *   - pending -> failed (when operation fails or times out)
  *
@@ -40,7 +26,6 @@ harden(TxStatus);
  *
  * @enum {Readonly<(typeof TxType)[keyof typeof TxType]>}
  */
-
 export const TxType = keyMirror({
   CCTP_TO_EVM: null,
   GMP: null,
@@ -50,10 +35,54 @@ export const TxType = keyMirror({
   MAKE_ACCOUNT: null,
   /**
    * Placeholder for ProgressTracker protocols not yet recognized by the
-   * resolver, just so they can be published to vstorage, but not processed any
-   * further.  If these appear, it means the resolver source code needs to be
-   * updated.
+   * resolver client, just so they can be published to vstorage, but not
+   * processed any further.  If these appear, it means the resolver client
+   * source code needs to be updated.
    */
   UNKNOWN: null,
 });
 harden(TxType);
+
+/**
+ * @typedef {Partial<Omit<TrafficEntry, 'dst'>> & {
+ *   type: TxType & ('IBC_FROM_AGORIC' | 'IBC_FROM_REMOTE');
+ *   dest?: TrafficEntry['dst']
+ *   amount?: bigint;
+ * }} PublishedTrafficTxDetails
+ * Adapt orchestration TrafficEntry to the portfolio's PublishedTx type.
+ * - Rename 'dst' to 'dest' for consistency with portfolio-contract.
+ * - Add optional 'amount' property.
+ */
+
+/**
+ * Represents a transaction published in vstorage at
+ * `published.${contractInstance}.pendingTxs.tx${number}`
+ * with its type, optional amount, destination, and status.
+ *
+ * @typedef {object} PublishedPortfolioTxDetails
+ * @property {Exclude<TxType, PublishedTrafficTxDetails['type']>} type - The type of
+ * transaction (CCTP_TO_EVM, GMP, CCTP_TO_AGORIC, or MAKE_ACCOUNT)
+ * @property {bigint} [amount] - Optional transaction amount as a bigint, currently in micro-USDC (6 decimal fixed-point)
+ * @property {AccountId} [destinationAddress] - The destination account
+ * identifier for the transaction
+ * @property {AccountId} [sourceAddress] - The source LCA address initiating the
+ * transaction (required for GMP and MAKE_ACCOUNT transactions)
+ * @property {HexAddress} [expectedAddr] - The expected address of the EVM smart
+ * wallet to be created (only for type "MAKE_ACCOUNT")
+ * @property {HexAddress} [factoryAddr] - The address of the EVM smart wallet
+ * factory contract responsible for creating the smart wallet (only for type
+ * "MAKE_ACCOUNT")
+ */
+
+// eslint-disable-next-line @agoric/group-jsdoc-imports
+/**
+ * @typedef {object} PublishedTxBase
+ * @property {TxType} type - The type of transaction (CCTP_TO_EVM, GMP, CCTP_TO_AGORIC, or MAKE_ACCOUNT)
+ * @property {TxStatus} status - Current status of the transaction (pending, success, or failed)
+ * @property {string} [rejectionReason] - Optional reason for failure (only present when status is 'failed')
+ * @property {TxId} [nextTxId] - DEPRECATED in favor of {@link import('./types.js').FlowStep['phases']}. Optional ID of the next transaction in a sequence
+ */
+
+/**
+ * @typedef {PublishedTxBase & (PublishedTrafficTxDetails | PublishedPortfolioTxDetails)} PublishedTx
+ */

--- a/packages/portfolio-api/src/types.ts
+++ b/packages/portfolio-api/src/types.ts
@@ -149,7 +149,19 @@ export type FlowStep = {
   amount: NatAmount;
   src: AssetPlaceRef;
   dest: AssetPlaceRef;
-  phases?: Record<TxPhase, TxId[]>;
+  /**
+   * A single FlowStep can have an arbitrary number of associated pendingTxs
+   * entries. They are tracked by grouping them into "phases", containing an
+   * array of TxIds in order of execution.
+   *
+   * It is valid for the phases record
+   * - to be omitted,
+   * - to have one property,
+   * - to have no properties,
+   * - to have more than one property.
+   * and for each property, to have an array of zero or more TxIds.
+   */
+  phases?: Partial<Record<TxPhase, TxId[]>>;
   // XXX all parts: fee etc.
 };
 

--- a/packages/portfolio-deploy/src/axelar-configs.js
+++ b/packages/portfolio-deploy/src/axelar-configs.js
@@ -1,7 +1,7 @@
 /**
  * @import {AxelarChain} from '@agoric/portfolio-api/src/constants.js';
  * @import {EVMContractAddresses} from '@aglocal/portfolio-contract/src/portfolio.contract.js';
- * @import {BaseChainInfo, Bech32Address} from '@agoric/orchestration'
+ * @import {BaseChainInfo, Bech32Address, HexAddress} from '@agoric/orchestration'
  * @import {EVMContractAddressesMap} from '@aglocal/portfolio-contract/src/type-guards.js';
  */
 
@@ -50,7 +50,6 @@ export const AxelarChainIdMap = harden({
 // XXX: Ideally this should be Record<keyof typeof AxelarChain, HexAddress>.
 // Currently using a looser type to work around compile-time errors.
 /**
- * @typedef {`0x${string}`} HexAddress
  * @typedef {Record<string, HexAddress>} EvmAddressesMap
  * @typedef {{ mainnet: EvmAddressesMap, testnet: EvmAddressesMap }} AddressesMap
  */

--- a/packages/vats/src/types.ts
+++ b/packages/vats/src/types.ts
@@ -5,6 +5,7 @@ import type { PacketSDKType } from '@agoric/cosmic-proto/ibc/core/channel/v1/cha
 import type { BridgeId, Remote } from '@agoric/internal';
 import type { Bytes } from '@agoric/network';
 import type { Guarded } from '@endo/exo';
+import type { CaipChainId } from '@agoric/orchestration';
 import type { TargetApp } from './bridge-target.js';
 import type { LocalChainAccount } from './localchain.js';
 
@@ -152,10 +153,10 @@ export type IBCPacket = JsonSafe<{
 
 /**
  * The network host is the tuple type that identifies the system providing a
- * NetworkBinding. We currently only support chain-based Caip10 hosts, but
+ * NetworkBinding. We currently only support chain-based CAIP-2 hosts, but
  * others may be added later.
  */
-export type NetworkHost = [['chain', `${string}:${string}`]];
+export type NetworkHost = readonly [readonly ['chain', CaipChainId]];
 
 /**
  * A network binding is the protocol-specific minimal information needed to
@@ -163,18 +164,19 @@ export type NetworkHost = [['chain', `${string}:${string}`]];
  * it has been bound.
  */
 export interface NetworkBinding {
-  ibc: [['port', IBCPortID], ['channel', IBCChannelID]];
+  ibc: readonly [
+    readonly ['port', IBCPortID],
+    readonly ['channel', IBCChannelID],
+  ];
 }
 
 /**
  * A network endpoint is a tuple that identifies a specific network location,
  * including the protocol, host, and any protocol-specific binding information.
  */
-export type NetworkEndpoint<Proto extends keyof NetworkBinding> = [
-  Proto,
-  ...(NetworkHost | []),
-  ...(NetworkBinding[Proto] | []),
-];
+export type NetworkEndpoint<Proto extends keyof NetworkBinding> = Readonly<
+  [Proto, ...(NetworkHost | []), ...(NetworkBinding[Proto] | [])]
+>;
 
 export type IBCCounterParty = {
   port_id: IBCPortID;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3922,7 +3922,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@endo/pass-style@patch:@endo/pass-style@patch%3A@endo/pass-style@npm%253A1.6.3%23~/.yarn/patches/@endo-pass-style-npm-1.6.3-139d4e4c47.patch%3A%3Aversion=1.6.3&hash=1f61c8#~/.yarn/patches/@endo-pass-style-patch-fd208907c7.patch":
+"@endo/pass-style@patch:@endo/pass-style@patch%3A@endo/pass-style@npm%253A1.6.3%23~/.yarn/patches/@endo-pass-style-npm-1.6.3-139d4e4c47.patch%3A%3Aversion=1.6.3&hash=1f61c8#~/.yarn/patches/@endo-pass-style-patch-fd208907c7.patch::version=1.6.3&hash=f6a444":
   version: 1.6.3
   resolution: "@endo/pass-style@patch:@endo/pass-style@patch%3A@endo/pass-style@npm%253A1.6.3%23~/.yarn/patches/@endo-pass-style-npm-1.6.3-139d4e4c47.patch%3A%3Aversion=1.6.3&hash=1f61c8#~/.yarn/patches/@endo-pass-style-patch-fd208907c7.patch::version=1.6.3&hash=f6a444"
   dependencies:
@@ -3932,6 +3932,19 @@ __metadata:
     "@endo/eventual-send": "npm:^1.3.4"
     "@endo/promise-kit": "npm:^1.1.13"
   checksum: 10c0/15af68dd6c443cf95d65bd286d03b4feef0dd19f397ca5a2c13b7e61149f8c527ffb9be519165f388fa8efb3320eeb246b6620cf1ab9445e5a4c6aaa31524897
+  languageName: node
+  linkType: hard
+
+"@endo/pass-style@patch:@endo/pass-style@patch%3A@endo/pass-style@patch%253A@endo/pass-style@npm%25253A1.6.3%2523~/.yarn/patches/@endo-pass-style-npm-1.6.3-139d4e4c47.patch%253A%253Aversion=1.6.3&hash=1f61c8%23~/.yarn/patches/@endo-pass-style-patch-fd208907c7.patch%3A%3Aversion=1.6.3&hash=f6a444#~/.yarn/patches/@endo-pass-style-patch-613c0f4a7a.patch":
+  version: 1.6.3
+  resolution: "@endo/pass-style@patch:@endo/pass-style@patch%3A@endo/pass-style@patch%253A@endo/pass-style@npm%25253A1.6.3%2523~/.yarn/patches/@endo-pass-style-npm-1.6.3-139d4e4c47.patch%253A%253Aversion=1.6.3&hash=1f61c8%23~/.yarn/patches/@endo-pass-style-patch-fd208907c7.patch%3A%3Aversion=1.6.3&hash=f6a444#~/.yarn/patches/@endo-pass-style-patch-613c0f4a7a.patch::version=1.6.3&hash=4f57ac"
+  dependencies:
+    "@endo/common": "npm:^1.2.13"
+    "@endo/env-options": "npm:^1.1.11"
+    "@endo/errors": "npm:^1.2.13"
+    "@endo/eventual-send": "npm:^1.3.4"
+    "@endo/promise-kit": "npm:^1.1.13"
+  checksum: 10c0/0ea15dfa94bd7e792cc6cf0b959441e5cb1de3df5776cc2aa42cf0516855da4b097f47712772bece5755797ad952be753ab530af89cf9e68dc64a373c6b35502
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: Agoric/agoric-private#742

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Correct the resolver verification of the IBC-related (TrafficEntry) `pendingTx` vstorage data.

### Security Considerations
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? -->
Improves resolver availability rather than refusing to process abandoned PendingTxs.

### Scaling Considerations
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->
Reduces processing consumption.

### Documentation Considerations
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users? -->
Will correct an error condition.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
This fix will need careful review, since it will be deployed to resolver/planner instances in all four Ymax environments.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
The changed types and shapes should be low-impact, as only normal resolver operation should be possible, potentially settling (with success or failure) of existing `pendingTxs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared hex-address type and expanded transaction typings for broader address handling.

* **Bug Fixes**
  * Tightened readonly constraints and tuple shapes to reduce accidental mutation.

* **Documentation**
  * Clarified transaction field names, statuses, FlowStep semantics, and deprecation notes.

* **Tests**
  * Re-enabled settlement tests and added shape tests for published transactions.

* **Chores**
  * Updated an internal dependency patch mapping string for patch resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->