### PR TITLE
prefer performance.now()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ per https://agents.md/
 - ESLint configured via `eslint.config.mjs` (includes AVA, TypeScript, JSDoc, and repository-specific rules).
 - Package names: publishable packages use `@agoric/*`; private/local packages use `@aglocal/*` (verify with `yarn lint:package-names`).
 - `@aglocal` packages are private and never published; `@agoric` packages are published and may only depend on published packages, so `@agoric` packages must never import `@aglocal` packages.
+- For elapsed duration measurement (benchmarks, latency logs, monotonic timeout windows), prefer `performance.now()` over `Date.now()`. Use `Date.now()` for wall-clock timestamps, IDs, and protocol deadlines.
 - Entrypoints vs modules
     - Keep ambient authority (e.g., `process.env`, `console`, filesystem, network) in entrypoints
     - pass explicit capabilities (e.g., `io.console`) into shared JS modules.

--- a/packages/SwingSet/src/lib/runPolicies.js
+++ b/packages/SwingSet/src/lib/runPolicies.js
@@ -94,14 +94,14 @@ export function computronCounter(limit, options = {}) {
 }
 
 export function wallClockWaiter(seconds) {
-  const timeout = Date.now() + 1000 * seconds;
+  const timeout = performance.now() + 1000 * seconds;
   /** @type { RunPolicy } */
   const policy = harden({
     allowCleanup: () => true, // unlimited budget
-    vatCreated: () => Date.now() < timeout,
-    crankComplete: () => Date.now() < timeout,
-    crankFailed: () => Date.now() < timeout,
-    emptyCrank: () => Date.now() < timeout,
+    vatCreated: () => performance.now() < timeout,
+    crankComplete: () => performance.now() < timeout,
+    crankFailed: () => performance.now() < timeout,
+    emptyCrank: () => performance.now() < timeout,
   });
   return policy;
 }

