### PR TITLE
chore(ymax-resolver): add stable error codes to watcher timeout/not-found

### DIFF
--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -487,6 +487,17 @@ export type HandlePendingTxOpts = {
   pendingTxAbortControllers: Map<TxId, AbortController>;
 } & EvmContext;
 
+/**
+ * Stable error codes prefixed to watcher timeout and lookback not-found log
+ * messages. Ops alerting in #ops-ymax-resolver matches on these codes so that
+ * alert patterns don't break when log message text is updated.
+ */
+export const PendingTxCode = {
+  GMP_TX_NOT_FOUND: 'GMP_TX_NOT_FOUND',
+  WALLET_TX_NOT_FOUND: 'WALLET_TX_NOT_FOUND',
+  CCTP_TX_NOT_FOUND: 'CCTP_TX_NOT_FOUND',
+} as const;
+
 export const TX_TIMEOUT_MS = 30 * 60 * 1000; // 30 min
 export const handlePendingTx = async (
   tx: PendingTx,

--- a/services/ymax-planner/src/watchers/cctp-watcher.ts
+++ b/services/ymax-planner/src/watchers/cctp-watcher.ts
@@ -2,12 +2,12 @@ import type { Filter, WebSocketProvider, Log } from 'ethers';
 import { id, zeroPadValue, getAddress, ethers } from 'ethers';
 import type { CaipChainId } from '@agoric/orchestration';
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
+import { PendingTxCode, TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
 import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
   type WatcherTimeoutOptions,
 } from '../support.ts';
-import { TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
 import {
   deleteTxBlockLowerBound,
   getTxBlockLowerBound,
@@ -146,7 +146,9 @@ export const watchCctpTransfer = ({
 
     timeoutId = setTimeout(() => {
       if (!transferFound) {
-        log(`✗ No matching transfer found within ${timeoutMs / 60000} minutes`);
+        log(
+          `[${PendingTxCode.CCTP_TX_NOT_FOUND}] ✗ No matching transfer found within ${timeoutMs / 60000} minutes`,
+        );
       }
     }, timeoutMs);
   });
@@ -216,7 +218,7 @@ export const lookBackCctp = async ({
     );
 
     if (!matchingEvent) {
-      log(`No matching transfer found`);
+      log(`[${PendingTxCode.CCTP_TX_NOT_FOUND}] No matching transfer found`);
       return { settled: false };
     }
 

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -5,6 +5,7 @@ import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types.js';
 import type { CaipChainId } from '@agoric/orchestration';
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import { tryJsonParse } from '@agoric/internal';
+import { PendingTxCode } from '../pending-tx-manager.ts';
 import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
@@ -258,7 +259,7 @@ export const watchGmp = ({
     timeoutId = setTimeout(() => {
       if (!done) {
         log(
-          `✗ No transaction status found for txId ${txId} within ${
+          `[${PendingTxCode.GMP_TX_NOT_FOUND}] ✗ No transaction status found for txId ${txId} within ${
             timeoutMs / 60000
           } minutes`,
         );
@@ -350,7 +351,9 @@ export const lookBackGmp = async ({
       };
     }
 
-    log(`No matching MulticallStatus or MulticallExecuted found`);
+    log(
+      `[${PendingTxCode.GMP_TX_NOT_FOUND}] No matching MulticallStatus or MulticallExecuted found`,
+    );
     return { settled: false };
   } catch (error) {
     log(`Error:`, error);

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -4,12 +4,12 @@ import type { WebSocket } from 'ws';
 import type { CaipChainId } from '@agoric/orchestration';
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import { tryJsonParse } from '@agoric/internal';
+import { PendingTxCode, TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
 import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
   type WatcherTimeoutOptions,
 } from '../support.ts';
-import { TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
 import {
   deleteTxBlockLowerBound,
   getTxBlockLowerBound,
@@ -323,7 +323,7 @@ export const watchSmartWalletTx = ({
     timeoutId = setTimeout(() => {
       if (!done) {
         log(
-          `✗ No wallet creation found for expectedAddr ${expectedAddr} within ${
+          `[${PendingTxCode.WALLET_TX_NOT_FOUND}] ✗ No wallet creation found for expectedAddr ${expectedAddr} within ${
             timeoutMs / 60000
           } minutes`,
         );
@@ -418,7 +418,9 @@ export const lookBackSmartWalletTx = async ({
     ]);
 
     if (!matchingEvent) {
-      log(`No matching SmartWalletCreated event found`);
+      log(
+        `[${PendingTxCode.WALLET_TX_NOT_FOUND}] No matching SmartWalletCreated event found`,
+      );
       return { settled: false };
     }
 

--- a/services/ymax-planner/test/abort-signal.test.ts
+++ b/services/ymax-planner/test/abort-signal.test.ts
@@ -246,7 +246,7 @@ test('handlePendingTx aborts CCTP watcher in lookback mode when signal is aborte
     `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${fromBlock + 9}`,
     '[TEST] Aborting signal',
     `[${txId}] [LogScan] Aborted`,
-    `[${txId}] No matching transfer found`,
+    `[${txId}] [CCTP_TX_NOT_FOUND] No matching transfer found`,
     `[${txId}] Lookback completed without finding transaction, waiting for live mode`,
   ]);
 });
@@ -329,7 +329,7 @@ test('handlePendingTx aborts GMP watcher in lookback mode when signal is aborted
     `[${txId}] [LogScan] Searching chunk ${fromBlock} → ${fromBlock + 9}`,
     '[TEST] Aborting signal',
     `[${txId}] [LogScan] Aborted`,
-    `[${txId}] No matching MulticallStatus or MulticallExecuted found`,
+    `[${txId}] [GMP_TX_NOT_FOUND] No matching MulticallStatus or MulticallExecuted found`,
     `[${txId}] Lookback completed without finding transaction, waiting for live mode`,
   ]);
 });

--- a/services/ymax-planner/test/cctp-watcher.test.ts
+++ b/services/ymax-planner/test/cctp-watcher.test.ts
@@ -164,7 +164,7 @@ test('handlePendingTx keeps tx pending on amount mismatch until timeout and then
     `[${txId}] Watching for ERC-20 transfers to: ${receiver} with amount: ${expectedAmount}`,
     `[${txId}] Transfer detected: token=${usdcAddress} from=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 to=${receiver} amount=${notExpectedAmt} tx=0x123abc`,
     `[${txId}] Amount mismatch. Expected: ${expectedAmount}, Received: ${notExpectedAmt}`,
-    `[${txId}] ✗ No matching transfer found within 0.05 minutes`,
+    `[${txId}] [CCTP_TX_NOT_FOUND] ✗ No matching transfer found within 0.05 minutes`,
     `[${txId}] Transfer detected: token=${usdcAddress} from=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 to=${receiver} amount=${amount} tx=0x123abc`,
     `[${txId}] ✓ Amount matches! Expected: ${amount}, Received: ${amount}`,
     `[${txId}] CCTP tx resolved`,

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -129,7 +129,7 @@ test('handlePendingTx logs a time out on a GMP transaction with no matching even
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching transaction status for txId: ${txId} at contract: ${contractAddress}`,
-    `[${txId}] ✗ No transaction status found for txId ${txId} within 0.01 minutes`,
+    `[${txId}] [GMP_TX_NOT_FOUND] ✗ No transaction status found for txId ${txId} within 0.01 minutes`,
     `[${txId}] ✅ SUCCESS: txId=${txId} txHash=0x123abc block=18500000`,
     `[${txId}] GMP tx resolved`,
   ]);

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -166,7 +166,7 @@ test('handlePendingTx logs timeout on MAKE_ACCOUNT transaction with no matching 
     `[${txId}] Watching for wallet creation: subscribing to ${factoryAddress}, expecting event from ${factoryAddress}, expectedAddr ${expectedWalletAddr}`,
     `[${txId}] Attempting to subscribe to ${factoryAddress}...`,
     `[${txId}] ✓ Subscribed to ${factoryAddress} (subscription ID: mock-subscription-id)`,
-    `[${txId}] ✗ No wallet creation found for expectedAddr ${expectedWalletAddr} within 0.05 minutes`,
+    `[${txId}] [WALLET_TX_NOT_FOUND] ✗ No wallet creation found for expectedAddr ${expectedWalletAddr} within 0.05 minutes`,
     `[${txId}] ✅ SUCCESS: expectedAddr=${expectedWalletAddr} txHash=0x123abc block=18500000`,
     `[${txId}] MAKE_ACCOUNT tx resolved`,
   ]);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

- Add stable error codes (`GMP_TX_NOT_FOUND`, `WALLET_TX_NOT_FOUND`, `CCTP_TX_NOT_FOUND`) to watcher timeout and lookback not-found log messages.
- Ops alerting in `#ops-ymax-resolver` matches on log strings to detect pending tx timeouts; recent message text changes broke those patterns silently.
- Error codes are prefixed as [`GMP_TX_NOT_FOUND`] etc., decoupling alerting from message wording

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployments for `ymax0` and `ymax1`
- Updated alert mechanism to listen for the error codes added in this PR (`GMP_TX_NOT_FOUND`, `WALLET_TX_NOT_FOUND`, `CCTP_TX_NOT_FOUND`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized transaction error logging with diagnostic codes. Log messages now include specific codes when transactions are not found or timeout, improving operational visibility and enabling more consistent alerting across transaction watchers for better debugging and incident response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->