### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

_testing Graphite_

## Description

Added a basic Express server for the Graphite demo that provides a mock activity feed endpoint. The server runs on port 3000 and includes a `/feed` endpoint that returns sample activity data with entries for photo uploads, comments, and status updates.

### Security Considerations

This is a simple demo server with no authentication or data validation. For production use, proper security measures would need to be implemented.

### Scaling Considerations

The current implementation uses in-memory data storage which is suitable for demo purposes but would need to be replaced with a database for production use.

### Documentation Considerations

Users will need to know how to start the server and access the `/feed` endpoint to retrieve the activity data.

### Testing Considerations

Tests should be added to verify the server starts correctly and the `/feed` endpoint returns the expected data structure.

### Upgrade Considerations

As this is a new component, there are no upgrade considerations at this time.