### PR TITLE
chore: Clean up some code for working with Permit2 data

### DIFF
--- a/packages/orchestration/src/utils/permit2/signatureTransfer.ts
+++ b/packages/orchestration/src/utils/permit2/signatureTransfer.ts
@@ -116,6 +116,10 @@ export const PermitBatchTransferFromTypes = {
   TokenPermissions: TokenPermissionTypeParams,
 } as const satisfies TypedData;
 
+/**
+ * Generate an EIP-712 `types` record for a single-token
+ * `permitWitnessTransferFrom` call.
+ */
 export function permitWitnessTransferFromTypes<
   T extends TypedData,
   TD extends TypedDataParameter<string, Extract<keyof T, string>> =
@@ -125,7 +129,13 @@ export function permitWitnessTransferFromTypes<
     EIP712Domain: Permit2DomainTypeParams,
     PermitWitnessTransferFrom: [
       ...PermitTransferFromTypeParams,
-      // Enable runtime type to accept undefined field for base type extraction
+      // `witness` is required by static typing, but when it is undefined at
+      // runtime, this emits types in which PermitWitnessTransferFrom is
+      // truncated just before where a witness field belongs.
+      // Doing so simplifies the function returned by
+      // {@link makeWitnessTypeStringExtractor}, because the EIP-712 string
+      // encoding of that type has its first `)` at that position (i.e.,
+      // `PermitWitnessTransferFrom(TokenPermissions permitted,...,uint256 deadline)TokenPermissions(...)`).
       ...((witness ? [witness.witnessField] : []) as [TD]),
     ],
     TokenPermissions: TokenPermissionTypeParams,
@@ -133,6 +143,10 @@ export function permitWitnessTransferFromTypes<
   } as const satisfies TypedData;
 }
 
+/**
+ * Generate an EIP-712 `types` record for a multi-token
+ * `permitWitnessTransferFrom` call.
+ */
 export function permitBatchWitnessTransferFromTypes<
   T extends TypedData,
   TD extends TypedDataParameter<string, Extract<keyof T, string>> =
@@ -142,7 +156,13 @@ export function permitBatchWitnessTransferFromTypes<
     EIP712Domain: Permit2DomainTypeParams,
     PermitBatchWitnessTransferFrom: [
       ...PermitBatchTransferFromTypeParams,
-      // Enable runtime type to accept undefined field for base type extraction
+      // `witness` is required by static typing, but when it is undefined at
+      // runtime, this emits types in which PermitBatchWitnessTransferFrom is
+      // truncated just before where a witness field belongs.
+      // Doing so simplifies the function returned by
+      // {@link makeWitnessTypeStringExtractor}, because the EIP-712 string
+      // encoding of that type has its first `)` at that position (i.e.,
+      // `PermitBatchWitnessTransferFrom(TokenPermissions[] permitted,...,uint256 deadline)TokenPermissions(...)`).
       ...((witness ? [witness.witnessField] : []) as [TD]),
     ],
     TokenPermissions: TokenPermissionTypeParams,

--- a/packages/orchestration/src/utils/permit2/signatureTransferHelpers.ts
+++ b/packages/orchestration/src/utils/permit2/signatureTransferHelpers.ts
@@ -161,12 +161,8 @@ export const extractWitnessFieldFromTypes = <
   return candidateType[candidateType.length - 1] as T;
 };
 
