### PR TITLE
refactor(testing): confine vm-config references to boot and cosmic-swingset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,4 @@ per https://agents.md/
 - PRs: link related issues, describe changes and risks; ensure `yarn build`, `yarn test`, and `yarn lint` pass. Prefer “Squash and merge.”
 - Integration tests: use labels `force:integration`/`bypass:integration` when appropriate; otherwise they run as part of the merge queue.
 - Commit hygiene (codegen, lockfile updates, formatting, linting, tests): see `docs/commit-hygiene.md`.
+- When adding a new workspace/package, MUST regenerate `packages/agoric-cli/src/sdk-package-names.js` via `yarn workspace agoric build` (or `node packages/agoric-cli/scripts/get-sdk-package-names.js > packages/agoric-cli/src/sdk-package-names.js`) and commit the updated generated file.

--- a/docs/testing/integration-package-spike.md
+++ b/docs/testing/integration-package-spike.md
@@ -1,0 +1,49 @@
+# Spike: per-package integration test workspaces
+
+## Motivation
+
+Some tests in leaf workspaces (for example `@agoric/vats`) are integration-level
+because they exercise bootstrap behaviors and runtime assembly instead of a
+single unit. Keeping those tests in the leaf package hides dependency edges and
+makes affected-test analysis harder.
+
+This spike demonstrates a pattern that keeps the package graph honest by moving
+integration tests into a separate unpublished workspace.
+
+## Pattern
+
+For a publishable package `@agoric/<name>`, add an unpublished integration
+workspace `@aglocal/<name>-integration`.
+
+In this spike:
+
+- `@aglocal/vats-integration` depends on `@agoric/vats`.
+- A bootstrap-oriented test moved from `packages/vats/test` to
+  `packages/vats-integration/test`.
+- Integration-only dependencies stay in the integration workspace instead of the
+  publishable package test tree.
+
+## Requirements for incremental adoption
+
+### MUST
+
+- MUST keep publishable package names under `@agoric/*` and integration
+  workspaces under `@aglocal/*`.
+- MUST keep runtime/manifest/boot-dependent tests in integration workspaces.
+- MUST avoid adding `@aglocal/*` dependencies to `@agoric/*` packages.
+- MUST keep each integration workspace runnable with a single command
+  (`yarn workspace <pkg> test`).
+
+### SHOULD
+
+- SHOULD move only clearly integration-level tests first (no flag day).
+- SHOULD preserve existing test semantics while relocating tests.
+- SHOULD document why moved tests are integration-level.
+- SHOULD keep unit tests in the original publishable package.
+
+## Why this helps affected-test analysis
+
+Once integration tests live in distinct `@aglocal/*-integration` workspaces,
+the workspace dependency graph directly shows that those tests depend on boot and
+manifest plumbing. A future affected-test tool can traverse workspace and import
+edges without inferring hidden runtime dependencies from ad-hoc test code.

--- a/docs/testing/vm-config-dependency-audit.md
+++ b/docs/testing/vm-config-dependency-audit.md
@@ -1,0 +1,25 @@
+# vm-config dependency audit
+
+Direct package.json deps on @agoric/vm-config:
+- @aglocal/boot (dependencies: workspace:*) in packages/boot/package.json
+
+Textual @agoric/vm-config/<file> references outside packages/vm-config:
+- packages/boot/tools/supports.ts:432:    configSpecifier = '@agoric/vm-config/decentral-itest-vaults-config.json',
+- packages/boot/tools/authorityViz.js:240:  specifier || Fail`Usage: $0 @agoric/vm-config/decentral-...json`;
+- packages/boot/test/orchestration/restart-contracts.test.ts:67:    '@agoric/vm-config/decentral-itest-orchestration-config.json',
+- packages/boot/test/orchestration/axelar-gmp.test.ts:42:    '@agoric/vm-config/decentral-itest-orchestration-config.json',
+- packages/boot/test/orchestration/orchestration.test.ts:51:    '@agoric/vm-config/decentral-itest-orchestration-config.json',
+- packages/boot/test/orchestration/lca.test.ts:19:    '@agoric/vm-config/decentral-itest-orchestration-config.json',
+- packages/boot/test/orchestration/contract-upgrade.test.ts:19:    '@agoric/vm-config/decentral-itest-orchestration-config.json',
+- packages/boot/test/orchestration/vstorage-chain-info.test.ts:41:    '@agoric/vm-config/decentral-itest-orchestration-chains-config.json',
+- packages/boot/test/bootstrapTests/walletFactory.ts:14:  configSpecifier = '@agoric/vm-config/decentral-main-vaults-config.json',
+- packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts:19:const PLATFORM_CONFIG = '@agoric/vm-config/decentral-itest-vaults-config.json';
+- packages/boot/test/bootstrapTests/ec-membership-update.test.ts:47:    configSpecifier: '@agoric/vm-config/decentral-main-vaults-config.json',
+- packages/boot/test/bootstrapTests/terminate-governed.test.ts:7:const PLATFORM_CONFIG = '@agoric/vm-config/decentral-main-vaults-config.json';
+- packages/boot/test/bootstrapTests/vtransfer.test.ts:15:    configSpecifier: '@agoric/vm-config/decentral-demo-config.json',
+- packages/boot/test/bootstrapTests/vow-offer-results.test.ts:14:    '@agoric/vm-config/decentral-itest-orchestration-config.json',
+- packages/boot/test/bootstrapTests/vats-restart.test.ts:14:const PLATFORM_CONFIG = '@agoric/vm-config/decentral-itest-vaults-config.json';
+- packages/boot/test/bootstrapTests/demo-config.test.ts:13:    configSpecifier: '@agoric/vm-config/decentral-demo-config.json',
+- packages/boot/test/bootstrapTests/upgradeAPI.test.ts:109:const PLATFORM_CONFIG = '@agoric/vm-config/decentral-main-vaults-config.json';
+- packages/boot/test/configs.test.js:21:  new URL(importMetaResolve(`@agoric/vm-config/${configName}`, import.meta.url))
+- packages/boot/test/configs.test.js:192:  const cmd = runViz(['@agoric/vm-config/decentral-itest-vaults-config.json']);

