### PR TITLE
chore(ymax-resolver): resolve operation events

### DIFF
--- a/packages/portfolio-api/src/resolver.js
+++ b/packages/portfolio-api/src/resolver.js
@@ -29,6 +29,7 @@ harden(TxStatus);
 export const TxType = keyMirror({
   CCTP_TO_EVM: null,
   GMP: null,
+  ROUTED_GMP: null,
   CCTP_TO_AGORIC: null,
   IBC_FROM_AGORIC: null,
   IBC_FROM_REMOTE: null,

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -126,6 +126,7 @@ type PendingTxRecord = { blockHeight: bigint; tx: PendingTx };
 const RESOLVER_SUPPORTED_TRANSACTIONS: TxType[] = [
   TxType.CCTP_TO_EVM,
   TxType.GMP,
+  TxType.ROUTED_GMP,
   TxType.MAKE_ACCOUNT,
 ];
 

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -78,7 +78,7 @@ type GmpTx = PendingTx & { type: typeof TxType.GMP };
 type MakeAccountTx = PendingTx & { type: typeof TxType.MAKE_ACCOUNT };
 type RoutedGmpTx = PendingTx & {
   type: typeof TxType.ROUTED_GMP;
-  payloadHash: string;
+  payloadHash?: string;
 };
 
 type LiveWatchOpts = { mode: 'live'; timeoutMs: number; signal?: AbortSignal };
@@ -485,7 +485,6 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
     // Parse destinationAddress (CAIP-10 router address)
     assert(destinationAddress, `${logPrefix} Missing destinationAddress`);
     assert(sourceAddress, `${logPrefix} Missing sourceAddress`);
-    assert(payloadHash, `${logPrefix} Missing payloadHash`);
 
     const { namespace, reference, accountAddress } =
       parseAccountId(destinationAddress);

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -474,7 +474,7 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
   watch: async (ctx, tx, log, opts) => {
     await null;
 
-    const { txId, destinationAddress, payloadHash } = tx;
+    const { txId, destinationAddress, payloadHash, sourceAddress } = tx;
     const logPrefix = `[${txId}]`;
 
     if (opts.signal?.aborted) {
@@ -484,6 +484,8 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
 
     // Parse destinationAddress (CAIP-10 router address)
     assert(destinationAddress, `${logPrefix} Missing destinationAddress`);
+    assert(sourceAddress, `${logPrefix} Missing sourceAddress`);
+    assert(payloadHash, `${logPrefix} Missing payloadHash`);
 
     const { namespace, reference, accountAddress } =
       parseAccountId(destinationAddress);
@@ -495,6 +497,9 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
     const rpcUrl =
       ctx.rpcUrls[caipId] || Fail`${logPrefix} No RPC URL for chain: ${caipId}`;
     const rpcClient = makeJsonRpcClient(ctx.fetch, rpcUrl);
+
+    const lcaAddress = parseAccountId(sourceAddress).accountAddress;
+
     const watchArgs = {
       routerAddress: accountAddress as `0x${string}`,
       provider,
@@ -502,6 +507,7 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
       kvStore: ctx.kvStore,
       txId,
       payloadHash,
+      sourceAddress: lcaAddress,
       log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
     };
 
@@ -578,7 +584,7 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
       await ctx.ydsNotifier?.notifySettlement(txId, transferResult.txHash);
     }
 
-    log(`${logPrefix} ROUTED_GMP tx resolved`);
+    log(`${logPrefix} ROUTED_GMP watch completed`);
   },
 };
 

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -76,7 +76,10 @@ export type GmpTransfer = {
 type CctpTx = PendingTx & { type: typeof TxType.CCTP_TO_EVM; amount: bigint };
 type GmpTx = PendingTx & { type: typeof TxType.GMP };
 type MakeAccountTx = PendingTx & { type: typeof TxType.MAKE_ACCOUNT };
-type RoutedGmpTx = PendingTx & { type: typeof TxType.ROUTED_GMP };
+type RoutedGmpTx = PendingTx & {
+  type: typeof TxType.ROUTED_GMP;
+  payloadHash: string;
+};
 
 type LiveWatchOpts = { mode: 'live'; timeoutMs: number; signal?: AbortSignal };
 type LookBackWatchOpts = {
@@ -471,7 +474,7 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
   watch: async (ctx, tx, log, opts) => {
     await null;
 
-    const { txId, destinationAddress } = tx;
+    const { txId, destinationAddress, payloadHash } = tx;
     const logPrefix = `[${txId}]`;
 
     if (opts.signal?.aborted) {
@@ -489,13 +492,16 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
       Fail`${logPrefix} No EVM provider for chain: ${caipId}`;
 
     const provider = ctx.evmProviders[caipId] as WebSocketProvider;
-
+    const rpcUrl =
+      ctx.rpcUrls[caipId] || Fail`${logPrefix} No RPC URL for chain: ${caipId}`;
+    const rpcClient = makeJsonRpcClient(ctx.fetch, rpcUrl);
     const watchArgs = {
       routerAddress: accountAddress as `0x${string}`,
       provider,
       chainId: caipId,
       kvStore: ctx.kvStore,
       txId,
+      payloadHash,
       log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
     };
 
@@ -539,6 +545,8 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
         publishTimeMs: opts.publishTimeMs,
         signal: abortController.signal,
         setTimeout: ctx.setTimeout,
+        rpcClient,
+        makeAbortController: ctx.makeAbortController,
       });
 
       if (lookBackResult.settled) {

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -492,16 +492,15 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
     caipId in ctx.evmProviders ||
       Fail`${logPrefix} No EVM provider for chain: ${caipId}`;
 
-    const provider = ctx.evmProviders[caipId] as WebSocketProvider;
-    const rpcUrl =
-      ctx.rpcUrls[caipId] || Fail`${logPrefix} No RPC URL for chain: ${caipId}`;
-    const rpcClient = makeJsonRpcClient(ctx.fetch, rpcUrl);
+    const rpc =
+      ctx.retryProviders[caipId] ||
+      Fail`${logPrefix} No retry provider for chain: ${caipId}`;
 
     const lcaAddress = parseAccountId(sourceAddress).accountAddress;
 
     const watchArgs = {
       routerAddress: accountAddress as `0x${string}`,
-      provider,
+      provider: rpc,
       chainId: caipId,
       kvStore: ctx.kvStore,
       txId,
@@ -541,8 +540,8 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
 
       await null;
       // Wait for at least one block to ensure overlap between lookback and live mode
-      const currentBlock = await provider.getBlockNumber();
-      await waitForBlock(provider, currentBlock + 1);
+      const currentBlock = await rpc.getBlockNumber();
+      await waitForBlock(rpc, currentBlock + 1);
 
       // Scan historical blocks
       const lookBackResult = await lookBackOperationResult({
@@ -550,7 +549,6 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
         publishTimeMs: opts.publishTimeMs,
         signal: abortController.signal,
         setTimeout: ctx.setTimeout,
-        rpcClient,
         makeAbortController: ctx.makeAbortController,
       });
 

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -31,6 +31,10 @@ import {
   watchSmartWalletTx,
   lookBackSmartWalletTx,
 } from './watchers/wallet-watcher.ts';
+import {
+  watchOperationResult,
+  lookBackOperationResult,
+} from './watchers/operation-watcher.ts';
 import type { YdsNotifier } from './yds-notifier.ts';
 
 export type EvmChain = keyof typeof AxelarChain;
@@ -72,6 +76,7 @@ export type GmpTransfer = {
 type CctpTx = PendingTx & { type: typeof TxType.CCTP_TO_EVM; amount: bigint };
 type GmpTx = PendingTx & { type: typeof TxType.GMP };
 type MakeAccountTx = PendingTx & { type: typeof TxType.MAKE_ACCOUNT };
+type RoutedGmpTx = PendingTx & { type: typeof TxType.ROUTED_GMP };
 
 type LiveWatchOpts = { mode: 'live'; timeoutMs: number; signal?: AbortSignal };
 type LookBackWatchOpts = {
@@ -462,6 +467,113 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
   },
 };
 
+const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
+  watch: async (ctx, tx, log, opts) => {
+    await null;
+
+    const { txId, destinationAddress } = tx;
+    const logPrefix = `[${txId}]`;
+
+    if (opts.signal?.aborted) {
+      log(`${logPrefix} ROUTED_GMP watch aborted before starting`);
+      return;
+    }
+
+    // Parse destinationAddress (CAIP-10 router address)
+    assert(destinationAddress, `${logPrefix} Missing destinationAddress`);
+
+    const { namespace, reference, accountAddress } =
+      parseAccountId(destinationAddress);
+    const caipId: CaipChainId = `${namespace}:${reference}`;
+    caipId in ctx.evmProviders ||
+      Fail`${logPrefix} No EVM provider for chain: ${caipId}`;
+
+    const provider = ctx.evmProviders[caipId] as WebSocketProvider;
+
+    const watchArgs = {
+      routerAddress: accountAddress as `0x${string}`,
+      provider,
+      chainId: caipId,
+      kvStore: ctx.kvStore,
+      txId,
+      log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
+    };
+
+    let transferResult: WatcherResult | undefined;
+
+    if (opts.mode === 'live') {
+      transferResult = await watchOperationResult({
+        ...watchArgs,
+        timeoutMs: opts.timeoutMs,
+        signal: opts.signal,
+      });
+    } else {
+      // Lookback mode with concurrent live watching
+      const abortController = ctx.makeAbortController(
+        undefined,
+        opts.signal ? [opts.signal] : undefined,
+      );
+
+      const liveResultP = watchOperationResult({
+        ...watchArgs,
+        timeoutMs: opts.timeoutMs,
+        signal: abortController.signal,
+      });
+
+      void liveResultP.then(result => {
+        if (result.settled) {
+          const reason = `${logPrefix} Live mode completed`;
+          log(reason);
+          abortController.abort(reason);
+        }
+      });
+
+      await null;
+      // Wait for at least one block to ensure overlap between lookback and live mode
+      const currentBlock = await provider.getBlockNumber();
+      await waitForBlock(provider, currentBlock + 1);
+
+      // Scan historical blocks
+      const lookBackResult = await lookBackOperationResult({
+        ...watchArgs,
+        publishTimeMs: opts.publishTimeMs,
+        signal: abortController.signal,
+        setTimeout: ctx.setTimeout,
+      });
+
+      if (lookBackResult.settled) {
+        transferResult = lookBackResult;
+        const reason = `${logPrefix} Lookback found transaction`;
+        log(reason);
+        abortController.abort(reason);
+      } else {
+        log(
+          `${logPrefix} Lookback completed without finding transaction, waiting for live mode`,
+        );
+        transferResult = await liveResultP;
+      }
+    }
+
+    if (opts.signal?.aborted) {
+      return;
+    }
+
+    transferResult.settled &&
+      (await resolvePendingTx({
+        signingSmartWalletKit: ctx.signingSmartWalletKit,
+        txId,
+        status:
+          transferResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED,
+      }));
+
+    if (transferResult?.txHash) {
+      await ctx.ydsNotifier?.notifySettlement(txId, transferResult.txHash);
+    }
+
+    log(`${logPrefix} ROUTED_GMP tx resolved`);
+  },
+};
+
 const ibcFromAgoricMonitor: PendingTxMonitor = {
   // CAVEAT: IBC_FROM_AGORIC watch not needed - settled by contract
   watch: async (_ctx, _tx, _log, _opts) => {
@@ -475,6 +587,7 @@ const MONITORS = new Map<
 >([
   [TxType.CCTP_TO_EVM, cctpMonitor],
   [TxType.GMP, gmpMonitor],
+  [TxType.ROUTED_GMP, routedGmpMonitor],
   [TxType.MAKE_ACCOUNT, makeAccountMonitor],
   [TxType.IBC_FROM_AGORIC, ibcFromAgoricMonitor],
 ]);
@@ -501,6 +614,7 @@ export type HandlePendingTxOpts = {
  */
 export const PendingTxCode = {
   GMP_TX_NOT_FOUND: 'GMP_TX_NOT_FOUND',
+  ROUTED_GMP_TX_NOT_FOUND: 'ROUTED_GMP_TX_NOT_FOUND',
   WALLET_TX_NOT_FOUND: 'WALLET_TX_NOT_FOUND',
   CCTP_TX_NOT_FOUND: 'CCTP_TX_NOT_FOUND',
 } as const;

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -255,6 +255,31 @@ export const getConfirmationsRequired = (chainId: CaipChainId): number => {
 };
 
 /**
+ * Time to wait before confirming a transaction revert, in milliseconds.
+ * This gives Axelar relayers a window to retry the transaction
+ * (observed ~6 min retries for SubcallOutOfGas cases).
+ */
+const REVERT_WAIT_TIME_MS = 10 * 60 * 1_000; // 10 minutes
+
+/**
+ * Get the number of confirmations required before confirming a transaction
+ * revert. Uses a higher threshold than normal confirmations to give Axelar
+ * relayers time to retry reverted transactions.
+ *
+ * The value is computed from {@link REVERT_WAIT_TIME_MS} and the chain's
+ * block time, floored at the normal confirmation requirement.
+ */
+export const getRevertConfirmationsRequired = (
+  chainId: CaipChainId,
+): number => {
+  const blockTimeMs = getBlockTimeMs(chainId);
+  return Math.max(
+    getConfirmationsRequired(chainId),
+    Math.ceil(REVERT_WAIT_TIME_MS / blockTimeMs),
+  );
+};
+
+/**
  * @deprecated should come from e.g. @agoric/portfolio-api/src/constants.js
  *   or @agoric/orchestration
  */

--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -56,10 +56,11 @@ const parseOperationResultLog = (
   const idHash = log.topics[1];
   const [success, reason] = abiCoder.decode(['bool', 'bytes'], log.data);
 
+  // XXX: decode the reason bytes into a human-readable error message
   return {
     idHash,
     success,
-    reason: reason.length > 0 ? `0x${Buffer.from(reason).toString('hex')}` : '',
+    reason: reason.length > 0 ? reason : '',
   };
 };
 
@@ -112,6 +113,7 @@ export const watchOperationResult = ({
     signal?.addEventListener('abort', () => finish({ settled: false }));
 
     const listenForOperationResult = async (eventLog: Log) => {
+      await null;
       try {
         const { idHash, success, reason } = parseOperationResultLog(eventLog);
 
@@ -257,7 +259,7 @@ export const lookBackOperationResult = async ({
     const result = await handleOperationFailure(
       matchingEvent,
       baseFilter,
-      log => parseOperationResultLog(log, abiCoder),
+      logEntry => parseOperationResultLog(logEntry, abiCoder),
       `expectedId=${expectedId}`,
       chainId,
       provider,

--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -1,0 +1,236 @@
+import type { Filter, WebSocketProvider, Log } from 'ethers';
+import { id, AbiCoder } from 'ethers';
+import type { CaipChainId } from '@agoric/orchestration';
+import type { KVStore } from '@agoric/internal/src/kv-store.js';
+import {
+  getBlockNumberBeforeRealTime,
+  scanEvmLogsInChunks,
+  type WatcherTimeoutOptions,
+} from '../support.ts';
+import { TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
+import {
+  deleteTxBlockLowerBound,
+  getTxBlockLowerBound,
+  setTxBlockLowerBound,
+} from '../kv-store.ts';
+import type { WatcherResult } from '../pending-tx-manager.ts';
+
+/**
+ * The Keccak256 hash (event signature) of the PortfolioRouter `OperationResult` event.
+ *
+ * Event signature: OperationResult(string indexed id, bool success, bytes reason)
+ *
+ * This event is emitted by the PortfolioRouter contract after processing each
+ * RouterInstruction. It indicates whether the instruction (which may include
+ * deposit, account provision, and/or multicall operations) succeeded or failed.
+ */
+const OPERATION_RESULT_SIGNATURE = id('OperationResult(string,bool,bytes)');
+
+type OperationResultWatch = {
+  routerAddress: `0x${string}`;
+  provider: WebSocketProvider;
+  expectedId: string;
+  log?: (...args: unknown[]) => void;
+  kvStore: KVStore;
+  txId: `tx${number}`;
+};
+
+/**
+ * Parse the OperationResult event log.
+ *
+ * Event: OperationResult(string indexed id, bool success, bytes reason)
+ * - topics[0]: event signature
+ * - topics[1]: keccak256(id) (indexed string is stored as hash)
+ * - data: abi.encode(bool success, bytes reason)
+ */
+const parseOperationResultLog = (
+  log: Log,
+  abiCoder: AbiCoder = new AbiCoder(),
+): { idHash: string; success: boolean; reason: string } => {
+  if (!log.topics || log.topics.length < 2 || !log.data) {
+    throw new Error('Malformed OperationResult log');
+  }
+
+  const idHash = log.topics[1];
+  const [success, reason] = abiCoder.decode(['bool', 'bytes'], log.data);
+
+  return {
+    idHash,
+    success,
+    reason: reason.length > 0 ? `0x${Buffer.from(reason).toString('hex')}` : '',
+  };
+};
+
+/**
+ * Watch for OperationResult events in real-time (live mode).
+ *
+ * Subscribes to the PortfolioRouter contract and waits for an OperationResult
+ * event with the expected instruction ID.
+ */
+export const watchOperationResult = ({
+  routerAddress,
+  provider,
+  expectedId,
+  timeoutMs = TX_TIMEOUT_MS,
+  log = () => {},
+  setTimeout = globalThis.setTimeout,
+  signal,
+}: OperationResultWatch & WatcherTimeoutOptions): Promise<WatcherResult> => {
+  return new Promise(resolve => {
+    if (signal?.aborted) {
+      resolve({ settled: false });
+      return;
+    }
+
+    // For indexed strings, Solidity stores keccak256(string) in the topic
+    const expectedIdHash = id(expectedId);
+    const filter: Filter = {
+      address: routerAddress,
+      topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
+    };
+
+    log(
+      `Watching for OperationResult on router ${routerAddress} with id: ${expectedId}`,
+    );
+
+    let resultFound = false;
+    let timeoutId: NodeJS.Timeout;
+    let listeners: Array<{ event: any; listener: any }> = [];
+
+    const finish = (result: WatcherResult) => {
+      resolve(result);
+      if (timeoutId) clearTimeout(timeoutId);
+      for (const { event, listener } of listeners) {
+        void provider.off(event, listener);
+      }
+      listeners = [];
+    };
+
+    signal?.addEventListener('abort', () => finish({ settled: false }));
+
+    const listenForOperationResult = async (eventLog: Log) => {
+      try {
+        const { idHash, success, reason } = parseOperationResultLog(eventLog);
+
+        if (idHash === expectedIdHash) {
+          log(
+            `✓ ID matches! Expected: ${expectedId} (hash: ${expectedIdHash}) idHash=${idHash} success=${success} reason=${reason} tx=${eventLog.transactionHash}`,
+          );
+          resultFound = true;
+          finish({
+            settled: true,
+            txHash: eventLog.transactionHash,
+            success,
+          });
+          return;
+        }
+        log(`ID hash mismatch. Expected: ${expectedIdHash}, Got: ${idHash}`);
+      } catch (error: any) {
+        log(`Error:`, error);
+        return;
+      }
+    };
+
+    void provider.on(filter, listenForOperationResult);
+    listeners.push({ event: filter, listener: listenForOperationResult });
+
+    timeoutId = setTimeout(() => {
+      if (!resultFound) {
+        log(
+          `✗ No matching OperationResult found within ${timeoutMs / 60000} minutes`,
+        );
+      }
+    }, timeoutMs);
+  });
+};
+
+/**
+ * Look back through historical blocks for an OperationResult event (lookback mode).
+ *
+ * Scans historical EVM logs for the OperationResult event with the expected
+ * instruction ID, starting from the transaction publish time.
+ */
+export const lookBackOperationResult = async ({
+  routerAddress,
+  provider,
+  expectedId,
+  publishTimeMs,
+  chainId,
+  log = () => {},
+  signal,
+  kvStore,
+  txId,
+}: OperationResultWatch & {
+  publishTimeMs: number;
+  chainId: CaipChainId;
+  signal?: AbortSignal;
+}): Promise<WatcherResult> => {
+  await null;
+  try {
+    const fromBlock = await getBlockNumberBeforeRealTime(
+      provider,
+      publishTimeMs,
+    );
+    const toBlock = await provider.getBlockNumber();
+
+    const savedFromBlock =
+      (await getTxBlockLowerBound(kvStore, txId)) || fromBlock;
+
+    // For indexed strings, Solidity stores keccak256(string) in the topic
+    const expectedIdHash = id(expectedId);
+
+    log(
+      `Searching blocks ${savedFromBlock} → ${toBlock} for OperationResult with id ${expectedId} (hash: ${expectedIdHash})`,
+    );
+
+    const baseFilter: Filter = {
+      address: routerAddress,
+      topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
+    };
+
+    const abiCoder = new AbiCoder();
+
+    const matchingEvent = await scanEvmLogsInChunks(
+      {
+        provider,
+        baseFilter,
+        fromBlock: savedFromBlock,
+        toBlock,
+        chainId,
+        log,
+        signal,
+        onRejectedChunk: async (_, to) => {
+          await setTxBlockLowerBound(kvStore, txId, to);
+        },
+      },
+      ev => {
+        try {
+          const parsed = parseOperationResultLog(ev, abiCoder);
+          log(`Check: idHash=${parsed.idHash} success=${parsed.success}`);
+          // The filter already ensures idHash matches, but we verify anyway
+          return parsed.idHash === expectedIdHash;
+        } catch (e) {
+          log(`Parse error:`, e);
+          return false;
+        }
+      },
+    );
+
+    if (!matchingEvent) {
+      log(`No matching OperationResult found`);
+      return { settled: false };
+    }
+
+    const parsed = parseOperationResultLog(matchingEvent, abiCoder);
+
+    deleteTxBlockLowerBound(kvStore, txId);
+    return {
+      settled: true,
+      txHash: matchingEvent.transactionHash,
+      success: parsed.success,
+    };
+  } catch (error) {
+    log(`Error:`, error);
+    return { settled: false };
+  }
+};

--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -21,6 +21,7 @@ import {
 import type { WatcherResult } from '../pending-tx-manager.ts';
 import {
   extractPayloadHash,
+  extractPaddedTxId,
   fetchReceiptWithRetry,
   handleTxRevert,
   handleOperationFailure,
@@ -36,14 +37,14 @@ import {
  * Event signature:
  *   OperationResult(string indexed id, string indexed sourceAddressIndex,
  *     string sourceAddress, address indexed allegedRemoteAccount,
- *     bool success, bytes reason)
+ *     bytes4 instructionSelector, bool success, bytes reason)
  *
  * This event is emitted by the PortfolioRouter contract after processing each
  * RouterInstruction. It indicates whether the instruction (which may include
  * deposit, account provision, and/or multicall operations) succeeded or failed.
  */
 const OPERATION_RESULT_SIGNATURE = id(
-  'OperationResult(string,string,string,address,bool,bytes)',
+  'OperationResult(string,string,string,address,bytes4,bool,bytes)',
 );
 
 type OperationResultWatch = {
@@ -53,7 +54,7 @@ type OperationResultWatch = {
   log?: (...args: unknown[]) => void;
   kvStore: KVStore;
   txId: `tx${number}`;
-  payloadHash: string;
+  payloadHash?: string;
   /** The LCA address used as padding template for the txId. */
   sourceAddress: string;
 };
@@ -63,8 +64,40 @@ type OperationResultWatch = {
  */
 export const padTxId = (txId: string, sourceAddress: string): string => {
   const paddingLength = sourceAddress.length - txId.length;
-  assert(paddingLength > 0, 'sourceAddress must be longer than txId');
+  assert(paddingLength >= 0, 'sourceAddress must not be shorter than txId');
   return txId + '\0'.repeat(paddingLength);
+};
+
+/**
+ * Check whether a transaction's calldata matches the expected padded txId
+ * or payloadHash. Resilient to contract bugs that may not correctly pad the
+ * txId — returns true if either identifier matches, and warns if they disagree.
+ */
+const matchesTxPayload = (
+  txData: string,
+  paddedTxId: string,
+  payloadHash: string | undefined,
+  log: (...args: unknown[]) => void,
+  txHash: string,
+  txId: string,
+): boolean => {
+  const extractedTxId = extractPaddedTxId(txData);
+  const txIdMatches = extractedTxId === paddedTxId;
+
+  const hashMatches = payloadHash
+    ? extractPayloadHash(txData) === payloadHash
+    : false;
+
+  if (txIdMatches && payloadHash && !hashMatches) {
+    log(`⚠️  payloadHash mismatch for txId=${txId} txHash=${txHash}`);
+  }
+  if (!txIdMatches && hashMatches) {
+    log(
+      `⚠️  paddedTxId mismatch for txId=${txId} txHash=${txHash} (matched by payloadHash)`,
+    );
+  }
+
+  return txIdMatches || hashMatches;
 };
 
 /**
@@ -73,32 +106,43 @@ export const padTxId = (txId: string, sourceAddress: string): string => {
  * Event: OperationResult(
  *   string indexed id, string indexed sourceAddressIndex,
  *   string sourceAddress, address indexed allegedRemoteAccount,
- *   bool success, bytes reason
+ *   bytes4 instructionSelector, bool success, bytes reason
  * )
  * - topics[0]: event signature
  * - topics[1]: keccak256(id)                        — indexed string hash
  * - topics[2]: keccak256(sourceAddressIndex)         — indexed string hash
  * - topics[3]: allegedRemoteAccount                  — indexed address
- * - data: abi.encode(string, bool, bytes)
+ * - data: abi.encode(string, bytes4, bool, bytes)
  */
 const parseOperationResultLog = (
   log: Log,
   abiCoder: AbiCoder = new AbiCoder(),
-): { idHash: string; sourceAddress: string; success: boolean } => {
+): {
+  idHash: string;
+  sourceAddress: string;
+  allegedRemoteAccount: string;
+  instructionSelector: string;
+  success: boolean;
+  reason: string;
+} => {
   if (!log.topics || log.topics.length < 4 || !log.data) {
     throw new Error('Malformed OperationResult log');
   }
 
   const idHash = log.topics[1];
-  const [sourceAddress, success] = abiCoder.decode(
-    ['string', 'bool', 'bytes'],
+  const allegedRemoteAccount = log.topics[3];
+  const [sourceAddress, instructionSelector, success, reason] = abiCoder.decode(
+    ['string', 'bytes4', 'bool', 'bytes'],
     log.data,
   );
 
   return {
     idHash,
     sourceAddress,
+    allegedRemoteAccount,
+    instructionSelector,
     success,
+    reason,
   };
 };
 
@@ -175,17 +219,11 @@ export const watchOperationResult = ({
       await null;
       if (done) return;
       try {
-        const { idHash, success } = parseOperationResultLog(eventLog);
-
-        if (idHash !== expectedIdHash) {
-          return;
-        }
+        const { success } = parseOperationResultLog(eventLog);
 
         if (success) {
           const txHash = eventLog.transactionHash;
-          log(
-            `✅ SUCCESS: expectedId=${txId} idHash=${idHash} txHash=${txHash}`,
-          );
+          log(`✅ SUCCESS: expectedId=${txId} txHash=${txHash}`);
           return finish({ settled: true, txHash, success: true });
         }
 
@@ -242,8 +280,17 @@ export const watchOperationResult = ({
           const txData = tx.input;
           if (!txHash || !txData) return;
 
-          // Validate the payload hash matches
-          if (extractPayloadHash(txData) !== payloadHash) return;
+          if (
+            !matchesTxPayload(
+              txData,
+              paddedTxId,
+              payloadHash,
+              log,
+              txHash,
+              txId,
+            )
+          )
+            return;
 
           const receipt = await fetchReceiptWithRetry(
             provider,
@@ -450,7 +497,8 @@ export const lookBackOperationResult = async ({
       log,
       signal: sharedSignal,
       toAddress: routerAddress,
-      verifyFailedTx: tx => extractPayloadHash(tx.data) === payloadHash,
+      verifyFailedTx: tx =>
+        matchesTxPayload(tx.data, paddedTxId, payloadHash, log, tx.hash, txId),
       onRejectedChunk: updateFailedTxLowerBound,
       rpcClient,
     });

--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -1,14 +1,14 @@
-import type { Filter, WebSocketProvider, Log } from 'ethers';
+import type { Filter, Log } from 'ethers';
 import { id, AbiCoder } from 'ethers';
 import type { WebSocket } from 'ws';
 import type { CaipChainId } from '@agoric/orchestration';
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import { tryJsonParse } from '@agoric/internal';
-import type { JSONRPCClient } from 'json-rpc-2.0';
 import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
   scanFailedTxsInChunks,
+  type EvmRpc,
   type WatcherTimeoutOptions,
 } from '../evm-scanner.ts';
 import type { MakeAbortController } from '../support.ts';
@@ -49,7 +49,7 @@ const OPERATION_RESULT_SIGNATURE = id(
 
 type OperationResultWatch = {
   routerAddress: `0x${string}`;
-  provider: WebSocketProvider;
+  provider: EvmRpc;
   chainId: CaipChainId;
   log?: (...args: unknown[]) => void;
   kvStore: KVStore;
@@ -389,13 +389,11 @@ export const lookBackOperationResult = async ({
   kvStore,
   setTimeout = globalThis.setTimeout,
   payloadHash,
-  rpcClient,
   makeAbortController,
 }: OperationResultWatch & {
   publishTimeMs: number;
   signal?: AbortSignal;
   setTimeout?: typeof globalThis.setTimeout;
-  rpcClient: JSONRPCClient;
   makeAbortController: MakeAbortController;
 }): Promise<WatcherResult> => {
   await null;
@@ -500,7 +498,6 @@ export const lookBackOperationResult = async ({
       verifyFailedTx: tx =>
         matchesTxPayload(tx.data, paddedTxId, payloadHash, log, tx.hash, txId),
       onRejectedChunk: updateFailedTxLowerBound,
-      rpcClient,
     });
 
     if (failedTx) {

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -223,6 +223,32 @@ export const fetchReceiptWithRetry = async (
 };
 
 /**
+ * Wait for sufficient block confirmations on a transaction.
+ *
+ * Implements the finality protection pattern: wait for enough confirmations
+ * to ensure the result is permanent before reporting it. This prevents
+ * premature failure reports that could be reversed by a blockchain reorg.
+ *
+ * @returns Confirmed receipt and confirmation count, or null if reorged out
+ */
+const waitForFinalConfirmations = async (
+  txHash: string,
+  chainId: CaipChainId | `${string}:${string}`,
+  provider: WebSocketProvider,
+  log: (...args: unknown[]) => void,
+): Promise<{ receipt: TransactionReceipt; confirmations: number } | null> => {
+  const confirmations = getConfirmationsRequired(chainId);
+  const receipt = await provider.waitForTransaction(txHash, confirmations);
+  if (!receipt) {
+    log(
+      `Transaction ${txHash} not confirmed after waiting for ${confirmations} confirmations (possibly reorged out)`,
+    );
+    return null;
+  }
+  return { receipt, confirmations };
+};
+
+/**
  * Handle receipt status for a transaction that has been validated as matching
  * the watcher's criteria. Returns the result to report to the caller.
  *
@@ -251,34 +277,24 @@ export const handleTxRevert = async (
   // success → failure just as it can flip failure → success.
   if (receipt.status !== 0) return null;
 
-  /**
-   * Transaction reverted - For failure cases, we wait for full finality
-   * confirmations to ensure the failure is permanent. A failure that reorgs
-   * into a success is very hard for our system to recover from, so we must
-   * be certain of the failure.
-   */
-  const confirmations = getConfirmationsRequired(chainId);
-  const confirmedReceipt = await provider.waitForTransaction(
+  const confirmed = await waitForFinalConfirmations(
     txHash,
-    confirmations,
+    chainId,
+    provider,
+    log,
   );
-  if (!confirmedReceipt) {
-    log(
-      `Transaction ${txHash} was not confirmed after waiting for ${confirmations} confirmations (possibly reorged out)`,
-    );
-    return null;
-  }
+  if (!confirmed) return null;
 
   // Re-check status after confirmations in case of reorg
-  if (confirmedReceipt.status === 0) {
+  if (confirmed.receipt.status === 0) {
     log(
-      `❌ REVERTED (${confirmations} confirmations): ${identifier} txHash=${txHash} block=${confirmedReceipt.blockNumber} - transaction failed`,
+      `❌ REVERTED (${confirmed.confirmations} confirmations): ${identifier} txHash=${txHash} block=${confirmed.receipt.blockNumber} - transaction failed`,
     );
     return { settled: true, txHash, success: false };
   } else {
     // Transaction was reorged and succeeded - treat as success
     log(
-      `✅ SUCCESS (after reorg, ${confirmations} confirmations): ${identifier} txHash=${txHash} block=${confirmedReceipt.blockNumber}`,
+      `✅ SUCCESS (after reorg, ${confirmed.confirmations} confirmations): ${identifier} txHash=${txHash} block=${confirmed.receipt.blockNumber}`,
     );
     return { settled: true, txHash, success: true };
   }
@@ -311,34 +327,18 @@ export const handleOperationFailure = async <T extends { success: boolean }>(
   log: (...args: unknown[]) => void,
 ): Promise<{ settled: true; txHash: string; success: boolean } | null> => {
   const txHash = eventLog.transactionHash;
-  const originalBlock = eventLog.blockNumber;
 
-  const confirmations = getConfirmationsRequired(chainId);
-  const currentBlock = await provider.getBlockNumber();
-  const confirmedBlocks = currentBlock - originalBlock;
+  const confirmed = await waitForFinalConfirmations(
+    txHash,
+    chainId,
+    provider,
+    log,
+  );
+  if (!confirmed) return null;
 
-  let finalBlock = originalBlock;
+  const finalBlock = confirmed.receipt.blockNumber;
 
-  if (confirmedBlocks < confirmations) {
-    log(
-      `⏳ FAILURE detected, waiting for ${confirmations} confirmations (have ${confirmedBlocks}): ${identifier} txHash=${txHash}`,
-    );
-
-    const receipt = await provider.waitForTransaction(txHash, confirmations);
-
-    if (!receipt) {
-      log(
-        `Transaction ${txHash} not confirmed after waiting (possibly reorged out)`,
-      );
-      return null;
-    }
-
-    // If reorged, the tx may have landed in a different block.
-    finalBlock = receipt.blockNumber;
-  }
-
-  // Re-fetch logs to verify the failure is still present.
-  // Use finalBlock (post-wait)
+  // Re-fetch logs to verify the failure is still present
   const logsInBlock = await provider.getLogs({
     ...filter,
     fromBlock: finalBlock,
@@ -349,7 +349,7 @@ export const handleOperationFailure = async <T extends { success: boolean }>(
 
   if (!confirmedLog) {
     log(
-      `Event not found after ${confirmations} confirmations (possibly reorged): ${identifier} txHash=${txHash}`,
+      `Event not found after ${confirmed.confirmations} confirmations (possibly reorged): ${identifier} txHash=${txHash}`,
     );
     return null;
   }
@@ -358,13 +358,13 @@ export const handleOperationFailure = async <T extends { success: boolean }>(
 
   if (confirmedParsed.success) {
     log(
-      `✅ SUCCESS (after reorg, ${confirmations} confirmations): ${identifier} txHash=${txHash}`,
+      `✅ SUCCESS (after reorg, ${confirmed.confirmations} confirmations): ${identifier} txHash=${txHash}`,
     );
     return { settled: true, txHash, success: true };
   }
 
   log(
-    `❌ FAILURE (${confirmations} confirmations): ${identifier} txHash=${txHash}`,
+    `❌ FAILURE (${confirmed.confirmations} confirmations): ${identifier} txHash=${txHash}`,
   );
   return { settled: true, txHash, success: false };
 };

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -1,5 +1,11 @@
-import type { TransactionReceipt } from 'ethers';
+import type {
+  TransactionReceipt,
+  WebSocketProvider,
+  Filter,
+  Log,
+} from 'ethers';
 import { Interface, AbiCoder, getAddress } from 'ethers';
+import type { CaipChainId } from '@agoric/orchestration';
 import { depositFactoryCreateAndDepositInputs } from '@aglocal/portfolio-contract/src/utils/evm-orch-factory.ts';
 import { decodeAbiParameters } from 'viem';
 import type { EvmRpc } from '../evm-scanner.ts';
@@ -261,4 +267,87 @@ export const handleTxRevert = async (
     );
     return { settled: true, txHash, success: true };
   }
+};
+
+/**
+ * Handle event-level failure with finality protection.
+ *
+ * This is for cases where the transaction succeeded (status 1) but the
+ * business logic failed (e.g., OperationResult event with success=false).
+ * We wait for confirmations and re-verify the event to ensure the failure
+ * is permanent before reporting it.
+ *
+ * @param eventLog - The event log containing the failure
+ * @param filter - Filter to re-fetch the event after confirmations
+ * @param parseEvent - Function to parse the event and return its success status
+ * @param identifier - A string identifier for logging
+ * @param chainId - Chain ID to determine confirmation requirements
+ * @param provider - WebSocket provider for waiting for confirmations
+ * @param log - Logging function
+ * @returns Object with settled flag, success status, and transaction hash, or null if reorged
+ */
+export const handleOperationFailure = async <T extends { success: boolean }>(
+  eventLog: Log,
+  filter: Filter,
+  parseEvent: (log: Log) => T,
+  identifier: string,
+  chainId: CaipChainId,
+  provider: WebSocketProvider,
+  log: (...args: unknown[]) => void,
+): Promise<{ settled: true; txHash: string; success: boolean } | null> => {
+  await null;
+  const txHash = eventLog.transactionHash;
+  const eventBlock = eventLog.blockNumber;
+
+  const confirmations = getConfirmationsRequired(chainId);
+  const currentBlock = await provider.getBlockNumber();
+  const confirmedBlocks = currentBlock - eventBlock;
+
+  if (confirmedBlocks < confirmations) {
+    log(
+      `⏳ FAILURE detected, waiting for ${confirmations} confirmations (have ${confirmedBlocks}): ${identifier} txHash=${txHash}`,
+    );
+
+    const confirmedReceipt = await provider.waitForTransaction(
+      txHash,
+      confirmations,
+    );
+
+    if (!confirmedReceipt) {
+      log(
+        `Transaction ${txHash} was not confirmed after waiting (possibly reorged out)`,
+      );
+      return null;
+    }
+  }
+
+  // Re-fetch the logs to verify the failure is still present
+  const confirmedLogs = await provider.getLogs({
+    ...filter,
+    fromBlock: eventBlock,
+    toBlock: eventBlock,
+  });
+
+  const confirmedEvent = confirmedLogs.find(l => l.transactionHash === txHash);
+
+  if (!confirmedEvent) {
+    log(
+      `Event not found after ${confirmations} confirmations (possibly reorged): ${identifier}`,
+    );
+    return null;
+  }
+
+  const confirmedParsed = parseEvent(confirmedEvent);
+
+  if (confirmedParsed.success) {
+    log(
+      `✅ SUCCESS (after reorg, ${confirmations} confirmations): ${identifier} txHash=${txHash}`,
+    );
+    return { settled: true, txHash, success: true };
+  }
+
+  log(
+    `❌ FAILURE (${confirmations} confirmations): ${identifier} txHash=${txHash}`,
+  );
+  return { settled: true, txHash, success: false };
 };

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -138,6 +138,41 @@ export const extractPayloadHash = (data: string): string | null => {
   const [_commandId, _sourceChain, _sourceAddress, payload] = parsed.args;
   return keccak256(payload);
 };
+
+/**
+ * Parses the `execute(bytes32, string, string, bytes)` calldata, extracts the
+ * inner `payload`, strips its 4-byte function selector, and abi-decodes the
+ * first argument as a string — which is the padded txId.
+ *
+ * The router payload is always function-encoded where the first argument is
+ * a string (the padded txId) and the second is an address.
+ *
+ * @param data - Transaction input data (the full `execute()` calldata)
+ * @returns The padded txId string, or null if parsing fails
+ */
+export const extractPaddedTxId = (
+  data: string,
+  abiCoder: AbiCoder = new AbiCoder(),
+): string | null => {
+  try {
+    const parsed = axelarExecuteIface.parseTransaction({ data });
+    if (!parsed) return null;
+
+    const [_commandId, _sourceChain, sourceAddress, payload] = parsed.args;
+    // Strip the 4-byte selector (0x + 8 hex chars) to get the ABI-encoded args
+    const encodedArgs = `0x${payload.slice(10)}`;
+    const [paddedTxId] = abiCoder.decode(['string'], encodedArgs);
+
+    // Sanity check: the padded txId should match the source address length
+    if (paddedTxId.length !== sourceAddress.length) {
+      return null;
+    }
+
+    return paddedTxId;
+  } catch {
+    return null;
+  }
+};
 //#endregion
 
 //#region Alchemy alchemy_minedTransactions subscription types

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -1,15 +1,13 @@
-import type {
-  TransactionReceipt,
-  WebSocketProvider,
-  Filter,
-  Log,
-} from 'ethers';
+import type { TransactionReceipt, Filter, Log } from 'ethers';
 import { Interface, AbiCoder, getAddress, keccak256 } from 'ethers';
 import type { CaipChainId } from '@agoric/orchestration';
 import { depositFactoryCreateAndDepositInputs } from '@aglocal/portfolio-contract/src/utils/evm-orch-factory.ts';
 import { decodeAbiParameters } from 'viem';
 import type { EvmRpc } from '../evm-scanner.ts';
-import { getConfirmationsRequired } from '../support.ts';
+import {
+  getConfirmationsRequired,
+  getRevertConfirmationsRequired,
+} from '../support.ts';
 
 /** Scope tag for failed-transaction lookback searches. */
 export const FAILED_TX_SCOPE = 'failedTx';
@@ -264,23 +262,21 @@ export const fetchReceiptWithRetry = async (
  * to ensure the result is permanent before reporting it. This prevents
  * premature failure reports that could be reversed by a blockchain reorg.
  *
- * @returns Confirmed receipt and confirmation count, or null if reorged out
+ * @returns Confirmed receipt, or null if reorged out
  */
 const waitForFinalConfirmations = async (
   txHash: string,
-  chainId: CaipChainId | `${string}:${string}`,
-  provider: WebSocketProvider,
+  confirmations: number,
+  provider: EvmRpc,
   log: (...args: unknown[]) => void,
-): Promise<{ receipt: TransactionReceipt; confirmations: number } | null> => {
-  const confirmations = getConfirmationsRequired(chainId);
+): Promise<TransactionReceipt | null> => {
   const receipt = await provider.waitForTransaction(txHash, confirmations);
   if (!receipt) {
     log(
       `Transaction ${txHash} not confirmed after waiting for ${confirmations} confirmations (possibly reorged out)`,
     );
-    return null;
   }
-  return { receipt, confirmations };
+  return receipt;
 };
 
 /**
@@ -312,24 +308,25 @@ export const handleTxRevert = async (
   // success → failure just as it can flip failure → success.
   if (receipt.status !== 0) return null;
 
-  const confirmed = await waitForFinalConfirmations(
+  const confirmations = getRevertConfirmationsRequired(chainId);
+  const confirmedReceipt = await waitForFinalConfirmations(
     txHash,
-    chainId,
+    confirmations,
     provider,
     log,
   );
-  if (!confirmed) return null;
+  if (!confirmedReceipt) return null;
 
   // Re-check status after confirmations in case of reorg
-  if (confirmed.receipt.status === 0) {
+  if (confirmedReceipt.status === 0) {
     log(
-      `❌ REVERTED (${confirmed.confirmations} confirmations): ${identifier} txHash=${txHash} block=${confirmed.receipt.blockNumber} - transaction failed`,
+      `❌ REVERTED (${confirmations} confirmations): ${identifier} txHash=${txHash} block=${confirmedReceipt.blockNumber} - transaction failed`,
     );
     return { settled: true, txHash, success: false };
   } else {
     // Transaction was reorged and succeeded - treat as success
     log(
-      `✅ SUCCESS (after reorg, ${confirmed.confirmations} confirmations): ${identifier} txHash=${txHash} block=${confirmed.receipt.blockNumber}`,
+      `✅ SUCCESS (after reorg, ${confirmations} confirmations): ${identifier} txHash=${txHash} block=${confirmedReceipt.blockNumber}`,
     );
     return { settled: true, txHash, success: true };
   }
@@ -358,20 +355,21 @@ export const handleOperationFailure = async <T extends { success: boolean }>(
   parseEvent: (log: Log) => T,
   identifier: string,
   chainId: CaipChainId,
-  provider: WebSocketProvider,
+  provider: EvmRpc,
   log: (...args: unknown[]) => void,
 ): Promise<{ settled: true; txHash: string; success: boolean } | null> => {
   const txHash = eventLog.transactionHash;
 
-  const confirmed = await waitForFinalConfirmations(
+  const confirmations = getConfirmationsRequired(chainId);
+  const confirmedReceipt = await waitForFinalConfirmations(
     txHash,
-    chainId,
+    confirmations,
     provider,
     log,
   );
-  if (!confirmed) return null;
+  if (!confirmedReceipt) return null;
 
-  const finalBlock = confirmed.receipt.blockNumber;
+  const finalBlock = confirmedReceipt.blockNumber;
 
   // Re-fetch logs to verify the failure is still present
   const logsInBlock = await provider.getLogs({
@@ -384,7 +382,7 @@ export const handleOperationFailure = async <T extends { success: boolean }>(
 
   if (!confirmedLog) {
     log(
-      `Event not found after ${confirmed.confirmations} confirmations (possibly reorged): ${identifier} txHash=${txHash}`,
+      `Event not found after ${confirmations} confirmations (possibly reorged): ${identifier} txHash=${txHash}`,
     );
     return null;
   }
@@ -393,13 +391,13 @@ export const handleOperationFailure = async <T extends { success: boolean }>(
 
   if (confirmedParsed.success) {
     log(
-      `✅ SUCCESS (after reorg, ${confirmed.confirmations} confirmations): ${identifier} txHash=${txHash}`,
+      `✅ SUCCESS (after reorg, ${confirmations} confirmations): ${identifier} txHash=${txHash}`,
     );
     return { settled: true, txHash, success: true };
   }
 
   log(
-    `❌ FAILURE (${confirmed.confirmations} confirmations): ${identifier} txHash=${txHash}`,
+    `❌ FAILURE (${confirmations} confirmations): ${identifier} txHash=${txHash}`,
   );
   return { settled: true, txHash, success: false };
 };

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -4,7 +4,7 @@ import type {
   Filter,
   Log,
 } from 'ethers';
-import { Interface, AbiCoder, getAddress } from 'ethers';
+import { Interface, AbiCoder, getAddress, keccak256 } from 'ethers';
 import type { CaipChainId } from '@agoric/orchestration';
 import { depositFactoryCreateAndDepositInputs } from '@aglocal/portfolio-contract/src/utils/evm-orch-factory.ts';
 import { decodeAbiParameters } from 'viem';
@@ -122,6 +122,21 @@ export const extractDepositFactoryExecuteData = (
   } catch {
     return null;
   }
+};
+
+/**
+ * Parses the `execute(bytes32, string, string, bytes)` calldata, extracts
+ * the raw `payload` bytes (arg index 3), and returns `keccak256(payload)`.
+ *
+ * @param data - Transaction input data (the full `execute()` calldata)
+ * @returns keccak256(payload) hex string, or null if parsing fails
+ */
+export const extractPayloadHash = (data: string): string | null => {
+  const parsed = axelarExecuteIface.parseTransaction({ data });
+  if (!parsed) return null;
+
+  const [_commandId, _sourceChain, _sourceAddress, payload] = parsed.args;
+  return keccak256(payload);
 };
 //#endregion
 
@@ -295,49 +310,51 @@ export const handleOperationFailure = async <T extends { success: boolean }>(
   provider: WebSocketProvider,
   log: (...args: unknown[]) => void,
 ): Promise<{ settled: true; txHash: string; success: boolean } | null> => {
-  await null;
   const txHash = eventLog.transactionHash;
-  const eventBlock = eventLog.blockNumber;
+  const originalBlock = eventLog.blockNumber;
 
   const confirmations = getConfirmationsRequired(chainId);
   const currentBlock = await provider.getBlockNumber();
-  const confirmedBlocks = currentBlock - eventBlock;
+  const confirmedBlocks = currentBlock - originalBlock;
+
+  let finalBlock = originalBlock;
 
   if (confirmedBlocks < confirmations) {
     log(
       `⏳ FAILURE detected, waiting for ${confirmations} confirmations (have ${confirmedBlocks}): ${identifier} txHash=${txHash}`,
     );
 
-    const confirmedReceipt = await provider.waitForTransaction(
-      txHash,
-      confirmations,
-    );
+    const receipt = await provider.waitForTransaction(txHash, confirmations);
 
-    if (!confirmedReceipt) {
+    if (!receipt) {
       log(
-        `Transaction ${txHash} was not confirmed after waiting (possibly reorged out)`,
+        `Transaction ${txHash} not confirmed after waiting (possibly reorged out)`,
       );
       return null;
     }
+
+    // If reorged, the tx may have landed in a different block.
+    finalBlock = receipt.blockNumber;
   }
 
-  // Re-fetch the logs to verify the failure is still present
-  const confirmedLogs = await provider.getLogs({
+  // Re-fetch logs to verify the failure is still present.
+  // Use finalBlock (post-wait)
+  const logsInBlock = await provider.getLogs({
     ...filter,
-    fromBlock: eventBlock,
-    toBlock: eventBlock,
+    fromBlock: finalBlock,
+    toBlock: finalBlock,
   });
 
-  const confirmedEvent = confirmedLogs.find(l => l.transactionHash === txHash);
+  const confirmedLog = logsInBlock.find(l => l.transactionHash === txHash);
 
-  if (!confirmedEvent) {
+  if (!confirmedLog) {
     log(
-      `Event not found after ${confirmations} confirmations (possibly reorged): ${identifier}`,
+      `Event not found after ${confirmations} confirmations (possibly reorged): ${identifier} txHash=${txHash}`,
     );
     return null;
   }
 
-  const confirmedParsed = parseEvent(confirmedEvent);
+  const confirmedParsed = parseEvent(confirmedLog);
 
   if (confirmedParsed.success) {
     log(

--- a/services/ymax-planner/test/config.test.ts
+++ b/services/ymax-planner/test/config.test.ts
@@ -6,7 +6,11 @@ import {
   defaultAgoricNetworkSpecForCluster,
   type SecretManager,
 } from '../src/config.ts';
-import { createEVMContext } from '../src/support.ts';
+import {
+  createEVMContext,
+  getConfirmationsRequired,
+  getRevertConfirmationsRequired,
+} from '../src/support.ts';
 
 const { entries, keys } = Object;
 
@@ -180,6 +184,58 @@ test('loadConfig rejects invalid contract instance', async t => {
   await t.throwsAsync(() => callLoadConfig({ CONTRACT_INSTANCE: 'ymax2' }), {
     message: /CONTRACT_INSTANCE must be 'ymax0' or 'ymax1'/,
   });
+});
+
+// --- Unit tests for getRevertConfirmationsRequired ---
+
+test('getRevertConfirmationsRequired exceeds normal confirmations', t => {
+  // All chains should have revert confirmations >= normal confirmations
+  const chainIds = [
+    'eip155:1', // Ethereum (12s blocks)
+    'eip155:42161', // Arbitrum (0.3s blocks)
+    'eip155:43114', // Avalanche (2s blocks)
+    'eip155:8453', // Base (2.5s blocks)
+    'eip155:10', // Optimism (2s blocks)
+  ] as const;
+
+  for (const chainId of chainIds) {
+    const normal = getConfirmationsRequired(chainId);
+    const revert = getRevertConfirmationsRequired(chainId);
+    t.true(
+      revert > normal,
+      `${chainId}: revert (${revert}) should exceed normal (${normal})`,
+    );
+  }
+});
+
+test('getRevertConfirmationsRequired scales with block time', t => {
+  // Faster chains need more confirmations to cover the same wall-clock time
+  const arbitrum = getRevertConfirmationsRequired('eip155:42161'); // 0.3s blocks
+  const ethereum = getRevertConfirmationsRequired('eip155:1'); // 12s blocks
+
+  t.true(
+    arbitrum > ethereum,
+    `Arbitrum (${arbitrum}) should need more confirmations than Ethereum (${ethereum})`,
+  );
+});
+
+test('getRevertConfirmationsRequired computes expected values', t => {
+  // 10 min = 600_000ms; ceil(600_000 / blockTimeMs)
+  const expected: Record<string, number> = {
+    'eip155:1': 50, // ceil(600_000 / 12_000)
+    'eip155:42161': 2000, // ceil(600_000 / 300)
+    'eip155:43114': 300, // ceil(600_000 / 2_000)
+    'eip155:8453': 240, // ceil(600_000 / 2_500)
+    'eip155:10': 300, // ceil(600_000 / 2_000)
+  };
+
+  for (const [chainId, expectedConfs] of Object.entries(expected)) {
+    t.is(
+      getRevertConfirmationsRequired(chainId as any),
+      expectedConfs,
+      `${chainId}: expected ${expectedConfs} revert confirmations`,
+    );
+  }
 });
 
 // --- Unit tests for createEVMContext ---

--- a/services/ymax-planner/test/operation-watcher.test.ts
+++ b/services/ymax-planner/test/operation-watcher.test.ts
@@ -77,7 +77,6 @@ test('watchOperationResult detects successful OperationResult event (live mode)'
   const result = await watchOperationResult({
     routerAddress: routerAddress as `0x${string}`,
     provider,
-    expectedId,
     chainId,
     kvStore,
     txId,
@@ -141,7 +140,6 @@ test('watchOperationResult detects failed OperationResult event with finality pr
   const result = await watchOperationResult({
     routerAddress: routerAddress as `0x${string}`,
     provider,
-    expectedId,
     chainId,
     kvStore,
     txId,
@@ -186,7 +184,6 @@ test('lookBackOperationResult finds successful OperationResult event (lookback m
   const result = await lookBackOperationResult({
     routerAddress: routerAddress as `0x${string}`,
     provider,
-    expectedId,
     chainId,
     kvStore,
     txId,
@@ -247,7 +244,6 @@ test('lookBackOperationResult finds failed OperationResult event with finality p
   const result = await lookBackOperationResult({
     routerAddress: routerAddress as `0x${string}`,
     provider,
-    expectedId,
     chainId,
     kvStore,
     txId,

--- a/services/ymax-planner/test/operation-watcher.test.ts
+++ b/services/ymax-planner/test/operation-watcher.test.ts
@@ -1,0 +1,266 @@
+import test from 'ava';
+import { AbiCoder, id } from 'ethers';
+import type { Log } from 'ethers';
+import { makeKVStoreFromMap } from '@agoric/internal/src/kv-store.js';
+import { createMockProvider } from './mocks.ts';
+import {
+  watchOperationResult,
+  lookBackOperationResult,
+} from '../src/watchers/operation-watcher.ts';
+
+const OPERATION_RESULT_SIGNATURE = id('OperationResult(string,bool,bytes)');
+
+/**
+ * Create a mock OperationResult event log.
+ *
+ * Event: OperationResult(string indexed id, bool success, bytes reason)
+ * - topics[0]: event signature
+ * - topics[1]: keccak256(id) (indexed string stored as hash)
+ * - data: abi.encode(bool success, bytes reason)
+ */
+const createMockOperationResultLog = (
+  routerAddress: string,
+  expectedId: string,
+  success: boolean,
+  reason: string = '',
+  blockNumber: number = 1000,
+  transactionHash: string = '0x123abc',
+): Pick<
+  Log,
+  'address' | 'topics' | 'data' | 'blockNumber' | 'transactionHash'
+> => {
+  const abiCoder = new AbiCoder();
+  const expectedIdHash = id(expectedId);
+  const reasonBytes = reason ? Buffer.from(reason, 'utf8') : new Uint8Array(0);
+  const data = abiCoder.encode(['bool', 'bytes'], [success, reasonBytes]);
+
+  return {
+    address: routerAddress,
+    topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
+    data,
+    blockNumber,
+    transactionHash,
+  };
+};
+
+test('watchOperationResult detects successful OperationResult event (live mode)', async t => {
+  const routerAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const expectedId = 'tx1';
+  const chainId = 'eip155:1';
+  const txId = 'tx1' as `tx${number}`;
+  const provider = createMockProvider(1000);
+  const kvStore = makeKVStoreFromMap(new Map());
+
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  // Emit success event after a short delay
+  setTimeout(() => {
+    const mockLog = createMockOperationResultLog(
+      routerAddress,
+      expectedId,
+      true, // success
+      '',
+      18500000,
+      '0x123abc',
+    );
+
+    const expectedIdHash = id(expectedId);
+    const filter = {
+      address: routerAddress,
+      topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
+    };
+
+    (provider as any).emit(filter, mockLog);
+  }, 50);
+
+  const result = await watchOperationResult({
+    routerAddress: routerAddress as `0x${string}`,
+    provider,
+    expectedId,
+    chainId,
+    kvStore,
+    txId,
+    timeoutMs: 3000,
+    log: logger,
+  });
+
+  t.true(result.settled, 'Should be settled');
+  t.true(result.success, 'Should be successful');
+  t.is(result.txHash, '0x123abc', 'Should have correct txHash');
+
+  t.true(
+    logMessages.some(msg => msg.includes('✅ SUCCESS')),
+    'Should log success message',
+  );
+});
+
+test('watchOperationResult detects failed OperationResult event with finality protection (live mode)', async t => {
+  const routerAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const expectedId = 'tx2';
+  const chainId = 'eip155:1';
+  const txId = 'tx2' as `tx${number}`;
+  const provider = createMockProvider(1000);
+  const kvStore = makeKVStoreFromMap(new Map());
+
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  const txHash = '0xfailedtx';
+  const blockNumber = 1000;
+
+  const mockLog = createMockOperationResultLog(
+    routerAddress,
+    expectedId,
+    false, // failure
+    'revert reason',
+    blockNumber,
+    txHash,
+  );
+  (provider as any).getLogs = async () => [mockLog];
+
+  // Override waitForTransaction to return a receipt (needed for finality check)
+  (provider as any).waitForTransaction = async () => ({
+    status: 1,
+    blockNumber,
+    blockHash: '0xblockhash',
+    transactionHash: txHash,
+  });
+
+  // Emit failure event after a short delay
+  setTimeout(() => {
+    const expectedIdHash = id(expectedId);
+    const filter = {
+      address: routerAddress,
+      topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
+    };
+
+    (provider as any).emit(filter, mockLog);
+  }, 50);
+
+  const result = await watchOperationResult({
+    routerAddress: routerAddress as `0x${string}`,
+    provider,
+    expectedId,
+    chainId,
+    kvStore,
+    txId,
+    timeoutMs: 3000,
+    log: logger,
+  });
+
+  t.true(result.settled, 'Should be settled');
+  t.false(result.success, 'Should be failed');
+  t.is(result.txHash, txHash, 'Should have correct txHash');
+
+  t.true(
+    logMessages.some(msg => msg.includes('FAILURE')),
+    'Should log failure message',
+  );
+});
+
+test('lookBackOperationResult finds successful OperationResult event (lookback mode)', async t => {
+  const routerAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const expectedId = 'tx3';
+  const chainId = 'eip155:1';
+  const txId = 'tx3' as `tx${number}`;
+  const kvStore = makeKVStoreFromMap(new Map());
+  const latestBlock = 1000;
+  const blockNumber = latestBlock; // Put the log at latest block so it's in scan range
+  const txHash = '0xsuccesstx';
+
+  const mockLog = createMockOperationResultLog(
+    routerAddress,
+    expectedId,
+    true, // success
+    '',
+    blockNumber,
+    txHash,
+  );
+
+  const provider = createMockProvider(latestBlock, [mockLog]);
+
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  const result = await lookBackOperationResult({
+    routerAddress: routerAddress as `0x${string}`,
+    provider,
+    expectedId,
+    chainId,
+    kvStore,
+    txId,
+    publishTimeMs: Date.now() - 60000, // 1 minute ago
+    log: logger,
+  });
+
+  t.true(result.settled, 'Should be settled');
+  t.true(result.success, 'Should be successful');
+  t.is(result.txHash, txHash, 'Should have correct txHash');
+
+  t.true(
+    logMessages.some(msg => msg.includes('✅ SUCCESS')),
+    'Should log success message',
+  );
+});
+
+test('lookBackOperationResult finds failed OperationResult event with finality protection (lookback mode)', async t => {
+  const routerAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const expectedId = 'tx4';
+  const chainId = 'eip155:1';
+  const txId = 'tx4' as `tx${number}`;
+  const kvStore = makeKVStoreFromMap(new Map());
+  const latestBlock = 1000;
+  const blockNumber = latestBlock; // Put the log at latest block so it's in scan range
+  const txHash = '0xfailedtx';
+
+  const mockLog = createMockOperationResultLog(
+    routerAddress,
+    expectedId,
+    false, // failure
+    'execution reverted',
+    blockNumber,
+    txHash,
+  );
+
+  const provider = createMockProvider(latestBlock, [mockLog]);
+  (provider as any).getLogs = async (args: any) => {
+    if (
+      args.fromBlock <= blockNumber &&
+      (args.toBlock === undefined || args.toBlock >= blockNumber)
+    ) {
+      return [mockLog];
+    }
+    return [];
+  };
+
+  (provider as any).waitForTransaction = async () => ({
+    status: 1,
+    blockNumber,
+    blockHash: '0xblockhash',
+    transactionHash: txHash,
+  });
+
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  const result = await lookBackOperationResult({
+    routerAddress: routerAddress as `0x${string}`,
+    provider,
+    expectedId,
+    chainId,
+    kvStore,
+    txId,
+    publishTimeMs: Date.now() - 60000, // 1 minute ago
+    log: logger,
+  });
+
+  t.true(result.settled, 'Should be settled');
+  t.false(result.success, 'Should be failed');
+  t.is(result.txHash, txHash, 'Should have correct txHash');
+
+  t.true(
+    logMessages.some(msg => msg.includes('FAILURE')),
+    'Should log failure message',
+  );
+});

--- a/services/ymax-planner/test/operation-watcher.test.ts
+++ b/services/ymax-planner/test/operation-watcher.test.ts
@@ -264,7 +264,6 @@ test('lookBackOperationResult finds successful OperationResult event (lookback m
     txId,
     sourceAddress: MOCK_SOURCE_ADDRESS,
     payloadHash: MOCK_PAYLOAD_HASH,
-    rpcClient: {} as any,
     makeAbortController,
     publishTimeMs: Date.now() - 60000, // 1 minute ago
     log: logger,
@@ -328,7 +327,6 @@ test('lookBackOperationResult finds failed OperationResult event with finality p
     txId,
     sourceAddress: MOCK_SOURCE_ADDRESS,
     payloadHash: MOCK_PAYLOAD_HASH,
-    rpcClient: {} as any,
     makeAbortController,
     publishTimeMs: Date.now() - 60000, // 1 minute ago
     log: logger,
@@ -412,9 +410,6 @@ test('lookBackOperationResult phase 2 detects reverted tx via padded txId', asyn
   const logMessages: string[] = [];
   const logger = (...args: any[]) => logMessages.push(args.join(' '));
 
-  // Mock rpcClient (not used for trace_filter path but required by type)
-  const mockRpcClient = {} as any;
-
   const result = await lookBackOperationResult({
     routerAddress: routerAddress as `0x${string}`,
     provider,
@@ -423,7 +418,6 @@ test('lookBackOperationResult phase 2 detects reverted tx via padded txId', asyn
     txId,
     sourceAddress: MOCK_SOURCE_ADDRESS,
     payloadHash,
-    rpcClient: mockRpcClient,
     makeAbortController,
     publishTimeMs: Date.now() - 60000,
     log: logger,
@@ -542,8 +536,6 @@ test('lookBackOperationResult returns not-found when both phases find nothing', 
   const logMessages: string[] = [];
   const logger = (...args: any[]) => logMessages.push(args.join(' '));
 
-  const mockRpcClient = {} as any;
-
   const result = await lookBackOperationResult({
     routerAddress: routerAddress as `0x${string}`,
     provider,
@@ -552,7 +544,6 @@ test('lookBackOperationResult returns not-found when both phases find nothing', 
     txId,
     sourceAddress: MOCK_SOURCE_ADDRESS,
     payloadHash,
-    rpcClient: mockRpcClient,
     makeAbortController,
     publishTimeMs: Date.now() - 60000,
     log: logger,

--- a/services/ymax-planner/test/operation-watcher.test.ts
+++ b/services/ymax-planner/test/operation-watcher.test.ts
@@ -19,10 +19,26 @@ import {
 } from '../src/watchers/operation-watcher.ts';
 
 const OPERATION_RESULT_SIGNATURE = id(
-  'OperationResult(string,string,string,address,bool,bytes)',
+  'OperationResult(string,string,string,address,bytes4,bool,bytes)',
 );
 
 const MOCK_SOURCE_ADDRESS = 'agoric1testaddr0123456789abcdefghijklmno';
+
+/**
+ * Build a mock router payload that embeds the padded txId as the first
+ * function argument, mirroring the real contract's `processInstruction`
+ * calldata layout: `selector + abi.encode(string paddedTxId, address, ...)`.
+ */
+const buildRouterPayload = (paddedTxId: string) => {
+  const abiCoder = new AbiCoder();
+  const mockSelector = '0xdeadbeef'; // 4-byte function selector
+  const mockAddress = '0x0000000000000000000000000000000000000001';
+  const encodedArgs = abiCoder.encode(
+    ['string', 'address'],
+    [paddedTxId, mockAddress],
+  );
+  return mockSelector + encodedArgs.slice(2); // selector + encoded args
+};
 
 /**
  * Encode Axelar execute() calldata with a given payload, returning the
@@ -47,13 +63,13 @@ const encodeExecuteCalldata = (payload: string) => {
  * Event: OperationResult(
  *   string indexed id, string indexed sourceAddressIndex,
  *   string sourceAddress, address indexed allegedRemoteAccount,
- *   bool success, bytes reason
+ *   bytes4 instructionSelector, bool success, bytes reason
  * )
  * - topics[0]: event signature
  * - topics[1]: keccak256(paddedId)                  — indexed string hash
  * - topics[2]: keccak256(sourceAddressIndex)         — indexed string hash
  * - topics[3]: allegedRemoteAccount                  — indexed address
- * - data: abi.encode(string, bool, bytes)
+ * - data: abi.encode(string, bytes4, bool, bytes)
  */
 const createMockOperationResultLog = (
   routerAddress: string,
@@ -72,8 +88,8 @@ const createMockOperationResultLog = (
   const mockAccountAddress = zeroPadValue('0x01', 32);
   const reasonBytes = reason ? Buffer.from(reason, 'utf8') : new Uint8Array(0);
   const data = abiCoder.encode(
-    ['string', 'bool', 'bytes'],
-    [MOCK_SOURCE_ADDRESS, success, reasonBytes],
+    ['string', 'bytes4', 'bool', 'bytes'],
+    [MOCK_SOURCE_ADDRESS, '0x00000000', success, reasonBytes],
   );
 
   return {
@@ -330,7 +346,7 @@ test('lookBackOperationResult finds failed OperationResult event with finality p
 
 // --- Revert detection tests ---
 
-test('lookBackOperationResult phase 2 detects reverted tx via payloadHash', async t => {
+test('lookBackOperationResult phase 2 detects reverted tx via padded txId', async t => {
   const routerAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
   const txId = 'tx5' as `tx${number}`;
   const chainId = 'eip155:1';
@@ -338,8 +354,9 @@ test('lookBackOperationResult phase 2 detects reverted tx via payloadHash', asyn
   const latestBlock = 1000;
   const revertTxHash = '0xrevertedtx';
 
-  // Encode execute calldata with a known payload
-  const payload = new AbiCoder().encode(['string'], ['test-payload']);
+  // Build a router payload containing the padded txId
+  const paddedId = padTxId(txId, MOCK_SOURCE_ADDRESS);
+  const payload = buildRouterPayload(paddedId);
   const { calldata, payloadHash } = encodeExecuteCalldata(payload);
 
   // No OperationResult events (phase 1 finds nothing)
@@ -430,8 +447,9 @@ test('watchOperationResult detects revert via Alchemy subscription (live mode)',
   const revertTxHash = '0xrevertedlivetx';
   const blockNumber = 1001;
 
-  // Encode execute calldata with a known payload
-  const payload = new AbiCoder().encode(['string'], ['live-test-payload']);
+  // Build a router payload containing the padded txId
+  const paddedId = padTxId(txId, MOCK_SOURCE_ADDRESS);
+  const payload = buildRouterPayload(paddedId);
   const { calldata, payloadHash } = encodeExecuteCalldata(payload);
 
   // Receipt for the reverted tx (no OperationResult events)

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -376,7 +376,7 @@ test('find a failed tx in MAKE_ACCOUNT lookback mode via trace_filter', async t 
   t.true(
     logs.some(l =>
       l.includes(
-        `[${txId}] ❌ REVERTED (25 confirmations): expectedAddr=${expectedWalletAddr} txHash=${failedTxHash} block=${latestBlock} - transaction failed`,
+        `[${txId}] ❌ REVERTED (240 confirmations): expectedAddr=${expectedWalletAddr} txHash=${failedTxHash} block=${latestBlock} - transaction failed`,
       ),
     ),
   );


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
refs:
- https://github.com/Agoric/agoric-private/issues/787

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Add support for resolving the `OperationResult` event emitted by the new Router contract. This event conveys the status of account creation, wallet contract multicalls, and deposit transactions. A new watcher listens for these events and settles transactions based on the reported status.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
- Currently unit tests have been added for live and lookback mode. 
- `ymax0` testing is pending.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- Deployment of ymax contract changes relevant to the Router.
- New planner deployment for `ymax0` and `ymax1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operation result monitoring: real-time event watching and historical look-back scanning.
  * Finality protection to confirm failures after on-chain confirmations.
  * Configurable timeouts, abort-signal support, and persisted look-back progress for resumable scans.
  * Improved event parsing and more robust error handling.

* **Tests**
  * Comprehensive tests covering live and look-back success/failure scenarios and finality behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->