### PR TITLE
wallet-admin tool etc.

### DIFF
--- a/multichain-testing/Makefile
+++ b/multichain-testing/Makefile
@@ -233,6 +233,8 @@ publish-ymax: ,$(CONTRACT_INSTANCE)-installed
 
 AGORIC_NET ?= devnet
 YMAX_TOOL=./scripts/ymax-tool.ts
+YMAX_ADMIN=../packages/portfolio-deploy/scripts/wallet-admin.ts
+PRIVATE_ARGS_OVERRIDES_SRC=$(DEPLOY)/config/private-args-overrides/$(if $(filter main,$(AGORIC_NET)),main,devnet).json
 
 ,$(CONTRACT_INSTANCE)-installed: $(DEPLOY)/dist/bundle-$(CONTRACT_INSTANCE).json
 	agd keys --keyring-backend=test show $(PUBLISHER)
@@ -240,7 +242,7 @@ YMAX_TOOL=./scripts/ymax-tool.ts
 
 ,privateArgsOverrides.json:
 	@echo "Using AGORIC_NET=$(AGORIC_NET)"
-	AGORIC_NET=$(AGORIC_NET) $(YMAX_TOOL) --buildEthOverrides >$@ || (rm $@; false)
+	cp $(PRIVATE_ARGS_OVERRIDES_SRC) $@ || (rm $@; false)
 
 yctrl-redeploy: ,$(CONTRACT_INSTANCE)-deployed
 
@@ -249,15 +251,15 @@ CONTRACT_FLAG=--contract=$(CONTRACT_INSTANCE)
 
 ,$(CONTRACT_INSTANCE)-deployed: $(DEPLOY)/dist/bundle-$(CONTRACT_INSTANCE).json ,$(CONTRACT_INSTANCE)-bundle-id ,$(CONTRACT_INSTANCE)-installed ,privateArgsOverrides.json
 	@[ -n "$$MNEMONIC" ] || (echo "ymaxControl MNEMONIC not set; see gov keys sheet"; false)
-	if [ -n "$$REASON" ]; then AGORIC_NET=devnet ./scripts/ymax-tool.ts $(CONTRACT_FLAG) --terminate "$(REASON)"; else true; fi
-	AGORIC_NET=devnet ./scripts/ymax-tool.ts $(CONTRACT_FLAG) --installAndStart $$(cat ,$(CONTRACT_INSTANCE)-bundle-id) <,privateArgsOverrides.json
+	if [ -n "$$REASON" ]; then AGORIC_NET=devnet $(YMAX_ADMIN) $(DEPLOY)/src/ymax-terminate.ts --contract $(CONTRACT_INSTANCE) --message "$(REASON)"; else true; fi
+	AGORIC_NET=devnet $(YMAX_ADMIN) $(DEPLOY)/src/ymax-install-and-start.ts --contract $(CONTRACT_INSTANCE) --bundle "$$(cat ,$(CONTRACT_INSTANCE)-bundle-id)" --overrides ,privateArgsOverrides.json
 	agoric follow -B $(NETCONFIG) -lF :published.agoricNames.instance >$@ || (rm $@; false)
 
 ,upgrade: $(DEPLOY)/dist/bundle-$(CONTRACT_INSTANCE).json ,$(CONTRACT_INSTANCE)-bundle-id ,$(CONTRACT_INSTANCE)-installed
-	AGORIC_NET=devnet ./scripts/ymax-tool.ts $(CONTRACT_FLAG) --upgrade $$(cat ,$(CONTRACT_INSTANCE)-bundle-id)
+	AGORIC_NET=devnet $(YMAX_ADMIN) $(DEPLOY)/src/ymax-upgrade.ts --contract $(CONTRACT_INSTANCE) --bundle "$$(cat ,$(CONTRACT_INSTANCE)-bundle-id)"
 
 ,creatorFacet: ,$(CONTRACT_INSTANCE)-deployed
-	AGORIC_NET=devnet ./scripts/ymax-tool.ts $(CONTRACT_FLAG) --getCreatorFacet
+	AGORIC_NET=devnet $(YMAX_ADMIN) $(DEPLOY)/src/ymax-get-creator-facet.ts --contract $(CONTRACT_INSTANCE)
 	touch $@
 
 ##
@@ -268,16 +270,16 @@ introduce-parties: ,invitePlanner ,inviteResolver
 PLANNER ?= agoric140yw0u2qrvmrgp33ejpddgnrwpm74vpfpx5v7n
 
 ,invitePlanner: ,creatorFacet
-	AGORIC_NET=devnet ./scripts/ymax-tool.ts $(CONTRACT_FLAG) --invitePlanner $(PLANNER)
+	AGORIC_NET=devnet $(YMAX_ADMIN) $(DEPLOY)/src/ymax-deliver-invitation.ts --contract $(CONTRACT_INSTANCE) --kind planner --to $(PLANNER)
 	touch $@
-	@echo now use planner MNEMONIC: ymax-tool.ts $(CONTRACT_FLAG) --redeem --description planner
+	@echo now use planner MNEMONIC: $(YMAX_ADMIN) $(DEPLOY)/src/redeem-invitation.ts --contract $(CONTRACT_INSTANCE) --description planner
 
 RESOLVER ?= $(PLANNER)
 ,inviteResolver: ,creatorFacet
 	AGORIC_NET=$(AGORIC_NET) \
-		$(YMAX_TOOL) $(CONTRACT_FLAG) --inviteResolver $(RESOLVER)
+		$(YMAX_ADMIN) $(DEPLOY)/src/ymax-deliver-invitation.ts --contract $(CONTRACT_INSTANCE) --kind resolver --to $(RESOLVER)
 	touch $@
-	@echo now use resolver MNEMONIC: ymax-tool.ts $(CONTRACT_FLAG) --redeem --description resolver
+	@echo now use resolver MNEMONIC: $(YMAX_ADMIN) $(DEPLOY)/src/redeem-invitation.ts --contract $(CONTRACT_INSTANCE) --description resolver --no-save
 
 check-vstorage: ,vstorage-outdated-$(AGORIC_NET).json
 

--- a/multichain-testing/Makefile
+++ b/multichain-testing/Makefile
@@ -234,25 +234,23 @@ publish-ymax: ,$(CONTRACT_INSTANCE)-installed
 AGORIC_NET ?= devnet
 YMAX_TOOL=./scripts/ymax-tool.ts
 YMAX_ADMIN=../packages/portfolio-deploy/scripts/wallet-admin.ts
-PRIVATE_ARGS_OVERRIDES_SRC=$(DEPLOY)/config/private-args-overrides/$(if $(filter main,$(AGORIC_NET)),main,devnet).json
+# Optional operator-supplied JSON file; omitted means privateArgsOverrides = {}
+PRIVATE_ARGS_OVERRIDES ?=
+OVERRIDES_ARG=$(if $(PRIVATE_ARGS_OVERRIDES),--overrides $(PRIVATE_ARGS_OVERRIDES),)
 
 ,$(CONTRACT_INSTANCE)-installed: $(DEPLOY)/dist/bundle-$(CONTRACT_INSTANCE).json
 	agd keys --keyring-backend=test show $(PUBLISHER)
 	AGORIC_NET=devnet ./scripts/install-bundle.ts $< >$@ || (rm $@; false)
-
-,privateArgsOverrides.json:
-	@echo "Using AGORIC_NET=$(AGORIC_NET)"
-	cp $(PRIVATE_ARGS_OVERRIDES_SRC) $@ || (rm $@; false)
 
 yctrl-redeploy: ,$(CONTRACT_INSTANCE)-deployed
 
 NETCONFIG=https://devnet.agoric.net/network-config
 CONTRACT_FLAG=--contract=$(CONTRACT_INSTANCE)
 
-,$(CONTRACT_INSTANCE)-deployed: $(DEPLOY)/dist/bundle-$(CONTRACT_INSTANCE).json ,$(CONTRACT_INSTANCE)-bundle-id ,$(CONTRACT_INSTANCE)-installed ,privateArgsOverrides.json
+,$(CONTRACT_INSTANCE)-deployed: $(DEPLOY)/dist/bundle-$(CONTRACT_INSTANCE).json ,$(CONTRACT_INSTANCE)-bundle-id ,$(CONTRACT_INSTANCE)-installed
 	@[ -n "$$MNEMONIC" ] || (echo "ymaxControl MNEMONIC not set; see gov keys sheet"; false)
 	if [ -n "$$REASON" ]; then AGORIC_NET=devnet $(YMAX_ADMIN) $(DEPLOY)/src/ymax-terminate.ts --contract $(CONTRACT_INSTANCE) --message "$(REASON)"; else true; fi