--- a/packages/agoric-cli/src/sdk-package-names.js
+++ b/packages/agoric-cli/src/sdk-package-names.js
@@ -9,6 +9,7 @@ export default [
   "@aglocal/portfolio-contract",
   "@aglocal/portfolio-deploy",
   "@aglocal/swingset-runner",
+  "@aglocal/vats-integration",
   "@aglocal/ymax-planner",
   "@agoric/access-token",
   "@agoric/async-flow",

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -527,7 +527,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     const agServerResolve = spec =>
       require.resolve(spec, { paths: [serverDir] });
     const coreConfigPath = agServerResolve(
-      '@agoric/vm-config/decentral-core-config.json',
+      '@agoric/cosmic-swingset/src/vm-config/decentral-core-config.json',
     );
     const economyTemplPath = agServerResolve(
       '@agoric/cosmic-swingset/economy-template.json',

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -41,6 +41,7 @@
     "import-meta-resolve": "^4.1.0"
   },
   "devDependencies": {
+    "@agoric/cosmic-swingset": "workspace:*",
     "@agoric/deploy-script-support": "workspace:*",
     "@agoric/governance": "workspace:*",
     "@agoric/inter-protocol": "workspace:*",

--- a/packages/builders/test/inter-proposals.test.js
+++ b/packages/builders/test/inter-proposals.test.js
@@ -7,7 +7,7 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
  * @import {TestFn} from 'ava';
  */
 
-const configSpecifier = '@agoric/vm-config/decentral-itest-vaults-config.json';
+const configSpecifier = '@agoric/cosmic-swingset/src/vm-config/decentral-itest-vaults-config.json';
 const noop = harden(() => {});
 
 /** @type {TestFn<ReturnType<typeof makeTestContext>>} */

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -141,18 +141,18 @@ scenario2-setup:
 
 t1/decentral-economy-config.json: $(ECONOMY_PROPOSALS)
 	jq -s '.[0] * { coreProposals: .[1] }' \
-		../vm-config/decentral-core-config.json \
+		src/vm-config/decentral-core-config.json \
 		'$(ECONOMY_PROPOSALS)' > t1/decentral-economy-config.json
 
 scenario2-run-chain-economy: t1/decentral-economy-config.json
-	echo "DEPRECATED use: CHAIN_BOOTSTRAP_VAT_CONFIG=@agoric/vm-config/decentral-itest-vaults-config.json scenario2-run-chain"
+	echo "DEPRECATED use: CHAIN_BOOTSTRAP_VAT_CONFIG=./src/vm-config/decentral-itest-vaults-config.json scenario2-run-chain"
 	CHAIN_BOOTSTRAP_VAT_CONFIG="$$PWD/t1/decentral-economy-config.json" \
 		$(MAKE) scenario2-run-chain
 
 # We want to use the same configuration that will be deployed to the next
 # devnet.agoric.net so that developers can test their code against it locally.
-scenario2-run-chain: ../vm-config/decentral-devnet-config.json
-	CHAIN_BOOTSTRAP_VAT_CONFIG="$${CHAIN_BOOTSTRAP_VAT_CONFIG-$$PWD/../vm-config/decentral-devnet-config.json}" \
+scenario2-run-chain: src/vm-config/decentral-devnet-config.json
+	CHAIN_BOOTSTRAP_VAT_CONFIG="$${CHAIN_BOOTSTRAP_VAT_CONFIG-$$PWD/src/vm-config/decentral-devnet-config.json}" \
 		OTEL_EXPORTER_PROMETHEUS_PORT=$(OTEL_EXPORTER_PROMETHEUS_PORT) \
 		GENESIS_HASH=$$(shasum -a 256 t1/n0/config/genesis.json | cut -d' ' -f1) \
 		$(AGC) --home=t1/n0 start --log_level=warn $(AGC_START_ARGS)

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -30,7 +30,6 @@
     "@agoric/swing-store": "workspace:*",
     "@agoric/swingset-vat": "workspace:*",
     "@agoric/telemetry": "workspace:*",
-    "@agoric/vm-config": "workspace:*",
     "@endo/bundle-source": "^4.1.2",
     "@endo/env-options": "^1.1.11",
     "@endo/errors": "^1.2.13",

--- a/packages/cosmic-swingset/src/sim-params.js
+++ b/packages/cosmic-swingset/src/sim-params.js
@@ -77,7 +77,7 @@ export const defaultBeansPerUnit = [
 ];
 
 const defaultBootstrapVatConfig =
-  '@agoric/vm-config/decentral-demo-config.json';
+  './vm-config/decentral-demo-config.json';
 
 /** @type {PowerFlagFeeSDKType[]} */
 export const defaultPowerFlagFees = [

--- a/packages/cosmic-swingset/src/vm-config/decentral-core-config.json
+++ b/packages/cosmic-swingset/src/vm-config/decentral-core-config.json
@@ -1,0 +1,63 @@
+{
+  "$comment": "This SwingSet config file (see loadSwingsetConfigFile) is minimal; it has no proposals. It is used by ../cosmic-swingset/Makefile and `agoric start`, which add proposals to it.",
+  "bootstrap": "bootstrap",
+  "defaultReapInterval": 1000,
+  "vats": {
+    "bootstrap": {
+      "sourceSpec": "@agoric/vats/src/core/boot-chain.js",
+      "creationOptions": {
+        "critical": true
+      }
+    }
+  },
+  "clearStorageSubtrees": [
+    "published"
+  ],
+  "exportStorageSubtrees": [
+    "published.psm.IST",
+    "published.wallet",
+    "published.provisionPool.metrics"
+  ],
+  "bundles": {
+    "agoricNames": {
+      "sourceSpec": "@agoric/vats/src/vat-agoricNames.js"
+    },
+    "centralSupply": {
+      "sourceSpec": "@agoric/vats/src/centralSupply.js"
+    },
+    "mintHolder": {
+      "sourceSpec": "@agoric/vats/src/mintHolder.js"
+    },
+    "zcf": {
+      "sourceSpec": "@agoric/zoe/contractFacet.js"
+    },
+    "bank": {
+      "sourceSpec": "@agoric/vats/src/vat-bank.js"
+    },
+    "board": {
+      "sourceSpec": "@agoric/vats/src/vat-board.js"
+    },
+    "bridge": {
+      "sourceSpec": "@agoric/vats/src/vat-bridge.js"
+    },
+    "mints": {
+      "sourceSpec": "@agoric/vats/src/vat-mints.js"
+    },
+    "priceAuthority": {
+      "sourceSpec": "@agoric/vats/src/vat-priceAuthority.js"
+    },
+    "provisionPool": {
+      "sourceSpec": "@agoric/inter-protocol/src/provisionPool.js"
+    },
+    "provisioning": {
+      "sourceSpec": "@agoric/vats/src/vat-provisioning.js"
+    },
+    "walletFactory": {
+      "sourceSpec": "@agoric/smart-wallet/src/walletFactory.js"
+    },
+    "zoe": {
+      "sourceSpec": "@agoric/vats/src/vat-zoe.js"
+    }
+  },
+  "defaultManagerType": "xs-worker"
+}

--- a/packages/cosmic-swingset/src/vm-config/decentral-demo-config.json
+++ b/packages/cosmic-swingset/src/vm-config/decentral-demo-config.json
@@ -1,0 +1,157 @@
+{
+  "$comment": "This SwingSet config file (see loadSwingsetConfigFile) includes non-production facilities such as a faucet. It is used by the sim chain (agoric start dev) and testnet-load-generator (aka loadgen).",
+  "bootstrap": "bootstrap",
+  "defaultReapInterval": 1000,
+  "snapshotInterval": 1000,
+  "coreProposals": [
+    "@agoric/builders/scripts/vats/init-core.js",
+    "@agoric/builders/scripts/vats/init-network.js",
+    "@agoric/builders/scripts/vats/init-localchain.js",
+    "@agoric/builders/scripts/vats/init-transfer.js",
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/init-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "econCommitteeOptions": {
+            "committeeSize": 3
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "interchainAssetOptions": {
+            "denom": "ibc/toyatom",
+            "decimalPlaces": 6,
+            "initialPrice": 12.34,
+            "keyword": "ATOM",
+            "oracleBrand": "ATOM",
+            "proposedName": "ATOM"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/toyusdc",
+            "decimalPlaces": 6,
+            "keyword": "USDC_axl",
+            "proposedName": "USD Coin"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/toyellie",
+            "decimalPlaces": 6,
+            "keyword": "AUSD",
+            "proposedName": "Anchor USD"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/price-feed-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
+          "oracleAddresses": [
+            "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",
+            "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang"
+          ],
+          "IN_BRAND_LOOKUP": [
+            "agoricNames",
+            "oracleBrand",
+            "ATOM"
+          ],
+          "IN_BRAND_DECIMALS": 6,
+          "OUT_BRAND_LOOKUP": [
+            "agoricNames",
+            "oracleBrand",
+            "USD"
+          ],
+          "OUT_BRAND_DECIMALS": 4
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/invite-committee-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "voterAddresses": {
+            "gov1": "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",
+            "gov2": "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang",
+            "gov3": "agoric1w8wktaur4zf8qmmtn3n7x3r0jhsjkjntcm3u6h"
+          }
+        }
+      ]
+    }
+  ],
+  "vats": {
+    "bootstrap": {
+      "sourceSpec": "@agoric/vats/src/core/boot-sim.js",
+      "creationOptions": {
+        "critical": true
+      }
+    }
+  },
+  "clearStorageSubtrees": [
+    "published"
+  ],
+  "exportStorageSubtrees": [
+    "published.psm.IST",
+    "published.wallet",
+    "published.provisionPool.metrics"
+  ],
+  "bundles": {
+    "agoricNames": {
+      "sourceSpec": "@agoric/vats/src/vat-agoricNames.js"
+    },
+    "bank": {
+      "sourceSpec": "@agoric/vats/src/vat-bank.js"
+    },
+    "centralSupply": {
+      "sourceSpec": "@agoric/vats/src/centralSupply.js"
+    },
+    "bridge": {
+      "sourceSpec": "@agoric/vats/src/vat-bridge.js"
+    },
+    "mintHolder": {
+      "sourceSpec": "@agoric/vats/src/mintHolder.js"
+    },
+    "mints": {
+      "sourceSpec": "@agoric/vats/src/vat-mints.js"
+    },
+    "board": {
+      "sourceSpec": "@agoric/vats/src/vat-board.js"
+    },
+    "priceAuthority": {
+      "sourceSpec": "@agoric/vats/src/vat-priceAuthority.js"
+    },
+    "provisioning": {
+      "sourceSpec": "@agoric/vats/src/vat-provisioning.js"
+    },
+    "zcf": {
+      "sourceSpec": "@agoric/zoe/contractFacet.js"
+    },
+    "zoe": {
+      "sourceSpec": "@agoric/vats/src/vat-zoe.js"
+    }
+  },
+  "defaultManagerType": "xs-worker"
+}

--- a/packages/cosmic-swingset/src/vm-config/decentral-devnet-config.json
+++ b/packages/cosmic-swingset/src/vm-config/decentral-devnet-config.json
@@ -1,0 +1,230 @@
+{
+  "$comment": "This SwingSet config file (see loadSwingsetConfigFile) includes non-production facilities such as a faucet. Pending #5819, it includes vaults in coreProposals; once #5819 is done, vaults are expected to be added by devnet governance.",
+  "bootstrap": "bootstrap",
+  "defaultReapInterval": 1000,
+  "coreProposals": {
+    "steps": [
+      [
+        "@agoric/builders/scripts/vats/init-core.js"
+      ],
+      [
+        "@agoric/builders/scripts/vats/init-network.js",
+        "@agoric/builders/scripts/vats/init-localchain.js",
+        "@agoric/builders/scripts/vats/init-transfer.js"
+      ],
+      [
+        "@agoric/builders/scripts/vats/init-orchestration.js",
+        "@agoric/builders/scripts/orchestration/write-chain-info.js"
+      ],
+      [
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/init-core.js",
+          "entrypoint": "defaultProposalBuilder",
+          "args": [
+            {
+              "econCommitteeOptions": {
+                "committeeSize": 3
+              },
+              "referencedUi": "bafybeidvpbtlgefi3ptuqzr2fwfyfjqfj6onmye63ij7qkrb4yjxekdh3e",
+              "minInitialPoolLiquidity": "0"
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+          "entrypoint": "defaultProposalBuilder",
+          "args": [
+            {
+              "interchainAssetOptions": {
+                "denom": "ibc/toyatom",
+                "decimalPlaces": 6,
+                "initialPrice": 12.34,
+                "keyword": "ATOM",
+                "oracleBrand": "ATOM",
+                "proposedName": "ATOM"
+              }
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+          "entrypoint": "psmProposalBuilder",
+          "args": [
+            {
+              "anchorOptions": {
+                "denom": "ibc/toyusdc",
+                "decimalPlaces": 6,
+                "keyword": "USDC_axl",
+                "proposedName": "USD Coin"
+              }
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+          "entrypoint": "psmProposalBuilder",
+          "args": [
+            {
+              "anchorOptions": {
+                "denom": "ibc/usdc5678",
+                "decimalPlaces": 6,
+                "keyword": "USDC_grv",
+                "proposedName": "USC Coin"
+              }
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+          "entrypoint": "psmProposalBuilder",
+          "args": [
+            {
+              "anchorOptions": {
+                "denom": "ibc/usdt1234",
+                "decimalPlaces": 6,
+                "keyword": "USDT_axl",
+                "proposedName": "Tether USD"
+              }
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+          "entrypoint": "psmProposalBuilder",
+          "args": [
+            {
+              "anchorOptions": {
+                "denom": "ibc/toyollie",
+                "decimalPlaces": 6,
+                "keyword": "USDT_grv",
+                "proposedName": "Tether USD"
+              }
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+          "entrypoint": "psmProposalBuilder",
+          "args": [
+            {
+              "anchorOptions": {
+                "denom": "ibc/toyellie",
+                "decimalPlaces": 6,
+                "keyword": "AUSD",
+                "proposedName": "Anchor USD"
+              }
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/price-feed-core.js",
+          "entrypoint": "defaultProposalBuilder",
+          "args": [
+            {
+              "contractTerms": {
+                "POLL_INTERVAL": 30,
+                "maxSubmissionCount": 1000,
+                "minSubmissionCount": 3,
+                "restartDelay": 1,
+                "timeout": 10,
+                "minSubmissionValue": 1,
+                "maxSubmissionValue": 9007199254740991
+              },
+              "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
+              "oracleAddresses": [
+                "agoric10vjkvkmpp9e356xeh6qqlhrny2htyzp8hf88fk",
+                "agoric1qj07c7vfk3knqdral0sej7fa6eavkdn8vd8etf",
+                "agoric1lw4e4aas9q84tq0q92j85rwjjjapf8dmnllnft",
+                "agoric1ra0g6crtsy6r3qnpu7ruvm7qd4wjnznyzg5nu4",
+                "agoric1zj6vrrrjq4gsyr9lw7dplv4vyejg3p8j2urm82"
+              ],
+              "IN_BRAND_LOOKUP": [
+                "agoricNames",
+                "oracleBrand",
+                "ATOM"
+              ],
+              "IN_BRAND_DECIMALS": 6,
+              "OUT_BRAND_LOOKUP": [
+                "agoricNames",
+                "oracleBrand",
+                "USD"
+              ],
+              "OUT_BRAND_DECIMALS": 4
+            }
+          ]
+        },
+        {
+          "module": "@agoric/builders/scripts/inter-protocol/invite-committee-core.js",
+          "entrypoint": "defaultProposalBuilder",
+          "args": [
+            {
+              "voterAddresses": {
+                "gov1": "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",
+                "gov2": "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang",
+                "gov3": "agoric1w8wktaur4zf8qmmtn3n7x3r0jhsjkjntcm3u6h"
+              }
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "vats": {
+    "bootstrap": {
+      "sourceSpec": "@agoric/vats/src/core/boot-chain.js",
+      "creationOptions": {
+        "critical": true
+      }
+    }
+  },
+  "clearStorageSubtrees": [
+    "published"
+  ],
+  "exportStorageSubtrees": [
+    "published.psm.IST",
+    "published.wallet",
+    "published.provisionPool.metrics"
+  ],
+  "bundles": {
+    "agoricNames": {
+      "sourceSpec": "@agoric/vats/src/vat-agoricNames.js"
+    },
+    "bank": {
+      "sourceSpec": "@agoric/vats/src/vat-bank.js"
+    },
+    "board": {
+      "sourceSpec": "@agoric/vats/src/vat-board.js"
+    },
+    "bridge": {
+      "sourceSpec": "@agoric/vats/src/vat-bridge.js"
+    },
+    "centralSupply": {
+      "sourceSpec": "@agoric/vats/src/centralSupply.js"
+    },
+    "mintHolder": {
+      "sourceSpec": "@agoric/vats/src/mintHolder.js"
+    },
+    "mints": {
+      "sourceSpec": "@agoric/vats/src/vat-mints.js"
+    },
+    "priceAuthority": {
+      "sourceSpec": "@agoric/vats/src/vat-priceAuthority.js"
+    },
+    "provisionPool": {
+      "sourceSpec": "@agoric/inter-protocol/src/provisionPool.js"
+    },
+    "provisioning": {
+      "sourceSpec": "@agoric/vats/src/vat-provisioning.js"
+    },
+    "walletFactory": {
+      "sourceSpec": "@agoric/smart-wallet/src/walletFactory.js"
+    },
+    "zcf": {
+      "sourceSpec": "@agoric/zoe/contractFacet.js"
+    },
+    "zoe": {
+      "sourceSpec": "@agoric/vats/src/vat-zoe.js"
+    }
+  },
+  "defaultManagerType": "xs-worker"
+}

--- a/packages/cosmic-swingset/src/vm-config/decentral-itest-orchestration-config.json
+++ b/packages/cosmic-swingset/src/vm-config/decentral-itest-orchestration-config.json
@@ -1,0 +1,143 @@
+{
+    "$comment": "This SwingSet config file (see loadSwingsetConfigFile) is designed to bring up vats to test Fast USDC. Compare with decentral-itest-vaults-config.json.",
+    "bootstrap": "bootstrap",
+    "defaultReapInterval": 1000,
+    "coreProposals": [
+        "@agoric/builders/scripts/vats/init-core.js",
+        "@agoric/builders/scripts/vats/init-network.js",
+        "@agoric/builders/scripts/vats/init-localchain.js",
+        "@agoric/builders/scripts/vats/init-transfer.js",
+        "@agoric/builders/scripts/vats/init-orchestration.js",
+        {
+            "module": "@agoric/builders/scripts/inter-protocol/init-core.js",
+            "entrypoint": "defaultProposalBuilder",
+            "args": [
+                {
+                    "econCommitteeOptions": {
+                        "committeeSize": 3
+                    },
+                    "referencedUi": "bafybeidvpbtlgefi3ptuqzr2fwfyfjqfj6onmye63ij7qkrb4yjxekdh3e",
+                    "minInitialPoolLiquidity": "0"
+                }
+            ]
+        },
+        {
+            "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+            "entrypoint": "defaultProposalBuilder",
+            "args": [
+                {
+                    "interestRateValue": 1000,
+                    "interchainAssetOptions": {
+                        "denom": "ibc/toyatom",
+                        "decimalPlaces": 6,
+                        "initialPrice": 12.34,
+                        "keyword": "ATOM",
+                        "oracleBrand": "ATOM",
+                        "proposedName": "ATOM"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+            "entrypoint": "psmProposalBuilder",
+            "args": [
+                {
+                    "anchorOptions": {
+                        "denom": "ibc/toyusdc",
+                        "decimalPlaces": 6,
+                        "keyword": "USDC_axl",
+                        "proposedName": "USD Coin"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+            "entrypoint": "psmProposalBuilder",
+            "args": [
+                {
+                    "anchorOptions": {
+                        "denom": "ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9",
+                        "decimalPlaces": 6,
+                        "keyword": "USDC",
+                        "proposedName": "USDC"
+                    }
+                }
+            ]
+        },
+        {
+            "$comment": "XXX orchesration works without oracles but some test setup dependency fails to resolve without this",
+            "module": "@agoric/builders/scripts/inter-protocol/price-feed-core.js",
+            "entrypoint": "defaultProposalBuilder",
+            "args": [
+                {
+                    "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
+                    "oracleAddresses": [
+                        "@PRIMARY_ADDRESS@",
+                        "agoric1dy0yegdsev4xvce3dx7zrz2ad9pesf5svzud6y"
+                    ],
+                    "IN_BRAND_LOOKUP": [
+                        "agoricNames",
+                        "oracleBrand",
+                        "ATOM"
+                    ],
+                    "IN_BRAND_DECIMALS": 6,
+                    "OUT_BRAND_LOOKUP": [
+                        "agoricNames",
+                        "oracleBrand",
+                        "USD"
+                    ],
+                    "OUT_BRAND_DECIMALS": 4
+                }
+            ]
+        }
+    ],
+    "vats": {
+        "bootstrap": {
+            "sourceSpec": "@agoric/vats/src/core/boot-chain.js",
+            "creationOptions": {
+                "critical": true
+            }
+        }
+    },
+    "bundles": {
+        "agoricNames": {
+            "sourceSpec": "@agoric/vats/src/vat-agoricNames.js"
+        },
+        "bank": {
+            "sourceSpec": "@agoric/vats/src/vat-bank.js"
+        },
+        "board": {
+            "sourceSpec": "@agoric/vats/src/vat-board.js"
+        },
+        "bridge": {
+            "sourceSpec": "@agoric/vats/src/vat-bridge.js"
+        },
+        "centralSupply": {
+            "sourceSpec": "@agoric/vats/src/centralSupply.js"
+        },
+        "mintHolder": {
+            "sourceSpec": "@agoric/vats/src/mintHolder.js"
+        },
+        "priceAuthority": {
+            "sourceSpec": "@agoric/vats/src/vat-priceAuthority.js"
+        },
+        "provisionPool": {
+            "sourceSpec": "@agoric/inter-protocol/src/provisionPool.js"
+        },
+        "provisioning": {
+            "sourceSpec": "@agoric/vats/src/vat-provisioning.js"
+        },
+        "walletFactory": {
+            "sourceSpec": "@agoric/smart-wallet/src/walletFactory.js"
+        },
+        "zcf": {
+            "sourceSpec": "@agoric/zoe/contractFacet.js"
+        },
+        "zoe": {
+            "sourceSpec": "@agoric/vats/src/vat-zoe.js"
+        }
+    },
+    "defaultManagerType": "xs-worker"
+}

--- a/packages/cosmic-swingset/src/vm-config/decentral-itest-vaults-config.json
+++ b/packages/cosmic-swingset/src/vm-config/decentral-itest-vaults-config.json
@@ -1,0 +1,244 @@
+{
+  "$comment": "Not just vaults! This SwingSet config (see loadSwingsetConfigFile) started for integration testing of Vaults is designed to bring up vaults but became the defacto config for integration testing outside this repo (e.g. instagoric). It includes coreProposals to start Inter Protocol (including vaults) plus Orchestration. Testing facilities are limited to an initialPrice for ATOM and addresses with known keys.",
+  "bootstrap": "bootstrap",
+  "defaultReapInterval": 1000,
+  "coreProposals": [
+    "@agoric/builders/scripts/vats/init-core.js",
+    "@agoric/builders/scripts/vats/init-network.js",
+    "@agoric/builders/scripts/vats/init-localchain.js",
+    "@agoric/builders/scripts/vats/init-transfer.js",
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/init-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "econCommitteeOptions": {
+            "committeeSize": 3
+          },
+          "referencedUi": "bafybeidvpbtlgefi3ptuqzr2fwfyfjqfj6onmye63ij7qkrb4yjxekdh3e",
+          "minInitialPoolLiquidity": "0"
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "interestRateValue": 1000,
+          "interchainAssetOptions": {
+            "denom": "ibc/toyatom",
+            "decimalPlaces": 6,
+            "initialPrice": 12.34,
+            "keyword": "ATOM",
+            "oracleBrand": "ATOM",
+            "proposedName": "ATOM"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/toyusdc",
+            "decimalPlaces": 6,
+            "keyword": "USDC_axl",
+            "proposedName": "USD Coin"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/usdc5678",
+            "decimalPlaces": 6,
+            "keyword": "USDC_grv",
+            "proposedName": "USC Coin"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/usdt1234",
+            "decimalPlaces": 6,
+            "keyword": "USDT_axl",
+            "proposedName": "Tether USD"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/toyollie",
+            "decimalPlaces": 6,
+            "keyword": "USDT_grv",
+            "proposedName": "Tether USD"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/toyellie",
+            "decimalPlaces": 6,
+            "keyword": "AUSD",
+            "proposedName": "Anchor USD"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/3914BDEF46F429A26917E4D8D434620EC4817DC6B6E68FB327E190902F1E9242",
+            "decimalPlaces": 18,
+            "keyword": "DAI_axl",
+            "proposedName": "DAI"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/3D5291C23D776C3AA7A7ABB34C7B023193ECD2BC42EA19D3165B2CF9652117E7",
+            "decimalPlaces": 18,
+            "keyword": "DAI_grv",
+            "proposedName": "DAI"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/price-feed-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "contractTerms": {
+            "POLL_INTERVAL": 30,
+            "maxSubmissionCount": 1000,
+            "minSubmissionCount": 3,
+            "restartDelay": 1,
+            "timeout": 10,
+            "minSubmissionValue": 1,
+            "maxSubmissionValue": 9007199254740991
+          },
+          "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
+          "oracleAddresses": [
+            "agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr",
+            "agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8",
+            "agoric144rrhh4m09mh7aaffhm6xy223ym76gve2x7y78",
+            "agoric19d6gnr9fyp6hev4tlrg87zjrzsd5gzr5qlfq2p",
+            "agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj"
+          ],
+          "IN_BRAND_LOOKUP": [
+            "agoricNames",
+            "oracleBrand",
+            "ATOM"
+          ],
+          "IN_BRAND_DECIMALS": 6,
+          "OUT_BRAND_LOOKUP": [
+            "agoricNames",
+            "oracleBrand",
+            "USD"
+          ],
+          "OUT_BRAND_DECIMALS": 4
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/invite-committee-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "voterAddresses": {
+            "gov1": "agoric1ldmtatp24qlllgxmrsjzcpe20fvlkp448zcuce",
+            "gov2": "agoric140dmkrz2e42ergjj7gyvejhzmjzurvqeq82ang",
+            "gov3": "agoric1w8wktaur4zf8qmmtn3n7x3r0jhsjkjntcm3u6h"
+          }
+        }
+      ]
+    }
+  ],
+  "vats": {
+    "bootstrap": {
+      "sourceSpec": "@agoric/vats/src/core/boot-chain.js",
+      "creationOptions": {
+        "critical": true
+      }
+    }
+  },
+  "clearStorageSubtrees": [
+    "published"
+  ],
+  "exportStorageSubtrees": [
+    "published.psm.IST",
+    "published.wallet",
+    "published.provisionPool.metrics"
+  ],
+  "bundles": {
+    "agoricNames": {
+      "sourceSpec": "@agoric/vats/src/vat-agoricNames.js"
+    },
+    "bank": {
+      "sourceSpec": "@agoric/vats/src/vat-bank.js"
+    },
+    "board": {
+      "sourceSpec": "@agoric/vats/src/vat-board.js"
+    },
+    "bridge": {
+      "sourceSpec": "@agoric/vats/src/vat-bridge.js"
+    },
+    "centralSupply": {
+      "sourceSpec": "@agoric/vats/src/centralSupply.js"
+    },
+    "mintHolder": {
+      "sourceSpec": "@agoric/vats/src/mintHolder.js"
+    },
+    "priceAuthority": {
+      "sourceSpec": "@agoric/vats/src/vat-priceAuthority.js"
+    },
+    "provisionPool": {
+      "sourceSpec": "@agoric/inter-protocol/src/provisionPool.js"
+    },
+    "provisioning": {
+      "sourceSpec": "@agoric/vats/src/vat-provisioning.js"
+    },
+    "walletFactory": {
+      "sourceSpec": "@agoric/smart-wallet/src/walletFactory.js"
+    },
+    "zcf": {
+      "sourceSpec": "@agoric/zoe/contractFacet.js"
+    },
+    "zoe": {
+      "sourceSpec": "@agoric/vats/src/vat-zoe.js"
+    }
+  },
+  "defaultManagerType": "xs-worker"
+}

--- a/packages/cosmic-swingset/src/vm-config/decentral-main-vaults-config.json
+++ b/packages/cosmic-swingset/src/vm-config/decentral-main-vaults-config.json
@@ -1,0 +1,232 @@
+{
+  "$comment": "This SwingSet config file (see loadSwingsetConfigFile) is designed to bring up vaults in a decentralized networks in an automated fashion. It includes coreProposals to start vaults. It has no testing facilities.",
+  "bootstrap": "bootstrap",
+  "defaultReapInterval": 1000,
+  "coreProposals": [
+    "@agoric/builders/scripts/vats/init-core.js",
+    "@agoric/builders/scripts/vats/init-network.js",
+    "@agoric/builders/scripts/vats/init-localchain.js",
+    "@agoric/builders/scripts/vats/init-transfer.js",
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/init-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "econCommitteeOptions": {
+            "committeeSize": 6
+          },
+          "referencedUi": "NO REFERENCED UI",
+          "minInitialPoolLiquidity": "0"
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "debtLimitValue": 0,
+          "interchainAssetOptions": {
+            "denom": "ibc/BA313C4A19DFBF943586C0387E6B11286F9E416B4DD27574E6909CABE0E342FA",
+            "decimalPlaces": 6,
+            "keyword": "ATOM",
+            "oracleBrand": "ATOM",
+            "proposedName": "ATOM"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F",
+            "decimalPlaces": 6,
+            "keyword": "USDC_axl",
+            "proposedName": "USD Coin"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/6831292903487E58BF9A195FDDC8A2E626B3DF39B88F4E7F41C935CADBAF54AC",
+            "decimalPlaces": 6,
+            "keyword": "USDC_grv",
+            "proposedName": "USC Coin"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/F2331645B9683116188EF36FC04A809C28BD36B54555E8705A37146D0182F045",
+            "decimalPlaces": 6,
+            "keyword": "USDT_axl",
+            "proposedName": "Tether USD"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/386D09AE31DA7C0C93091BB45D08CB7A0730B1F697CD813F06A5446DCF02EEB2",
+            "decimalPlaces": 6,
+            "keyword": "USDT_grv",
+            "proposedName": "Tether USD"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/3914BDEF46F429A26917E4D8D434620EC4817DC6B6E68FB327E190902F1E9242",
+            "decimalPlaces": 18,
+            "keyword": "DAI_axl",
+            "proposedName": "DAI"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/add-collateral-core.js",
+      "entrypoint": "psmProposalBuilder",
+      "args": [
+        {
+          "anchorOptions": {
+            "denom": "ibc/3D5291C23D776C3AA7A7ABB34C7B023193ECD2BC42EA19D3165B2CF9652117E7",
+            "decimalPlaces": 18,
+            "keyword": "DAI_grv",
+            "proposedName": "DAI"
+          }
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/price-feed-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "contractTerms": {
+            "POLL_INTERVAL": 30,
+            "maxSubmissionCount": 1000,
+            "minSubmissionCount": 3,
+            "restartDelay": 1,
+            "timeout": 10,
+            "minSubmissionValue": 1,
+            "maxSubmissionValue": 9007199254740991
+          },
+          "AGORIC_INSTANCE_NAME": "ATOM-USD price feed",
+          "oracleAddresses": [
+            "agoric1krunjcqfrf7la48zrvdfeeqtls5r00ep68mzkr",
+            "agoric19uscwxdac6cf6z7d5e26e0jm0lgwstc47cpll8",
+            "agoric144rrhh4m09mh7aaffhm6xy223ym76gve2x7y78",
+            "agoric19d6gnr9fyp6hev4tlrg87zjrzsd5gzr5qlfq2p",
+            "agoric1n4fcxsnkxe4gj6e24naec99hzmc4pjfdccy5nj"
+          ],
+          "IN_BRAND_LOOKUP": [
+            "agoricNames",
+            "oracleBrand",
+            "ATOM"
+          ],
+          "IN_BRAND_DECIMALS": 6,
+          "OUT_BRAND_LOOKUP": [
+            "agoricNames",
+            "oracleBrand",
+            "USD"
+          ],
+          "OUT_BRAND_DECIMALS": 4
+        }
+      ]
+    },
+    {
+      "module": "@agoric/builders/scripts/inter-protocol/invite-committee-core.js",
+      "entrypoint": "defaultProposalBuilder",
+      "args": [
+        {
+          "voterAddresses": {
+            "Jason Potts": "agoric1gx9uu7y6c90rqruhesae2t7c2vlw4uyyxlqxrx",
+            "Chloe White": "agoric1d4228cvelf8tj65f4h7n2td90sscavln2283h5",
+            "Thibault Schrepel": "agoric14543m33dr28x7qhwc558hzlj9szwhzwzpcmw6a",
+            "Chris Berg": "agoric13p9adwk0na5npfq64g22l6xucvqdmu3xqe70wq",
+            "Youssef Amrani": "agoric1el6zqs8ggctj5vwyukyk4fh50wcpdpwgugd5l5",
+            "Joe Clark": "agoric1zayxg4e9vd0es9c9jlpt36qtth255txjp6a8yc"
+          }
+        }
+      ]
+    }
+  ],
+  "vats": {
+    "bootstrap": {
+      "sourceSpec": "@agoric/vats/src/core/boot-chain.js",
+      "creationOptions": {
+        "critical": true
+      }
+    }
+  },
+  "clearStorageSubtrees": [
+    "published"
+  ],
+  "exportStorageSubtrees": [
+    "published.psm.IST",
+    "published.wallet",
+    "published.provisionPool.metrics"
+  ],
+  "bundles": {
+    "agoricNames": {
+      "sourceSpec": "@agoric/vats/src/vat-agoricNames.js"
+    },
+    "bank": {
+      "sourceSpec": "@agoric/vats/src/vat-bank.js"
+    },
+    "board": {
+      "sourceSpec": "@agoric/vats/src/vat-board.js"
+    },
+    "bridge": {
+      "sourceSpec": "@agoric/vats/src/vat-bridge.js"
+    },
+    "centralSupply": {
+      "sourceSpec": "@agoric/vats/src/centralSupply.js"
+    },
+    "mintHolder": {
+      "sourceSpec": "@agoric/vats/src/mintHolder.js"
+    },
+    "priceAuthority": {
+      "sourceSpec": "@agoric/vats/src/vat-priceAuthority.js"
+    },
+    "provisionPool": {
+      "sourceSpec": "@agoric/inter-protocol/src/provisionPool.js"
+    },
+    "provisioning": {
+      "sourceSpec": "@agoric/vats/src/vat-provisioning.js"
+    },
+    "walletFactory": {
+      "sourceSpec": "@agoric/smart-wallet/src/walletFactory.js"
+    },
+    "zcf": {
+      "sourceSpec": "@agoric/zoe/contractFacet.js"
+    },
+    "zoe": {
+      "sourceSpec": "@agoric/vats/src/vat-zoe.js"
+    }
+  },
+  "defaultManagerType": "xs-worker"
+}

--- a/packages/cosmic-swingset/test/prometheus.test.ts
+++ b/packages/cosmic-swingset/test/prometheus.test.ts
@@ -90,7 +90,7 @@ const testPrometheusMetrics = async t => {
     OTEL_EXPORTER_PROMETHEUS_PORT,
     SLOGSENDER_AGENT_OTEL_EXPORTER_PROMETHEUS_PORT,
     SLOGSENDER_AGENT: 'process',
-    CHAIN_BOOTSTRAP_VAT_CONFIG: '@agoric/vm-config/decentral-core-config.json',
+    CHAIN_BOOTSTRAP_VAT_CONFIG: './vm-config/decentral-core-config.json',
   };
   const testKit = await makeCosmicSwingsetTestKit(receiveBridgeSend, { env });
   const { pushCoreEval, runNextBlock, shutdown } = testKit;

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -49,7 +49,7 @@ if [ -n "$LOADGEN" ]; then
   solodir="$LOADGEN"/_agstate/agoric-servers/testnet-8000
   "$thisdir/../../solo/bin/ag-solo" init "$solodir" --webport=8000
   SOLO_ADDR=$(cat "$solodir/ag-cosmos-helper-address")
-  VAT_CONFIG="@agoric/vm-config/decentral-demo-config.json"
+  VAT_CONFIG="@agoric/cosmic-swingset/src/vm-config/decentral-demo-config.json"
 fi
 
 "$thisdir/docker-deployment.cjs" > deployment.json

--- a/packages/fast-usdc-deploy/package.json
+++ b/packages/fast-usdc-deploy/package.json
@@ -20,6 +20,7 @@
     "lint:types": "yarn run -T tsc"
   },
   "devDependencies": {
+    "@agoric/cosmic-swingset": "workspace:*",
     "@agoric/swing-store": "workspace:*",
     "@agoric/vats": "workspace:*",
     "@endo/promise-kit": "^1.1.13",

--- a/packages/fast-usdc-deploy/test/chain-impact.test.ts
+++ b/packages/fast-usdc-deploy/test/chain-impact.test.ts
@@ -44,7 +44,7 @@ const test: TestFn<
   }
 > = anyTest;
 
-const config = '@agoric/vm-config/decentral-itest-orchestration-config.json';
+const config = '@agoric/cosmic-swingset/src/vm-config/decentral-itest-orchestration-config.json';
 
 /**
  * Contracts such as Fast USDC may delay cleanup of some state.

--- a/packages/fast-usdc-deploy/test/fast-usdc.test.ts
+++ b/packages/fast-usdc-deploy/test/fast-usdc.test.ts
@@ -70,7 +70,7 @@ const {
 } = fetchedChainInfo.agoric.connections['noble-1'].transferChannel;
 
 test.before('bootstrap', async t => {
-  const config = '@agoric/vm-config/decentral-itest-orchestration-config.json';
+  const config = '@agoric/cosmic-swingset/src/vm-config/decentral-itest-orchestration-config.json';
   insistManagerType(defaultManagerType);
   const harness = ['xs-worker', 'xsnap'].includes(defaultManagerType)
     ? makeSwingsetHarness()

--- a/packages/fast-usdc-deploy/test/walletFactory.ts
+++ b/packages/fast-usdc-deploy/test/walletFactory.ts
@@ -11,7 +11,7 @@ import { makeWalletFactoryDriver } from '@aglocal/boot/tools/drivers.js';
 
 export const makeWalletFactoryContext = async (
   t,
-  configSpecifier = '@agoric/vm-config/decentral-main-vaults-config.json',
+  configSpecifier = '@agoric/cosmic-swingset/src/vm-config/decentral-main-vaults-config.json',
   opts = {},
 ) => {
   const swingsetTestKit = await makeSwingsetTestKit(t.log, undefined, {

--- a/packages/portfolio-deploy/package.json
+++ b/packages/portfolio-deploy/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@aglocal/boot": "workspace:*",
     "@agoric/client-utils": "workspace:*",
+    "@agoric/cosmic-swingset": "workspace:*",
     "@agoric/portfolio-api": "workspace:*",
     "@agoric/smart-wallet": "workspace:*",
     "@noble/hashes": "~1.5.0",

--- a/packages/portfolio-deploy/test/portfolio.test.ts
+++ b/packages/portfolio-deploy/test/portfolio.test.ts
@@ -150,7 +150,7 @@ const {
 } = process.env;
 
 test.before('bootstrap', async t => {
-  const config = '@agoric/vm-config/decentral-itest-orchestration-config.json';
+  const config = '@agoric/cosmic-swingset/src/vm-config/decentral-itest-orchestration-config.json';
   // TODO: impact testing
   insistManagerType(defaultManagerType);
   const harness = ['xs-worker', 'xsnap'].includes(defaultManagerType)

--- a/packages/portfolio-deploy/test/walletFactory.ts
+++ b/packages/portfolio-deploy/test/walletFactory.ts
@@ -13,7 +13,7 @@ import { makeWalletFactoryDriver } from '@aglocal/boot/tools/drivers.js';
 // XXX same as packages/boot/test/bootstrapTests/walletFactory.ts
 export const makeWalletFactoryContext = async (
   t,
-  configSpecifier = '@agoric/vm-config/decentral-main-vaults-config.json',
+  configSpecifier = '@agoric/cosmic-swingset/src/vm-config/decentral-main-vaults-config.json',
   opts = {},
 ) => {
   const swingsetTestKit = await makeSwingsetTestKit(t.log, undefined, {

--- a/packages/vats-integration/README.md
+++ b/packages/vats-integration/README.md
@@ -1,0 +1,13 @@
+# @aglocal/vats-integration
+
+This unpublished workspace holds integration tests for `@agoric/vats` that need
+bootstrap powers, runtime wiring, or boot behaviors.
+
+The package exists to make these dependencies explicit in the workspace graph,
+so integration edges are not hidden inside the leaf package test tree.
+
+Run tests:
+
+```bash
+yarn workspace @aglocal/vats-integration test
+```

--- a/packages/vats-integration/package.json
+++ b/packages/vats-integration/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@aglocal/vats-integration",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Integration tests for @agoric/vats that require bootstrap behaviors",
+  "type": "module",
+  "repository": "https://github.com/Agoric/agoric-sdk",
+  "scripts": {
+    "test": "ava",
+    "test:c8": "c8 --all ${C8_OPTIONS:-} ava",
+    "lint": "yarn run -T run-s --continue-on-error 'lint:*'",
+    "lint:eslint": "yarn run -T eslint ."
+  },
+  "dependencies": {
+    "@agoric/internal": "workspace:*",
+    "@agoric/notifier": "workspace:*",
+    "@agoric/swingset-vat": "workspace:*",
+    "@agoric/vat-data": "workspace:*",
+    "@agoric/vats": "workspace:*",
+    "@agoric/zoe": "workspace:*",
+    "@agoric/zone": "workspace:*",
+    "@endo/far": "^1.1.14",
+    "@endo/promise-kit": "^1.1.13"
+  },
+  "devDependencies": {
+    "@endo/init": "^1.1.12",
+    "ava": "^6.4.1",
+    "c8": "^10.1.3"
+  },
+  "ava": {
+    "files": [
+      "test/**/*.test.*"
+    ],
+    "require": [
+      "@endo/init/debug.js"
+    ],
+    "timeout": "20m"
+  },
+  "engines": {
+    "node": "^20.9 || ^22.11"
+  }
+}

--- a/packages/vats-integration/test/vat-bank-bootstrap.integration.test.js
+++ b/packages/vats-integration/test/vat-bank-bootstrap.integration.test.js
@@ -8,24 +8,24 @@ import { makePromiseKit } from '@endo/promise-kit';
 import { makeZoeKitForTest } from '@agoric/zoe/tools/setup-zoe.js';
 import { observeIteration } from '@agoric/notifier';
 import { makeHeapZone } from '@agoric/zone';
-import { buildRootObject } from '../src/vat-bank.js';
+import { buildRootObject } from '@agoric/vats/src/vat-bank.js';
 import {
   mintInitialSupply,
   addBankAssets,
   installBootContracts,
   produceStartUpgradable,
   produceDiagnostics,
-} from '../src/core/basic-behaviors.js';
-import { makeAgoricNamesAccess } from '../src/core/utils.js';
-import { makePromiseSpace } from '../src/core/promise-space.js';
-import { makePopulatedFakeVatAdmin } from '../tools/boot-test-utils.js';
+} from '@agoric/vats/src/core/basic-behaviors.js';
+import { makeAgoricNamesAccess } from '@agoric/vats/src/core/utils.js';
+import { makePromiseSpace } from '@agoric/vats/src/core/promise-space.js';
+import { makePopulatedFakeVatAdmin } from '@agoric/vats/tools/boot-test-utils.js';
 
 /**
  * @import {InitMsg} from '@agoric/internal/src/chain-utils.js';
- * @import {BootstrapPowers} from '../src/core/types.ts';
- * @import {Producer} from '../src/core/types.ts';
- * @import {VatLoader} from '../src/core/types.ts';
- * @import {WellKnownVats} from '../src/core/types.ts';
+ * @import {BootstrapPowers} from '@agoric/vats/src/core/types.ts';
+ * @import {Producer} from '@agoric/vats/src/core/types.ts';
+ * @import {VatLoader} from '@agoric/vats/src/core/types.ts';
+ * @import {WellKnownVats} from '@agoric/vats/src/core/types.ts';
  */
 
 test('mintInitialSupply, addBankAssets bootstrap actions', async t => {

--- a/packages/vats-integration/tsconfig.json
+++ b/packages/vats-integration/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  "include": [
+    "test"
+  ]
+}

--- a/scripts/audit-vm-config-deps.mjs
+++ b/scripts/audit-vm-config-deps.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+const root = process.cwd();
+const packagesDir = path.join(root, 'packages');
+
+const sections = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
+
+const packageDirs = fs
+  .readdirSync(packagesDir, { withFileTypes: true })
+  .filter(d => d.isDirectory())
+  .map(d => path.join('packages', d.name));
+
+const direct = [];
+for (const pkgDir of packageDirs) {
+  const packageJsonPath = path.join(root, pkgDir, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) continue;
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  for (const section of sections) {
+    const deps = pkg[section] || {};
+    if (Object.hasOwn(deps, '@agoric/vm-config')) {
+      direct.push({
+        workspace: pkg.name || pkgDir,
+        section,
+        range: deps['@agoric/vm-config'],
+        file: `${pkgDir}/package.json`,
+      });
+    }
+  }
+}
+
+const rgCmd = `rg -n "@agoric/vm-config/" packages scripts --glob '!packages/vm-config/**' --glob '!**/*.md' --glob '!scripts/audit-vm-config-deps.mjs'`;
+let references = '';
+try {
+  references = execSync(rgCmd, { cwd: root, encoding: 'utf8' }).trim();
+} catch (e) {
+  references = e.stdout?.trim() || '';
+}
+
+console.log('# vm-config dependency audit');
+console.log('');
+if (direct.length === 0) {
+  console.log('Direct package.json deps on @agoric/vm-config: none');
+} else {
+  console.log('Direct package.json deps on @agoric/vm-config:');
+  for (const item of direct) {
+    console.log(
+      `- ${item.workspace} (${item.section}: ${item.range}) in ${item.file}`,
+    );
+  }
+}
+
+console.log('');
+console.log('Textual @agoric/vm-config/<file> references outside packages/vm-config:');
+if (!references) {
+  console.log('- none');
+} else {
+  for (const line of references.split('\n')) {
+    console.log(`- ${line}`);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -154,6 +154,7 @@ __metadata:
   dependencies:
     "@agoric/client-utils": "workspace:*"
     "@agoric/cosmic-proto": "workspace:*"
+    "@agoric/cosmic-swingset": "workspace:*"
     "@agoric/deploy-script-support": "workspace:*"
     "@agoric/ertp": "workspace:*"
     "@agoric/fast-usdc": "workspace:*"
@@ -237,6 +238,7 @@ __metadata:
     "@aglocal/portfolio-contract": "workspace:*"
     "@agoric/client-utils": "workspace:*"
     "@agoric/cosmic-proto": "workspace:*"
+    "@agoric/cosmic-swingset": "workspace:*"
     "@agoric/deploy-script-support": "workspace:*"
     "@agoric/ertp": "workspace:*"
     "@agoric/internal": "workspace:*"
@@ -299,6 +301,25 @@ __metadata:
     import-meta-resolve: "npm:^4.1.0"
     n-readlines: "npm:^1.0.1"
     yargs: "npm:^16.1.0"
+  languageName: unknown
+  linkType: soft
+
+"@aglocal/vats-integration@workspace:packages/vats-integration":
+  version: 0.0.0-use.local
+  resolution: "@aglocal/vats-integration@workspace:packages/vats-integration"
+  dependencies:
+    "@agoric/internal": "workspace:*"
+    "@agoric/notifier": "workspace:*"
+    "@agoric/swingset-vat": "workspace:*"
+    "@agoric/vat-data": "workspace:*"
+    "@agoric/vats": "workspace:*"
+    "@agoric/zoe": "workspace:*"
+    "@agoric/zone": "workspace:*"
+    "@endo/far": "npm:^1.1.14"
+    "@endo/init": "npm:^1.1.12"
+    "@endo/promise-kit": "npm:^1.1.13"
+    ava: "npm:^6.4.1"
+    c8: "npm:^10.1.3"
   languageName: unknown
   linkType: soft
 
@@ -411,6 +432,7 @@ __metadata:
   resolution: "@agoric/builders@workspace:packages/builders"
   dependencies:
     "@agoric/client-utils": "workspace:*"
+    "@agoric/cosmic-swingset": "workspace:*"
     "@agoric/deploy-script-support": "workspace:*"
     "@agoric/ertp": "workspace:*"
     "@agoric/governance": "workspace:*"
@@ -551,7 +573,6 @@ __metadata:
     "@agoric/swing-store": "workspace:*"
     "@agoric/swingset-vat": "workspace:*"
     "@agoric/telemetry": "workspace:*"
-    "@agoric/vm-config": "workspace:*"
     "@endo/bundle-source": "npm:^4.1.2"
     "@endo/env-options": "npm:^1.1.11"
     "@endo/errors": "npm:^1.2.13"


### PR DESCRIPTION
### Motivation

- Reduce implicit workspace coupling by ensuring non-boot code no longer directly references `@agoric/vm-config/*` so only boot (and cosmic-swingset) provide runtime vm-config artifacts. 
- Make integration-level tests and bootstrap-dependent imports explicit in the workspace graph by moving bootstrap-oriented tests into an unpublished integration workspace. 

### Description

- Repointed textual `@agoric/vm-config/*` usages to local cosmic-swingset artifacts (`@agoric/cosmic-swingset/src/vm-config/...`) across `agoric-cli`, `@agoric/builders` tests, `@aglocal/fast-usdc-deploy`, `@aglocal/portfolio-deploy`, and `packages/deployment/scripts/integration-test.sh` and updated `Makefile`/`sim-params`/tests accordingly. 
- Inlined vm-config artifacts into `packages/cosmic-swingset/src/vm-config/` (added `decentral-core-config.json`, `decentral-demo-config.json`, `decentral-devnet-config.json`, `decentral-itest-orchestration-config.json`, `decentral-itest-vaults-config.json`, `decentral-main-vaults-config.json`) and removed `@agoric/vm-config` from `packages/cosmic-swingset/package.json`. 
- Added `@agoric/cosmic-swingset` devDependency where needed (e.g., `@agoric/builders`, `@aglocal/fast-usdc-deploy`, `@aglocal/portfolio-deploy`) and updated `yarn.lock` to reflect workspace changes. 
- Added `scripts/audit-vm-config-deps.mjs` to detect direct and textual references and wrote the audit snapshot at `docs/testing/vm-config-dependency-audit.md`. 
- Created an unpublished integration workspace `@aglocal/vats-integration` and moved the vat bootstrap-oriented integration test to `packages/vats-integration/test/` while updating imports to consume canonical `@agoric/vats` sources. 

### Testing

- Ran `node scripts/audit-vm-config-deps.mjs` and it completed successfully, producing the updated audit snapshot. 
- Ran `yarn run -T eslint` against modified test/start files and the lint run completed successfully. 
- Ran `yarn workspace @agoric/builders test test/inter-proposals.test.js` and the builders integration test passed (2 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69878538dabc832fbe1fdf78cc41bca0)