### PR TITLE
fix(portfolio-contract): Remove direct CCTPv2 routes from the production network

### DIFF
--- a/packages/portfolio-contract/tools/network/prod-network.ts
+++ b/packages/portfolio-contract/tools/network/prod-network.ts
@@ -181,6 +181,8 @@ export const PROD_NETWORK: NetworkSpec = {
     // Estimated time: ~13-60 seconds depending on finality threshold
     // Note: CCTPv2 contracts must be deployed on both source and destination chains
 
+    /* DIRECT CCTPv2 TEMPORARILY DISABLED
+
     // Arbitrum ↔ other EVM chains
     {
       src: '@Arbitrum',
@@ -368,6 +370,8 @@ export const PROD_NETWORK: NetworkSpec = {
       min: 100_000n,
       feeMode: 'evmToEvm',
     },
+
+    */
   ],
 };
 

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -757,7 +757,8 @@ test('planRebalanceToAllocations uses CCTPv2 for multi-EVM rebalance', async t =
   }
 });
 
-test('planRebalanceToAllocations selects correct routes for Base → Avalanche + Noble split', async t => {
+// Disabled per https://github.com/Agoric/agoric-private/issues/768
+test.failing('planRebalanceToAllocations selects correct routes for Base → Avalanche + Noble split', async t => {
   // Starting: Funds on Base
   // Goal: Split between Avalanche Aave and Noble USDN
   // Expected:

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -794,9 +794,10 @@ test.failing(
       'Avalanche route should use CCTPv2',
     );
 
-  // Snapshot the full plan for regression tracking
-  t.snapshot(plan, 'Base to Avalanche + Noble split routing');
-});
+    // Snapshot the full plan for regression tracking
+    t.snapshot(plan, 'Base to Avalanche + Noble split routing');
+  },
+);
 
 test('planRebalanceToAllocations regression - CCTPv2 multi-source rebalance', async t => {
   const targetAllocation = {

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -758,39 +758,41 @@ test('planRebalanceToAllocations uses CCTPv2 for multi-EVM rebalance', async t =
 });
 
 // Disabled per https://github.com/Agoric/agoric-private/issues/768
-test.failing('planRebalanceToAllocations selects correct routes for Base → Avalanche + Noble split', async t => {
-  // Starting: Funds on Base
-  // Goal: Split between Avalanche Aave and Noble USDN
-  // Expected:
-  //   - Base → Avalanche via CCTPv2 (direct, ~60s)
-  //   - Base → Noble via CCTPv1 (via @agoric, ~1080s)
-  // CCTPv2 should NOT be used for the Noble leg
+test.failing(
+  'planRebalanceToAllocations selects correct routes for Base → Avalanche + Noble split',
+  async t => {
+    // Starting: Funds on Base
+    // Goal: Split between Avalanche Aave and Noble USDN
+    // Expected:
+    //   - Base → Avalanche via CCTPv2 (direct, ~60s)
+    //   - Base → Noble via CCTPv1 (via @agoric, ~1080s)
+    // CCTPv2 should NOT be used for the Noble leg
 
-  const targetAllocation = {
-    Aave_Avalanche: 50n,
-    USDN: 50n,
-  };
-  const currentBalances = {
-    Aave_Base: makeDeposit(20_000_000n),
-  };
+    const targetAllocation = {
+      Aave_Avalanche: 50n,
+      USDN: 50n,
+    };
+    const currentBalances = {
+      Aave_Base: makeDeposit(20_000_000n),
+    };
 
-  const plan = await planRebalanceToAllocations({
-    ...plannerContext,
-    currentBalances,
-    targetAllocation,
-    network: PROD_NETWORK, // XXX why doesn't this work with the test net???
-  });
+    const plan = await planRebalanceToAllocations({
+      ...plannerContext,
+      currentBalances,
+      targetAllocation,
+      network: PROD_NETWORK, // XXX why doesn't this work with the test net???
+    });
 
-  // Check Avalanche route uses CCTPv2
-  const toAvalancheStep = plan.flow.find(
-    m => m.src === '@Base' && m.dest === '@Avalanche',
-  );
-  t.truthy(toAvalancheStep, 'Should have Base → Avalanche step');
-  t.deepEqual(
-    toAvalancheStep?.detail,
-    { cctpVersion: 2n },
-    'Avalanche route should use CCTPv2',
-  );
+    // Check Avalanche route uses CCTPv2
+    const toAvalancheStep = plan.flow.find(
+      m => m.src === '@Base' && m.dest === '@Avalanche',
+    );
+    t.truthy(toAvalancheStep, 'Should have Base → Avalanche step');
+    t.deepEqual(
+      toAvalancheStep?.detail,
+      { cctpVersion: 2n },
+      'Avalanche route should use CCTPv2',
+    );
 
   // Snapshot the full plan for regression tracking
   t.snapshot(plan, 'Base to Avalanche + Noble split routing');


### PR DESCRIPTION
Fixes https://github.com/Agoric/agoric-private/issues/768
Ref #12427

### Upgrade Considerations
Safe for immediate deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled cross-chain transfer routes between EVM networks (Arbitrum, Ethereum, Base, Avalanche) in production

* **Tests**
  * Updated test expectations for Base → Avalanche split transfer scenario

<!-- end of auto-generated comment: release notes by coderabbit.ai -->