-	AGORIC_NET=devnet $(YMAX_ADMIN) $(DEPLOY)/src/ymax-install-and-start.ts --contract $(CONTRACT_INSTANCE) --bundle "$$(cat ,$(CONTRACT_INSTANCE)-bundle-id)" --overrides ,privateArgsOverrides.json
+	AGORIC_NET=devnet $(YMAX_ADMIN) $(DEPLOY)/src/ymax-install-and-start.ts --contract $(CONTRACT_INSTANCE) --bundle "$$(cat ,$(CONTRACT_INSTANCE)-bundle-id)" $(OVERRIDES_ARG)
 	agoric follow -B $(NETCONFIG) -lF :published.agoricNames.instance >$@ || (rm $@; false)
 
 ,upgrade: $(DEPLOY)/dist/bundle-$(CONTRACT_INSTANCE).json ,$(CONTRACT_INSTANCE)-bundle-id ,$(CONTRACT_INSTANCE)-installed

--- a/multichain-testing/scripts/deploy-cli.ts
+++ b/multichain-testing/scripts/deploy-cli.ts
@@ -11,7 +11,7 @@
  *
  * For portfolio-contract (ymax) upgrades, use the safe upgrade workflow:
  * - See multichain-testing/ymax-ops/Makefile
- * - Use ymax-tool.ts --upgrade for in-place upgrades
+ * - Use wallet-admin.ts with ymax-upgrade.ts for in-place upgrades
  * - Preserves existing contract state and instances
  */
 import '@endo/init/debug.js';

--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -5,14 +5,12 @@
  *
  * Not fully supported. It has zero test coverage and some parts are already known to have bit-rotted.
  *
- * Scope: CLI ergonomics and IO/ambient authority (console, env, repl, stdin/stdout).
+ * Scope: CLI ergonomics and IO/ambient authority (console, env, stdin/stdout).
  * This entrypoint maps shell arguments to intent and delegates execution to
  * reusable lib functions.
  */
 import '@endo/init';
 
-import type { PortfolioPlanner } from '@aglocal/portfolio-contract/src/planner.exo.ts';
-import type { start as YMaxStart } from '@aglocal/portfolio-contract/src/portfolio.contract.ts';
 import type { MovementDesc } from '@aglocal/portfolio-contract/src/type-guards-steps.ts';
 import {
   TargetAllocationShape,
@@ -29,19 +27,16 @@ import {
   gmpAddresses as gmpConfigs,
   type AxelarChainConfig,
 } from '@aglocal/portfolio-deploy/src/axelar-configs.js';
-import { lookupInterchainInfo } from '@aglocal/portfolio-deploy/src/orch.start.js';
 import { findOutdated } from '@aglocal/portfolio-deploy/src/vstorage-outdated.js';
-import { makeYmaxControlKitForChain } from '@aglocal/portfolio-deploy/src/ymax-control.js';
 import {
   fetchEnvNetworkConfig,
+  makeSigningSmartWalletKit,
+  makeSmartWalletKit,
   makeVStorage,
-  makeVstorageKit,
-  type makeSmartWalletKit,
   type SigningSmartWalletKit,
+  type SmartWalletKit,
   type TypedPublishedFor,
-  type VstorageKit,
 } from '@agoric/client-utils';
-import type { ContractControl } from '@agoric/deploy-script-support/src/control/contract-control.contract.js';
 import { AmountMath, type Brand } from '@agoric/ertp';
 import {
   multiplyBy,
@@ -66,29 +61,14 @@ import {
   getYmaxWitness,
   type TargetAllocation as Allocation,
 } from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.ts';
-import { YMAX_CONTROL_WALLET_KEY } from '@agoric/portfolio-api/src/portfolio-constants.js';
 import type { OfferStatus } from '@agoric/smart-wallet/src/offers.js';
 import { M } from '@agoric/store';
-import type { NameHub } from '@agoric/vats';
-import type { EMethods } from '@agoric/vow/src/E.js';
-import type { Instance } from '@agoric/zoe/src/zoeService/types.js';
-import type { StartedInstanceKit as ZStarted } from '@agoric/zoe/src/zoeService/utils.js';
-import type { StdFee } from '@cosmjs/stargate';
-import { E } from '@endo/far';
+import { SigningStargateClient } from '@cosmjs/stargate';
 import type { CopyRecord } from '@endo/pass-style';
-import { once } from 'node:events';
-import { readFile } from 'node:fs/promises';
-import { createRequire } from 'node:module';
-import repl from 'node:repl';
 import { parseArgs } from 'node:util';
 import type { HDAccount } from 'viem';
 import { mnemonicToAccount } from 'viem/accounts';
 import { walletUpdates } from '../tools/wallet-store-reflect.ts';
-
-const nodeRequire = createRequire(import.meta.url);
-const asset = (spec: string) => readFile(nodeRequire.resolve(spec), 'utf8');
-
-type YMaxStartFn = typeof YMaxStart;
 
 const getUsage = (programName: string): string =>
   `USAGE: ${programName} [options...] [operation]
@@ -101,28 +81,11 @@ Options:
   --evm-router <chainId>  Use an EVM router wallet and deposit from the given chain (e.g. 'Ethereum')
   --evm-verified-signer   Send the signer address as verified for EVM messages
   --contract=[ymax0]      Contract key in agoricNames.instance ('ymax0' or 'ymax1'), used for
-                          portfolios and invitations
-  --description=[planner] For use with --redeem ('planner', 'resolver', or 'evmWalletHandler',
-                          optionally preceded by 'deliver ')
+                          portfolios
 
 Operations:
   -h, --help                Show this help message
-  --repl                    Start a repl with walletStore and ${YMAX_CONTROL_WALLET_KEY} bound
   --checkStorage            Report outdated ymax0 vstorage nodes (older than agoricNames.instance)
-  --pruneStorage            Prune vstorage nodes read from Record<ParentPath, ChildPathSegment[]>
-                            stdin
-  --buildEthOverrides       Build privateArgsOverrides sufficient to add new EVM chains
-  --getCreatorFacet         Read the creator facet read from wallet store entry '${YMAX_CONTROL_WALLET_KEY}' and
-                            save the result in a new entry ('creatorFacet' for contract 'ymax0',
-                            otherwise \`creatorFacet-\${contract}\`)
-  --installAndStart <id>    Start a contract with bundleId <id> and privateArgsOverrides from stdin
-  --upgrade <id>            Upgrade to bundleId <id> and privateArgsOverrides from stdin
-  --terminate <message>     Terminate the contract instance
-  --inviteOwnerProxy <addr> Send EVM portfolio owner proxy invitation per --contract to <addr>
-  --invitePlanner <addr>    Send planner invitation per --contract to <addr>
-  --inviteResolver <addr>   Send resolver invitation per --contract to <addr>
-  --redeem                  Redeem invitation per --description
-  --submit-for <id>         Submit (empty) plan for portfolio <id>
   --open                    [default operation] Open a new portfolio per --positions and
                             --target-allocation. Uses an EVM wallet if --evm or --evm-router
 
@@ -132,11 +95,11 @@ Environment variables:
               "$subdomain,$chainId" or "$fqdn,$chainId" for submitting to $subdomain.rpc.agoric.net
               or $fqdn
   MNEMONIC:   The private key used to sign transactions (needed for all operations except
-              --checkStorage and --buildEthOverrides). For --evm / --evm-router, this is
+              --checkStorage). For --evm / --evm-router, this is
               the EVM wallet mnemonic.
   MNEMONIC_EVM_MESSAGE_HANDLER:
               The private key used to sign transactions from the EVM wallet handler
-              (needed for --evm / --evm-router, act as override for --redeem of evmWalletHandler).
+              (needed for --evm / --evm-router).
 `.trim();
 
 const parseToolArgs = (argv: string[]) =>
@@ -150,35 +113,12 @@ const parseToolArgs = (argv: string[]) =>
       evm: { type: 'string', default: '' },
       'evm-router': { type: 'string', default: '' },
       'evm-verified-signer': { type: 'boolean', default: false },
-      redeem: { type: 'boolean', default: false },
       contract: { type: 'string', default: 'ymax0' },
-      description: { type: 'string', default: 'planner' },
-      repl: { type: 'boolean', default: false },
-      getCreatorFacet: { type: 'boolean', default: false },
-      terminate: { type: 'string' },
-      buildEthOverrides: { type: 'boolean' },
-      installAndStart: { type: 'string' },
-      upgrade: { type: 'string' },
-      inviteOwnerProxy: { type: 'string' },
-      invitePlanner: { type: 'string' },
-      inviteResolver: { type: 'string' },
       checkStorage: { type: 'boolean' },
-      pruneStorage: { type: 'boolean', default: false },
-      'submit-for': { type: 'string' },
       help: { type: 'boolean', short: 'h', default: false },
     },
     allowPositionals: false,
   });
