### PR TITLE
fix: allow sourceAddress in PublishedTxShapes CCTP_TO_EVM

### DIFF
--- a/packages/portfolio-contract/src/resolver/types.ts
+++ b/packages/portfolio-contract/src/resolver/types.ts
@@ -79,6 +79,7 @@ const PublishedTxShapes: Record<string, TypedPattern<PublishedTx>> = harden({
       amount: M.nat(),
     },
     {
+      sourceAddress: AccountIdShape,
       ...optionalPublishedTxProps,
     },
     {},

--- a/packages/portfolio-contract/test/offer-shapes.test.ts
+++ b/packages/portfolio-contract/test/offer-shapes.test.ts
@@ -529,6 +529,11 @@ test('published tx shape accepts nextTxId field', t => {
   } as const;
 
   const cases = harden({
+    hasSource: {
+      ...cctp,
+      status: TxStatus.PENDING,
+      sourceAddress: 'comsos:agoric:agoric123lkjsdlj',
+    },
     cctpPending: {
       ...cctp,
       status: TxStatus.PENDING,


### PR DESCRIPTION
refs:
 - https://github.com/Agoric/agoric-sdk/pull/12394

## Description

The planner is struggling; symptoms:

```
🚨 Failed to read old pending tx published.ymax0.pendingTxs.tx1257 {
  amount: 1495000n,
  destinationAddress: 'eip155:43114:0x4fb064a73f01d65ac01b6ab98e414bb0c9cf3602',
  sourceAddress: 'eip155:42161:0x24039fed660bb7cae8bbdd0a0359d54b9099a992',
  status: 'pending',
  type: 'CCTP_TO_EVM'
} (Error#1)
```


### Security / Scaling / Documentation Considerations

none

### Testing Considerations

shape test updated

### Upgrade Considerations

compatible with
 - ymax0 planner deploy-on-merge
 - future contract upgrades



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source address support for cross-chain transaction types.

* **Tests**
  * Added validation test case for source address field in transaction data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->