--- a/packages/SwingSet/test/run-policy/run-policy.test.js
+++ b/packages/SwingSet/test/run-policy/run-policy.test.js
@@ -97,13 +97,13 @@ async function testCranks(t, mode) {
     const seqnum = JSON.parse(kernelStorage.kvStore.get(ckey));
     t.deepEqual(seqnum, kser(5));
   } else if (mode === 'wallclock') {
-    const startMS = Date.now();
+    const startMS = performance.now();
     // On an idle system, this does about 120 cranks per second when run
     // alone. When the rest of test-run-policy.js is running in parallel, it
     // does about 100 cps.
     more = await c.run(wallClockWaiter(1.0));
     t.truthy(more, 'vat was supposed to run forever');
-    const elapsedMS = Date.now() - startMS;
+    const elapsedMS = performance.now() - startMS;
     const elapsed = elapsedMS / 1000;
     // console.log(`elapsed`, elapsed, more);
     t.true(elapsed < 200.0, `time distort: ${elapsed} >= 200.0s`);

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -106,7 +106,7 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
     const lockPath = path.resolve(lockRoot, lockName);
     const ownerPath = path.resolve(lockPath, 'owner.json');
     await mkdir(lockRoot, { recursive: true });
-    const started = Date.now();
+    const started = performance.now();
 
     const isPidAlive = lockPid => {
       if (!Number.isInteger(lockPid) || lockPid <= 0) {
@@ -169,7 +169,7 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
           if (brokeStaleLock) {
             continue;
           }
-          const waitedMs = Date.now() - started;
+          const waitedMs = performance.now() - started;
           if (waitedMs >= BUNDLE_LOCK_ACQUIRE_TIMEOUT_MS) {
             throw Error(
               `Timed out waiting for bundle lock ${lockPath} after ${waitedMs}ms`,
@@ -250,7 +250,7 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
    * @returns {Promise<LoadedRegistryBundles<T>>}
    */
   const loadRegistry = async registry => {
-    const started = Date.now();
+    const started = performance.now();
     await null;
     try {
       const loaded = await Promise.all(
@@ -270,7 +270,7 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
         harden(Object.fromEntries(loaded))
       );
     } finally {
-      const elapsedMs = Date.now() - started;
+      const elapsedMs = performance.now() - started;
       console.log(
         `${styles.dim.open}[bundleTool][registry] loaded ${Object.keys(registry).length} bundle(s) in ${elapsedMs}ms`,
         styles.dim.close,

--- a/packages/cosmic-swingset/src/kernel-stats.js
+++ b/packages/cosmic-swingset/src/kernel-stats.js
@@ -35,7 +35,7 @@ const inboundQueueMeta = harden(
   makeQueueMetricsMeta('cosmic_swingset_inbound_queue', 'inbound queue'),
 );
 
-const maxAgeCache = (fn, maxAge, clock = Date.now) => {
+const maxAgeCache = (fn, maxAge, clock = () => performance.now()) => {
   // An initial invocation verifies that the function doesn't [always] throw.
   let cached = fn();
   let lastTime = -Infinity;
@@ -51,12 +51,12 @@ const maxAgeCache = (fn, maxAge, clock = Date.now) => {
 };
 
 const wrapDeltaMS = (finisher, useDeltaMS) => {
-  const startMS = Date.now();
+  const startMS = performance.now();
   return (...finishArgs) => {
     try {
       return finisher(...finishArgs);
     } finally {
-      const deltaMS = Date.now() - startMS;
+      const deltaMS = performance.now() - startMS;
       useDeltaMS(deltaMS, finishArgs);
     }
   };

--- a/packages/cosmic-swingset/tools/test-kit.js
+++ b/packages/cosmic-swingset/tools/test-kit.js
@@ -298,7 +298,7 @@ export const makeCosmicSwingsetTestKit = async (
     blockTime: lastBlockTime,
     params: lastBlockParams,
   } = initMessage;
-  let lastBlockWalltime = Date.now();
+  let lastBlockWalltime = performance.now();
   await blockingSend(initMessage);
 
   /**
@@ -313,7 +313,7 @@ export const makeCosmicSwingsetTestKit = async (
   // Advance block time at a nominal rate of one second per real millisecond,
   // but introduce discontinuities as necessary to maintain monotonicity.
   const nextBlockTime = () => {
-    const delta = Math.floor(Date.now() - lastBlockWalltime);
+    const delta = Math.floor(performance.now() - lastBlockWalltime);
     return lastBlockTime + (delta > 0 ? delta : 1);
   };
 
@@ -334,7 +334,7 @@ export const makeCosmicSwingsetTestKit = async (
       blockTime > lastBlockTime ||
       Fail`blockTime ${blockTime} must be greater than ${lastBlockTime}`;
     needsBootstrap = false;
-    lastBlockWalltime = Date.now();
+    lastBlockWalltime = performance.now();
     lastBlockHeight = blockHeight;
     lastBlockTime = blockTime;
     lastBlockParams = params;

--- a/packages/governance/test/swingsetTests/committeeBinary/committee.test.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/committee.test.js
@@ -12,11 +12,11 @@ const CONTRACT_FILES = ['committee', 'binaryVoteCounter'];
 const dirname = path.dirname(new URL(import.meta.url).pathname);
 
 test.before(async t => {
-  const start = Date.now();
+  const start = performance.now();
   const kernelBundles = await buildKernelBundles();
   const bundleCache = await unsafeSharedBundleCache;
   const { zcfBundle } = await bundleCache.loadRegistry(zoeSourceSpecRegistry);
-  const step2 = Date.now();
+  const step2 = performance.now();
   const contractBundles = {};
   await Promise.all(
     CONTRACT_FILES.map(async settings => {
@@ -27,7 +27,7 @@ test.before(async t => {
       contractBundles[bundleName] = bundle;
     }),
   );
-  const step3 = Date.now();
+  const step3 = performance.now();
 
   const vats = {};
   await Promise.all(
@@ -49,7 +49,7 @@ test.before(async t => {
   config.bundles = { zcf: { bundle: zcfBundle } };
   config.defaultManagerType = 'xs-worker'; // originally wanted for metering
 
-  const step4 = Date.now();
+  const step4 = performance.now();
   const ktime = `${(step2 - start) / 1000}s kernel`;
   const ctime = `${(step3 - step2) / 1000}s contracts`;
   const vtime = `${(step4 - step3) / 1000}s vats`;

--- a/packages/governance/test/swingsetTests/contractGovernor/governor.test.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/governor.test.js
@@ -19,11 +19,11 @@ const CONTRACT_FILES = [
 const dirname = path.dirname(new URL(import.meta.url).pathname);
 
 test.before(async t => {
-  const start = Date.now();
+  const start = performance.now();
   const kernelBundles = await buildKernelBundles();
   const bundleCache = await unsafeSharedBundleCache;
   const { zcfBundle } = await bundleCache.loadRegistry(zoeSourceSpecRegistry);
-  const step2 = Date.now();
+  const step2 = performance.now();
   const contractBundles = {};
   await Promise.all(
     CONTRACT_FILES.map(async settings => {
@@ -40,7 +40,7 @@ test.before(async t => {
       contractBundles[bundleName] = bundle;
     }),
   );
-  const step3 = Date.now();
+  const step3 = performance.now();
 
   const vats = {};
   await Promise.all(
@@ -62,7 +62,7 @@ test.before(async t => {
   config.bundles = { zcf: { bundle: zcfBundle } };
   config.defaultManagerType = 'xs-worker';
 
-  const step4 = Date.now();
+  const step4 = performance.now();
   const ktime = `${(step2 - start) / 1000}s kernel`;
   const ctime = `${(step3 - step2) / 1000}s contracts`;
   const vtime = `${(step4 - step3) / 1000}s vats`;

--- a/packages/store/test/perf-patterns.js
+++ b/packages/store/test/perf-patterns.js
@@ -213,12 +213,12 @@ const repetitions = 200;
 const measure = async (title, specimen, yesPattern, factor = 1) => {
   const times = factor * repetitions;
   await gcAndFinalize();
-  const startAt = Date.now();
+  const startAt = performance.now();
   for (let j = 0; j < times; j += 1) {
     // mustMatch(specimen, yesPattern);
     assert(matches(specimen, yesPattern), title);
   }
-  const totalTime = Date.now() - startAt;
+  const totalTime = performance.now() - startAt;
   const perStep = totalTime / times;
   measurements.push([title, perStep, Math.round(1000 / perStep)]);
   console.log(

--- a/packages/telemetry/src/ingest-slog-entrypoint.js
+++ b/packages/telemetry/src/ingest-slog-entrypoint.js
@@ -74,7 +74,7 @@ async function run() {
   let blocksInThisPeriod = 0;
   let startOfLastPeriod = 0;
 
-  let lastTime = Date.now();
+  let lastTime = performance.now();
   let lineCount = 0;
 
   const stats = async flush => {
@@ -109,7 +109,7 @@ async function run() {
       progress.lastSlogTime = obj.time;
     }
 
-    let now = Date.now();
+    let now = performance.now();
     await maybeUpdateStats(now);
 
     if (!update) {
@@ -128,7 +128,7 @@ async function run() {
       maybeWait = new Promise(resolve => setTimeout(resolve, delayMS));
     }
     await maybeWait;
-    now = Date.now();
+    now = performance.now();
 
     if (now - startOfLastPeriod >= PROCESSING_PERIOD) {
       startOfLastPeriod = now;
@@ -152,7 +152,7 @@ async function run() {
     linesProcessedThisPeriod += 1;
     if (isAfterCommit) {
       blocksInThisPeriod += 1;
-      lastTime = Date.now();
+      lastTime = performance.now();
       await stats(true);
     }
   }

--- a/packages/vm-config/test/paths.test.js
+++ b/packages/vm-config/test/paths.test.js
@@ -40,13 +40,13 @@ const allowedBuilderModules = new Set([
  * @param {string} currentPath
  */
 const walk = (node, onSourceSpec, onModule, currentPath = '$') => {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
   if (Array.isArray(node)) {
     node.forEach((child, i) =>
       walk(child, onSourceSpec, onModule, `${currentPath}[${i}]`),
     );
-    return;
-  }
-  if (!node || typeof node !== 'object') {
     return;
   }
   const record = /** @type {Record<string, unknown>} */ (node);

--- a/packages/zoe/test/swingsetTests/makeKind/makeKind.test.js
+++ b/packages/zoe/test/swingsetTests/makeKind/makeKind.test.js
@@ -17,11 +17,11 @@ const dirname = path.dirname(new URL(import.meta.url).pathname);
 const test = anyTest;
 
 test.before(async t => {
-  const start = Date.now();
+  const start = performance.now();
   const kernelBundles = await buildKernelBundles();
   const bundleCache = await unsafeSharedBundleCache;
   const { zcfBundle } = await bundleCache.loadRegistry(zoeSourceSpecRegistry);
-  const step2 = Date.now();
+  const step2 = performance.now();
   const contractBundles = {};
   await Promise.all(
     CONTRACT_FILES.map(async settings => {
@@ -38,7 +38,7 @@ test.before(async t => {
       contractBundles[bundleName] = { bundle };
     }),
   );
-  const step3 = Date.now();
+  const step3 = performance.now();
 
   const vats = {};
   await Promise.all(
@@ -60,7 +60,7 @@ test.before(async t => {
   config.bundles = { zcf: { bundle: zcfBundle }, ...contractBundles };
   config.defaultManagerType = 'xs-worker';
 
-  const step4 = Date.now();
+  const step4 = performance.now();
   const ktime = `${(step2 - start) / 1000}s kernel`;
   const ctime = `${(step3 - step2) / 1000}s contracts`;
   const vtime = `${(step4 - step3) / 1000}s vats`;

--- a/packages/zoe/test/swingsetTests/offerArgs/offerArgs.test.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/offerArgs.test.js
@@ -17,11 +17,11 @@ const dirname = path.dirname(new URL(import.meta.url).pathname);
 const test = anyTest;
 
 test.before(async t => {
-  const start = Date.now();
+  const start = performance.now();
   const kernelBundles = await buildKernelBundles();
   const bundleCache = await unsafeSharedBundleCache;
   const { zcfBundle } = await bundleCache.loadRegistry(zoeSourceSpecRegistry);
-  const step2 = Date.now();
+  const step2 = performance.now();
   const contractBundles = {};
   await Promise.all(
     CONTRACT_FILES.map(async settings => {
@@ -38,7 +38,7 @@ test.before(async t => {
       contractBundles[bundleName] = { bundle };
     }),
   );
-  const step3 = Date.now();
+  const step3 = performance.now();
 
   const vats = {};
   await Promise.all(
@@ -61,7 +61,7 @@ test.before(async t => {
   config.defaultManagerType = 'xs-worker';
   config.relaxDurabilityRules = true;
 
-  const step4 = Date.now();
+  const step4 = performance.now();
   const ktime = `${(step2 - start) / 1000}s kernel`;
   const ctime = `${(step3 - step2) / 1000}s contracts`;
   const vtime = `${(step4 - step3) / 1000}s vats`;

--- a/packages/zoe/test/swingsetTests/privateArgs/privateArgs.test.js
+++ b/packages/zoe/test/swingsetTests/privateArgs/privateArgs.test.js
@@ -17,11 +17,11 @@ const dirname = path.dirname(new URL(import.meta.url).pathname);
 const test = anyTest;
 
 test.before(async t => {
-  const start = Date.now();
+  const start = performance.now();
   const kernelBundles = await buildKernelBundles();
   const bundleCache = await unsafeSharedBundleCache;
   const { zcfBundle } = await bundleCache.loadRegistry(zoeSourceSpecRegistry);
-  const step2 = Date.now();
+  const step2 = performance.now();
   const contractBundles = {};
   await Promise.all(
     CONTRACT_FILES.map(async settings => {
@@ -38,7 +38,7 @@ test.before(async t => {
       contractBundles[bundleName] = { bundle };
     }),
   );
-  const step3 = Date.now();
+  const step3 = performance.now();
 
   const vats = {};
   await Promise.all(
@@ -60,7 +60,7 @@ test.before(async t => {
   config.bundles = { zcf: { bundle: zcfBundle }, ...contractBundles };
   config.defaultManagerType = 'xs-worker';
 
-  const step4 = Date.now();
+  const step4 = performance.now();
   const ktime = `${(step2 - start) / 1000}s kernel`;
   const ctime = `${(step3 - step2) / 1000}s contracts`;
   const vtime = `${(step4 - step3) / 1000}s vats`;

--- a/packages/zoe/test/swingsetTests/runMint/runMint.test.js
+++ b/packages/zoe/test/swingsetTests/runMint/runMint.test.js
@@ -20,11 +20,11 @@ const dirname = path.dirname(new URL(import.meta.url).pathname);
 const test = anyTest;
 
 test.before(async t => {
-  const start = Date.now();
+  const start = performance.now();
   const kernelBundles = await buildKernelBundles();
   const bundleCache = await unsafeSharedBundleCache;
   const { zcfBundle } = await bundleCache.loadRegistry(zoeSourceSpecRegistry);
-  const step2 = Date.now();
+  const step2 = performance.now();
   const contractBundles = {};
   const contractNames = [];
   await Promise.all(
@@ -43,7 +43,7 @@ test.before(async t => {
       contractNames.push(bundleName);
     }),
   );
-  const step3 = Date.now();
+  const step3 = performance.now();
 
   const vats = {};
   await Promise.all(
@@ -65,7 +65,7 @@ test.before(async t => {
   config.bundles = { zcf: { bundle: zcfBundle }, ...contractBundles };
   config.defaultManagerType = 'xs-worker';
 
-  const step4 = Date.now();
+  const step4 = performance.now();
   const ktime = `${(step2 - start) / 1000}s kernel`;
   const ctime = `${(step3 - step2) / 1000}s contracts`;
   const vtime = `${(step4 - step3) / 1000}s vats`;

--- a/packages/zoe/test/swingsetTests/zoe/zoe.test.js
+++ b/packages/zoe/test/swingsetTests/zoe/zoe.test.js
@@ -24,11 +24,11 @@ const CONTRACT_FILES = [
 ];
 
 test.before(async t => {
-  const start = Date.now();
+  const start = performance.now();
   const kernelBundles = await buildKernelBundles();
   const bundleCache = await unsafeSharedBundleCache;
   const { zcfBundle } = await bundleCache.loadRegistry(zoeSourceSpecRegistry);
-  const step2 = Date.now();
+  const step2 = performance.now();
   const contractBundles = {};
   const contractNames = [];
   await Promise.all(
@@ -48,7 +48,7 @@ test.before(async t => {
     }),
   );
   const bundles = { zcf: { bundle: zcfBundle }, ...contractBundles };
-  const step3 = Date.now();
+  const step3 = performance.now();
 
   const vats = {};
   await Promise.all(
@@ -70,7 +70,7 @@ test.before(async t => {
   config.defaultManagerType = 'xs-worker';
   config.relaxDurabilityRules = true;
 
-  const step4 = Date.now();
+  const step4 = performance.now();
   const ktime = `${(step2 - start) / 1000}s kernel`;
   const ctime = `${(step3 - step2) / 1000}s contracts`;
   const vtime = `${(step4 - step3) / 1000}s vats`;


### PR DESCRIPTION
incidental

## Description

Per a request in https://github.com/Agoric/agoric-sdk/pull/12447, document and adopt preferring `performance.now()` for perf measurements