-
-const makeFee = ({
-  gas = 20_000, // cosmjs default
-  adjustment = 1.0,
-  denom = 'ubld',
-  price = 0.01, // ubld. per 2025-11 community discussion
-} = {}): StdFee => ({
-  gas: `${Math.round(gas * adjustment)}`,
-  amount: [{ denom, amount: `${Math.round(gas * adjustment * price)}` }],
-});
 
 type GoalData = Partial<Record<YieldProtocol, ParsableNumber>>;
 const YieldProtocolShape = M.or(...Object.keys(YieldProtocol));
@@ -191,11 +131,6 @@ const GoalDataShape: TypedPattern<GoalData> = M.recordOf(
 const trace = makeTracer('YMXTool');
 const { fromEntries } = Object;
 const { make } = AmountMath;
-
-const { bytecode: walletBytecode } = JSON.parse(
-  // eslint-disable-next-line @jessie.js/safe-await-separator
-  await asset('@aglocal/portfolio-deploy/tools/evm-orch/Wallet.json'),
-);
 
 const parseTypedJSON = <T>(
   json: string,
@@ -213,10 +148,10 @@ const parseTypedJSON = <T>(
   return result;
 };
 
-type SmartWalletKit = Awaited<ReturnType<typeof makeSmartWalletKit>>;
 type PortfolioReadPublished = <P extends string>(
   subpath: P,
 ) => Promise<TypedPublishedFor<P, PortfolioPublishedPathTypes>>;
+type SigningKitOptions = Parameters<typeof makeSigningSmartWalletKit>[0];
 
 const noPoll = (wk: SmartWalletKit): SmartWalletKit => ({
   ...wk,
@@ -416,90 +351,6 @@ const openPositionsEVM = async ({
 };
 
 /**
- * Get the creator facet key for a contract instance.
- * @param contract - The contract name (e.g., 'ymax0', 'ymax1')
- * @returns The key for accessing the creator facet in wallet store
- */
-const getCreatorFacetKey = (contract: string): string =>
-  contract === 'ymax0' ? 'creatorFacet' : `creatorFacet-${contract}`;
-
-/**
- * Build a NameHub suitable for use by lookupInterchainInfo,
- * filtering odd stuff found in devnet.
- *
- * @param vsk
- */
-const agoricNamesForChainInfo = (vsk: VstorageKit) => {
-  const { vstorage } = vsk;
-  const { readPublished } = vsk;
-
-  const byChainId = {};
-
-  const chainEntries = async (kind: string) => {
-    const out: [string, unknown][] = [];
-    const children = await vstorage.keys(`published.agoricNames.${kind}`);
-    for (const child of children) {
-      // console.error('readPublished', kind, child);
-      const value = await readPublished(`agoricNames.${kind}.${child}`);
-      // console.debug(kind, child, value);
-      if (kind === 'chain') {
-        const { chainId, namespace } = value as Record<string, string>;
-        if (namespace !== 'cosmos') {
-          console.warn('namespace?? skipping', kind, child, value);
-          continue;
-        }
-        if (typeof chainId === 'string') {
-          if (chainId in byChainId) throw Error(`oops! ${child} ${chainId}`);
-          byChainId[chainId] = value;
-        }
-      }
-      out.push([child, value]);
-    }
-    if (kind === 'chainConnection') {
-      const relevantConnections = out.filter(([key, _val]) => {
-        const [c1, c2] = key.split('_'); // XXX incomplete
-        return c1 in byChainId && c2 in byChainId;
-      });
-      return harden(relevantConnections);
-    }
-    return harden(out);
-  };
-
-  const lookup = async (kind: string) => {
-    switch (kind) {
-      case 'chain':
-      case 'chainConnection':
-        return harden({
-          entries: () => chainEntries(kind),
-        });
-      default:
-        return harden({
-          entries: async () => {
-            // console.debug(kind, 'entries');
-            return readPublished(`agoricNames.${kind}`) as Promise<
-              [[string, unknown]]
-            >;
-          },
-        });
-    }
-  };
-
-  const refuse = () => {
-    throw Error('access denied');
-  };
-
-  const agoricNames: NameHub = harden({
-    lookup,
-    entries: refuse,
-    has: refuse,
-    keys: refuse,
-    values: refuse,
-  });
-
-  return agoricNames;
-};
-
-/**
  * Get network-specific configurations based on AGORIC_NET environment variable
  *
  * @param network - The network name from AGORIC_NET env var
@@ -523,59 +374,10 @@ const getNetworkConfig = (network: 'main' | 'devnet') => {
   }
 };
 
-/**
- * Build privateArgsOverrides sufficient to add new EVM chains.
- *
- * @param vsk
- * @param axelarConfig
- * @param gmpAddresses
- */
-const overridesForEthChainInfo = async (
-  vsk: VstorageKit,
-  axelarConfig:
-    | typeof axelarConfigTestnet
-    | typeof axelarConfigMainnet = axelarConfigTestnet,
-  gmpAddresses:
-    | typeof gmpConfigs.testnet
-    | typeof gmpConfigs.mainnet = gmpConfigs.testnet,
-) => {
-  const { chainInfo: cosmosChainInfo } = await lookupInterchainInfo(
-    agoricNamesForChainInfo(vsk),
-    { agoric: ['ubld'], noble: ['uusdc'], axelar: ['uaxl'] },
-  );
-  const chainInfo = {
-    ...cosmosChainInfo,
-    ...objectMap(axelarConfig, info => info.chainInfo),
-  };
-
-  const privateArgsOverrides: Pick<
-    Parameters<YMaxStartFn>[1],
-    'axelarIds' | 'chainInfo' | 'contracts' | 'gmpAddresses'
-  > = harden({
-    axelarIds: objectMap(axelarConfig, c => c.axelarId),
-    contracts: objectMap(axelarConfig, c => c.contracts),
-    chainInfo,
-    gmpAddresses,
-    walletBytecode,
-  });
-  return privateArgsOverrides;
-};
-
-async function readText(stream: typeof process.stdin) {
-  const chunks: Buffer[] = [];
-  for await (const chunk of stream as AsyncIterable<Buffer>) chunks.push(chunk);
-  return Buffer.concat(chunks).toString('utf8');
-}
-
 const main = async (
   argv = process.argv,
   env = process.env,
-  {
-    fetch = globalThis.fetch,
-    now = Date.now,
-    stdin = process.stdin,
-    stdout = process.stdout,
-  } = {},
+  { fetch = globalThis.fetch, now = Date.now, stdout = process.stdout } = {},
 ) => {
   const { values } = parseToolArgs(argv);
 
@@ -590,23 +392,6 @@ const main = async (
     const vs = makeVStorage({ fetch }, networkConfig);
     const toPrune = await findOutdated(vs);
     stdout.write(JSON.stringify(toPrune, null, 2));
-    stdout.write('\n');
-    return;
-  }
-
-  if (values.buildEthOverrides) {
-    const vsk = makeVstorageKit({ fetch }, networkConfig);
-    const { AGORIC_NET: net } = env;
-    if (net !== 'main' && net !== 'devnet') {
-      throw Error(`unsupported/unknown net: ${net}`);
-    }
-    const { axelarConfig, gmpAddresses } = getNetworkConfig(net);
-    const privateArgsOverrides = await overridesForEthChainInfo(
-      vsk,
-      axelarConfig,
-      gmpAddresses,
-    );
-    stdout.write(JSON.stringify(privateArgsOverrides, null, 2));
     stdout.write('\n');
     return;
   }
@@ -626,180 +411,23 @@ const main = async (
       throw Error(`MNEMONIC_EVM_MESSAGE_HANDLER not set for EVM wallet`);
   }
 
-  if (values.redeem && values.description.includes('evmWalletHandler')) {
-    if (env.MNEMONIC_EVM_MESSAGE_HANDLER) {
-      console.warn(
-        `Using MNEMONIC_EVM_MESSAGE_HANDLER for evmWalletHandler redemption`,
-      );
-      MNEMONIC = env.MNEMONIC_EVM_MESSAGE_HANDLER;
-    }
-  }
-
-  const fresh = () => new Date(now()).toISOString();
-  const {
-    walletKit,
-    signer: sig,
-    walletStore,
-    ymaxControl,
-  } = await makeYmaxControlKitForChain(
-    { env, fetch, setTimeout, now },
-    {
-      mnemonic: MNEMONIC,
-      networkConfig,
-      walletKitTransform: values['skip-poll'] ? wk => noPoll(wk) : undefined,
-      log: trace,
-      makeNonce: fresh,
-      fee: makeFee({ gas: 809068, adjustment: 1.4 }),
-    },
+  const delay = (ms: number) =>
+    new Promise<void>(resolve => setTimeout(resolve, ms));
+  const walletKitBase = await makeSmartWalletKit(
+    { fetch, delay },
+    networkConfig,
+  );
+  const walletKit = values['skip-poll'] ? noPoll(walletKitBase) : walletKitBase;
+  // XXX TypeScript sees duplicate @cosmjs package identities between the
+  // workspace root and multichain-testing, so this identical runtime API needs
+  // an unknown cast to satisfy makeSigningSmartWalletKit's parameter type.
+  const connectWithSigner =
+    SigningStargateClient.connectWithSigner as unknown as SigningKitOptions['connectWithSigner'];
+  const sig = await makeSigningSmartWalletKit(
+    { walletUtils: walletKit, connectWithSigner },
+    MNEMONIC,
   );
   trace('address', sig.address);
-
-  if (values.redeem) {
-    const { contract, description } = values;
-    trace('getting instance', contract);
-    const { [contract]: instance } = fromEntries(
-      await walletKit.readPublished('agoricNames.instance'),
-    );
-
-    // XXX generalize to --no-save or some such?
-    // For wallets without myStore support, redeem without saving
-    const noSaveDescriptions = ['resolver', 'evmWalletHandler'];
-    const descWithoutDeliver = description.replace(/^deliver /, '');
-    if (noSaveDescriptions.includes(descWithoutDeliver)) {
-      const id = `redeem-${fresh()}`;
-      await sig.sendBridgeAction({
-        method: 'executeOffer',
-        offer: {
-          id,
-          invitationSpec: { source: 'purse', description, instance },
-          proposal: {},
-        },
-      });
-      await sig.pollOffer(sig.address, id, undefined, true);
-      return;
-    }
-
-    const saveTo = description.replace(/^deliver /, '');
-    const result = await walletStore.saveOfferResult(
-      { instance, description },
-      saveTo,
-    );
-    trace('redeem result', result);
-    return;
-  }
-
-  const yc = walletStore.get<ContractControl<YMaxStartFn>>(
-    YMAX_CONTROL_WALLET_KEY,
-  );
-
-  if (values.repl) {
-    const tools = {
-      E,
-      harden,
-      networkConfig,
-      walletKit,
-      signing: sig,
-      walletStore,
-      [YMAX_CONTROL_WALLET_KEY]: yc,
-    };
-    console.error('bindings:', Object.keys(tools).join(', '));
-    const session = repl.start({ prompt: 'ymax> ', useGlobal: true });
-    Object.assign(session.context, tools);
-    await once(session, 'exit');
-    return;
-  }
-
-  if (values.getCreatorFacet) {
-    const { contract } = values;
-    const creatorFacetKey = getCreatorFacetKey(contract);
-    await ymaxControl.saveAs(creatorFacetKey).getCreatorFacet();
-    return;
-  }
-
-  if (values.terminate) {
-    const { terminate: message } = values;
-    await yc.terminate({ message });
-    return;
-  }
-
-  if (values.installAndStart) {
-    const { installAndStart: bundleId } = values;
-
-    const privateArgsOverrides = JSON.parse(await readText(stdin));
-
-    const { BLD, USDC } = fromEntries(
-      await walletKit.readPublished('agoricNames.issuer'),
-    );
-
-    // work around goofy devnet PoC token
-    const { upoc26 } = fromEntries(
-      await walletKit.readPublished('agoricNames.vbankAsset'),
-    );
-
-    await yc.installAndStart({
-      bundleId,
-      issuers: { USDC, BLD, Fee: BLD, Access: upoc26.issuer },
-      privateArgsOverrides,
-    });
-    return;
-  }
-
-  if (values.upgrade) {
-    const { upgrade: bundleId } = values;
-
-    const privateArgsOverrides = JSON.parse(await readText(stdin));
-
-    await yc.upgrade({ bundleId, privateArgsOverrides });
-    return;
-  }
-
-  if (values.pruneStorage) {
-    const txt = await readText(stdin);
-    const toPrune: Record<string, string[]> = JSON.parse(txt);
-    // avoid: Must not have more than 80 properties: (an object)
-    const batchSize = 50;
-
-    const es = Object.entries(toPrune);
-    for (let i = 0; i < es.length; i += batchSize) {
-      const batch = es.slice(i, i + batchSize);
-      await yc.pruneChainStorage(fromEntries(batch));
-    }
-    return;
-  }
-
-  // Deliver planner/resolver/EVM Wallet Handler invitations as specified.
-  type CFMethods = ZStarted<YMaxStartFn>['creatorFacet'];
-  const inviters: Partial<
-    Record<
-      keyof typeof values,
-      (cf: EMethods<CFMethods>, ps: Instance, addr: string) => Promise<void>
-    >
-  > = {
-    invitePlanner: (cf, ps, addr) => cf.deliverPlannerInvitation(addr, ps),
-    inviteResolver: (cf, ps, addr) => cf.deliverResolverInvitation(addr, ps),
-    inviteOwnerProxy: (cf, ps, addr) =>
-      cf.deliverEVMWalletHandlerInvitation(addr, ps),
-  };
-  for (const [optName, inviter] of Object.entries(inviters)) {
-    const { contract, [optName as keyof typeof values]: addr } = values;
-    if (typeof addr !== 'string') continue;
-    const creatorFacetKey = getCreatorFacetKey(contract);
-    const creatorFacet = walletStore.get<CFMethods>(creatorFacetKey);
-    const instances = await walletKit.readPublished('agoricNames.instance');
-    const { postalService } = fromEntries(instances);
-    // @ts-expect-error xxx PASS_STYLE
-    await inviter(creatorFacet, postalService, addr);
-    return;
-  }
-
-  if (values['submit-for']) {
-    const portfolioId = Number(values['submit-for']);
-    const planner = walletStore.get<PortfolioPlanner>('planner');
-    const policyVersion = 0; // XXX should get from vstorage
-    const rebalanceCount = 0;
-    await planner.submit(portfolioId, [], policyVersion, rebalanceCount);
-    return;
-  }
 
   // if (values['open'])
   const positionData = parseTypedJSON(values.positions, GoalDataShape);
@@ -863,7 +491,7 @@ const main = async (
       // XXX would be nice if readPublished allowed ^published.
       const subPath = path.replace(/^published./, '') as typeof path;
       const pq = makePortfolioQuery(
-        walletKit.readPublished as PortfolioReadPublished,
+        sig.readPublished as PortfolioReadPublished,
         subPath,
       );
       const status = await pq.getPortfolioStatus();

--- a/multichain-testing/ymax-ops/Makefile
+++ b/multichain-testing/ymax-ops/Makefile
@@ -6,11 +6,13 @@ AGORIC_NET ?= devnet
 CONTRACT ?= ymax0
 
 YMAX_TOOL=../scripts/ymax-tool.ts
+WALLET_ADMIN=../../packages/portfolio-deploy/scripts/wallet-admin.ts
 AGD=agd
 AGORIC=agoric
 JQ=jq
 
 DEPLOY=../../packages/portfolio-deploy
+OVERRIDES_SRC=$(DEPLOY)/config/private-args-overrides/$(if $(filter main,$(AGORIC_NET)),main,devnet).json
 
 ##
 # default make target: no chain interaction
@@ -67,22 +69,22 @@ redeem-ymaxControl:
 	@[ -n "$$MNEMONIC" ] || (echo "ymaxControl MNEMONIC not set; see 1password"; false)
 	@echo "Using AGORIC_NET=$(AGORIC_NET)"
 	AGORIC_NET=$(AGORIC_NET) \
-		$(YMAX_TOOL) --redeem --contract 'postalService' --description 'deliver ymaxControl'
+		$(WALLET_ADMIN) $(DEPLOY)/src/redeem-invitation.ts --contract postalService --description 'deliver ymaxControl'
 
 REASON ?=
 $(CONTRACT)-terminate:
 	@test -n "$(REASON)" || { echo "REASON not set."; exit 1; }
 	AGORIC_NET=$(AGORIC_NET) \
-		$(YMAX_TOOL) --terminate "$(REASON)"
+		$(WALLET_ADMIN) $(DEPLOY)/src/ymax-terminate.ts --contract $(CONTRACT) --message "$(REASON)"
 
 ,privateArgsOverrides.json:
 	@echo "Using AGORIC_NET=$(AGORIC_NET)"
-	AGORIC_NET=$(AGORIC_NET) $(YMAX_TOOL) --buildEthOverrides >$@ || (rm $@; false)
+	cp $(OVERRIDES_SRC) $@
 
 NETCONFIG=https://$(AGORIC_NET).agoric.net/network-config
 ,$(CONTRACT)-deployed: ,ymax-bundle-id ,privateArgsOverrides.json ,ymax-installed
 	AGORIC_NET=$(AGORIC_NET) \
-		$(YMAX_TOOL) --installAndStart $$(cat ,ymax-bundle-id) <,privateArgsOverrides.json
+		$(WALLET_ADMIN) $(DEPLOY)/src/ymax-install-and-start.ts --contract $(CONTRACT) --bundle "$$(cat ,ymax-bundle-id)" --overrides ,privateArgsOverrides.json
 	agoric follow -B $(NETCONFIG) -lF :published.agoricNames.instance >$@ || (rm $@; false)
 	tail $@
 
@@ -93,24 +95,24 @@ NETCONFIG=https://$(AGORIC_NET).agoric.net/network-config
 
 ,creatorFacet-$(CONTRACT): ,$(CONTRACT)-deployed
 	AGORIC_NET=$(AGORIC_NET) \
-		$(YMAX_TOOL) --getCreatorFacet
+		$(WALLET_ADMIN) $(DEPLOY)/src/ymax-get-creator-facet.ts --contract $(CONTRACT)
 	touch $@
 
 PLANNER ?= agoric1y3e3mlnrkuh6j2qcnlrtap42j8mzw240vwr74j
 ,invitePlanner-$(CONTRACT): ,creatorFacet-$(CONTRACT) ,$(CONTRACT)-planner-provisioned.json
 	AGORIC_NET=$(AGORIC_NET) \
-		$(YMAX_TOOL) --invitePlanner $(PLANNER) >$@ || \
+		$(WALLET_ADMIN) $(DEPLOY)/src/ymax-deliver-invitation.ts --contract $(CONTRACT) --kind planner --to $(PLANNER) >$@ || \
 		(rm $@; false)
 	tail $@
-	@echo now use planner MNEMONIC: ymax-tool.ts --redeem
+	@echo now use planner MNEMONIC: $(WALLET_ADMIN) $(DEPLOY)/src/redeem-invitation.ts --contract $(CONTRACT) --description planner
 
 RESOLVER ?= agoric1y3e3mlnrkuh6j2qcnlrtap42j8mzw240vwr74j
 ,inviteResolver-$(CONTRACT): ,creatorFacet-$(CONTRACT)
 	AGORIC_NET=$(AGORIC_NET) \
-		$(YMAX_TOOL) --inviteResolver $(RESOLVER) >$@ || \
+		$(WALLET_ADMIN) $(DEPLOY)/src/ymax-deliver-invitation.ts --contract $(CONTRACT) --kind resolver --to $(RESOLVER) >$@ || \
 		(rm $@; false)
 	tail $@
-	@echo now use resolver MNEMONIC: ymax-tool.ts --redeem
+	@echo now use resolver MNEMONIC: $(WALLET_ADMIN) $(DEPLOY)/src/redeem-invitation.ts --contract $(CONTRACT) --description resolver --no-save
 
 check-vstorage: ,vstorage-outdated-$(AGORIC_NET).json
 
@@ -123,7 +125,7 @@ prune-vstorage: ,vstorage-pruned
 
 ,vstorage-pruned: ,vstorage-outdated-$(AGORIC_NET).json
 	@echo "Using AGORIC_NET=$(AGORIC_NET)"
-	AGORIC_NET=$(AGORIC_NET) $(YMAX_TOOL) --pruneStorage < $<
+	AGORIC_NET=$(AGORIC_NET) $(WALLET_ADMIN) $(DEPLOY)/src/ymax-prune-storage.ts --contract $(CONTRACT) --input $<
 	touch $@
 
 NODE=https://main.rpc.agoric.net:443
@@ -145,15 +147,15 @@ fund-fee-acct: ,$(CONTRACT)-node.json
 
 # check that the account we're using matches the contract we're upgrading...
 check-control-account:
-	$(YMAX_TOOL) --repl </dev/null | grep $(YMAX_CONTROL_ADDR)
+	$(WALLET_ADMIN) $(DEPLOY)/src/ymax-repl.ts </dev/null | grep $(YMAX_CONTROL_ADDR)
 
-,$(CONTRACT)-upgraded: ,ymax-bundle-id ,ymax-installed ,privateArgsOverrides.json check-control-account
+,$(CONTRACT)-upgraded: ,ymax-bundle-id ,ymax-installed ,privateArgsOverrides.json
 	AGORIC_NET=$(AGORIC_NET) \
-		$(YMAX_TOOL) --upgrade <,privateArgsOverrides.json $$(cat ,ymax-bundle-id) >$@ || (rm $@; false)
+		$(WALLET_ADMIN) $(DEPLOY)/src/ymax-upgrade.ts --contract $(CONTRACT) --overrides ,privateArgsOverrides.json --bundle "$$(cat ,ymax-bundle-id)" >$@ || (mv $@ $(@)_ERR; false)
 
 ,$(CONTRACT)-upgraded-repl: ,ymax-upgrade.js ,ymax-installed
 	AGORIC_NET=$(AGORIC_NET) \
-		$(YMAX_TOOL) --repl <,ymax-upgrade.js >$@ || (rm $@; false)
+		$(WALLET_ADMIN) $(DEPLOY)/src/ymax-repl.ts <,ymax-upgrade.js >$@ || (mv $@ $(@)_ERR; false)
 
 clean:
 	rm -rf ,* $(DEPLOY)/dist/

--- a/multichain-testing/ymax-ops/Makefile
+++ b/multichain-testing/ymax-ops/Makefile
@@ -12,7 +12,9 @@ AGORIC=agoric
 JQ=jq
 
 DEPLOY=../../packages/portfolio-deploy
-OVERRIDES_SRC=$(DEPLOY)/config/private-args-overrides/$(if $(filter main,$(AGORIC_NET)),main,devnet).json
+# Optional operator-supplied JSON file; omitted means privateArgsOverrides = {}
+PRIVATE_ARGS_OVERRIDES ?=
+OVERRIDES_ARG=$(if $(PRIVATE_ARGS_OVERRIDES),--overrides $(PRIVATE_ARGS_OVERRIDES),)
 
 ##
 # default make target: no chain interaction
@@ -77,14 +79,10 @@ $(CONTRACT)-terminate:
 	AGORIC_NET=$(AGORIC_NET) \
 		$(WALLET_ADMIN) $(DEPLOY)/src/ymax-terminate.ts --contract $(CONTRACT) --message "$(REASON)"
 
-,privateArgsOverrides.json:
-	@echo "Using AGORIC_NET=$(AGORIC_NET)"
-	cp $(OVERRIDES_SRC) $@
-
 NETCONFIG=https://$(AGORIC_NET).agoric.net/network-config
-,$(CONTRACT)-deployed: ,ymax-bundle-id ,privateArgsOverrides.json ,ymax-installed
+,$(CONTRACT)-deployed: ,ymax-bundle-id ,ymax-installed
 	AGORIC_NET=$(AGORIC_NET) \
-		$(WALLET_ADMIN) $(DEPLOY)/src/ymax-install-and-start.ts --contract $(CONTRACT) --bundle "$$(cat ,ymax-bundle-id)" --overrides ,privateArgsOverrides.json
+		$(WALLET_ADMIN) $(DEPLOY)/src/ymax-install-and-start.ts --contract $(CONTRACT) --bundle "$$(cat ,ymax-bundle-id)" $(OVERRIDES_ARG)
 	agoric follow -B $(NETCONFIG) -lF :published.agoricNames.instance >$@ || (rm $@; false)
 	tail $@
 
@@ -149,9 +147,9 @@ fund-fee-acct: ,$(CONTRACT)-node.json
 check-control-account:
 	$(WALLET_ADMIN) $(DEPLOY)/src/ymax-repl.ts </dev/null | grep $(YMAX_CONTROL_ADDR)
 
-,$(CONTRACT)-upgraded: ,ymax-bundle-id ,ymax-installed ,privateArgsOverrides.json
+,$(CONTRACT)-upgraded: ,ymax-bundle-id ,ymax-installed
 	AGORIC_NET=$(AGORIC_NET) \
-		$(WALLET_ADMIN) $(DEPLOY)/src/ymax-upgrade.ts --contract $(CONTRACT) --overrides ,privateArgsOverrides.json --bundle "$$(cat ,ymax-bundle-id)" >$@ || (mv $@ $(@)_ERR; false)
+		$(WALLET_ADMIN) $(DEPLOY)/src/ymax-upgrade.ts --contract $(CONTRACT) $(OVERRIDES_ARG) --bundle "$$(cat ,ymax-bundle-id)" >$@ || (mv $@ $(@)_ERR; false)
 
 ,$(CONTRACT)-upgraded-repl: ,ymax-upgrade.js ,ymax-installed
 	AGORIC_NET=$(AGORIC_NET) \

--- a/packages/portfolio-deploy/scripts/wallet-admin.ts
+++ b/packages/portfolio-deploy/scripts/wallet-admin.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env -S node --import ts-blank-space/register
+/**
+ * @file tools for smart wallet stores, e.g. ymaxControl
+ */
+import '@endo/init';
+
+import {
+  fetchEnvNetworkConfig,
+  makeSigningSmartWalletKit,
+  makeSmartWalletKit,
+  reflectWalletStore,
+} from '@agoric/client-utils';
+import { makeTracer } from '@agoric/internal';
+import { makeFileRW } from '@agoric/pola-io/src/file.js';
+import { SigningStargateClient, type StdFee } from '@cosmjs/stargate';
+import { Fail } from '@endo/errors';
+import { E } from '@endo/far';
+import fsp from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import type { RunTools } from '../src/wallet-admin-types.ts';
+
+const Usage = `tool.ts MODULE ...args`;
+
+const trace = makeTracer('wallet-admin');
+type ClientUtilsConnect = Parameters<
+  typeof makeSigningSmartWalletKit
+>[0]['connectWithSigner'];
+
+const makeFee = ({
+  gas = 20_000, // cosmjs default
+  adjustment = 1.0,
+  price = 0.03,
+  denom = 'ubld',
+} = {}): StdFee => ({
+  gas: `${Math.round(gas * adjustment)}`,
+  amount: [{ denom, amount: `${Math.round(gas * adjustment * price)}` }],
+});
+
+export const main = async (
+  argv = process.argv,
+  env = process.env,
+  {
+    fetch = globalThis.fetch,
+    setTimeout = globalThis.setTimeout,
+    connectWithSigner = SigningStargateClient.connectWithSigner as ClientUtilsConnect,
+    now = Date.now,
+    cwd = process.cwd,
+  } = {},
+) => {
+  const fresh = () => new Date(now()).toISOString();
+  const delay = (ms: number) =>
+    new Promise(resolve => setTimeout(resolve, ms)).then(_ => {});
+
+  const networkConfig = await fetchEnvNetworkConfig({ env, fetch });
+  const walletKit = await makeSmartWalletKit({ fetch, delay }, networkConfig);
+
+  const storeOpts = {
+    setTimeout,
+    log: trace,
+    makeNonce: fresh,
+    // use generous gas limit for portfolio-contract,
+    // and a gas price as observed on the RPC node we use on this network.
+    fee: makeFee({ gas: 2_500_000 }),
+    maxRetries: 30,
+  } as const;
+
+  const makeAccount = async (name: string) => {
+    trace('makeAccount', name);
+    const mnemonic = env[name] || Fail`${name} not set`;
+    const ssk = await makeSigningSmartWalletKit(
+      { connectWithSigner, walletUtils: walletKit },
+      mnemonic,
+    );
+    return harden({
+      ...ssk,
+      get store() {
+        return reflectWalletStore(ssk, storeOpts);
+      },
+    });
+  };
+
+  const [_node, _script, specifier, ...scriptArgs] = argv;
+
+  if (!specifier) throw Usage;
+  const cwdPath = `${cwd()}/`;
+  const nodeRequire = createRequire(cwdPath);
+  const modPath = nodeRequire.resolve(specifier);
+  const mod = await import(modPath);
+  const fn: (tools: Partial<RunTools>) => Promise<void> = mod.default;
+  if (!fn) {
+    throw Error(`no default export from ${specifier}`);
+  }
+
+  const cwdIO = makeFileRW(cwdPath, { fsp, path });
+  const tools = {
+    E,
+    harden,
+    scriptArgs,
+    walletKit,
+    makeAccount,
+    cwd: cwdIO,
+  };
+  await fn(tools);
+};
+
+// TODO: use endo-exec so we can unit test the above
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/portfolio-deploy/src/invite-ems.ts
+++ b/packages/portfolio-deploy/src/invite-ems.ts
@@ -1,0 +1,76 @@
+/**
+ * @file for use with wallet-admin
+ */
+import type { start as YMaxStart } from '@aglocal/portfolio-contract/src/portfolio.contract.ts';
+import { makeTracer } from '@agoric/internal';
+import type { Bech32Address } from '@agoric/orchestration';
+import type { StartedInstanceKit as ZStarted } from '@agoric/zoe/src/zoeService/utils.js';
+import type { Details } from 'ses';
+import type { RunTools } from './wallet-admin-types.ts';
+
+const Usage = `invite-ems ymax1 | ymax0`;
+
+// #region import from portfolio-deploy
+type CFMethods = ZStarted<typeof YMaxStart>['creatorFacet'];
+
+type YmaxContractName = 'ymax0' | 'ymax1';
+
+function assertYmaxContractName(
+  specimen: unknown,
+  details?: Details,
+): asserts specimen is YmaxContractName {
+  assert(specimen === 'ymax0' || specimen === 'ymax1', details);
+}
+
+const EVM_WALLET_HANDLER_KEY = 'evmWalletHandler';
+// #endregion
+
+const trace = makeTracer('invite-ems');
+
+const inviteEMS = async ({ scriptArgs, makeAccount, walletKit }: RunTools) => {
+  await null;
+  const [contract] = scriptArgs;
+  assertYmaxContractName(contract, Usage);
+
+  const traceC = trace.sub(contract);
+  const prefix = contract.toUpperCase();
+
+  const { postalService, ...instances } = walletKit.agoricNames.instance;
+
+  const deliverInvitation = async (emsAddr: Bech32Address) => {
+    const ctrlAcct = await makeAccount(`${prefix}_CTRL`);
+    traceC.sub('ymaxControl')(ctrlAcct.address);
+
+    const creatorFacet = ctrlAcct.store.get<CFMethods>('creatorFacet');
+
+    traceC('deliver EMS invitation to', emsAddr);
+    await creatorFacet.deliverEVMWalletHandlerInvitation(
+      emsAddr,
+      postalService,
+    );
+  };
+
+  const makeEMS = async () => {
+    const emsAcct = await makeAccount(`${prefix}_EMS`);
+    traceC.sub('EMS')(emsAcct.address);
+
+    return harden({
+      getAddress: () => emsAcct.address,
+      redeem: async (description = EVM_WALLET_HANDLER_KEY) => {
+        const instance = instances[contract];
+        const saveTo = description.replace(/^deliver /, '');
+        const result = await emsAcct.store.saveOfferResult(
+          { instance, description },
+          saveTo,
+        );
+        traceC('redeem result', result);
+      },
+    });
+  };
+
+  const ems = await makeEMS();
+  await deliverInvitation(ems.getAddress() as Bech32Address);
+  await ems.redeem();
+};
+
+export default inviteEMS;

--- a/packages/portfolio-deploy/src/redeem-invitation.ts
+++ b/packages/portfolio-deploy/src/redeem-invitation.ts
@@ -1,0 +1,60 @@
+/** @file redeem a privileged invitation from a wallet */
+import { parseArgs } from 'node:util';
+import type { RunTools } from './wallet-admin-types.ts';
+
+const options = {
+  contract: { type: 'string', default: 'ymax0' },
+  description: { type: 'string' },
+  'save-as': { type: 'string' },
+  'no-save': { type: 'boolean', default: false },
+  'mnemonic-env': { type: 'string' },
+} as const;
+
+const getMnemonicEnv = (description: string, explicit?: string): string =>
+  explicit ||
+  (description.includes('evmWalletHandler')
+    ? 'MNEMONIC_EVM_MESSAGE_HANDLER'
+    : 'MNEMONIC');
+
+const redeemInvitation = async ({
+  scriptArgs,
+  walletKit,
+  makeAccount,
+}: RunTools) => {
+  const { values } = parseArgs({ args: scriptArgs, options });
+  const {
+    contract,
+    description,
+    'save-as': saveAs,
+    'no-save': noSave,
+    'mnemonic-env': explicitMnemonicEnv,
+  } = values;
+  if (!description) throw Error('--description missing');
+
+  const mnemonicEnv = getMnemonicEnv(description, explicitMnemonicEnv);
+  const account = await makeAccount(mnemonicEnv);
+  const { [contract]: instance } = walletKit.agoricNames.instance;
+  if (!instance) throw Error(`contract? ${contract}`);
+
+  if (noSave) {
+    const id = `redeem-${new Date().toISOString()}`;
+    await account.sendBridgeAction({
+      method: 'executeOffer',
+      offer: {
+        id,
+        invitationSpec: { source: 'purse', description, instance },
+        proposal: {},
+      },
+    });
+    await account.pollOffer(account.address, id, undefined, true);
+    return;
+  }
+
+  const defaultSaveAs = description.replace(/^deliver /, '');
+  await account.store.saveOfferResult(
+    { instance, description },
+    saveAs || defaultSaveAs,
+  );
+};
+
+export default redeemInvitation;

--- a/packages/portfolio-deploy/src/submit-plan.ts
+++ b/packages/portfolio-deploy/src/submit-plan.ts
@@ -1,0 +1,25 @@
+/** @file submit an empty rebalance plan for a portfolio */
+import type { PortfolioPlanner } from '@aglocal/portfolio-contract/src/planner.exo.ts';
+import { parseArgs } from 'node:util';
+import type { RunTools } from './wallet-admin-types.ts';
+
+const options = {
+  'portfolio-id': { type: 'string' },
+} as const;
+
+const submitPlan = async ({ scriptArgs, makeAccount }: RunTools) => {
+  const { values } = parseArgs({ args: scriptArgs, options });
+  const { 'portfolio-id': rawPortfolioId } = values;
+  if (!rawPortfolioId) throw Error('--portfolio-id missing');
+  const portfolioId = Number(rawPortfolioId);
+  if (!Number.isInteger(portfolioId))
+    throw Error(`portfolio-id? ${rawPortfolioId}`);
+
+  const account = await makeAccount('MNEMONIC');
+  const planner = account.store.get<PortfolioPlanner>('planner');
+  const policyVersion = 0; // XXX should get from vstorage
+  const rebalanceCount = 0;
+  await planner.submit(portfolioId, [], policyVersion, rebalanceCount);
+};
+
+export default submitPlan;

--- a/packages/portfolio-deploy/src/wallet-admin-types.ts
+++ b/packages/portfolio-deploy/src/wallet-admin-types.ts
@@ -1,0 +1,25 @@
+/**
+ * @file types for admin tool endowments
+ *
+ * @see '../scripts/wallet-admin.ts'
+ */
+import type {
+  SigningSmartWalletKit,
+  SmartWalletKit,
+  reflectWalletStore,
+} from '@agoric/client-utils';
+import type { FileRW } from '@agoric/pola-io/src/file.js';
+import type { E } from '@endo/far';
+
+export type SigningSmartWalletKitWithStore = SigningSmartWalletKit & {
+  store: ReturnType<typeof reflectWalletStore>;
+};
+
+export interface RunTools {
+  scriptArgs: string[];
+  walletKit: SmartWalletKit;
+  makeAccount(name: string): Promise<SigningSmartWalletKitWithStore>;
+  E: typeof E;
+  harden: typeof harden;
+  cwd: FileRW;
+}

--- a/packages/portfolio-deploy/src/ymax-admin-helpers.ts
+++ b/packages/portfolio-deploy/src/ymax-admin-helpers.ts
@@ -1,0 +1,48 @@
+/** @file shared helpers for ymax wallet-admin modules */
+import type { start as YMaxStart } from '@aglocal/portfolio-contract/src/portfolio.contract.ts';
+import type { ContractControl } from '@agoric/deploy-script-support/src/control/contract-control.contract.js';
+import { makeTracer } from '@agoric/internal';
+import {
+  CONTROL_ADDRESSES,
+  PORTFOLIO_CONTRACT_NAMES,
+  YMAX_CONTROL_WALLET_KEY as WALLET_KEY,
+} from '@agoric/portfolio-api/src/portfolio-constants.js';
+import type { RunTools } from './wallet-admin-types.ts';
+
+export { WALLET_KEY };
+
+const trace = makeTracer('ymax-admin');
+
+export const netOfConfig = (c: { chainName: string }) =>
+  c.chainName === 'agoric-3' ? 'main' : 'devnet';
+
+export const getCreatorFacetKey = (contract: string): string =>
+  contract === 'ymax0' ? 'creatorFacet' : `creatorFacet-${contract}`;
+
+export const checkContract = (
+  contract: string,
+  address: string,
+  net: 'main' | 'devnet',
+) => {
+  const traceC = trace.sub(contract);
+  traceC.sub(WALLET_KEY)(address);
+
+  if (!(PORTFOLIO_CONTRACT_NAMES as readonly string[]).includes(contract)) {
+    throw Error(`contract? ${contract}`);
+  }
+  if (address !== CONTROL_ADDRESSES[contract][net]) {
+    throw Error(`wrong MNEMONIC for ${contract} on ${net}`);
+  }
+};
+
+export const getYmaxControlKit = async (
+  makeAccount: RunTools['makeAccount'],
+  contract: string,
+) => {
+  const account = await makeAccount('MNEMONIC');
+  const net = netOfConfig(account.networkConfig);
+  checkContract(contract, account.address, net);
+  const ymaxControl =
+    account.store.get<ContractControl<typeof YMaxStart>>(WALLET_KEY);
+  return { account, net, ymaxControl };
+};

--- a/packages/portfolio-deploy/src/ymax-deliver-invitation.ts
+++ b/packages/portfolio-deploy/src/ymax-deliver-invitation.ts
@@ -1,0 +1,42 @@
+/** @file deliver a ymax privileged invitation to a target address */
+import type { Instance } from '@agoric/zoe/src/zoeService/types.js';
+import { parseArgs } from 'node:util';
+import type { RunTools } from './wallet-admin-types.ts';
+import { getCreatorFacetKey, getYmaxControlKit } from './ymax-admin-helpers.ts';
+
+type InvitationKind = 'planner' | 'resolver' | 'ownerProxy';
+
+const options = {
+  contract: { type: 'string', default: 'ymax0' },
+  kind: { type: 'string' },
+  to: { type: 'string' },
+} as const;
+
+const inviters: Record<
+  InvitationKind,
+  (cf: any, ps: Instance, addr: string) => Promise<void>
+> = {
+  planner: (cf, ps, addr) => cf.deliverPlannerInvitation(addr, ps),
+  resolver: (cf, ps, addr) => cf.deliverResolverInvitation(addr, ps),
+  ownerProxy: (cf, ps, addr) => cf.deliverEVMWalletHandlerInvitation(addr, ps),
+};
+
+const deliverInvitation = async ({
+  scriptArgs,
+  walletKit,
+  makeAccount,
+}: RunTools) => {
+  const { values } = parseArgs({ args: scriptArgs, options });
+  const { contract, kind, to } = values;
+  if (!kind) throw Error('--kind missing');
+  if (!(kind in inviters)) throw Error(`kind? ${kind}`);
+  if (!to) throw Error('--to missing');
+
+  const { account } = await getYmaxControlKit(makeAccount, contract);
+  const creatorFacetKey = getCreatorFacetKey(contract);
+  const creatorFacet = account.store.get(creatorFacetKey);
+  const { postalService } = walletKit.agoricNames.instance;
+  await inviters[kind as InvitationKind](creatorFacet, postalService, to);
+};
+
+export default deliverInvitation;

--- a/packages/portfolio-deploy/src/ymax-get-creator-facet.ts
+++ b/packages/portfolio-deploy/src/ymax-get-creator-facet.ts
@@ -1,0 +1,17 @@
+/** @file save a ymax creator facet into the operator wallet store */
+import { parseArgs } from 'node:util';
+import type { RunTools } from './wallet-admin-types.ts';
+import { getCreatorFacetKey, getYmaxControlKit } from './ymax-admin-helpers.ts';
+
+const options = {
+  contract: { type: 'string', default: 'ymax0' },
+} as const;
+
+const getCreatorFacet = async ({ scriptArgs, makeAccount }: RunTools) => {
+  const { contract } = parseArgs({ args: scriptArgs, options }).values;
+  const { ymaxControl } = await getYmaxControlKit(makeAccount, contract);
+  const creatorFacetKey = getCreatorFacetKey(contract);
+  await ymaxControl.saveAs(creatorFacetKey).getCreatorFacet();
+};
+
+export default getCreatorFacet;

--- a/packages/portfolio-deploy/src/ymax-install-and-start.ts
+++ b/packages/portfolio-deploy/src/ymax-install-and-start.ts
@@ -1,0 +1,44 @@
+/** @file install and start a ymax contract via ymaxControl */
+import type { start as YMaxStart } from '@aglocal/portfolio-contract/src/portfolio.contract.ts';
+import type { ContractControl } from '@agoric/deploy-script-support/src/control/contract-control.contract.js';
+import { Fail } from '@endo/errors';
+import { parseArgs } from 'node:util';
+import type { RunTools } from './wallet-admin-types.ts';
+import { WALLET_KEY, getYmaxControlKit } from './ymax-admin-helpers.ts';
+
+const options = {
+  contract: { type: 'string', default: 'ymax0' },
+  bundle: { type: 'string' },
+  overrides: { type: 'string' },
+} as const;
+
+const installAndStartYmax = async ({
+  scriptArgs,
+  walletKit,
+  makeAccount,
+  cwd,
+}: RunTools) => {
+  const { values } = parseArgs({ args: scriptArgs, options });
+  const { contract, bundle: bundleId, overrides } = values;
+  if (!bundleId) throw Error('--bundle missing');
+
+  const privateArgsOverrides = await (overrides
+    ? cwd.readOnly().join(overrides).readJSON()
+    : {});
+
+  const { BLD, USDC } = walletKit.agoricNames.issuer;
+  const vbankAssets = walletKit.agoricNames.vbankAsset;
+  const accessIssuer =
+    vbankAssets.upoc26?.issuer || Fail`upoc26 issuer missing`;
+
+  const { account } = await getYmaxControlKit(makeAccount, contract);
+  const ymaxControl =
+    account.store.get<ContractControl<typeof YMaxStart>>(WALLET_KEY);
+  await ymaxControl.installAndStart({
+    bundleId,
+    issuers: { USDC, BLD, Fee: BLD, Access: accessIssuer as any },
+    privateArgsOverrides,
+  });
+};
+
+export default installAndStartYmax;

--- a/packages/portfolio-deploy/src/ymax-prune-storage.ts
+++ b/packages/portfolio-deploy/src/ymax-prune-storage.ts
@@ -1,0 +1,28 @@
+/** @file prune ymax-related chain storage via ymaxControl */
+import { parseArgs } from 'node:util';
+import type { RunTools } from './wallet-admin-types.ts';
+import { getYmaxControlKit } from './ymax-admin-helpers.ts';
+
+const options = {
+  contract: { type: 'string', default: 'ymax0' },
+  input: { type: 'string' },
+} as const;
+
+const pruneStorage = async ({ scriptArgs, makeAccount, cwd }: RunTools) => {
+  const { values } = parseArgs({ args: scriptArgs, options });
+  const { contract, input } = values;
+  if (!input) throw Error('--input missing');
+  const toPrune = await cwd.readOnly().join(input).readJSON();
+  const { ymaxControl } = await getYmaxControlKit(makeAccount, contract);
+
+  const batchSize = 50;
+  const es = Object.entries(toPrune as Record<string, string[]>);
+  for (let i = 0; i < es.length; i += batchSize) {
+    const batch = es.slice(i, i + batchSize);
+    console.error(`pruning ${batch.length} keys from ${contract}...`);
+    await ymaxControl.pruneChainStorage(Object.fromEntries(batch));
+  }
+  console.error(`pruned ${es.length} keys from ${contract}`);
+};
+
+export default pruneStorage;

--- a/packages/portfolio-deploy/src/ymax-repl.ts
+++ b/packages/portfolio-deploy/src/ymax-repl.ts
@@ -1,0 +1,36 @@
+/** @file start a repl with ymax wallet-admin bindings */
+import type { start as YMaxStart } from '@aglocal/portfolio-contract/src/portfolio.contract.ts';
+import type { ContractControl } from '@agoric/deploy-script-support/src/control/contract-control.contract.js';
+import { once } from 'node:events';
+import repl from 'node:repl';
+import type { RunTools } from './wallet-admin-types.ts';
+import { WALLET_KEY } from './ymax-admin-helpers.ts';
+
+const startYmaxRepl = async ({
+  E,
+  harden,
+  makeAccount,
+  walletKit,
+}: RunTools) => {
+  const account = await makeAccount('MNEMONIC');
+  const ymaxControl =
+    account.store.get<ContractControl<typeof YMaxStart>>(WALLET_KEY);
+
+  const tools = {
+    E,
+    harden,
+    networkConfig: account.networkConfig,
+    walletKit,
+    signing: account,
+    walletStore: account.store,
+    [WALLET_KEY]: ymaxControl,
+  };
+  console.error('bindings:', Object.keys(tools).join(', '));
+  console.log(account.address);
+
+  const session = repl.start({ prompt: 'ymax> ', useGlobal: true });
+  Object.assign(session.context, tools);
+  await once(session, 'exit');
+};
+
+export default startYmaxRepl;

--- a/packages/portfolio-deploy/src/ymax-terminate.ts
+++ b/packages/portfolio-deploy/src/ymax-terminate.ts
@@ -1,0 +1,19 @@
+/** @file terminate a ymax contract via ymaxControl */
+import { parseArgs } from 'node:util';
+import type { RunTools } from './wallet-admin-types.ts';
+import { getYmaxControlKit } from './ymax-admin-helpers.ts';
+
+const options = {
+  contract: { type: 'string', default: 'ymax0' },
+  message: { type: 'string' },
+} as const;
+
+const terminateYmax = async ({ scriptArgs, makeAccount }: RunTools) => {
+  const { values } = parseArgs({ args: scriptArgs, options });
+  const { message, contract } = values;
+  if (!message) throw Error('--message missing');
+  const { ymaxControl } = await getYmaxControlKit(makeAccount, contract);
+  await ymaxControl.terminate({ message });
+};
+
+export default terminateYmax;

--- a/packages/portfolio-deploy/src/ymax-upgrade.ts
+++ b/packages/portfolio-deploy/src/ymax-upgrade.ts
@@ -1,0 +1,39 @@
+/** @file upgrade ymax using ymaxControl */
+import type { start as YMaxStart } from '@aglocal/portfolio-contract/src/portfolio.contract.ts';
+import type { ContractControl } from '@agoric/deploy-script-support/src/control/contract-control.contract.js';
+import { parseArgs } from 'node:util';
+import type { RunTools } from './wallet-admin-types.ts';
+import {
+  WALLET_KEY,
+  checkContract,
+  netOfConfig,
+} from './ymax-admin-helpers.ts';
+
+const options = {
+  contract: { type: 'string', default: 'ymax0' },
+  bundle: { type: 'string' },
+  overrides: { type: 'string' },
+} as const;
+
+const upgradeYmax = async ({ scriptArgs, makeAccount, cwd }: RunTools) => {
+  const { values } = parseArgs({ args: scriptArgs, options });
+  const { contract, bundle: bundleId, overrides } = values;
+  if (!bundleId) throw Error('--bundle missing');
+
+  const privateArgsOverrides = await (overrides
+    ? cwd.readOnly().join(overrides).readJSON()
+    : {});
+
+  // XXX use different env var per account?
+  const account = await makeAccount(`MNEMONIC`);
+  const net = netOfConfig(account.networkConfig);
+  checkContract(contract, account.address, net);
+
+  const ymaxControl =
+    account.store.get<ContractControl<typeof YMaxStart>>(WALLET_KEY);
+
+  const { tx } = await ymaxControl.upgrade({ bundleId, privateArgsOverrides });
+  console.log('upgrade tx', tx);
+};
+
+export default upgradeYmax;


### PR DESCRIPTION
refs:

- https://github.com/Agoric/agoric-sdk/pull/12349
- https://github.com/Agoric/agoric-private/issues/744

## Description

Moves YMax deploy/admin flows out of `ymax-tool.ts` into standalone modules under `packages/portfolio-deploy`, run via `portfolio-deploy/scripts/wallet-admin.ts`.

### Security / Scaling / Documentation

N/A

## Upgrade Considerations

Manual deploy/upgrade no longer generates `,privateArgsOverrides.json`. Operators must pass `PRIVATE_ARGS_OVERRIDES=/path/to/file.json` explicitly when non-default overrides are needed; otherwise the workflow uses the default `{}` value.

### Testing Considerations

While the deploy/admin code still doesn't have unit tests, it's no longer intertwined with the rest of `ymax-tool.ts`, so we can have more confidence in it by inspection.

