### PR TITLE
fix: unsubscribe resolver on GMP send failure

### DIFF
--- a/packages/portfolio-contract/src/pos-gmp.flows.ts
+++ b/packages/portfolio-contract/src/pos-gmp.flows.ts
@@ -687,11 +687,16 @@ export const sendGMPContractCall = async (
     value: AXELAR_GMP,
     encoding: 'bech32' as const,
   };
-  await ctx.feeAccount.send(lca.getAddress(), fee, ...optsArgs);
-  await lca.transfer(gmp, fee, {
-    ...optsArgs[0],
-    memo: JSON.stringify(memo),
-  });
+  try {
+    await ctx.feeAccount.send(lca.getAddress(), fee, ...optsArgs);
+    await lca.transfer(gmp, fee, {
+      ...optsArgs[0],
+      memo: JSON.stringify(memo),
+    });
+  } catch (reason) {
+    resolverClient.unsubscribe(txId, `unsubscribe: ${reason}`);
+    throw reason;
+  }
   await result;
 };
 
@@ -786,11 +791,16 @@ export const sendPermit2GMP = async (
     value: AXELAR_GMP,
     encoding: 'bech32' as const,
   };
-  await ctx.feeAccount.send(lca.getAddress(), fee, ...optsArgs);
-  await lca.transfer(gmp, fee, {
-    ...optsArgs[0],
-    memo: JSON.stringify(memo),
-  });
+  try {
+    await ctx.feeAccount.send(lca.getAddress(), fee, ...optsArgs);
+    await lca.transfer(gmp, fee, {
+      ...optsArgs[0],
+      memo: JSON.stringify(memo),
+    });
+  } catch (reason) {
+    resolverClient.unsubscribe(txId, `unsubscribe: ${reason}`);
+    throw reason;
+  }
   await result;
 };
 

--- a/packages/portfolio-contract/src/pos-gmp.flows.ts
+++ b/packages/portfolio-contract/src/pos-gmp.flows.ts
@@ -671,23 +671,23 @@ export const sendGMPContractCall = async (
     undefined,
     sourceAddress,
   );
