### PR TITLE
ci(ymax-planner): add deploy-ymax1-planner to ymax1-mainnet environment

### DIFF
--- a/.github/workflows/deploy-ymax1-planner.yml
+++ b/.github/workflows/deploy-ymax1-planner.yml
@@ -21,6 +21,8 @@ permissions:
 jobs:
   deploy-ymax1-planner:
     runs-on: ubuntu-latest
+    environment:
+      name: ymax1-mainnet
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
This PR adds deploy-ymax1-planner to ymax1-mainnet environment, which has below protection rule applied at it

<img width="784" height="188" alt="image" src="https://github.com/user-attachments/assets/6b7706e9-c54f-4769-9900-e513b4bed46c" />


### Security Considerations
Reduce the list of people who can deploy to ymax1

### Scaling Considerations
N/A

### Documentation Considerations
N/A

### Testing Considerations
N/A

### Upgrade Considerations
This would allow us an opportunity to review things before deploying to ymax1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment pipeline configuration to specify the target deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->