-export const isPermit2MessageType = (type: string): type is PrimaryTypeName => {
-  return (
-    type === 'PermitBatchWitnessTransferFrom' ||
-    type === 'PermitWitnessTransferFrom'
-  );
-};
+export const isPermit2MessageType = (type: string): type is PrimaryTypeName =>
+  type in PrimaryTypes;
 
 export const TokenPermissionsComponents = [
   { name: 'token', type: 'address' },

--- a/packages/orchestration/src/utils/permit2/signatureTransferHelpers.ts
+++ b/packages/orchestration/src/utils/permit2/signatureTransferHelpers.ts
@@ -95,9 +95,7 @@ export const makeWitnessTypeStringExtractor = (powers: {
 
     const prefix = encodedTypePrefixes[primaryType];
     if (!encodedType.startsWith(prefix)) {
-      throw new Error(
-        `TypedData has an invalid type string for ${primaryType}`,
-      );
+      throw new Error(`${primaryType} must start with expected base fields`);
     }
 
     return encodedType.substring(prefix.length);
@@ -138,13 +136,13 @@ export const extractWitnessFieldFromTypes = <
   const baseFieldDefs = permit2BaseTypeParams[primaryTypeName];
   if (fieldDefs.length !== baseFieldDefs.length + 1) {
     throw new Error(
-      `TypedData has an invalid number of fields for ${primaryType}`,
+      `${primaryTypeName} must have ${baseFieldDefs.length + 1} fields`,
     );
   }
   for (const [i, { name, type }] of baseFieldDefs.entries()) {
     if (fieldDefs[i].name !== name || fieldDefs[i].type !== type) {
       throw new Error(
-        `TypedData has an invalid field at index ${i} for ${primaryType}`,
+        `${primaryTypeName} field at index ${i} must be \`${type} ${name}\``,
       );
     }
   }

--- a/packages/orchestration/src/utils/viem-utils/hashTypedData.ts
+++ b/packages/orchestration/src/utils/viem-utils/hashTypedData.ts
@@ -11,6 +11,10 @@ type MessageTypeProperty = {
   type: string;
 };
 
+/**
+ * Serialize an EIP-712 struct definition to a string per
+ * https://eips.ethereum.org/EIPS/eip-712#definition-of-encodetype
+ */
 export function encodeType({
   primaryType,
   types,

--- a/packages/portfolio-api/src/evm-wallet/eip712-messages.ts
+++ b/packages/portfolio-api/src/evm-wallet/eip712-messages.ts
@@ -322,7 +322,9 @@ export function validateYmaxOperationTypeName<T extends OperationTypeNames>(
 export const splitWitnessFieldType = <T extends OperationTypeNames>(
   fieldName: `${typeof YMAX_DOMAIN_NAME}V${typeof YMAX_DOMAIN_VERSION}${T}`,
 ) => {
-  const match = fieldName.match(/^YmaxV(\d+)(\w+)$/u);
+  const match =
+    fieldName.startsWith(YMAX_DOMAIN_NAME) &&
+    fieldName.substring(YMAX_DOMAIN_NAME.length).match(/^V(\d+)(\w+)$/u);
   if (!match) {
     throw new Error(`Invalid witness field type name: ${fieldName}`);
   }

--- a/packages/portfolio-api/src/evm-wallet/message-handler-helpers.ts
+++ b/packages/portfolio-api/src/evm-wallet/message-handler-helpers.ts
@@ -91,6 +91,11 @@ export const makeEVMHandlerUtils = (viemUtils: {
     validateTypedData,
     encodeType,
   } = viemUtils;
+
+  const getPermit2WitnessTypeString = makeWitnessTypeStringExtractor({
+    encodeType,
+  });
+
   /**
    * Extract operation type name and data from an EIP-712 standalone Ymax typed data
    *
@@ -173,9 +178,6 @@ export const makeEVMHandlerUtils = (viemUtils: {
     owner: Address,
     signature: WithSignature<object>['signature'],
   ): PermitDetails => {
-    const witnessTypeStringExtractor = makeWitnessTypeStringExtractor({
-      encodeType,
-    });
     // @ts-expect-error generic/union type compatibility
     const permitData: YmaxPermitWitnessTransferFromData = data;
 
@@ -190,7 +192,7 @@ export const makeEVMHandlerUtils = (viemUtils: {
       types: permitData.types,
       data: witnessData,
     });
-    const witnessTypeString = witnessTypeStringExtractor(permitData.types);
+    const witnessTypeString = getPermit2WitnessTypeString(permitData.types);
 
     const { spender, ...permitStruct } = permit;
 


### PR DESCRIPTION
## Description
* Add explanatory comments (including JSDoc).
* Avoid redundant work.
* Simplify typing.
* DRY out common checks.
* Improve error messages.

### Security Considerations
None known.

### Scaling Considerations
n/a

### Documentation Considerations
Improved by new doc comments.

### Testing Considerations
n/a

### Upgrade Considerations
Did not change any signatures or behavior other than error messages, which are not considered stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utilities to generate and extract EIP-712 types for single- and multi-token permit messages and expose helpers for witness field extraction.

* **Refactor**
  * Restructured Permit2 message handling into a type-driven, centralized approach and consolidated witness type string extraction for reuse.
  * Switched to explicit parsing/validation for permit field names.

* **Documentation**
  * Clarified EIP-712 struct serialization and added comments on witness handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->