### PR TITLE
Allow EVM `depositFactory` to be the Permit2 spender

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -170,7 +170,7 @@ jobs:
     # BEGIN-TEST-BOILERPLATE
     timeout-minutes: 30
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16core # avoid exit 129
     strategy:
       matrix:
         engine: ['node-new', 'node-old', 'xs']
@@ -581,7 +581,7 @@ jobs:
     # BEGIN-TEST-BOILERPLATE
     timeout-minutes: 30
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16core # avoid exit 129
     strategy:
       matrix:
         # test:xs is noop in cosmic-swingset/package.json

--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -2211,21 +2211,22 @@ test('evmHandler.deposit (Arbitrum -> Base) completes a deposit flow', async t =
         chainId: Number(chainInfoWithCCTP[newChain].reference),
         token: contractsMock[newChain].usdc,
         amount: newDepositAmount.value,
-        // Wrong spender: should be predicted wallet address, not depositFactory.
-        spender: contractsMock[newChain].depositFactory,
+        // Wrong spender: should be predicted wallet address, not something bad.
+        spender: `${predictedSpender}BaDZ`,
         permit2Payload: newPermit2Payload,
       }),
     {
-      message: /permit spender .* does not match portfolio account/,
+      message: /permit spender .* does not match expected account/,
     },
-    'deposit rejects depositFactory spender for new chain',
+    'deposit rejects bad spender for new chain',
   );
+
   const newPermitDetails = {
     chainId: Number(chainInfoWithCCTP[newChain].reference),
     token: contractsMock[newChain].usdc,
     amount: newDepositAmount.value,
     // For deposits to existing portfolios, spender is the predicted smart wallet address
-    spender: predictedSpender as `0x${string}`,
+    spender: predictedSpender,
     permit2Payload: newPermit2Payload,
   } as const;
 

--- a/packages/portfolio-contract/test/portfolio.exo.test.ts
+++ b/packages/portfolio-contract/test/portfolio.exo.test.ts
@@ -407,6 +407,10 @@ test('evmHandler deposit handles factoryContract spender', t => {
       },
     ],
   ]);
+  t.notThrows(
+    () => evmHandler.deposit(permitDetails),
+    'evmHandler deposit accepts depositFactory spender',
+  );
 });
 
 test('evmHandler deposit rejects spender mismatch', t => {
@@ -446,7 +450,7 @@ test('evmHandler deposit rejects spender mismatch', t => {
   };
 
   t.throws(() => evmHandler.deposit(permitDetails), {
-    message: /permit spender .* does not match portfolio account/,
+    message: /permit spender .* does not match expected account/,
   });
 });
 


### PR DESCRIPTION
refs: Agoric/agoric-private#756

Adds test coverage for the EVM deposit flow where `depositFactory` contract address is used as the Permit2 spender, alongside existing portfolio wallet address support.

## Changes

- **`packages/portfolio-contract/test/portfolio.flows.test.ts`**: Three new deposit tests covering spender validation scenarios:
  - Unknown spender → rejected
  - `depositFactory` contract → accepted, flow completes
  - Portfolio wallet address → accepted, flow completes

- **`.github/workflows/test-all-packages.yml`**: Use `ubuntu-latest-16core` runner to avoid exit 129 timeout issues

## Implementation Context

The underlying spender validation logic in `portfolio.exo.ts` accepts either:
1. The chain's `depositFactory` contract address (shared across portfolios)
2. The portfolio's existing or predicted wallet address (unique per portfolio)

```typescript
const depositFactoryAddress = contracts[fromChain].depositFactory;
if (sameEvmAddress(depositDetails.spender, depositFactoryAddress)) {
  expectedSpender = depositFactoryAddress;
} else if (accounts.has(fromChain)) {
  expectedSpender = accounts.get(fromChain).remoteAddress;
} else {
  expectedSpender = predictWalletAddress({...});
}
```

Flow tests verify that deposits using `depositFactory` as spender correctly execute through the planner and complete with `state: 'done'`, confirming proper GMP call construction to the target EVM contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced deposit functionality to support authorization across multiple account types for more flexible transaction flows
  * Improved error messaging for clearer identification of authorization mismatches

* **Tests**
  * Expanded test coverage for deposit scenarios and authorization paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->