### PR TITLE
docs(portfolio-api): Update the FlowStep['phases'] JSDoc comment

### DIFF
--- a/packages/portfolio-api/src/types.ts
+++ b/packages/portfolio-api/src/types.ts
@@ -151,8 +151,9 @@ export type FlowStep = {
   dest: AssetPlaceRef;
   /**
    * A single FlowStep can have an arbitrary number of associated pendingTxs
-   * entries. They are tracked by grouping them into "phases", containing an
-   * array of TxIds in order of execution.
+   * entries. They are tracked by grouping them into "phases", each phase
+   * containing a sequence of TxIds in order of execution and with no implied
+   * relative sequencing constraints across phases.
    *
    * It is valid for the phases record
    * - to be omitted,


### PR DESCRIPTION
Ref https://github.com/Agoric/agoric-sdk/pull/12394#discussion_r2744614608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for flow phases: each phase is an ordered sequence of transaction identifiers and phases do not imply any ordering relative to one another. No behavioral or API changes — this update only improves clarity so implementers understand phase ordering expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->