### PR TITLE
disable workerThreads in some flaking packages

### DIFF
--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -68,6 +68,7 @@
     "require": [
       "@endo/init/debug.js"
     ],
+    "workerThreads": false,
     "timeout": "10m"
   },
   "publishConfig": {

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -59,6 +59,7 @@
     "require": [
       "@endo/init/debug.js"
     ],
+    "workerThreads": false,
     "timeout": "2m"
   },
   "typeCoverage": {

--- a/packages/swingset-liveslots/package.json
+++ b/packages/swingset-liveslots/package.json
@@ -58,6 +58,7 @@
     "require": [
       "@endo/init/debug.js"
     ],
+    "workerThreads": false,
     "timeout": "20m"
   },
   "publishConfig": {


### PR DESCRIPTION
_incidental_

## Description

These packages have been flaking with exit code 129.
See if disabling workerThreads helps.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
none

### Testing Considerations
per se

### Upgrade Considerations
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test runner configuration across multiple packages to disable worker threads during test runs. This change standardizes test execution, improving consistency and stability of local and CI test results without altering public APIs or functional behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->