### PR TITLE
feat(portfolio-contract): remove Access token requirement for openPortfolio

### DIFF
--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -532,10 +532,15 @@ export const contract = async (
     'usedAccessTokens',
     () => zcf.makeEmptySeatKit().zcfSeat,
   );
+  // Access token gating has been removed; if provided, consume one for backward compatibility.
   const consumeAccessToken = brands.Access
     ? (seat: ZCFSeat) => {
+        const {
+          give: { Access: offeredAccess },
+        } = seat.getProposal() as ProposalType['openPortfolio'];
+        if (!offeredAccess) return;
         const Access = AmountMath.make(brands.Access, 1n);
-        zcf.atomicRearrange([[seat, usedAccessTokens, { Access }]]);
+        zcf.atomicRearrange(harden([[seat, usedAccessTokens, { Access }]]));
       }
     : () => {};
 
@@ -548,8 +553,7 @@ export const contract = async (
      * The resulting portfolio can be rebalanced via continuing invitations.
      *
      * @see {@link ProposalType.openPortfolio} for proposal structure.
-     *   Note that if the contract is started with an `Access` issuer,
-     *   a non-empty amount of that token is required.
+     *   Access token, if present in terms, is accepted but not required.
      *
      * @see {@link OfferArgsFor.openPortfolio} for offer arguments
      * @see {@link openPortfolio} for the underlying flow implementation

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -8,7 +8,7 @@
  * makers for ongoing operations like rebalancing.
  *
  * **Proposals and Offer Args**
- * - {@link ProposalType.openPortfolio}: Initial funding with USDC, Access tokens, and protocol allocations
+ * - {@link ProposalType.openPortfolio}: Initial funding with USDC and protocol allocations
  * - {@link ProposalType.rebalance}: Add funds (give) or withdraw funds (want) from protocols
  * - {@link OfferArgsFor}: Cross-chain parameters like `destinationEVMChain` for EVM operations
  *
@@ -69,13 +69,14 @@ export const makeProposalShapes = (
   accessBrand?: Brand<'nat'>,
 ) => {
   const $Shape = makeNatAmountShape(usdcBrand);
-  const accessShape = harden({
+  const openOptionalGive = harden({
+    Deposit: $Shape,
     ...(accessBrand && { Access: makeNatAmountShape(accessBrand, 1n) }),
   });
 
   const openPortfolio = M.splitRecord(
     {
-      give: M.splitRecord(accessShape, { Deposit: $Shape }, {}),
+      give: M.splitRecord({}, openOptionalGive, {}),
     },
     { want: {}, exit: M.any() },
     {},

--- a/packages/portfolio-contract/test/offer-shapes.test.ts
+++ b/packages/portfolio-contract/test/offer-shapes.test.ts
@@ -35,12 +35,19 @@ test('ProposalShapes', t => {
   const cases = harden({
     openPortfolio: {
       pass: {
+        noGive: { give: {} },
         noPositions: { give: { Access: poc26(1n) } },
         withDeposit: { give: { Deposit: usdc(123n), Access: poc26(1n) } },
+        withDepositNoAccess: { give: { Deposit: usdc(123n) } },
         aaveGMPFeePaidByContract: {
           give: {
             Deposit: usdc(6123n),
             Access: poc26(1n),
+          },
+        },
+        aaveGMPFeePaidByContractNoAccess: {
+          give: {
+            Deposit: usdc(6123n),
           },
         },
         withDepositAndAccess: {

--- a/packages/portfolio-contract/test/portfolio.contract.test.ts
+++ b/packages/portfolio-contract/test/portfolio.contract.test.ts
@@ -2513,7 +2513,7 @@ test('open portfolio does not require Access token when Access issuer is present
   const { usdc, bld, poc26 } = common.brands;
   const { when } = common.utils.vowTools;
 
-  const { mint: _usdcMint, ...usdcSansMint } = usdc;
+  const usdcSansMint = usdc;
   const { mint: _bldMint, ...bldSansMint } = bld;
   const { mint: _poc26Mint, ...poc26SansMint } = poc26;
 
@@ -2523,7 +2523,7 @@ test('open portfolio does not require Access token when Access issuer is present
     when,
   );
 
-  const done = await wallet.executePublicOffer({
+  const doneP = wallet.executePublicOffer({
     id: 'open-no-access',
     invitationSpec: {
       source: 'contract',
@@ -2533,6 +2533,9 @@ test('open portfolio does not require Access token when Access issuer is present
     proposal: { give: {} },
     offerArgs: {},
   });
+  const done = await Promise.all([doneP, ackNFA(common.utils)]).then(
+    ([result]) => result,
+  );
 
   t.is(passStyleOf(done.result.invitationMakers), 'remotable');
   t.like(done.result.publicSubscribers, {


### PR DESCRIPTION
closes: #12457

## Description

This PR removes the `Access` token requirement from `portfolio-contract` `openPortfolio` offers, even when the contract was originally started with an `Access` issuer in terms (as in `ymax1`).

Implementation checklist:
- [x] Remove Access token gating in the open-portfolio path while preserving upgrade compatibility.

Changes included:
- `portfolio-contract`:
  - updated open-portfolio proposal handling so `give.Access` is not required
  - removed Access-token consumption for open offers
  - adjusted proposal-shape tests for optional Access behavior
  - added/updated contract test coverage proving open works without Access token even when Access issuer is present
- `portfolio-deploy`:
  - added upgrade test covering upgrade-in-place (no terminate/start) and preserved existing portfolios
  - verified post-upgrade open flow without Access token requirement

### Security Considerations

This changes admission policy for opening portfolios by removing Access-token gating. No additional authority boundaries are introduced.

### Scaling Considerations

No significant CPU/storage/network impact is expected.

### Documentation Considerations

User-facing behavior changes: Access token is no longer required to open a portfolio. Any docs that mention mandatory `Access: poc26.make(1n)` should be updated.

### Testing Considerations

- [x] Added targeted regression test for opening without `Access` when Access issuer is present.
- [x] Added `portfolio-deploy` upgrade test
  - deploy upgrade test exercises upgrade plumbing/state preservation and post-upgrade behavior, and does not attempt to prove old-bundle -> new-bundle migration.

### Upgrade Considerations

This change is intended for upgrade of an already-started instance (`ymax1`) without terminate/start, preserving existing user portfolio state.

Assumption for this PR:
- We presume there have been no intervening incompatible durable-state schema changes (in `portfolio-contract`) between the currently deployed `ymax1` code and this upgrade target.

Verification should explicitly confirm:
- pre-upgrade portfolios remain available
- post-upgrade open works without Access token




