### PR TITLE
perf(yarn): enable hardlink nmMode and use project-local Yarn cache in Docker

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,4 +2,7 @@ enableScripts: false
 
 nodeLinker: node-modules
 
+# Faster node_modules installs in Yarn 4 while keeping the node-modules linker.
+nmMode: hardlinks-local
+
 yarnPath: .yarn/releases/yarn-4.12.0.cjs

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -56,8 +56,8 @@ RUN /usr/src/agoric-sdk/scripts/ensure-corepack-yarn.sh /usr/src/agoric-sdk
 # Other tests ensure that golang/cosmos builds without mutating the lockfile.
 # XXX until https://github.com/Agoric/agoric-sdk/issues/9043, then just:
 # RUN yarn install
-RUN bash -c \
-  "for i in {1..3}; do yarn install --network-timeout 1000000 && exit 0 || (echo retrying; sleep 15;) done; exit 1"
+RUN --mount=type=cache,target=/usr/src/agoric-sdk/.yarn/cache bash -c \
+  "for i in {1..3}; do YARN_ENABLE_GLOBAL_CACHE=0 YARN_CACHE_FOLDER=/usr/src/agoric-sdk/.yarn/cache yarn install --network-timeout 1000000 && exit 0 || (echo retrying; sleep 15;) done; exit 1"
 RUN yarn build:gyp
 
 # Remove dev dependencies.
@@ -117,9 +117,9 @@ COPY --from=xsnap-package --link /usr/src/agoric-sdk/packages/xsnap packages/xsn
 RUN /usr/src/agoric-sdk/scripts/ensure-corepack-yarn.sh /usr/src/agoric-sdk
 # XXX until https://github.com/Agoric/agoric-sdk/issues/9043, then just:
 # RUN --mount=type=cache,target=$YARN_CACHE_FOLDER yarn install --immutable
-RUN --mount=type=cache,target=$YARN_CACHE_FOLDER bash -c \
+RUN --mount=type=cache,target=/usr/src/agoric-sdk/.yarn/cache bash -c \
   # FIXME restore --immutable
-  "for i in {1..3}; do yarn install --network-timeout 1000000 && exit 0 || (echo retrying; sleep 15;) done; exit 1"
+  "for i in {1..3}; do YARN_ENABLE_GLOBAL_CACHE=0 YARN_CACHE_FOLDER=/usr/src/agoric-sdk/.yarn/cache yarn install --network-timeout 1000000 && exit 0 || (echo retrying; sleep 15;) done; exit 1"
 
 # build everything except xsnap, built above. 'cosmos' was also built above but
 # it's safe to include here because its package "build" script is "exit 0".

--- a/services/ymax-planner/Dockerfile
+++ b/services/ymax-planner/Dockerfile
@@ -18,8 +18,8 @@ RUN ./scripts/ensure-corepack-yarn.sh /build
 # We could use `yarn workspaces focus @aglocal/ymax-planner` but there is a ghost dependency
 # of `@agoric/vats` on provisionPool.js in inter-protocol.
 # So for now we just build everything and don't expect immutability.
-# `yarn config` shows `enableGlobalCache: true` and `cacheFolder: '/root/.yarn/berry/cache'`
-RUN --mount=type=cache,target=/root/.yarn/berry/cache yarn install --mode=skip-build
+# Keep cache in-project so hardlink-based installs can run on a single filesystem in Docker.
+RUN --mount=type=cache,target=/build/.yarn/cache YARN_ENABLE_GLOBAL_CACHE=0 YARN_CACHE_FOLDER=/build/.yarn/cache yarn install --mode=skip-build
 
 # Build the service and its dependencies
 # XXX manual list of dependencies is brittle


### PR DESCRIPTION
### Motivation

- Speed up `node-modules` installs under Yarn 4 by enabling hardlink-based linking where supported. 
- Make Docker build layers compatible with hardlink-based installs by ensuring the cache and checkout live on the same filesystem inside the image.

### Description

- Add `nmMode: hardlinks-local` to `.yarnrc.yml` to enable Yarn 4 hardlinking while keeping `nodeLinker: node-modules`.
- Update `packages/deployment/Dockerfile.sdk` to mount a project-local cache at `/usr/src/agoric-sdk/.yarn/cache` and invoke `yarn install` with `YARN_ENABLE_GLOBAL_CACHE=0` and `YARN_CACHE_FOLDER=/usr/src/agoric-sdk/.yarn/cache` so linking can use hardlinks on a single FS.
- Apply the same project-local cache and `YARN_ENABLE_GLOBAL_CACHE=0` approach to `services/ymax-planner/Dockerfile` by mounting `/build/.yarn/cache` for its `yarn install --mode=skip-build` step.
- Preserve the existing `node-modules` linker and existing install/build commands to minimize behavioral risk.

### Testing

- Ran `yarn config get nodeLinker && yarn config get nmMode` which reported `node-modules` and `hardlinks-local`, respectively, and succeeded.
- Ran `yarn install --mode=skip-build` in this environment which completed successfully (with expected warnings) and finished in ~23s.
- Could not run a Docker build in this environment because the Docker CLI is not available, so Docker-layer validation was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69876ae4f17c832f88f9a154efdb632d)