### PR TITLE
feat: add morpho addresses for other chains

### DIFF
--- a/packages/portfolio-api/src/instruments.js
+++ b/packages/portfolio-api/src/instruments.js
@@ -51,6 +51,18 @@ export const InstrumentId = /** @type {const} */ ({
     'ERC4626_morphoHyperithmUsdcDegen_Ethereum',
   ERC4626_morphoGauntletUsdcCore_Ethereum:
     'ERC4626_morphoGauntletUsdcCore_Ethereum',
+  ERC4626_morphoSteakhousePrimeUsdc_Base:
+    'ERC4626_morphoSteakhousePrimeUsdc_Base',
+  ERC4626_morphoSteakhouseUsdc_Base: 'ERC4626_morphoSteakhouseUsdc_Base',
+  ERC4626_morphoGauntletUsdcPrime_Base: 'ERC4626_morphoGauntletUsdcPrime_Base',
+  ERC4626_morphoSeamlessUsdcVault_Base: 'ERC4626_morphoSeamlessUsdcVault_Base',
+  ERC4626_morphoSteakhouseHighYieldUsdc_Arbitrum:
+    'ERC4626_morphoSteakhouseHighYieldUsdc_Arbitrum',
+  ERC4626_morphoGauntletUsdcCore_Arbitrum:
+    'ERC4626_morphoGauntletUsdcCore_Arbitrum',
+  ERC4626_morphoHyperithmUsdc_Arbitrum: 'ERC4626_morphoHyperithmUsdc_Arbitrum',
+  ERC4626_morphoGauntletUsdcPrime_Optimism:
+    'ERC4626_morphoGauntletUsdcPrime_Optimism',
   USDN: 'USDN',
   USDNVault: 'USDNVault',
 });

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -190,6 +190,38 @@ export const ERC4626PoolPlaces = {
     protocol: 'ERC4626',
     chainName: 'Ethereum',
   },
+  ERC4626_morphoSteakhousePrimeUsdc_Base: {
+    protocol: 'ERC4626',
+    chainName: 'Base',
+  },
+  ERC4626_morphoSteakhouseUsdc_Base: {
+    protocol: 'ERC4626',
+    chainName: 'Base',
+  },
+  ERC4626_morphoGauntletUsdcPrime_Base: {
+    protocol: 'ERC4626',
+    chainName: 'Base',
+  },
+  ERC4626_morphoSeamlessUsdcVault_Base: {
+    protocol: 'ERC4626',
+    chainName: 'Base',
+  },
+  ERC4626_morphoSteakhouseHighYieldUsdc_Arbitrum: {
+    protocol: 'ERC4626',
+    chainName: 'Arbitrum',
+  },
+  ERC4626_morphoGauntletUsdcCore_Arbitrum: {
+    protocol: 'ERC4626',
+    chainName: 'Arbitrum',
+  },
+  ERC4626_morphoHyperithmUsdc_Arbitrum: {
+    protocol: 'ERC4626',
+    chainName: 'Arbitrum',
+  },
+  ERC4626_morphoGauntletUsdcPrime_Optimism: {
+    protocol: 'ERC4626',
+    chainName: 'Optimism',
+  },
 } as const satisfies Partial<Record<InstrumentId, PoolPlaceInfo>>;
 
 export type ERC4626InstrumentId = keyof typeof ERC4626PoolPlaces;

--- a/packages/portfolio-contract/test/network/prod-network.test.ts
+++ b/packages/portfolio-contract/test/network/prod-network.test.ts
@@ -74,6 +74,14 @@ const POOLS: ReadonlyArray<PoolKey> = [
   'ERC4626_morphoHyperithmUsdcMidcurve_Ethereum',
   'ERC4626_morphoHyperithmUsdcDegen_Ethereum',
   'ERC4626_morphoGauntletUsdcCore_Ethereum',
+  'ERC4626_morphoSteakhousePrimeUsdc_Base',
+  'ERC4626_morphoSteakhouseUsdc_Base',
+  'ERC4626_morphoGauntletUsdcPrime_Base',
+  'ERC4626_morphoSeamlessUsdcVault_Base',
+  'ERC4626_morphoSteakhouseHighYieldUsdc_Arbitrum',
+  'ERC4626_morphoGauntletUsdcCore_Arbitrum',
+  'ERC4626_morphoHyperithmUsdc_Arbitrum',
+  'ERC4626_morphoGauntletUsdcPrime_Optimism',
 ];
 
 // Helpers

--- a/packages/portfolio-deploy/src/axelar-configs.js
+++ b/packages/portfolio-deploy/src/axelar-configs.js
@@ -248,6 +248,7 @@ const beefyVaultAddresses = harden({
   },
 });
 