-  appendTxIds(optsArgs[0]?.progressTracker, [txId]);
-
-  const { AXELAR_GMP, AXELAR_GAS } = gmpAddresses;
-  const memo: AxelarGmpOutgoingMemo = {
-    destination_chain: axelarId,
-    destination_address: remoteAddress,
-    payload: buildGMPPayload(calls, txId),
-    type: AxelarGMPMessageType.ContractCall,
-    fee: { amount: String(fee.value), recipient: AXELAR_GAS },
-  };
-  const { chainId } = await gmpChain.getChainInfo();
-  const gmp = {
-    chainId,
-    value: AXELAR_GMP,
-    encoding: 'bech32' as const,
-  };
   try {
+    appendTxIds(optsArgs[0]?.progressTracker, [txId]);
+
+    const { AXELAR_GMP, AXELAR_GAS } = gmpAddresses;
+    const memo: AxelarGmpOutgoingMemo = {
+      destination_chain: axelarId,
+      destination_address: remoteAddress,
+      payload: buildGMPPayload(calls, txId),
+      type: AxelarGMPMessageType.ContractCall,
+      fee: { amount: String(fee.value), recipient: AXELAR_GAS },
+    };
+    const { chainId } = await gmpChain.getChainInfo();
+    const gmp = {
+      chainId,
+      value: AXELAR_GMP,
+      encoding: 'bech32' as const,
+    };
     await ctx.feeAccount.send(lca.getAddress(), fee, ...optsArgs);
     await lca.transfer(gmp, fee, {
       ...optsArgs[0],
@@ -776,22 +776,21 @@ export const sendPermit2GMP = async (
     undefined,
     sourceAddress,
   );
-
-  const { AXELAR_GMP, AXELAR_GAS } = gmpAddresses;
-  const memo: AxelarGmpOutgoingMemo = {
-    destination_chain: axelarId,
-    destination_address: remoteAddress,
-    payload: buildGMPPayload(calls, txId),
-    type: AxelarGMPMessageType.ContractCall,
-    fee: { amount: String(fee.value), recipient: AXELAR_GAS },
-  };
-  const { chainId } = await gmpChain.getChainInfo();
-  const gmp = {
-    chainId,
-    value: AXELAR_GMP,
-    encoding: 'bech32' as const,
-  };
   try {
+    const { AXELAR_GMP, AXELAR_GAS } = gmpAddresses;
+    const memo: AxelarGmpOutgoingMemo = {
+      destination_chain: axelarId,
+      destination_address: remoteAddress,
+      payload: buildGMPPayload(calls, txId),
+      type: AxelarGMPMessageType.ContractCall,
+      fee: { amount: String(fee.value), recipient: AXELAR_GAS },
+    };
+    const { chainId } = await gmpChain.getChainInfo();
+    const gmp = {
+      chainId,
+      value: AXELAR_GMP,
+      encoding: 'bech32' as const,
+    };
     await ctx.feeAccount.send(lca.getAddress(), fee, ...optsArgs);
     await lca.transfer(gmp, fee, {
       ...optsArgs[0],

--- a/packages/portfolio-contract/src/pos-gmp.flows.ts
+++ b/packages/portfolio-contract/src/pos-gmp.flows.ts
@@ -652,6 +652,7 @@ export const sendGMPContractCall = async (
   calls: ContractCall[],
   ...optsArgs: [OrchestrationOptions?]
 ) => {
+  await null;
   const {
     lca,
     gmpChain,
@@ -731,6 +732,7 @@ export const sendPermit2GMP = async (
   transferAmount: bigint,
   ...optsArgs: [OrchestrationOptions?]
 ) => {
+  await null;
   const {
     lca,
     gmpChain,

--- a/packages/portfolio-contract/test/portfolio.flows.test.ts
+++ b/packages/portfolio-contract/test/portfolio.flows.test.ts
@@ -79,6 +79,8 @@ import {
 import {
   provideEVMAccount,
   provideEVMAccountWithPermit,
+  sendGMPContractCall,
+  type EVMContext,
 } from '../src/pos-gmp.flows.ts';
 import {
   makeSwapLockMessages,
@@ -3461,3 +3463,60 @@ test('move Aave position Base -> Optimism via CCTPv2', async t => {
   t.snapshot(log, 'call log');
   await documentStorageSchema(t, storage, docOpts);
 });
+
+test(
+  'sendGMPContractCall unsubscribes resolver on send failure',
+  expectUnhandled(1),
+  async t => {
+    const { resolverClient, storage } = mocks({});
+    const lcaAddress = harden({ chainId: 'agoric-3', value: 'agoric1test' });
+    const ctx = {
+      feeAccount: {
+        getAddress: () => lcaAddress,
+        send: async () => {
+          throw Error('fee send failed');
+        },
+      },
+      lca: { getAddress: () => lcaAddress, transfer: async () => {} },
+      gmpFee: { denom: 'uaxl', value: 100n },
+      gmpChain: {
+        getChainInfo: async () => ({ chainId: 'axelar-testnet-lisbon-3' }),
+      },
+      gmpAddresses,
+      resolverClient,
+      axelarIds: axelarIdsMock,
+      addresses: contractsMock.Avalanche,
+      nobleForwardingChannel: 'channel-0',
+    } as unknown as EVMContext;
+
+    const gmpAcct = {
+      namespace: 'eip155',
+      chainName: 'Avalanche',
+      remoteAddress: '0x1234567890AbcdEF1234567890aBcdef12345678',
+      chainId: 'eip155:43114',
+    } as const;
+
+    const calls = [
+      {
+        target: '0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2' as const,
+        functionSignature: 'supply(address,uint256,address,uint16)',
+        args: [
+          '0xCaC7Ffa82c0f43EBB0FC11FCd32123EcA46626cf',
+          1_000_000n,
+          '0x1234567890AbcdEF1234567890aBcdef12345678',
+          0,
+        ],
+      },
+    ];
+
+    await t.throwsAsync(() => sendGMPContractCall(ctx, gmpAcct, calls), {
+      message: 'fee send failed',
+    });
+
+    await eventLoopIteration();
+    const values = storage.getDeserialized('published.ymax0.pendingTxs.tx0');
+    const last = values.at(-1) as any;
+    t.is(last.status, 'failed', 'transaction settled as failed');
+    t.truthy(last.rejectionReason, 'includes rejection reason');
+  },
+);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

refs:
- https://github.com/Agoric/agoric-private/issues/773

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Fix dangling resolver subscriptions when GMP transactions fail to send. In `sendGMPContractCall` and `sendPermit2GMP`, if the fee account send or the LCA transfer throws, the resolver was left subscribed to a `txId` whose transaction would never complete.


### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- An upgrade of `ymax0` and `ymax1` contracts.