### PR TITLE
chore: Update CAIP URLs

### DIFF
--- a/packages/orchestration/src/orchestration-api.ts
+++ b/packages/orchestration/src/orchestration-api.ts
@@ -89,7 +89,7 @@ export type AmountArg = DenomAmount | Amount<'nat'>;
  * and they use `chain_id`/`chainId` for what CAIP-2 calls the `reference`. We
  * qualify the term here to avoid confusion.
  *
- * @see {@link https://chainagnostic.org/CAIPs/caip-2}
+ * @see {@link https://standards.chainagnostic.org/CAIPs/caip-2}
  */
 export type CaipChainId = `${string}:${string}`;
 
@@ -100,7 +100,7 @@ export type CaipChainId = `${string}:${string}`;
  *   chain_id:          [-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32} (See [CAIP-2][])
  *   account_address:   [-.%a-zA-Z0-9]{1,128}
  *
- * @see {@link https://chainagnostic.org/CAIPs/caip-10}
+ * @see {@link https://standards.chainagnostic.org/CAIPs/caip-10}
  */
 export type AccountId = `${CaipChainId}:${string}`;
 
@@ -123,7 +123,7 @@ export type CosmosChainAddress = {
 
 /**
  * Info used to identify blockchains across ecosystems
- * @see {@link https://chainagnostic.org/CAIPs/caip-2}
+ * @see {@link https://standards.chainagnostic.org/CAIPs/caip-2}
  */
 export interface BaseChainInfo<N extends KnownNamespace = KnownNamespace> {
   /** CAIP-2 namespace, e.g. 'cosmos', 'eip155' */

--- a/packages/portfolio-api/src/constants.js
+++ b/packages/portfolio-api/src/constants.js
@@ -113,7 +113,7 @@ harden(SupportedChain);
 const caipChainIdFromEip155 = chainId => `eip155:${chainId}`;
 
 /**
- * cf. https://chainagnostic.org/CAIPs/caip-2
+ * cf. https://standards.chainagnostic.org/CAIPs/caip-2
  * Please keep in sync with ../../../services/ymax-planner/src/support.ts `spectrumChainIds`
  *
  * XXX this probably belongs in @agoric/orchestration


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated JSDoc references and inline comment URLs to use the standardized standards.chainagnostic.org domain for CAIP links, ensuring consistent external references.
  * These are documentation-only updates; no changes to code, APIs, or runtime behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->