+// XXX move to a new morpho-config.js https://github.com/Agoric/agoric-sdk/pull/12438#discussion_r2783437249
 /** @type {Record<string, AddressesMap>} */
 const erc4626VaultAddresses = harden({
   vaultU2: {
@@ -324,7 +325,45 @@ const erc4626VaultAddresses = harden({
   },
   morphoGauntletUsdcCore: {
     mainnet: {
+      Arbitrum: '0x7e97fa6893871A2751B5fE961978DCCb2c201E65', // https://app.morpho.org/arbitrum/vault/0x7e97fa6893871A2751B5fE961978DCCb2c201E65/gauntlet-usdc-core
       Ethereum: '0x8eB67A509616cd6A7c1B3c8C21D48FF57df3d458', // https://app.morpho.org/ethereum/vault/0x8eB67A509616cd6A7c1B3c8C21D48FF57df3d458/gauntlet-usdc-core
+    },
+    testnet: {},
+  },
+  morphoSteakhousePrimeUsdc: {
+    mainnet: {
+      Base: '0xBEEFE94c8aD530842bfE7d8B397938fFc1cb83b2', // https://app.morpho.org/base/vault/0xBEEFE94c8aD530842bfE7d8B397938fFc1cb83b2/steakhouse-prime-usdc
+    },
+    testnet: {},
+  },
+  morphoSteakhouseUsdc: {
+    mainnet: {
+      Base: '0xbeeF010f9cb27031ad51e3333f9aF9C6B1228183', // https://app.morpho.org/base/vault/0xbeeF010f9cb27031ad51e3333f9aF9C6B1228183/steakhouse-usdc
+    },
+    testnet: {},
+  },
+  morphoGauntletUsdcPrime: {
+    mainnet: {
+      Base: '0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61', // https://app.morpho.org/base/vault/0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61/gauntlet-usdc-prime
+      Optimism: '0xC30ce6A5758786e0F640cC5f881Dd96e9a1C5C59', // https://app.morpho.org/opmainnet/vault/0xC30ce6A5758786e0F640cC5f881Dd96e9a1C5C59/gauntlet-usdc-prime
+    },
+    testnet: {},
+  },
+  morphoSeamlessUsdcVault: {
+    mainnet: {
+      Base: '0x616a4E1db48e22028f6bbf20444Cd3b8e3273738', // https://app.morpho.org/base/vault/0x616a4E1db48e22028f6bbf20444Cd3b8e3273738/seamless-usdc-vault
+    },
+    testnet: {},
+  },
+  morphoSteakhouseHighYieldUsdc: {
+    mainnet: {
+      Arbitrum: '0x5c0C306Aaa9F877de636f4d5822cA9F2E81563BA', // https://app.morpho.org/arbitrum/vault/0x5c0C306Aaa9F877de636f4d5822cA9F2E81563BA/steakhouse-high-yield-usdc
+    },
+    testnet: {},
+  },
+  morphoHyperithmUsdc: {
+    mainnet: {
+      Arbitrum: '0x4B6F1C9E5d470b97181786b26da0d0945A7cf027', // https://app.morpho.org/arbitrum/vault/0x4B6F1C9E5d470b97181786b26da0d0945A7cf027/hyperithm-usdc
     },
     testnet: {},
   },
@@ -527,6 +566,8 @@ const mainnetContracts = {
     Beefy_compoundUsdc_Optimism:
       beefyVaultAddresses.compoundUsdc.mainnet.Optimism,
     walletHelper: walletHelperAddresses.mainnet.Optimism,
+    ERC4626_morphoGauntletUsdcPrime_Optimism:
+      erc4626VaultAddresses.morphoGauntletUsdcPrime.mainnet.Optimism,
   },
   Arbitrum: {
     aavePool: aaveAddresses.mainnet.Arbitrum,
@@ -546,6 +587,12 @@ const mainnetContracts = {
     Beefy_compoundUsdc_Arbitrum:
       beefyVaultAddresses.compoundUsdc.mainnet.Arbitrum,
     walletHelper: walletHelperAddresses.mainnet.Arbitrum,
+    ERC4626_morphoSteakhouseHighYieldUsdc_Arbitrum:
+      erc4626VaultAddresses.morphoSteakhouseHighYieldUsdc.mainnet.Arbitrum,
+    ERC4626_morphoGauntletUsdcCore_Arbitrum:
+      erc4626VaultAddresses.morphoGauntletUsdcCore.mainnet.Arbitrum,
+    ERC4626_morphoHyperithmUsdc_Arbitrum:
+      erc4626VaultAddresses.morphoHyperithmUsdc.mainnet.Arbitrum,
   },
   Base: {
     aavePool: aaveAddresses.mainnet.Base,
@@ -564,6 +611,14 @@ const mainnetContracts = {
     Beefy_morphoSeamlessUsdc_Base:
       beefyVaultAddresses.morphoSeamlessUsdc.mainnet.Base,
     walletHelper: walletHelperAddresses.mainnet.Base,
+    ERC4626_morphoSteakhousePrimeUsdc_Base:
+      erc4626VaultAddresses.morphoSteakhousePrimeUsdc.mainnet.Base,
+    ERC4626_morphoSteakhouseUsdc_Base:
+      erc4626VaultAddresses.morphoSteakhouseUsdc.mainnet.Base,
+    ERC4626_morphoGauntletUsdcPrime_Base:
+      erc4626VaultAddresses.morphoGauntletUsdcPrime.mainnet.Base,
+    ERC4626_morphoSeamlessUsdcVault_Base:
+      erc4626VaultAddresses.morphoSeamlessUsdcVault.mainnet.Base,
   },
 };
 harden(mainnetContracts);


### PR DESCRIPTION
## Description
Adds addresses of new morpho vaults required to be added.
These vaults belong to Arbitrum, Base and Optimism chains

### Testing Considerations
Testing of new addresses can only be performed on mainnet

### Upgrade Considerations
For these new addresses to work as expected. these components need to be upgraded:
- Ymax contract (To recevie the new addresses as private args)
- Ymax planner (To process the new addresses correctly)
- Ymax Web (Migration needs to be written to add these addresses as well)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for eight new ERC4626 USDC vaults across Base, Arbitrum, and Optimism (additional Morpho Steakhouse, Gauntlet, Seamless and Hyperithm vaults).

* **Configuration**
  * Public contract/config mappings updated to expose the new vault addresses on mainnet networks.

* **Tests**
  * Expanded network/prod tests to include the new vaults and cross-network pool validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->