### PR TITLE
tighter TypeScript config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -182,6 +182,7 @@ export default [
 
       'jsdoc/no-defaults': 'off',
       'no-use-before-define': 'off',
+      'no-nested-ternary': 'off',
     },
   },
   {

--- a/multichain-testing/tools/chaind-lib.js
+++ b/multichain-testing/tools/chaind-lib.js
@@ -224,6 +224,7 @@ export const makeAgd = ({ execFileSync }) => {
         } catch (e) {
           console.error(e);
           console.info('output:', out);
+          throw e;
         }
       },
     });
@@ -284,6 +285,7 @@ export const makeAgd = ({ execFileSync }) => {
         } catch (e) {
           console.error(e);
           console.info('output:', out);
+          throw e;
         }
       },
       ...ro,

--- a/packages/ERTP/test/unitTests/mathHelpers/mockBrand.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/mockBrand.js
@@ -7,7 +7,7 @@ import { AssetKind } from '../../../src/index.js';
 // @ts-expect-error FIXME losing PASS_STYLE
 export const mockNatBrand = Far('brand', {
   // eslint-disable-next-line no-unused-vars
-  isMyIssuer: async allegedIssuer => false,
+  isMyIssuer: async _allegedIssuer => false,
   getAllegedName: () => 'mock',
   getAmountShape: () => ({}),
   getDisplayInfo: () => ({
@@ -19,7 +19,7 @@ export const mockNatBrand = Far('brand', {
 // @ts-expect-error FIXME losing PASS_STYLE
 export const mockSetBrand = Far('brand', {
   // eslint-disable-next-line no-unused-vars
-  isMyIssuer: async allegedIssuer => false,
+  isMyIssuer: async _allegedIssuer => false,
   getAllegedName: () => 'mock',
   getAmountShape: () => ({}),
   getDisplayInfo: () => ({
@@ -31,7 +31,7 @@ export const mockSetBrand = Far('brand', {
 // @ts-expect-error FIXME losing PASS_STYLE
 export const mockCopySetBrand = Far('brand', {
   // eslint-disable-next-line no-unused-vars
-  isMyIssuer: async allegedIssuer => false,
+  isMyIssuer: async _allegedIssuer => false,
   getAllegedName: () => 'mock',
   getAmountShape: () => ({}),
   getDisplayInfo: () => ({
@@ -43,7 +43,7 @@ export const mockCopySetBrand = Far('brand', {
 // @ts-expect-error FIXME losing PASS_STYLE
 export const mockCopyBagBrand = Far('brand', {
   // eslint-disable-next-line no-unused-vars
-  isMyIssuer: async allegedIssuer => false,
+  isMyIssuer: async _allegedIssuer => false,
   getAllegedName: () => 'mock',
   getAmountShape: () => ({}),
   getDisplayInfo: () => ({

--- a/packages/SwingSet/src/devices/bridge/bridge.js
+++ b/packages/SwingSet/src/devices/bridge/bridge.js
@@ -88,7 +88,7 @@ function sanitize(data) {
   }
   // Golang likes to have its bigints as strings.
   return JSON.parse(
-    JSON.stringify(data, (key, value) =>
+    JSON.stringify(data, (_key, value) =>
       typeof value === 'bigint' ? value.toString() : value,
     ),
   );

--- a/packages/SwingSet/src/devices/loopbox/device-loopbox.js
+++ b/packages/SwingSet/src/devices/loopbox/device-loopbox.js
@@ -8,7 +8,7 @@ export function buildRootDeviceNode(tools) {
 
   function makeSender(sender) {
     return Far('sender', {
-      add(peer, msgnum, body) {
+      add(peer, _msgnum, body) {
         const oldDS = getDeviceState();
         oldDS.inboundHandlers[peer] || Fail`unregistered peer '${peer}'`;
         const h = oldDS.inboundHandlers[peer];

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -433,7 +433,7 @@ export default function buildKernel(
 
   // this is called for syscall.exit, which allows the crank to complete
   // before terminating the vat
-  function requestTermination(vatID, reject, info) {
+  function requestTermination(_vatID, reject, info) {
     insistCapData(info);
     vatRequestedTermination = { reject, info };
   }

--- a/packages/SwingSet/src/kernel/vat-loader/manager-local.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-local.js
@@ -36,7 +36,7 @@ export function makeLocalVatManagerFactory({
     return { syscall, finish };
   }
 
-  function createFromSetup(vatID, managerOptions) {
+  function createFromSetup(_vatID, managerOptions) {
     const { setup } = managerOptions;
     assert.typeof(setup, 'function', 'setup is not an in-realm function');
 

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
@@ -15,7 +15,7 @@ import { makeManagerKit } from './manager-helper.js';
 
 // eslint-disable-next-line no-unused-vars
 function parentLog(_first, ..._args) {
-  // console.error(`--parent: ${first}`, ...args);
+  // console.error(`--parent: ${_first}`, ..._args);
 }
 
 export function makeNodeSubprocessFactory(tools) {

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
@@ -14,7 +14,7 @@ import { makeManagerKit } from './manager-helper.js';
 // into it
 
 // eslint-disable-next-line no-unused-vars
-function parentLog(first, ...args) {
+function parentLog(_first, ..._args) {
   // console.error(`--parent: ${first}`, ...args);
 }
 

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -29,7 +29,7 @@ import {
  */
 
 // eslint-disable-next-line no-unused-vars
-function parentLog(first, ...args) {
+function parentLog(_first, ..._args) {
   // console.error(`--parent: ${first}`, ...args);
 }
 

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -30,7 +30,7 @@ import {
 
 // eslint-disable-next-line no-unused-vars
 function parentLog(_first, ..._args) {
-  // console.error(`--parent: ${first}`, ...args);
+  // console.error(`--parent: ${_first}`, ..._args);
 }
 
 const encoder = new TextEncoder();

--- a/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
@@ -32,7 +32,7 @@ import {
  */
 
 // eslint-disable-next-line no-unused-vars
-function workerLog(first, ...args) {
+function workerLog(_first, ..._args) {
   // console.error(`---worker: ${first}`, ...args);
 }
 

--- a/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
@@ -33,7 +33,7 @@ import {
 
 // eslint-disable-next-line no-unused-vars
 function workerLog(_first, ..._args) {
-  // console.error(`---worker: ${first}`, ...args);
+  // console.error(`---worker: ${_first}`, ..._args);
 }
 
 workerLog(`supervisor started`);

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -105,7 +105,7 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
       },
       get: ({ state }) => D(vatAdminDev).getMeter(state.meterID), // returns BigInts
       // getNotifier: ({ state }) => state.notifier, // XXX RESTORE
-      getNotifier: ({ _self }) => Fail`not implemented, see #7234`, // XXX TEMP
+      getNotifier: () => Fail`not implemented, see #7234`, // XXX TEMP
     },
     { finish: finishMeter },
   );
@@ -124,7 +124,7 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
       setThreshold(_context, _newThreshold) {},
       get: () => harden({ remaining: 'unlimited', threshold: 0 }),
       // getNotifier: ({ state }) => state.notifier, // will never fire // XXX RESTORE
-      getNotifier: ({ _self }) => Fail`not implemented, see #7234`, // XXX TEMP
+      getNotifier: () => Fail`not implemented, see #7234`, // XXX TEMP
     },
     { finish: finishMeter },
   );
@@ -565,7 +565,7 @@ export function buildRootObject(vatPowers, _vatParameters, baggage) {
 
   // XXX TEMP
   // eslint-disable-next-line no-unused-vars
-  function meterCrossedThreshold(meterID, remaining) {
+  function meterCrossedThreshold(_meterID, _remaining) {
     // const { updater } = meterByID.get(meterID); // XXX RESTORE
     // updater.updateState(remaining); // XXX RESTORE
   }

--- a/packages/SwingSet/test/bundleTool.test.ts
+++ b/packages/SwingSet/test/bundleTool.test.ts
@@ -107,9 +107,9 @@ test('concurrent load() calls for same key settle without hanging', async t => {
   const bundles = await Promise.all(loads);
   t.is(bundles.length, 24);
   t.truthy(bundles[0]);
-  bundles.forEach((bundle, i) => {
+  for (const [i, bundle] of bundles.entries()) {
     t.deepEqual(bundle, bundles[0], `bundles[${i}] matches bundles[0]`);
-  });
+  }
 });
 
 test('load() accepts file URL source specs', async t => {

--- a/packages/SwingSet/test/device-bridge-bootstrap.js
+++ b/packages/SwingSet/test/device-bridge-bootstrap.js
@@ -10,7 +10,7 @@ export function buildRootObject(vatPowers, vatParameters) {
   });
 
   return Far('root', {
-    async bootstrap(vats, devices) {
+    async bootstrap(_vats, devices) {
       const { argv } = vatParameters;
       harden(argv);
       D(devices.bridge).registerInboundHandler(handler);

--- a/packages/SwingSet/test/devices/bootstrap-0.js
+++ b/packages/SwingSet/test/devices/bootstrap-0.js
@@ -1,6 +1,6 @@
 import { extractMessage } from '../vat-util.js';
 
-export default function setup(syscall, state, _helpers, vatPowers) {
+export default function setup(_syscall, _state, _helpers, vatPowers) {
   function dispatch(vatDeliverObject) {
     if (vatDeliverObject[0] === 'message') {
       const { args } = extractMessage(vatDeliverObject);

--- a/packages/SwingSet/test/devices/bootstrap-1.js
+++ b/packages/SwingSet/test/devices/bootstrap-1.js
@@ -2,7 +2,7 @@ import { Fail } from '@endo/errors';
 import { kser, kunser, krefOf } from '@agoric/kmarshal';
 import { extractMessage } from '../vat-util.js';
 
-export default function setup(syscall, state, _helpers, vatPowers) {
+export default function setup(syscall, _state, _helpers, vatPowers) {
   const { testLog } = vatPowers;
   let deviceRef;
   function dispatch(vatDeliverObject) {

--- a/packages/SwingSet/test/devices/bootstrap-3.js
+++ b/packages/SwingSet/test/devices/bootstrap-3.js
@@ -4,7 +4,7 @@ import { Far } from '@endo/far';
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog: log } = vatPowers;
   return Far('root', {
-    async bootstrap(vats, devices) {
+    async bootstrap(_vats, devices) {
       if (vatParameters.argv[0] === 'write+read') {
         log(`w+r`);
         D(devices.d3).setState(harden({ s: 'new' }));

--- a/packages/SwingSet/test/devices/bootstrap-4.js
+++ b/packages/SwingSet/test/devices/bootstrap-4.js
@@ -6,7 +6,7 @@ import { extractMessage } from '../vat-util.js';
 // identifier, we must bypass liveslots, which would otherwise protect us
 // against the vat-fatal mistake
 
-export default function setup(syscall, state, _helpers, vatPowers) {
+export default function setup(syscall, _state, _helpers, vatPowers) {
   const { callNow } = syscall;
   const { testLog } = vatPowers;
   let d0;

--- a/packages/SwingSet/test/devices/bootstrap-5.js
+++ b/packages/SwingSet/test/devices/bootstrap-5.js
@@ -3,7 +3,7 @@ import { Far } from '@endo/far';
 export function buildRootObject(vatPowers, _vatParameters) {
   const { D } = vatPowers;
   return Far('root', {
-    async bootstrap(vats, devices) {
+    async bootstrap(_vats, devices) {
       let got;
       try {
         D(devices.d5).pleaseThrow('with message');

--- a/packages/SwingSet/test/devices/bootstrap-6.js
+++ b/packages/SwingSet/test/devices/bootstrap-6.js
@@ -3,7 +3,7 @@ import { Far } from '@endo/far';
 export function buildRootObject(vatPowers, _vatParameters) {
   const { D } = vatPowers;
   return Far('root', {
-    async bootstrap(vats, devices) {
+    async bootstrap(_vats, devices) {
       let got;
       try {
         // ideally, device nodes can round-trip through unrelated devices

--- a/packages/SwingSet/test/timer-device/bootstrap.js
+++ b/packages/SwingSet/test/timer-device/bootstrap.js
@@ -6,7 +6,7 @@ export function buildRootObject(vatPowers, vatParameters) {
   const { D } = vatPowers;
   const log = vatPowers.testLog;
   return Far('root', {
-    async bootstrap(vats, devices) {
+    async bootstrap(_vats, devices) {
       const { argv } = vatParameters;
       if (argv[0] === 'timer') {
         log(`starting wake test`);

--- a/packages/SwingSet/test/vat-controller-1.js
+++ b/packages/SwingSet/test/vat-controller-1.js
@@ -1,7 +1,7 @@
 // -*- js -*-
 import { extractMessage } from './vat-util.js';
 
-export default function setup(syscall, _state, _helpers, vatPowers) {
+export default function setup(_syscall, _state, _helpers, vatPowers) {
   function dispatch(vatDeliverObject) {
     if (vatDeliverObject[0] === 'message') {
       const { facetID, method, args } = extractMessage(vatDeliverObject);

--- a/packages/SwingSet/test/vat-warehouse/vat-warehouse-reload.js
+++ b/packages/SwingSet/test/vat-warehouse/vat-warehouse-reload.js
@@ -1,6 +1,6 @@
 import { Far } from '@endo/far';
 
-export function buildRootObject(vatPowers, vatParameters, baggage) {
+export function buildRootObject(vatPowers, _vatParameters, baggage) {
   let ephemeralCounter = 0;
   return Far('root', {
     count() {

--- a/packages/SwingSet/tools/vat.js
+++ b/packages/SwingSet/tools/vat.js
@@ -119,6 +119,7 @@ async function main() {
       return result;
     };
   }
+  return undefined;
 }
 
 main().then(

--- a/packages/agoric-cli/src/cosmos.js
+++ b/packages/agoric-cli/src/cosmos.js
@@ -4,7 +4,7 @@ import { makePspawn, getSDKBinaries } from './helpers.js';
 
 const filename = new URL(import.meta.url).pathname;
 
-export default async function cosmosMain(progname, rawArgs, powers, opts) {
+export default async function cosmosMain(_progname, rawArgs, powers, opts) {
   const IMAGE = `ghcr.io/agoric/agoric-sdk`;
   const { anylogger, fs, spawn, process } = powers;
   const log = anylogger('agoric:cosmos');

--- a/packages/agoric-cli/src/follow.js
+++ b/packages/agoric-cli/src/follow.js
@@ -47,7 +47,7 @@ const makeCapDataToQclass = () => {
   return capDataToQclass;
 };
 
-export default async function followerMain(progname, rawArgs, powers, opts) {
+export default async function followerMain(_progname, rawArgs, powers, opts) {
   const { anylogger } = powers;
   const console = anylogger('agoric:follower');
 

--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -13,7 +13,7 @@ const REQUIRED_AGORIC_START_PACKAGES = [
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);
 
-export default async function installMain(progname, rawArgs, powers, opts) {
+export default async function installMain(_progname, rawArgs, powers, opts) {
   const { anylogger, fs, spawn } = powers;
   const log = anylogger('agoric:install');
 

--- a/packages/agoric-cli/src/lib/chain.js
+++ b/packages/agoric-cli/src/lib/chain.js
@@ -116,6 +116,7 @@ export const execSwingsetTransaction = (swingsetArgs, opts) => {
     stdout.write(`${agdBinary} `);
     stdout.write(cmd.join(' '));
     stdout.write('\n');
+    return undefined;
   } else {
     const yesCmd = cmd.concat(['--yes']);
     if (verbose) console.log('Executing ', agdBinary, yesCmd);

--- a/packages/agoric-cli/src/lib/format.js
+++ b/packages/agoric-cli/src/lib/format.js
@@ -23,10 +23,10 @@ export const parseFiniteNumber = input => {
 /**
  * JSON.stringify replacer to handle bigint
  *
- * @param {unknown} k
+ * @param {unknown} _k
  * @param {unknown} v
  */
-export const bigintReplacer = (k, v) => (typeof v === 'bigint' ? `${v}` : v);
+export const bigintReplacer = (_k, v) => (typeof v === 'bigint' ? `${v}` : v);
 
 /** @type {Partial<VBankAssetDetail>} */
 // eslint-disable-next-line no-unused-vars

--- a/packages/agoric-cli/src/main-publish.js
+++ b/packages/agoric-cli/src/main-publish.js
@@ -13,7 +13,7 @@ import { makeBundlePublisher, makeCosmosBundlePublisher } from './publish.js';
  * @import {CosmosConnectionSpec} from './publish.js';
  */
 
-const publishMain = async (progname, rawArgs, powers, opts) => {
+const publishMain = async (_progname, rawArgs, powers, opts) => {
   const { fs } = powers;
 
   const { node: rpcAddress, home: homeDirectory, chainID = 'agoric' } = opts;

--- a/packages/agoric-cli/src/set-defaults.js
+++ b/packages/agoric-cli/src/set-defaults.js
@@ -6,7 +6,12 @@ import {
   finishCosmosGenesis,
 } from './chain-config.js';
 
-export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
+export default async function setDefaultsMain(
+  _progname,
+  rawArgs,
+  powers,
+  opts,
+) {
   const { anylogger, fs } = powers;
   const log = anylogger('agoric:set-defaults');
 

--- a/packages/agoric-cli/tools/resm-plugin/deploy.js
+++ b/packages/agoric-cli/tools/resm-plugin/deploy.js
@@ -5,7 +5,7 @@ const PONG_TIMEOUT = 10_000;
 
 // @ts-expect-error TS1287: A top-level 'export' modifier cannot be used on value declarations in a CommonJS module when 'verbatimModuleSyntax' is enabled.
 export default async function deployPlugin(
-  homePromise,
+  _homePromise,
   { installUnsafePlugin },
 ) {
   const plugin = await installUnsafePlugin('./src/plugin.js', {});

--- a/packages/async-flow/src/replay-membrane.js
+++ b/packages/async-flow/src/replay-membrane.js
@@ -665,6 +665,7 @@ export const makeReplayMembraneForTesting = ({
       }
     }
     unnestFlag = false;
+    return undefined;
   };
 
   /**

--- a/packages/boot/test/bootstrapTests/ibcClientMock.js
+++ b/packages/boot/test/bootstrapTests/ibcClientMock.js
@@ -12,13 +12,13 @@ import { heapVowE as E } from '@agoric/vow/vat.js';
  */
 
 /**
- * @param {ZCF} zcf
+ * @param {ZCF} _zcf
  * @param {{
  *   portAllocator: ERemote<PortAllocator>;
  * }} privateArgs
  * @param {Baggage} _baggage
  */
-export const start = async (zcf, privateArgs, _baggage) => {
+export const start = async (_zcf, privateArgs, _baggage) => {
   const { portAllocator } = privateArgs;
 
   const myPort = await E(portAllocator).allocateCustomIBCPort();

--- a/packages/boot/test/bootstrapTests/ibcServerMock.js
+++ b/packages/boot/test/bootstrapTests/ibcServerMock.js
@@ -16,14 +16,14 @@ const { log } = console;
 
 /**
  *
- * @param {ZCF} zcf
+ * @param {ZCF} _zcf
  * @param {{
  *   address: string,
  *   portAllocator: ERef<PortAllocator>;
  * }} privateArgs
  * @param {Baggage} _baggage
  */
-export const start = async (zcf, privateArgs, _baggage) => {
+export const start = async (_zcf, privateArgs, _baggage) => {
   const { portAllocator } = privateArgs;
 
   const boundPort = await E(portAllocator).allocateCustomIBCPort();

--- a/packages/boot/test/upgrading/upgrade-vats.test.ts
+++ b/packages/boot/test/upgrading/upgrade-vats.test.ts
@@ -245,7 +245,7 @@ test('upgrade vat-bank', async t => {
                 return '1000';
               }
               default:
-                Fail`unexpected call to bank handler ${obj}`;
+                throw Fail`unexpected call to bank handler ${obj}`;
             }
           },
         },

--- a/packages/casting/test/fake-rpc-server.js
+++ b/packages/casting/test/fake-rpc-server.js
@@ -99,13 +99,13 @@ export const startFakeServer = (t, fakeValues, options = {}) => {
       next();
     });
     app.use(express.json());
-    app.get('/bad-network-config', (req, res) => {
+    app.get('/bad-network-config', (_req, res) => {
       res.json({
         chainName,
         rpcAddrs: 'not an array',
       });
     });
-    app.get('/network-config', (req, res) => {
+    app.get('/network-config', (_req, res) => {
       res.json({
         chainName,
         rpcAddrs: [`http://localhost:${PORT}/tendermint-rpc`],

--- a/packages/client-utils/src/signing-smart-wallet-kit.ts
+++ b/packages/client-utils/src/signing-smart-wallet-kit.ts
@@ -11,8 +11,8 @@ import type {
 } from '@cosmjs/stargate';
 import { toAccAddress } from '@cosmjs/stargate/build/queryclient/utils.js';
 import type { EReturn } from '@endo/far';
-import { MsgWalletSpendAction } from './codegen/agoric/swingset/msgs.js';
-import { TxRaw } from './codegen/cosmos/tx/v1beta1/tx.js';
+import { MsgWalletSpendAction } from '@agoric/cosmic-proto/agoric/swingset/msgs.js';
+import { TxRaw } from '@agoric/cosmic-proto/cosmos/tx/v1beta1/tx.js';
 import { makeStargateClientKit } from './signing-client.js';
 import type { SmartWalletKit } from './smart-wallet-kit.js';
 

--- a/packages/client-utils/src/smart-wallet-kit.js
+++ b/packages/client-utils/src/smart-wallet-kit.js
@@ -128,13 +128,12 @@ harden(makeSmartWalletKitFromVstorageKit);
 export const makeSmartWalletKit = async (
   {
     fetch,
-    // eslint-disable-next-line no-unused-vars -- keep for removing ambient authority
+    // unused but keep for eventually removing ambient authority
     delay: _delay,
     names = true,
   },
   networkConfig,
 ) => {
-  void _delay;
   const vsk = makeVstorageKit({ fetch }, networkConfig);
   return makeSmartWalletKitFromVstorageKit(vsk, { names });
 };

--- a/packages/client-utils/src/smart-wallet-kit.js
+++ b/packages/client-utils/src/smart-wallet-kit.js
@@ -67,13 +67,13 @@ export const makeSmartWalletKitFromVstorageKit = async (
    *
    * @param {string} from
    * @param {string|number} id
-   * @param {number|string} [minHeight] - deprecated, start polling before broadcasting the offer
+   * @param {number|string} [_minHeight] - deprecated, start polling before broadcasting the offer
    * @param {boolean} [untilNumWantsSatisfied]
    */
   const pollOffer = async (
     from,
     id,
-    minHeight,
+    _minHeight = undefined,
     untilNumWantsSatisfied = false,
   ) => {
     const getAddrLastUpdate = () => getLastUpdate(from);
@@ -129,11 +129,12 @@ export const makeSmartWalletKit = async (
   {
     fetch,
     // eslint-disable-next-line no-unused-vars -- keep for removing ambient authority
-    delay,
+    delay: _delay,
     names = true,
   },
   networkConfig,
 ) => {
+  void _delay;
   const vsk = makeVstorageKit({ fetch }, networkConfig);
   return makeSmartWalletKitFromVstorageKit(vsk, { names });
 };

--- a/packages/client-utils/test/mocks.ts
+++ b/packages/client-utils/test/mocks.ts
@@ -80,8 +80,8 @@ export class MockSigningSmartWalletKit {
 
     this.sendBridgeAction = async (
       action: any,
-      fee: any,
-      memo: any,
+      _fee: any,
+      _memo: any,
       signerData: any,
     ): Promise<SubmitTxResponse> => {
       // Simulate network delay

--- a/packages/cosmic-proto/test/address-hooks.test.js
+++ b/packages/cosmic-proto/test/address-hooks.test.js
@@ -179,7 +179,14 @@ test(
  * >}
  */
 const lengthCheckMacro = test.macro({
-  title(providedTitle = '', prefix, baseAddress, hookData, charLimit, throws) {
+  title(
+    providedTitle = '',
+    _prefix,
+    _baseAddress,
+    _hookData,
+    charLimit,
+    throws,
+  ) {
     let sep = providedTitle.endsWith(' ') ? '' : ' ';
     const limitDesc = charLimit ? `${sep}charLimit=${charLimit}` : '';
     if (limitDesc) sep = ' ';

--- a/packages/cosmic-swingset/src/export-kernel-db.js
+++ b/packages/cosmic-swingset/src/export-kernel-db.js
@@ -82,7 +82,7 @@ export const checkExportDataMode = (mode, isImport = false) => {
       if (isImport) {
         break;
       }
-      // Fall through
+      throw Fail`Invalid value ${q(mode)} for "export-data-mode"`;
     }
     default:
       throw Fail`Invalid value ${q(mode)} for "export-data-mode"`;

--- a/packages/cosmic-swingset/src/helpers/json-stable-stringify.js
+++ b/packages/cosmic-swingset/src/helpers/json-stable-stringify.js
@@ -32,7 +32,7 @@ export default function stableStringify(obj, opts) {
   let space = opts.space || '';
   if (typeof space === 'number') space = Array(space + 1).join(' ');
   const cycles = typeof opts.cycles === 'boolean' ? opts.cycles : false;
-  const replacer = opts.replacer || ((key, value) => value);
+  const replacer = opts.replacer || ((_key, value) => value);
 
   const cmp =
     opts.cmp &&

--- a/packages/cosmic-swingset/src/import-kernel-db.js
+++ b/packages/cosmic-swingset/src/import-kernel-db.js
@@ -168,7 +168,7 @@ export const performStateSyncImport = async (
         .pipe(
           new Transform({
             objectMode: true,
-            transform(data, encoding, callback) {
+            transform(data, _encoding, callback) {
               try {
                 callback(null, JSON.parse(data));
               } catch (error) {

--- a/packages/cosmic-swingset/src/import-kernel-db.js
+++ b/packages/cosmic-swingset/src/import-kernel-db.js
@@ -82,10 +82,10 @@ const checkAndGetImportSwingStoreOptions = (options, manifest) => {
 
   switch (artifactMode) {
     case 'debug':
-    // eslint-disable-next-line no-fallthrough
+    // @ts-expect-error intentional fallthrough for mode hierarchy
     case 'operational':
       if (manifest.artifactMode === 'operational') break;
-    // eslint-disable-next-line no-fallthrough
+    // @ts-expect-error intentional fallthrough for mode hierarchy
     case 'replay':
       if (manifest.artifactMode === 'replay') break;
     // eslint-disable-next-line no-fallthrough

--- a/packages/cosmic-swingset/test/inquisitor.test.ts
+++ b/packages/cosmic-swingset/test/inquisitor.test.ts
@@ -59,7 +59,7 @@ test('makeHelpers', async t => {
       default:
         break;
     }
-    Fail`port ${q(destPortName)} not implemented for message ${msg}`;
+    throw Fail`port ${q(destPortName)} not implemented for message ${msg}`;
   };
   const testKit = await makeCosmicSwingsetTestKit(receiveBridgeSend);
   const { pushCoreEval, runNextBlock, swingStore, shutdown } = testKit;
@@ -134,7 +134,7 @@ test('vat lifecycle', async t => {
       default:
         break;
     }
-    Fail`port ${q(destPortName)} not implemented for message ${msg}`;
+    throw Fail`port ${q(destPortName)} not implemented for message ${msg}`;
   };
 
   // Launch the swingset and make a vat with some state.

--- a/packages/cosmic-swingset/test/prometheus.test.ts
+++ b/packages/cosmic-swingset/test/prometheus.test.ts
@@ -11,7 +11,6 @@ import {
   BLOCK_HISTOGRAM_METRICS,
 } from '@agoric/internal/src/metrics.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
-import { avaRetry } from '@agoric/internal/tools/avaRetry.js';
 
 import {
   leadingPrometheusNameRegExp,
@@ -250,9 +249,5 @@ const testPrometheusMetrics = async t => {
   t.log(`compared ${comparisonCount} values`);
 };
 
-// TODO(#11175): skip flaky test
-if (false && !IS_SUBPROCESS_RETRY) {
-  avaRetry(test, 'Prometheus metric definitions', testPrometheusMetrics);
-} else {
-  test.skip('Prometheus metric definitions', testPrometheusMetrics);
-}
+// TODO(#11175): re-enable flaky test
+test.skip('Prometheus metric definitions', testPrometheusMetrics);

--- a/packages/cosmic-swingset/test/prometheus.test.ts
+++ b/packages/cosmic-swingset/test/prometheus.test.ts
@@ -83,7 +83,7 @@ const testPrometheusMetrics = async t => {
       default:
         break;
     }
-    Fail`port ${q(destPortName)} not implemented for message ${msg}`;
+    throw Fail`port ${q(destPortName)} not implemented for message ${msg}`;
   };
   const env = {
     ...process.env,

--- a/packages/cosmic-swingset/test/run-policy.test.ts
+++ b/packages/cosmic-swingset/test/run-policy.test.ts
@@ -61,7 +61,7 @@ test('cleanup work must be limited by vat_cleanup_budget', async t => {
         return handleVstorage(msg);
       }
       default:
-        Fail`port ${q(destPortName)} not implemented for message ${msg}`;
+        throw Fail`port ${q(destPortName)} not implemented for message ${msg}`;
     }
   };
   const options = {

--- a/packages/cosmic-swingset/tools/inquisitor.mjs
+++ b/packages/cosmic-swingset/tools/inquisitor.mjs
@@ -810,7 +810,7 @@ const main = async (argv, options = {}, powers = {}) => {
         return handleVstorage(msg);
       }
       default:
-        Fail`[inquisitor] bridge port ${q(destPort)} not implemented for message ${msg}`;
+        throw Fail`[inquisitor] bridge port ${q(destPort)} not implemented for message ${msg}`;
     }
   };
   const config = {

--- a/packages/deploy-script-support/test/unitTests/coreProposalBehavior.test.js
+++ b/packages/deploy-script-support/test/unitTests/coreProposalBehavior.test.js
@@ -53,7 +53,7 @@ test('coreProposalBehavior', async t => {
       t.is(bcap, bundleCap);
       return {
         fromInstallation,
-        getManifestForTest: (powers, ...args) => {
+        getManifestForTest: (_powers, ...args) => {
           t.deepEqual(args, ['arg1', 'arg2']);
           return {
             manifest: {

--- a/packages/deployment/src/init.js
+++ b/packages/deployment/src/init.js
@@ -68,7 +68,7 @@ const genericAskApiKey =
 
 const genericAskDatacenter =
   ({ inquirer }) =>
-  async (provider, PLACEMENT, dcs, placement) => {
+  async (_provider, PLACEMENT, dcs, placement) => {
     const questions = [];
     const count = nodeCount(calculateTotal(placement), true);
     const DONE = {
@@ -132,7 +132,7 @@ const makeProviders = ({ env, inquirer, wr, setup, fetch }) => ({
         /* eslint-enable */
       };
     },
-    askDatacenter: async (provider, PLACEMENT, dcs, placement) => {
+    askDatacenter: async (_provider, PLACEMENT, _dcs, placement) => {
       const { NUM_NODES } = await inquirer.prompt([
         {
           name: 'NUM_NODES',
@@ -169,7 +169,7 @@ module "${PLACEMENT}" {
     value: 'digitalocean',
     askDetails: genericAskApiKey({ env, inquirer }),
     askDatacenter: genericAskDatacenter({ inquirer }),
-    datacenters: async (provider, PLACEMENT, DETAILS) => {
+    datacenters: async (_provider, _PLACEMENT, DETAILS) => {
       const { API_KEYS: apikey } = DETAILS;
       const res = await fetch('https://api.digitalocean.com/v2/regions', {
         headers: { Authorization: `Bearer ${apikey}` },

--- a/packages/fast-usdc-contract/src/exos/advancer.ts
+++ b/packages/fast-usdc-contract/src/exos/advancer.ts
@@ -259,7 +259,7 @@ export const prepareAdvancerKit = (
               );
             } else {
               // This is supposed to be caught in handleTransactionEvent()
-              Fail`🚨 can only transfer to Agoric addresses, via IBC, or via CCTP`;
+              throw Fail`🚨 can only transfer to Agoric addresses, via IBC, or via CCTP`;
             }
           });
         },

--- a/packages/fast-usdc-contract/src/exos/advancer.ts
+++ b/packages/fast-usdc-contract/src/exos/advancer.ts
@@ -214,7 +214,7 @@ export const prepareAdvancerKit = (
       /* c8 ignore start */
       depositHandler: {
         /**
-         * @param result
+         * @param _result
          * @param ctx
          * @throws {never} WARNING: this function must not throw, because user funds are at risk
          */
@@ -299,7 +299,7 @@ export const prepareAdvancerKit = (
       },
       transferHandler: {
         /**
-         * @param {undefined} result
+         * @param {undefined} _result
          * @param {OldAdvancerVowCtx} ctx
          * @throws {never} WARNING: this function must not throw, because user funds are at risk
          */
@@ -331,7 +331,7 @@ export const prepareAdvancerKit = (
       },
       transferCctpHandler: {
         /**
-         * @param result
+         * @param _result
          * @param ctx
          * @throws {never} WARNING: this function must not throw, because user funds are at risk
          */

--- a/packages/fast-usdc-contract/src/exos/advancer.ts
+++ b/packages/fast-usdc-contract/src/exos/advancer.ts
@@ -219,7 +219,7 @@ export const prepareAdvancerKit = (
          * @throws {never} WARNING: this function must not throw, because user funds are at risk
          */
         onFulfilled(
-          result: undefined,
+          _result: undefined,
           ctx: OldAdvancerVowCtx & { tmpSeat: ZCFSeat },
         ) {
           return asVow(() => {
@@ -303,7 +303,7 @@ export const prepareAdvancerKit = (
          * @param {OldAdvancerVowCtx} ctx
          * @throws {never} WARNING: this function must not throw, because user funds are at risk
          */
-        onFulfilled(result: undefined, ctx: AdvancerVowCtx) {
+        onFulfilled(_result: undefined, ctx: AdvancerVowCtx) {
           const { notifier } = this.state;
           const { advanceAmount, destination, ...detail } = ctx;
           log('Advance succeeded', { advanceAmount, destination });
@@ -335,7 +335,7 @@ export const prepareAdvancerKit = (
          * @param ctx
          * @throws {never} WARNING: this function must not throw, because user funds are at risk
          */
-        onFulfilled(result: undefined, ctx: OldAdvancerVowCtx) {
+        onFulfilled(_result: undefined, ctx: OldAdvancerVowCtx) {
           const { advanceAmount } = ctx;
           // assets are on noble, transfer to dest.
           const intermediaryAccount = getNobleICA();
@@ -358,7 +358,7 @@ export const prepareAdvancerKit = (
          * @throws {never} WARNING: this function must not throw, because user funds are at risk
          */
         onFulfilled(
-          result: undefined,
+          _result: undefined,
           {
             advanceAmount,
             tmpReturnSeat,

--- a/packages/fast-usdc-contract/src/fast-usdc.flows.ts
+++ b/packages/fast-usdc-contract/src/fast-usdc.flows.ts
@@ -61,7 +61,7 @@ export const makeNobleAccount = (async (orch: Orchestrator) => {
 harden(makeNobleAccount);
 
 export const forwardFunds = async (
-  orch: Orchestrator,
+  _orch: Orchestrator,
   {
     currentChainReference,
     supportsCctp,
@@ -185,7 +185,7 @@ export interface ContextAdvance {
 }
 
 export const advanceFunds = (async (
-  orch: Orchestrator,
+  _orch: Orchestrator,
   {
     chainHubTools,
     feeConfig,

--- a/packages/fast-usdc-contract/test/exos/advancer.test.ts
+++ b/packages/fast-usdc-contract/test/exos/advancer.test.ts
@@ -323,7 +323,7 @@ test('updates status to ADVANCE_SKIPPED on insufficient pool funds', async t => 
   } = t.context;
 
   const mockBorrowerFacet = Far('LiquidityPool Borrow Facet', {
-    borrow: (seat: ZCFSeat, amount: NatAmount) => {
+    borrow: (_seat: ZCFSeat, amount: NatAmount) => {
       throw new Error(
         `Cannot borrow. Requested ${q(amount)} must be less than pool balance ${q(usdc.make(1n))}.`,
       );
@@ -783,7 +783,7 @@ test('alerts if `returnToPool` fallback fails', async t => {
     borrow: () => {
       // note: will not be tracked by `inspectBorrowerFacetCalls`
     },
-    returnToPool: (seat: ZCFSeat, amount: NatAmount) => {
+    returnToPool: (_seat: ZCFSeat, amount: NatAmount) => {
       throw new Error(
         `⚠️ borrowSeatAllocation ${q({ USDC: usdc.make(0n) })} less than amountKWR ${q(amount)}`,
       );

--- a/packages/fast-usdc-deploy/src/add-operators.build.js
+++ b/packages/fast-usdc-deploy/src/add-operators.build.js
@@ -30,7 +30,7 @@ const crossVatContext = /** @type {const} */ ({
 
 /** @type {CoreEvalBuilder} */
 export const defaultProposalBuilder = async (
-  powers,
+  _powers,
   /** @type {FastUSDCConfig} */ config,
 ) => {
   return harden({

--- a/packages/fast-usdc-deploy/src/fast-usdc-update.build.js
+++ b/packages/fast-usdc-deploy/src/fast-usdc-update.build.js
@@ -23,12 +23,12 @@ const feedPolicyUsage = 'use --feedPolicy <policy> ...';
  */
 
 /**
- * @param {Parameters<CoreEvalBuilder>[0]} powers
+ * @param {Parameters<CoreEvalBuilder>[0]} _powers
  * @param {FastUSDCConfig} config
  * @satisfies {CoreEvalBuilder}
  */
 export const updateProposalBuilder = async (
-  powers,
+  _powers,
   /** @type {Pick<FastUSDCConfig, 'feedPolicy'>} */ config,
 ) => {
   return harden({

--- a/packages/fast-usdc-deploy/test/fu-sim-iter.ts
+++ b/packages/fast-usdc-deploy/test/fu-sim-iter.ts
@@ -39,7 +39,7 @@ const nobleAgoricChannelId = 'channel-21';
 
 const makeTxOracle = (
   ctx: WalletFactoryTestContext,
-  name: string,
+  _name: string,
   addr: string,
 ) => {
   const { agoricNamesRemotes, walletFactoryDriver: wfd } = ctx;

--- a/packages/fast-usdc/test/cli/transfer.test.ts
+++ b/packages/fast-usdc/test/cli/transfer.test.ts
@@ -109,6 +109,7 @@ test('Transfer registers the noble forwarding account if it does not exist', asy
         return {};
       }
     }
+    throw Error(`unexpected query: ${query}`);
   });
   const nobleSignerAddress = 'noble09876';
   const signerMock = makeMockSigner();
@@ -190,6 +191,7 @@ test('Transfer signs and broadcasts the depositForBurn message on Ethereum', asy
         return {};
       }
     }
+    throw Error(`unexpected query: ${query}`);
   });
   const nobleSignerAddress = 'noble09876';
   const signerMock = makeMockSigner();

--- a/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
@@ -211,7 +211,7 @@ const setupOfferFilterChange = async (
   log,
   governor,
   installations,
-  invitation,
+  _invitation,
   strings = ['foo', 'bar:'],
 ) => {
   const filterChangeSpec = harden(strings);
@@ -255,7 +255,7 @@ const setupApiCall = async (zoe, log, governor, installations) => {
 const validateElectorateChange = async (
   zoe,
   log,
-  voters1,
+  _voters1,
   detailsP,
   governorInstance,
   electorateInstance,

--- a/packages/inter-protocol/src/econCommitteeCharter.js
+++ b/packages/inter-protocol/src/econCommitteeCharter.js
@@ -55,10 +55,10 @@ harden(meta);
 
 /**
  * @param {ZCF<{ binaryVoteCounterInstallation: Installation }>} zcf
- * @param {undefined} privateArgs
+ * @param {undefined} _privateArgs
  * @param {Baggage} baggage
  */
-export const start = async (zcf, privateArgs, baggage) => {
+export const start = async (zcf, _privateArgs, baggage) => {
   const { binaryVoteCounterInstallation: counter } = zcf.getTerms();
   /** @type {MapStore<Instance<unknown>, GovernorCreatorFacet<any>>} */
   const instanceToGovernor = provideDurableMapStore(

--- a/packages/inter-protocol/test/psm/psm.test.js
+++ b/packages/inter-protocol/test/psm/psm.test.js
@@ -743,7 +743,7 @@ const makeMockBankManager = t => {
       Far('depositFacet', {
         receive: () => /** @type {any} */ (null),
       }),
-    addAsset: async (denom, keyword, proposedName, kit) => {
+    addAsset: async (denom, keyword, _proposedName, kit) => {
       t.log('addAsset', { denom, keyword, issuer: `${kit.issuer}` });
       t.truthy(kit.mint);
     },

--- a/packages/inter-protocol/test/reserve/setup.js
+++ b/packages/inter-protocol/test/reserve/setup.js
@@ -30,11 +30,11 @@ import * as faucetContractExports from '../vaultFactory/faucet.js';
 /**
  * NOTE: called separately by each test so zoe/priceAuthority don't interfere
  *
- * @param {any} t
+ * @param {any} _t
  * @param {ZoeManualTimer | undefined} timer
  * @param {FarZoeKit} farZoeKit
  */
-const setupReserveBootstrap = async (t, timer, farZoeKit) => {
+const setupReserveBootstrap = async (_t, timer, farZoeKit) => {
   const space = /** @type {any} */ (makePromiseSpace());
   const { produce, consume } = /** @type {EconomyBootstrapPowers} */ (space);
 

--- a/packages/inter-protocol/test/smartWallet/contexts.js
+++ b/packages/inter-protocol/test/smartWallet/contexts.js
@@ -58,10 +58,10 @@ export const importBootTestUtils = async (log, bundleCache) => {
 };
 
 /**
- * @param {ExecutionContext} t
+ * @param {ExecutionContext} _t
  * @param {(logger, cache) => Promise<ChainBootstrapSpace & WellKnownSpaces>} makeSpace
  */
-export const makeDefaultTestContext = async (t, makeSpace) => {
+export const makeDefaultTestContext = async (_t, makeSpace) => {
   // To debug, pass t.log instead of null logger
   const log = () => null;
 

--- a/packages/inter-protocol/test/supports.js
+++ b/packages/inter-protocol/test/supports.js
@@ -44,12 +44,12 @@ export { makeMockChainStorageRoot };
 export const DENOM_UNIT = 1_000_000n;
 
 /**
- * @param {ExecutionContext} t
+ * @param {ExecutionContext} _t
  * @param {string} sourceRoot
  * @param {string} bundleName
  * @returns {Promise<SourceBundle>}
  */
-export const provideBundle = (t, sourceRoot, bundleName) => {
+export const provideBundle = (_t, sourceRoot, bundleName) => {
   return bundleCache.load(sourceRoot, bundleName);
 };
 harden(provideBundle);

--- a/packages/internal/src/lib-nodejs/spawnSubprocessWorker.js
+++ b/packages/internal/src/lib-nodejs/spawnSubprocessWorker.js
@@ -19,7 +19,7 @@ import {
 // JSON-serializable data.
 
 // eslint-disable-next-line no-unused-vars
-function parentLog(first, ...args) {
+function parentLog(_first, ..._args) {
   // console.error(`--parent: ${first}`, ...args);
 }
 

--- a/packages/internal/src/lib-nodejs/spawnSubprocessWorker.js
+++ b/packages/internal/src/lib-nodejs/spawnSubprocessWorker.js
@@ -20,7 +20,7 @@ import {
 
 // eslint-disable-next-line no-unused-vars
 function parentLog(_first, ..._args) {
-  // console.error(`--parent: ${first}`, ...args);
+  // console.error(`--parent: ${_first}`, ..._args);
 }
 
 // we send on fd3, and receive on fd4. We pass fd1/2 (stdout/err) through, so

--- a/packages/internal/src/lib-nodejs/worker-protocol.js
+++ b/packages/internal/src/lib-nodejs/worker-protocol.js
@@ -7,11 +7,11 @@ import { Transform } from 'stream';
 export function arrayEncoderStream() {
   /**
    * @param {any} object
-   * @param {BufferEncoding} encoding
+   * @param {BufferEncoding} _encoding
    * @param {any} callback
    * @this {{ push: (b: Buffer) => void }}
    */
-  function transform(object, encoding, callback) {
+  function transform(object, _encoding, callback) {
     if (!Array.isArray(object)) {
       throw Error('stream requires Arrays');
     }
@@ -30,11 +30,11 @@ export function arrayEncoderStream() {
 export function arrayDecoderStream() {
   /**
    * @param {Buffer} buf
-   * @param {BufferEncoding} encoding
+   * @param {BufferEncoding} _encoding
    * @param {any} callback
    * @this {{ push: (b: Buffer) => void }}
    */
-  function transform(buf, encoding, callback) {
+  function transform(buf, _encoding, callback) {
     let err;
     try {
       if (!Buffer.isBuffer(buf)) {

--- a/packages/internal/src/marshal/wrap-marshaller.js
+++ b/packages/internal/src/marshal/wrap-marshaller.js
@@ -31,7 +31,7 @@ class SlotWrapper {
   #slot;
 
   /** @type {InterfaceSpec} */
-  [Symbol.toStringTag];
+  [Symbol.toStringTag] = 'Alleged: SlotWrapper';
 
   /**
    * @param {Slot} slot

--- a/packages/internal/src/netstring.js
+++ b/packages/internal/src/netstring.js
@@ -21,11 +21,11 @@ export function encode(data) {
 export function netstringEncoderStream() {
   /**
    * @param {Buffer} chunk
-   * @param {BufferEncoding} encoding
+   * @param {BufferEncoding} _encoding
    * @param {any} callback
    * @this {{ push: (b: Buffer) => void }}
    */
-  function transform(chunk, encoding, callback) {
+  function transform(chunk, _encoding, callback) {
     if (!Buffer.isBuffer(chunk)) {
       throw Error('stream requires Buffers');
     }
@@ -93,11 +93,11 @@ export function netstringDecoderStream(optMaxChunkSize) {
   let buffered = Buffer.from('');
   /**
    * @param {Buffer} chunk
-   * @param {BufferEncoding} encoding
+   * @param {BufferEncoding} _encoding
    * @param {any} callback
    * @this {{ push: (b: Buffer) => void }}
    */
-  function transform(chunk, encoding, callback) {
+  function transform(chunk, _encoding, callback) {
     if (!Buffer.isBuffer(chunk)) {
       throw Error('stream requires Buffers');
     }

--- a/packages/internal/src/node/fs-stream.js
+++ b/packages/internal/src/node/fs-stream.js
@@ -60,7 +60,16 @@ export const makeFsStreamWriter = async filePath => {
     return { handle: fh, stream: fh.createWriteStream({ flush: true }) };
   })();
   await fsStreamReady(stream);
-  const writeAsync = promisify(stream.write.bind(stream));
+  const writeAsync = data =>
+    new Promise((resolve, reject) => {
+      const waitForDrain = !stream.write(data, err => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(waitForDrain);
+      });
+    });
   const closeAsync =
     useStdout || !(/** @type {any} */ (stream).close)
       ? undefined

--- a/packages/internal/src/node/fs-stream.js
+++ b/packages/internal/src/node/fs-stream.js
@@ -44,6 +44,53 @@ export const fsStreamReady = stream =>
     stream.on('error', onError);
   });
 
+/**
+ * Wait for a stream event and reject on stream error first.
+ *
+ * @param {ReadStream | WriteStream | Socket} stream
+ * @param {'drain' | 'ready'} eventName
+ * @returns {Promise<void>}
+ */
+const onceWithError = (stream, eventName) =>
+  new Promise((resolve, reject) => {
+    const onEvent = () => {
+      cleanup();
+      resolve();
+    };
+    /** @param {Error} err */
+    const onError = err => {
+      cleanup();
+      reject(err);
+    };
+    const cleanup = () => {
+      stream.off(eventName, onEvent);
+      stream.off('error', onError);
+    };
+    stream.on(eventName, onEvent);
+    stream.on('error', onError);
+  });
+
+/**
+ * @param {WriteStream | Socket} stream
+ * @param {string | Uint8Array} data
+ * @returns {Promise<boolean>} whether caller must await drain
+ */
+const writeChunk = (stream, data) =>
+  new Promise((resolve, reject) => {
+    let waitForDrain;
+    try {
+      waitForDrain = !stream.write(data, err => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(waitForDrain);
+      });
+    } catch (err) {
+      reject(err);
+    }
+  });
+
 /** @typedef {NonNullable<Awaited<ReturnType<typeof makeFsStreamWriter>>>} FsStreamWriter */
 /** @param {string | undefined | null} filePath */
 export const makeFsStreamWriter = async filePath => {
@@ -60,16 +107,7 @@ export const makeFsStreamWriter = async filePath => {
     return { handle: fh, stream: fh.createWriteStream({ flush: true }) };
   })();
   await fsStreamReady(stream);
-  const writeAsync = data =>
-    new Promise((resolve, reject) => {
-      const waitForDrain = !stream.write(data, err => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        resolve(waitForDrain);
-      });
-    });
+  const waitForDrainAsync = () => onceWithError(stream, 'drain');
   const closeAsync =
     useStdout || !(/** @type {any} */ (stream).close)
       ? undefined
@@ -96,11 +134,11 @@ export const makeFsStreamWriter = async filePath => {
   const write = async data => {
     const written = closed
       ? Promise.reject(Error('Stream closed'))
-      : writeAsync(data);
+      : writeChunk(stream, data);
     updateFlushed(written);
     const waitForDrain = await written;
     if (waitForDrain) {
-      await new Promise(resolve => stream.once('drain', resolve));
+      await waitForDrainAsync();
     }
   };
 

--- a/packages/internal/test/utils.test.js
+++ b/packages/internal/test/utils.test.js
@@ -552,7 +552,7 @@ test('partialMap', t => {
   // Manually map input to its reverse, expecting absence of false/undefined.
   const input = [true, false, undefined, null, 0, 0n, '', [], {}, Symbol('')];
   const expect = [true, ...input.slice(3)].reverse();
-  const output = partialMap(input, (value, idx, arr) => {
+  const output = partialMap(input, (_value, idx, arr) => {
     t.is(arr, input);
     return arr.at(-(idx + 1));
   });

--- a/packages/network/src/network.js
+++ b/packages/network/src/network.js
@@ -1580,7 +1580,7 @@ const prepareFinalizer = (zone, { watch }) => {
     },
     finalize(obj) {
       if (!objToFinalizerInfo.has(obj)) {
-        return;
+        return undefined;
       }
       const disposeInfo = objToFinalizerInfo.get(obj);
       if ('conn' in disposeInfo) {
@@ -1594,6 +1594,7 @@ const prepareFinalizer = (zone, { watch }) => {
         objToFinalizerInfo.delete(obj);
         return watch(E(closer).close());
       }
+      return undefined;
     },
     unpin(obj) {
       objToFinalizerInfo.delete(obj);

--- a/packages/network/test/network-misc.test.js
+++ b/packages/network/test/network-misc.test.js
@@ -302,7 +302,7 @@ test('loopback protocol', async t => {
       undefined,
       () => ({}),
       {
-        async onReceive(c, packet, _connectionHandler) {
+        async onReceive(_c, packet, _connectionHandler) {
           t.is(`${packet}`, 'ping', 'expected ping');
           return 'pingack';
         },

--- a/packages/orchestration/src/examples/staking-combinations.contract.js
+++ b/packages/orchestration/src/examples/staking-combinations.contract.js
@@ -39,13 +39,13 @@ const emptyOfferShape = harden({
  * @param {ZCF} zcf
  * @param {OrchestrationPowers & {
  *   marshaller: Remote<Marshaller>;
- * }} privateArgs
+ * }} _privateArgs
  * @param {Zone} zone
  * @param {OrchestrationTools} tools
  */
 const contract = async (
   zcf,
-  privateArgs,
+  _privateArgs,
   zone,
   { orchestrateAll, zoeTools, chainHub },
 ) => {

--- a/packages/orchestration/src/examples/staking-combinations.flows.js
+++ b/packages/orchestration/src/examples/staking-combinations.flows.js
@@ -47,7 +47,7 @@ harden(makeAccount);
 
 /**
  * @satisfies {OrchestrationFlow}
- * @param {Orchestrator} orch
+ * @param {Orchestrator} _orch
  * @param {object} ctx
  * @param {GuestInterface<ChainHub>} ctx.chainHub
  * @param {Promise<GuestInterface<LocalOrchestrationAccountKit['holder']>>} ctx.sharedLocalAccountP
@@ -58,7 +58,7 @@ harden(makeAccount);
  * @returns {Promise<void>}
  */
 export const depositAndDelegate = async (
-  orch,
+  _orch,
   { chainHub, sharedLocalAccountP, zoeTools },
   account,
   seat,
@@ -96,8 +96,8 @@ harden(depositAndDelegate);
 
 /**
  * @satisfies {OrchestrationFlow}
- * @param {Orchestrator} orch
- * @param {object} ctx
+ * @param {Orchestrator} _orch
+ * @param {object} _ctx
  * @param {GuestInterface<CosmosOrchestrationAccount>} account
  * @param {{
  *   delegations: { amount: AmountArg; validator: CosmosValidatorAddress }[];
@@ -106,8 +106,8 @@ harden(depositAndDelegate);
  * @returns {Promise<void>}
  */
 export const undelegateAndTransfer = async (
-  orch,
-  ctx,
+  _orch,
+  _ctx,
   account,
   { delegations, destination },
 ) => {

--- a/packages/orchestration/src/examples/swap.contract.js
+++ b/packages/orchestration/src/examples/swap.contract.js
@@ -61,13 +61,13 @@ harden(makeNatAmountShape);
  *   marshaller: Remote<Marshaller>;
  *   chainInfo: Record<string, CosmosChainInfo>;
  *   assetInfo: [Denom, DenomDetail & { brandKey?: string }][];
- * }} privateArgs
+ * }} _privateArgs
  * @param {Zone} zone
  * @param {OrchestrationTools} tools
  */
 const contract = async (
   zcf,
-  privateArgs,
+  _privateArgs,
   zone,
   { orchestrateAll, zoeTools },
 ) => {

--- a/packages/orchestration/src/examples/unbond.contract.js
+++ b/packages/orchestration/src/examples/unbond.contract.js
@@ -26,13 +26,13 @@ import * as flows from './unbond.flows.js';
  *   storageNode: Remote<StorageNode>;
  *   marshaller: Remote<Marshaller>;
  *   timerService: Remote<TimerService>;
- * }} privateArgs
+ * }} _privateArgs
  * @param {Zone} zone
  * @param {OrchestrationTools} tools
  */
 const contract = async (
   zcf,
-  privateArgs,
+  _privateArgs,
   zone,
   { orchestrateAll, zcfTools },
 ) => {

--- a/packages/orchestration/src/vat-orchestration.js
+++ b/packages/orchestration/src/vat-orchestration.js
@@ -14,11 +14,11 @@ import { prepareCosmosInterchainService } from './exos/cosmos-interchain-service
  *
  * @param {VatPowers & {
  *   D: DProxy;
- * }} vatPowers
- * @param {never} vatParameters
+ * }} _vatPowers
+ * @param {never} _vatParameters
  * @param {Baggage} baggage
  */
-export const buildRootObject = (vatPowers, vatParameters, baggage) => {
+export const buildRootObject = (_vatPowers, _vatParameters, baggage) => {
   const zone = makeDurableZone(baggage);
   const vowTools = prepareSwingsetVowTools(zone.subZone('VowTools'));
   const makeCosmosInterchainService = prepareCosmosInterchainService(

--- a/packages/orchestration/test/examples/bad.flows.js
+++ b/packages/orchestration/test/examples/bad.flows.js
@@ -26,7 +26,7 @@ export async function notHardened() {
   console.log('This function is the most minimal flow, but it’s not hardened');
 }
 
-export const usesE = async (orch, { someEref }) => {
+export const usesE = async (_orch, { someEref }) => {
   // eslint-disable-next-line no-restricted-syntax -- intentional for test
   await E(someEref).foo();
 };

--- a/packages/orchestration/test/facade.test.ts
+++ b/packages/orchestration/test/facade.test.ts
@@ -39,10 +39,10 @@ test('calls between flows', async t => {
   const { vt, orchestrateAll } = t.context;
 
   const flows = {
-    outer(orch, ctx, ...recipients) {
+    outer(_orch, ctx, ...recipients) {
       return ctx.peerFlows.inner('Hello', ...recipients);
     },
-    inner(orch, ctx, ...strs) {
+    inner(_orch, _ctx, ...strs) {
       return Promise.resolve(strs.join(' '));
     },
   } as Record<string, OrchestrationFlow<any>>;
@@ -59,10 +59,10 @@ test('context mapping individual flows', async t => {
   const { vt, orchestrateAll } = t.context;
 
   const flows = {
-    outer(orch, ctx, ...recipients) {
+    outer(_orch, ctx, ...recipients) {
       return ctx.peerFlows.inner('Hello', ...recipients);
     },
-    inner(orch, ctx, ...strs) {
+    inner(_orch, _ctx, ...strs) {
       return Promise.resolve(strs.join(' '));
     },
   } as Record<string, OrchestrationFlow<any>>;

--- a/packages/orchestration/test/fixtures/zoe-tools.flows.js
+++ b/packages/orchestration/test/fixtures/zoe-tools.flows.js
@@ -24,7 +24,7 @@ const { values } = Object;
  * facilitate failure path testing of ZoeTools.
  *
  * @satisfies {OrchestrationFlow}
- * @param {Orchestrator} orch
+ * @param {Orchestrator} _orch
  * @param {object} ctx
  * @param {Promise<GuestInterface<LocalOrchestrationAccountKit['holder']>>} ctx.sharedLocalAccountP
  * @param {GuestInterface<ZoeTools>} ctx.zoeTools
@@ -32,7 +32,7 @@ const { values } = Object;
  * @param {{ destAddr: CosmosChainAddress }} offerArgs
  */
 export const depositSend = async (
-  orch,
+  _orch,
   { sharedLocalAccountP, zoeTools: { localTransfer, withdrawToSeat } },
   seat,
   offerArgs,
@@ -67,14 +67,14 @@ harden(depositSend);
  * account.
  *
  * @satisfies {OrchestrationFlow}
- * @param {Orchestrator} orch
+ * @param {Orchestrator} _orch
  * @param {object} ctx
  * @param {Promise<GuestInterface<LocalOrchestrationAccountKit['holder']>>} ctx.sharedLocalAccountP
  * @param {GuestInterface<ZoeTools>} ctx.zoeTools
  * @param {ZCFSeat} seat
  */
 export const deposit = async (
-  orch,
+  _orch,
   { sharedLocalAccountP, zoeTools: { localTransfer } },
   seat,
 ) => {
@@ -99,14 +99,14 @@ harden(deposit);
  * Withdraw funds from the contract's local account to the offer's seat.
  *
  * @satisfies {OrchestrationFlow}
- * @param {Orchestrator} orch
+ * @param {Orchestrator} _orch
  * @param {object} ctx
  * @param {Promise<GuestInterface<LocalOrchestrationAccountKit['holder']>>} ctx.sharedLocalAccountP
  * @param {GuestInterface<ZoeTools>} ctx.zoeTools
  * @param {ZCFSeat} seat
  */
 export const withdraw = async (
-  orch,
+  _orch,
   { sharedLocalAccountP, zoeTools: { withdrawToSeat } },
   seat,
 ) => {

--- a/packages/orchestration/test/types.test-d.ts
+++ b/packages/orchestration/test/types.test-d.ts
@@ -211,7 +211,7 @@ expectNotType<CosmosValidatorAddress>(chainAddr);
 {
   type TransferStepsVow = HostOf<OrchestrationAccount<any>['transferSteps']>;
 
-  const transferStepsVow: TransferStepsVow = (...args: any[]): Vow<any> =>
+  const transferStepsVow: TransferStepsVow = (..._args: any[]): Vow<any> =>
     ({}) as any;
   expectType<(...args: any[]) => Vow<any>>(transferStepsVow);
 }
@@ -228,7 +228,7 @@ expectNotType<CosmosValidatorAddress>(chainAddr);
 
   const vowObject: VowObject = {
     foo: () => ({}) as Vow<number>,
-    bar: (x: string) => ({}) as Vow<boolean>,
+    bar: (_x: string) => ({}) as Vow<boolean>,
     bizz: () => ({ foo: 1 }),
   };
 
@@ -243,14 +243,17 @@ expectNotType<CosmosValidatorAddress>(chainAddr);
   // orchestrate()
 
   const facade: OrchestrationFacade = null as any;
-  const echo = <T extends number>(orc: Orchestrator, ctx: undefined, num: T) =>
-    num;
+  const echo = <T extends number>(
+    _orc: Orchestrator,
+    _ctx: undefined,
+    num: T,
+  ) => num;
   // @ts-expect-error requires an async function
   facade.orchestrate('name', undefined, echo);
 
   const slowEcho = <T extends number>(
-    orc: Orchestrator,
-    ctx: undefined,
+    _orc: Orchestrator,
+    _ctx: undefined,
     num: T,
   ) => Promise.resolve(num);
   {

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -1644,7 +1644,7 @@ const resolveCCTPIn = (
  * Prompt.
  */
 export const onAgoricTransfer = (async (
-  orch: Orchestrator,
+  _orch: Orchestrator,
   ctx: OnTransferContext,
   event: VTransferIBCEvent,
   pKit: PortfolioKit,

--- a/packages/portfolio-contract/src/pos-usdn.flows.ts
+++ b/packages/portfolio-contract/src/pos-usdn.flows.ts
@@ -160,7 +160,7 @@ harden(agoricToNoble);
 export const nobleToAgoric = {
   how: 'IBC from Noble',
   connections: [{ src: 'noble', dest: 'agoric' }],
-  apply: async (ctx, amount, src, dest, ...optsArgs) => {
+  apply: async (_ctx, amount, src, dest, ...optsArgs) => {
     const nobleAmount = { value: amount.value, denom: 'uusdc' };
     await src.ica.transfer(dest.lca.getAddress(), nobleAmount, ...optsArgs);
   },

--- a/packages/portfolio-contract/test/contract-setup.ts
+++ b/packages/portfolio-contract/test/contract-setup.ts
@@ -1,5 +1,5 @@
-import type { VstorageKit } from '@agoric/client-utils';
 import { mustMatch, type ERemote } from '@agoric/internal';
+import type { VstorageKit } from '@agoric/client-utils';
 import { defaultSerializer } from '@agoric/internal/src/storage-test-utils.js';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { ROOT_STORAGE_PATH } from '@agoric/orchestration/tools/contract-tests.js';
@@ -32,7 +32,6 @@ import { chainInfoWithCCTP, setupPortfolioTest } from './supports.ts';
 const contractName = 'ymax0';
 type StartFn = typeof contractExports.start;
 const { values } = Object;
-
 const makeReadPublished = (
   storage: Awaited<
     ReturnType<typeof setupPortfolioTest>
@@ -44,7 +43,7 @@ const makeReadPublished = (
       .getDeserialized(`${ROOT_STORAGE_PATH}.${subpath}`)
       .at(-1);
     return val;
-  }) as unknown as VstorageKit<PortfolioPublishedPathTypes>['readPublished'];
+  }) as VstorageKit<PortfolioPublishedPathTypes>['readPublished'];
 
 const makeEvmWalletHandler = async (
   zoe: ZoeService,

--- a/packages/portfolio-contract/test/supports.ts
+++ b/packages/portfolio-contract/test/supports.ts
@@ -1,5 +1,5 @@
-import type { VstorageKit } from '@agoric/client-utils';
 import { encodeAddressHook } from '@agoric/cosmic-proto/address-hooks.js';
+import type { VstorageKit } from '@agoric/client-utils';
 import { makeIssuerKit } from '@agoric/ertp';
 import type { Brand, NatAmount } from '@agoric/ertp';
 import {

--- a/packages/portfolio-contract/test/target-allocation.test.ts
+++ b/packages/portfolio-contract/test/target-allocation.test.ts
@@ -1,8 +1,8 @@
 /**
  * @file Test target allocation functionality
  */
-import type { VstorageKit } from '@agoric/client-utils';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
+import type { VstorageKit } from '@agoric/client-utils';
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { E } from '@endo/far';
 import { makeTrader } from '../tools/portfolio-actors.js';
@@ -66,7 +66,7 @@ test('multiple portfolios have independent allocations', async t => {
     await eventLoopIteration();
     const val = storage.getDeserialized(`orchtest.${subpath}`).at(-1);
     return val;
-  }) as unknown as VstorageKit<PortfolioPublishedPathTypes>['readPublished'];
+  }) as VstorageKit<PortfolioPublishedPathTypes>['readPublished'];
 
   // Create two separate wallets and traders
   const { mint: _, ...poc26SansMint } = poc26;

--- a/packages/portfolio-contract/tools/graph-diagnose.ts
+++ b/packages/portfolio-contract/tools/graph-diagnose.ts
@@ -359,7 +359,7 @@ export const diagnoseNearMisses = (graph: FlowGraph) => {
 
 /** Build a canonical leaf/hub -> hub/leaf path skeleton between two nodes. */
 export const canonicalPathBetween = (
-  graph: FlowGraph,
+  _graph: FlowGraph,
   src: string,
   dest: string,
 ): string[] => {

--- a/packages/portfolio-contract/tools/portfolio-actors.ts
+++ b/packages/portfolio-contract/tools/portfolio-actors.ts
@@ -165,7 +165,7 @@ export const makeTrader = (
      * This enables ongoing portfolio management after initial creation.
      */
     async rebalance(
-      t: ExecutionContext,
+      _t: ExecutionContext,
       proposal: ProposalType['rebalance'],
       offerArgs: OfferArgsFor['rebalance'],
     ) {
@@ -187,7 +187,7 @@ export const makeTrader = (
       });
     },
     async simpleRebalance(
-      t: ExecutionContext,
+      _t: ExecutionContext,
       proposal: ProposalType['rebalance'],
       offerArgs: OfferArgsFor['rebalance'],
     ) {
@@ -208,7 +208,7 @@ export const makeTrader = (
         offerArgs,
       });
     },
-    async withdraw(t: ExecutionContext, Cash: NatAmount) {
+    async withdraw(_t: ExecutionContext, Cash: NatAmount) {
       if (!openId) throw Error('not open');
       const invitationMakerName: PortfolioContinuingInvitationMaker =
         'Withdraw';
@@ -222,7 +222,7 @@ export const makeTrader = (
       const proposal: ProposalType['withdraw'] = { give: {}, want: { Cash } };
       return wallet.executeContinuingOffer({ id, invitationSpec, proposal });
     },
-    async deposit(t: ExecutionContext, Deposit: NatAmount) {
+    async deposit(_t: ExecutionContext, Deposit: NatAmount) {
       if (!openId) throw Error('not open');
       const invitationMakerName: PortfolioContinuingInvitationMaker = 'Deposit';
       const id = `Deposit-${(nonce += 1)}`;

--- a/packages/portfolio-contract/tools/portfolio-actors.ts
+++ b/packages/portfolio-contract/tools/portfolio-actors.ts
@@ -10,8 +10,8 @@
  *
  * @see type-guards.ts for the authoritative interface specification
  */
-import { type VstorageKit } from '@agoric/client-utils';
 import { AmountMath, type NatAmount } from '@agoric/ertp';
+import type { VstorageKit } from '@agoric/client-utils';
 import type { ChainInfo } from '@agoric/orchestration';
 import { ROOT_STORAGE_PATH } from '@agoric/orchestration/tools/contract-tests.js';
 import {

--- a/packages/portfolio-deploy/src/portfolio-control.build.js
+++ b/packages/portfolio-deploy/src/portfolio-control.build.js
@@ -16,11 +16,11 @@ import {
 const sourceSpec = './portfolio-control.core.js';
 
 /**
- * @param {Parameters<CoreEvalBuilder>[0]} tools
+ * @param {Parameters<CoreEvalBuilder>[0]} _tools
  * @param {DelegatePortfolioOptions} config
  * @satisfies {CoreEvalBuilder}
  */
-const defaultProposalBuilder = async (tools, config) => {
+const defaultProposalBuilder = async (_tools, config) => {
   return harden({
     sourceSpec,
     getManifestCall: [

--- a/packages/portfolio-deploy/src/portfolio-control.core.js
+++ b/packages/portfolio-deploy/src/portfolio-control.core.js
@@ -115,7 +115,7 @@ export const delegatePortfolioContract = async (permitted, config) => {
   );
 };
 
-export const getManifestForPortfolioControl = (utils, { options }) => {
+export const getManifestForPortfolioControl = (_utils, { options }) => {
   const { contractName } = options;
   return {
     manifest: {

--- a/packages/smart-wallet/src/marshal-contexts.js
+++ b/packages/smart-wallet/src/marshal-contexts.js
@@ -188,10 +188,10 @@ export const makeExportContext = () => {
 
   /**
    * @template {PassableCap} V
-   * @param {string & keyof typeof walletObjects} kind
+   * @param {string & keyof typeof walletObjects} _kind
    * @param {IdTable<number, V>} table
    */
-  const makeSaver = (kind, table) => {
+  const makeSaver = (_kind, table) => {
     let nonce = 0;
     /** @param {V} val */
     const saver = val => {
@@ -376,7 +376,7 @@ export const makeImportContext = (makePresence = defaultMakePresence) => {
 const makePresence = (iface, handler) => {
   let obj;
 
-  void new HandledPromise((resolve, reject, resolveWithPresence) => {
+  void new HandledPromise((_resolve, _reject, resolveWithPresence) => {
     obj = resolveWithPresence(handler);
   });
   assert(obj);

--- a/packages/smart-wallet/src/smartWallet.js
+++ b/packages/smart-wallet/src/smartWallet.js
@@ -1295,6 +1295,7 @@ export const prepareSmartWallet = (baggage, shared, setTestJig) => {
                 // but leave async rejections alone because the offer handler recorded them
                 // with greater detail
                 recordError(err);
+                return undefined;
               }
             },
             // record errors in the unserialize and leave the rejection handled

--- a/packages/smart-wallet/test/contexts.js
+++ b/packages/smart-wallet/test/contexts.js
@@ -14,10 +14,10 @@ import { withAmountUtils } from './supports.js';
  */
 
 /**
- * @param {ExecutionContext} t
+ * @param {ExecutionContext} _t
  * @param {(logger) => Promise<ChainBootstrapSpace>} makeSpace
  */
-export const makeDefaultTestContext = async (t, makeSpace) => {
+export const makeDefaultTestContext = async (_t, makeSpace) => {
   // To debug, pass t.log instead of null logger
   const log = () => null;
   const { consume } = await makeSpace(log);

--- a/packages/swing-store/src/archiver.js
+++ b/packages/swing-store/src/archiver.js
@@ -42,7 +42,7 @@ export const makeArchiveSnapshot = (dirPath, powers) => {
       const writer = fs.createWriteStream('', { fd, flush: true });
       const reader = Readable.from(gzData);
       const destroyReader = promisify(reader.destroy.bind(reader));
-      addCleanup(() => destroyReader(null));
+      addCleanup(() => destroyReader(undefined));
       reader.pipe(writer);
       await streamFinished(writer);
       fs.renameSync(tmpName, destPath);

--- a/packages/swing-store/src/snapStore.js
+++ b/packages/swing-store/src/snapStore.js
@@ -228,7 +228,7 @@ export function makeSnapStore(
         await measureSeconds(async () => {
           const snapReader = Readable.from(snapshotStream);
           const destroyReader = promisify(snapReader.destroy.bind(snapReader));
-          addCleanup(() => destroyReader(null));
+          addCleanup(() => destroyReader(undefined));
           snapReader.on('data', chunk => {
             uncompressedSize += chunk.length;
           });

--- a/packages/swingset-liveslots/src/liveslots.js
+++ b/packages/swingset-liveslots/src/liveslots.js
@@ -840,7 +840,7 @@ function build(
 
   function DeviceHandler(slot) {
     return {
-      get(target, prop) {
+      get(_target, prop) {
         if (typeof prop !== 'string' && typeof prop !== 'symbol') {
           return undefined;
         }

--- a/packages/swingset-liveslots/test/baggage.test.js
+++ b/packages/swingset-liveslots/test/baggage.test.js
@@ -6,7 +6,7 @@ import { setupTestLiveslots } from './liveslots-helpers.js';
 import { vstr } from './util.js';
 import { parseVatSlot } from '../src/parseVatSlots.js';
 
-function buildRootObject(vatPowers, vatParameters, baggage) {
+function buildRootObject(_vatPowers, _vatParameters, baggage) {
   baggage.has('outside');
   baggage.init('outside', 'outer val');
   return Far('root', {

--- a/packages/swingset-liveslots/test/initial-vrefs.test.js
+++ b/packages/swingset-liveslots/test/initial-vrefs.test.js
@@ -5,7 +5,7 @@ import { kunser } from '@agoric/kmarshal';
 import { M } from '@agoric/store';
 import { setupTestLiveslots } from './liveslots-helpers.js';
 
-function buildRootObject(vatPowers, vatParameters, baggage) {
+function buildRootObject(vatPowers, _vatParameters, baggage) {
   const vd = vatPowers.VatData;
 
   let vinstance1;

--- a/packages/swingset-runner/src/anylogger-legacy.js
+++ b/packages/swingset-runner/src/anylogger-legacy.js
@@ -2,7 +2,12 @@ import anylogger from '@agoric/internal/vendor/anylogger.js';
 
 const oldExt = anylogger.ext;
 
-/** Restore the pre-vendoring default: enabled levels log to console. */
+/**
+ * Restore the pre-vendoring default: enabled levels log to console.
+ *
+ * @param {Record<string, unknown>} logger
+ * @param {...unknown} rest
+ */
 anylogger.ext = (logger, ...rest) => {
   const extended = oldExt(logger, ...rest);
   const fallbackSink = console.log.bind(console);

--- a/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
+++ b/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
@@ -32,7 +32,7 @@ const decoder = new TextDecoder();
 
 // eslint-disable-next-line no-unused-vars
 function workerLog(_first, ..._args) {
-  // console.log(`---worker: ${first}`, ...args);
+  // console.log(`---worker: ${_first}`, ..._args);
 }
 
 workerLog(`supervisor started`);

--- a/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
+++ b/packages/swingset-xsnap-supervisor/lib/supervisor-subprocess-xsnap.js
@@ -31,7 +31,7 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 // eslint-disable-next-line no-unused-vars
-function workerLog(first, ...args) {
+function workerLog(_first, ..._args) {
   // console.log(`---worker: ${first}`, ...args);
 }
 

--- a/packages/vat-data/src/index.test-d.ts
+++ b/packages/vat-data/src/index.test-d.ts
@@ -49,7 +49,7 @@ type SingleCounterContext = {
   state: SingleCounterState;
   self: KindFacet<typeof counterBehavior>;
 };
-const initCounter = (name: string, str: string): SingleCounterState => ({
+const initCounter = (name: string, _str: string): SingleCounterState => ({
   counter: 0,
   name,
 });
@@ -106,7 +106,7 @@ const facetedCounterBehavior = {
   },
   other: {
     emptyFn: () => null,
-    echo: (context: MultiCounterContext, toEcho: string) => toEcho,
+    echo: (_context: MultiCounterContext, toEcho: string) => toEcho,
   },
 };
 

--- a/packages/vats/src/core/demoIssuers.js
+++ b/packages/vats/src/core/demoIssuers.js
@@ -69,7 +69,7 @@ const separators = whole => {
   // ack: https://stackoverflow.com/a/45950572/7963, https://regex101.com/
   const revStr = s => s.split('').reverse().join('');
   const lohi = revStr(`${whole}`);
-  const s = lohi.replace(/(?=\d{4})(\d{3})/g, (m, p1) => `${p1}${sep}`);
+  const s = lohi.replace(/(?=\d{4})(\d{3})/g, (_m, p1) => `${p1}${sep}`);
   return revStr(s);
 };
 

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -651,6 +651,7 @@ export const prepareIBCProtocol = (zone, powers) => {
               console.error('Unexpected IBC_EVENT', obj.event);
               assert.fail(X`unrecognized method ${obj.event}`, TypeError);
           }
+          return undefined;
         },
       },
       util: {
@@ -830,6 +831,7 @@ export const prepareIBCProtocol = (zone, powers) => {
                 `${channelKey}: async negotiated version was ${negotiatedVersion} but synchronous version was ${version}`,
               );
             }
+            return undefined;
           } catch (e) {
             // Clean up after our failed attempt.
             channelKeyToAttempt.delete(channelKey);

--- a/packages/vats/test/boot.test.js
+++ b/packages/vats/test/boot.test.js
@@ -99,7 +99,7 @@ test('evaluateBundleCap is available to core eval', async (/** @type {ECtx} */ t
     const bundleID = bundle.endoZipBase64Sha512;
     vatAdminState.installBundle(bundleID, bundle);
     const bridgeManager = {
-      register: (name, fn) => {
+      register: (_name, fn) => {
         handler = fn;
       },
     };

--- a/packages/vats/tools/fake-bridge.js
+++ b/packages/vats/tools/fake-bridge.js
@@ -110,7 +110,7 @@ export const makeFakeBankBridge = (
           });
         }
         default:
-          Fail`unknown type ${type}`;
+          throw Fail`unknown type ${type}`;
       }
     },
     fromBridge: async obj => {

--- a/packages/vm-config/test/paths.test.js
+++ b/packages/vm-config/test/paths.test.js
@@ -44,9 +44,9 @@ const walk = (node, onSourceSpec, onModule, currentPath = '$') => {
     return;
   }
   if (Array.isArray(node)) {
-    node.forEach((child, i) =>
-      walk(child, onSourceSpec, onModule, `${currentPath}[${i}]`),
-    );
+    for (const [i, child] of node.entries()) {
+      walk(child, onSourceSpec, onModule, `${currentPath}[${i}]`);
+    }
     return;
   }
   const record = /** @type {Record<string, unknown>} */ (node);

--- a/packages/vow/test/types.test-d.ts
+++ b/packages/vow/test/types.test-d.ts
@@ -12,7 +12,7 @@ vt.retryable(zone, 'foo', () => null);
 vt.retryable(zone, 'foo', () => Promise.resolve(null));
 
 expectType<(p1: number, p2: string) => Vow<{ someValue: 'bar' }>>(
-  vt.retryable(zone, 'foo', (p1: number, p2: string) =>
+  vt.retryable(zone, 'foo', (_p1: number, _p2: string) =>
     Promise.resolve({ someValue: 'bar' } as const),
   ),
 );

--- a/packages/vow/test/watch.test.js
+++ b/packages/vow/test/watch.test.js
@@ -41,11 +41,11 @@ const prepareArityCheckWatcher = (zone, t) => {
     undefined,
     expectedArgs => ({ expectedArgs }),
     {
-      onFulfilled(value, ...args) {
+      onFulfilled(_value, ...args) {
         t.deepEqual(args, this.state.expectedArgs);
         return 'fulfilled';
       },
-      onRejected(reason, ...args) {
+      onRejected(_reason, ...args) {
         t.deepEqual(args, this.state.expectedArgs);
         return 'rejected';
       },

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -591,7 +591,7 @@ export function makeWalletRoot({
 
   // handle the update, which has already resolved to a record. The update means
   // the offer is 'done'.
-  function updateOrResubscribe(id, seat, update) {
+  function updateOrResubscribe(id, _seat, update) {
     const { updateCount } = update;
     assert(updateCount === undefined);
     idToSeat.delete(id);

--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -1249,6 +1249,7 @@ export function makeWalletRoot({
           if (!exited) {
             return subscribeToUpdates(id, seat);
           }
+          return undefined;
         });
 
       const offerResultP = E(seat).getOfferResult();

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -284,6 +284,7 @@ export async function xsnap(options) {
         snapshotLoader = undefined;
         return cleanup();
       }
+      return undefined;
     });
   }
 

--- a/packages/zoe/src/contracts/auction/assertBidSeat.js
+++ b/packages/zoe/src/contracts/auction/assertBidSeat.js
@@ -1,7 +1,7 @@
 import { AmountMath } from '@agoric/ertp';
 import { Fail } from '@endo/errors';
 
-export const assertBidSeat = (zcf, sellSeat, bidSeat) => {
+export const assertBidSeat = (_zcf, sellSeat, bidSeat) => {
   const minBid = sellSeat.getProposal().want.Ask;
   const bid = bidSeat.getAmountAllocated('Bid', minBid.brand);
   AmountMath.isGTE(bid, minBid) ||

--- a/packages/zoe/src/zoeService/utils.test-d.ts
+++ b/packages/zoe/src/zoeService/utils.test-d.ts
@@ -3,8 +3,8 @@ import type { StartedInstanceKit } from './utils.js';
 import type { ZCF } from '../types-index.js';
 
 const someContractStartFn = (
-  zcf: ZCF,
-  privateArgs: { someNumber: number; someString: string },
+  _zcf: ZCF,
+  _privateArgs: { someNumber: number; someString: string },
 ) => ({});
 
 type PsmInstanceKit = StartedInstanceKit<typeof someContractStartFn>;

--- a/packages/zoe/test/types.test-d.ts
+++ b/packages/zoe/test/types.test-d.ts
@@ -121,8 +121,8 @@ const mock = null as any;
 
 {
   const start = async (
-    zcf: ZCF<{ anchorBrand: Brand<'nat'> }>,
-    privateArgs: {
+    _zcf: ZCF<{ anchorBrand: Brand<'nat'> }>,
+    _privateArgs: {
       storageNode: StorageNode;
       marshaller: Marshaller;
       feeMintAccess?: FeeMintAccess;

--- a/packages/zoe/test/unitTests/contracts/otcDesk.test.js
+++ b/packages/zoe/test/unitTests/contracts/otcDesk.test.js
@@ -108,7 +108,7 @@ const makeAlice = async (
 const makeBob = (
   t,
   zoe,
-  installation,
+  _installation,
   issuers,
   origPayments,
   coveredCallInstallation,

--- a/scripts/maintenance/tsconfig-flags-lib.mjs
+++ b/scripts/maintenance/tsconfig-flags-lib.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import ts from 'typescript';
+
+/**
+ * Flags where `true` increases type strictness.
+ */
+export const STRICTNESS_FLAGS = [
+  {
+    name: 'strict',
+    category: 'strict-family',
+    note: 'Master switch for strict-mode flags',
+  },
+  { name: 'noImplicitAny', category: 'strict-family' },
+  { name: 'strictNullChecks', category: 'strict-family' },
+  { name: 'strictFunctionTypes', category: 'strict-family' },
+  { name: 'strictBindCallApply', category: 'strict-family' },
+  { name: 'strictPropertyInitialization', category: 'strict-family' },
+  { name: 'noImplicitThis', category: 'strict-family' },
+  { name: 'useUnknownInCatchVariables', category: 'strict-family' },
+  { name: 'alwaysStrict', category: 'strict-family' },
+  { name: 'noImplicitReturns', category: 'additional' },
+  { name: 'noFallthroughCasesInSwitch', category: 'additional' },
+  { name: 'noUncheckedIndexedAccess', category: 'additional' },
+  { name: 'exactOptionalPropertyTypes', category: 'additional' },
+  { name: 'noImplicitOverride', category: 'additional' },
+  { name: 'noPropertyAccessFromIndexSignature', category: 'additional' },
+  { name: 'noUnusedLocals', category: 'additional' },
+  { name: 'noUnusedParameters', category: 'additional' },
+];
+
+/**
+ * @param {string} configPath
+ */
+export const loadParsedConfig = (configPath = 'tsconfig.check.json') => {
+  const absConfigPath = path.resolve(process.cwd(), configPath);
+  const readResult = ts.readConfigFile(absConfigPath, ts.sys.readFile);
+  if (readResult.error) {
+    throw new Error(
+      ts.flattenDiagnosticMessageText(readResult.error.messageText, '\n'),
+    );
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    readResult.config,
+    ts.sys,
+    path.dirname(absConfigPath),
+    undefined,
+    absConfigPath,
+  );
+
+  if (parsed.errors.length > 0) {
+    const msg = parsed.errors
+      .map(err => ts.flattenDiagnosticMessageText(err.messageText, '\n'))
+      .join('\n');
+    throw new Error(msg);
+  }
+
+  return { absConfigPath, parsed };
+};
+
+/**
+ * @param {ts.CompilerOptions} options
+ * @param {string} flagName
+ */
+export const isFlagEnabled = (options, flagName) => options[flagName] === true;
+
+/**
+ * @param {ts.CompilerOptions} options
+ */
+export const getOffFlags = options =>
+  STRICTNESS_FLAGS.filter(({ name }) => !isFlagEnabled(options, name));
+
+/**
+ * @param {string} configPath
+ * @param {string} flagName
+ */
+export const tscArgsForFlag = (configPath, flagName) => [
+  'run',
+  '-T',
+  'tsc',
+  '-p',
+  configPath,
+  '--pretty',
+  'false',
+  '--noEmit',
+  `--${flagName}`,
+  'true',
+];

--- a/scripts/maintenance/typecheck-flag-picker.mjs
+++ b/scripts/maintenance/typecheck-flag-picker.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { spawn } from 'node:child_process';
+import {
+  getOffFlags,
+  loadParsedConfig,
+  tscArgsForFlag,
+} from './tsconfig-flags-lib.mjs';
+
+const args = process.argv.slice(2);
+
+const getArg = name => {
+  const prefix = `${name}=`;
+  const match = args.find(arg => arg.startsWith(prefix));
+  return match ? match.slice(prefix.length) : undefined;
+};
+
+const configPath = getArg('--config') || 'tsconfig.check.json';
+const explicitFlag = getArg('--flag');
+const listOnly = args.includes('--list');
+
+const { parsed } = loadParsedConfig(configPath);
+const offFlags = getOffFlags(parsed.options);
+
+if (offFlags.length === 0) {
+  console.log(`No strictness flags are OFF in ${configPath}.`);
+  process.exit(0);
+}
+
+console.log(`OFF strictness flags in ${configPath}:`);
+offFlags.forEach(({ name, category }, index) => {
+  console.log(`${String(index + 1).padStart(2, ' ')}. ${name} (${category})`);
+});
+
+if (listOnly) {
+  process.exit(0);
+}
+
+let selectedFlag = explicitFlag;
+if (!selectedFlag) {
+  const rl = readline.createInterface({ input, output });
+  const answer = await rl.question(
+    '\nPick a flag number to enable for this run: ',
+  );
+  rl.close();
+
+  const selectedIndex = Number.parseInt(answer, 10) - 1;
+  if (!Number.isInteger(selectedIndex) || !offFlags[selectedIndex]) {
+    console.error(`Invalid selection: ${answer}`);
+    process.exit(1);
+  }
+
+  selectedFlag = offFlags[selectedIndex].name;
+}
+
+if (!offFlags.some(flag => flag.name === selectedFlag)) {
+  console.error(
+    `Flag '${selectedFlag}' is not currently OFF in ${configPath} (or is unknown in this tool).`,
+  );
+  process.exit(1);
+}
+
+const tscArgs = tscArgsForFlag(configPath, selectedFlag);
+console.log(`\nRunning: yarn ${tscArgs.join(' ')}`);
+
+const child = spawn('yarn', tscArgs, {
+  cwd: process.cwd(),
+  stdio: 'inherit',
+  env: process.env,
+});
+
+child.on('close', code => {
+  process.exit(code ?? 1);
+});

--- a/scripts/maintenance/typecheck-flag-report.mjs
+++ b/scripts/maintenance/typecheck-flag-report.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import {
+  getOffFlags,
+  loadParsedConfig,
+  tscArgsForFlag,
+} from './tsconfig-flags-lib.mjs';
+
+const ERROR_RE = /error TS\d+:/g;
+
+/**
+ * @param {string} configPath
+ * @param {string} flagName
+ */
+const countErrorsForFlag = (configPath, flagName) =>
+  new Promise(resolve => {
+    const args = tscArgsForFlag(configPath, flagName);
+    const child = spawn('yarn', args, {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+
+    let stderrText = '';
+    let stdoutText = '';
+
+    child.stdout.on('data', chunk => {
+      stdoutText += chunk.toString();
+    });
+    child.stderr.on('data', chunk => {
+      stderrText += chunk.toString();
+    });
+
+    child.on('close', code => {
+      const combined = `${stdoutText}\n${stderrText}`;
+      const matches = combined.match(ERROR_RE);
+      const errorCount = matches ? matches.length : 0;
+      resolve({ flagName, code: code ?? 1, errorCount });
+    });
+  });
+
+const configPath = process.argv[2] || 'tsconfig.check.json';
+const { parsed } = loadParsedConfig(configPath);
+const offFlags = getOffFlags(parsed.options);
+
+if (offFlags.length === 0) {
+  console.log(`No strictness flags are OFF in ${configPath}.`);
+  process.exit(0);
+}
+
+console.log(`Typecheck strictness report for ${configPath}`);
+console.log(
+  `Found ${offFlags.length} OFF flags. Running one tsc pass per flag...`,
+);
+
+const results = [];
+for (const [index, { name, category }] of offFlags.entries()) {
+  const label = `[${index + 1}/${offFlags.length}] ${name} (${category})`;
+  console.log(label);
+  // eslint-disable-next-line no-await-in-loop
+  const result = await countErrorsForFlag(configPath, name);
+  results.push({ ...result, category });
+}
+
+results.sort(
+  (a, b) => a.errorCount - b.errorCount || a.flagName.localeCompare(b.flagName),
+);
+
+console.log('\nRanked by error count (lower is likely easier):');
+for (const [index, result] of results.entries()) {
+  const status = result.code === 0 ? 'clean' : `exit ${result.code}`;
+  console.log(
+    `${String(index + 1).padStart(2, ' ')}. ${result.flagName.padEnd(34)} ${String(result.errorCount).padStart(6, ' ')} errors  (${status})`,
+  );
+}

--- a/services/ymax-planner/scripts/process-tx-lib.ts
+++ b/services/ymax-planner/scripts/process-tx-lib.ts
@@ -51,7 +51,7 @@ export const processTx = async (
     env = process.env,
     fetch = globalThis.fetch,
     generateInterval = timersPromises.setInterval,
-    now = Date.now,
+    _now = Date.now,
     setTimeout = globalThis.setTimeout,
     connectWithSigner = SigningStargateClient.connectWithSigner,
     AbortController = globalThis.AbortController,
@@ -59,6 +59,7 @@ export const processTx = async (
     WebSocket = ws.WebSocket,
   } = {},
 ) => {
+  void _now;
   console.log(`\n🔍 Resolving transaction: ${txId}\n`);
 
   const maybeOpts = cliArgs;

--- a/services/ymax-planner/src/cosmos-rest-client.ts
+++ b/services/ymax-planner/src/cosmos-rest-client.ts
@@ -275,7 +275,7 @@ class CosmosApiError extends Error {
 
   public readonly url: string;
 
-  public readonly cause?: Error;
+  public override readonly cause?: Error;
 
   constructor(
     message: string,

--- a/services/ymax-planner/src/cosmos-rpc.ts
+++ b/services/ymax-planner/src/cosmos-rpc.ts
@@ -28,9 +28,9 @@ export class CosmosRPCClient extends JSONRPCClient {
 
   #closedPK: PromiseWithResolvers<CloseEvent>;
 
-  #isClosed: boolean;
+  #isClosed = false;
 
-  #lastSentId: number;
+  #lastSentId = -1;
 
   #ws: WebSocket;
 
@@ -57,8 +57,6 @@ export class CosmosRPCClient extends JSONRPCClient {
     this.#subscriptions = new Map();
     this.#openedPK = Promise.withResolvers();
     this.#closedPK = Promise.withResolvers();
-    this.#isClosed = false;
-    this.#lastSentId = -1;
 
     ws.addEventListener('close', event => {
       this.#closedPK.resolve(event);
@@ -126,12 +124,12 @@ export class CosmosRPCClient extends JSONRPCClient {
     });
   }
 
-  async send(payload: any) {
+  override async send(payload: any) {
     if (this.#isClosed) throw Error('already closed');
     return super.send(payload);
   }
 
-  receive(response: JSONRPCResponse) {
+  override receive(response: JSONRPCResponse) {
     // console.log('Received RPC response:', response);
     return super.receive(response);
   }

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -680,7 +680,7 @@ export const startEngine = async (
     feeBrandName: string;
   },
 ) => {
-  const { evmCtx, cosmosRest, now, rpc, signingSmartWalletKit } = powers;
+  const { evmCtx, cosmosRest, rpc, signingSmartWalletKit } = powers;
   const vstoragePathPrefixes = makeVstoragePathPrefixes(contractInstance);
   const { portfoliosPathPrefix, pendingTxPathPrefix } = vstoragePathPrefixes;
   await null;

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -791,7 +791,6 @@ export const startEngine = async (
     log: console.warn.bind(console),
     error: console.error.bind(console),
     marshaller,
-    now,
     signingSmartWalletKit,
     vstoragePathPrefixes,
     pendingTxAbortControllers,

--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -408,6 +408,7 @@ export const scanEvmLogsInChunks = async (
           return evt;
         }
       }
+      return undefined;
     },
   });
 };

--- a/services/ymax-planner/test/abort-signal.test.ts
+++ b/services/ymax-planner/test/abort-signal.test.ts
@@ -1,8 +1,8 @@
 import test from 'ava';
-import { handlePendingTx } from '../src/pending-tx-manager.ts';
-import { createMockPendingTxOpts } from './mocks.ts';
 import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import { createMockPendingTxData } from '@aglocal/portfolio-contract/tools/mocks.ts';
+import { handlePendingTx } from '../src/pending-tx-manager.ts';
+import { createMockPendingTxOpts } from './mocks.ts';
 
 test('handlePendingTx aborts CCTP watcher in live mode when signal is aborted', async t => {
   const logs: string[] = [];

--- a/services/ymax-planner/test/abort-signal.test.ts
+++ b/services/ymax-planner/test/abort-signal.test.ts
@@ -99,7 +99,7 @@ test('handlePendingTx aborts GMP watcher in live mode when signal is aborted', a
 
   const ctxWithFetch = harden({
     ...opts,
-    fetch: async (url: string) => {
+    fetch: async (_url: string) => {
       return {
         ok: true,
         json: async () => ({

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -227,9 +227,13 @@ test('handleDeposit works with mocked dependencies', async t => {
   };
 
   // Mock VstorageKit
-  const mockVstorageKit: VstorageKit<PortfolioPublishedPathTypes> = {
-    readPublished: mockReadPublished,
-  } as VstorageKit<PortfolioPublishedPathTypes>;
+  const mockVstorageKit: Pick<
+    VstorageKit<PortfolioPublishedPathTypes>,
+    'readPublished'
+  > = {
+    readPublished:
+      mockReadPublished as VstorageKit<PortfolioPublishedPathTypes>['readPublished'],
+  };
 
   const result = await handleDeposit(portfolioKey, deposit, feeBrand, {
     readPublished: mockVstorageKit.readPublished,
@@ -301,9 +305,13 @@ test('handleDeposit handles missing targetAllocation gracefully', async t => {
   };
 
   // Mock VstorageKit
-  const mockVstorageKit: VstorageKit<PortfolioPublishedPathTypes> = {
-    readPublished: mockReadPublished,
-  } as VstorageKit<PortfolioPublishedPathTypes>;
+  const mockVstorageKit: Pick<
+    VstorageKit<PortfolioPublishedPathTypes>,
+    'readPublished'
+  > = {
+    readPublished:
+      mockReadPublished as VstorageKit<PortfolioPublishedPathTypes>['readPublished'],
+  };
 
   const result = await handleDeposit(portfolioKey, deposit, feeBrand, {
     readPublished: mockVstorageKit.readPublished,
@@ -347,9 +355,13 @@ test('handleDeposit handles different position types correctly', async t => {
   };
 
   // Mock VstorageKit
-  const mockVstorageKit: VstorageKit<PortfolioPublishedPathTypes> = {
-    readPublished: mockReadPublished,
-  } as VstorageKit<PortfolioPublishedPathTypes>;
+  const mockVstorageKit: Pick<
+    VstorageKit<PortfolioPublishedPathTypes>,
+    'readPublished'
+  > = {
+    readPublished:
+      mockReadPublished as VstorageKit<PortfolioPublishedPathTypes>['readPublished'],
+  };
 
   const result = await handleDeposit(
     portfolioKey,

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -479,7 +479,7 @@ export const createMockCosmosRestClient = (
   let mockAccount = initialAccount;
 
   return {
-    getAccountBalance: async (chainKey, address, denom) => {
+    getAccountBalance: async (_chainKey, _address, denom) => {
       const response =
         balanceResponses[callCount] ||
         balanceResponses[balanceResponses.length - 1];
@@ -489,7 +489,7 @@ export const createMockCosmosRestClient = (
         amount: response.amount,
       };
     },
-    async getAccountSequence(chainKey: string, address: string) {
+    async getAccountSequence(_chainKey: string, _address: string) {
       callCount++;
       return { account: mockAccount };
     },

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -30,6 +30,7 @@ const makeMockHandlePendingTx = () => {
     tx: PendingTx,
     { log: _log, ..._evmCtx }: any,
   ) => {
+    void _evmCtx;
     handledTxs.push(tx);
   };
   return { mockHandlePendingTx, handledTxs };

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -26,11 +26,7 @@ const marshaller = boardSlottingMarshaller();
 
 const makeMockHandlePendingTx = () => {
   const handledTxs: PendingTx[] = [];
-  const mockHandlePendingTx = async (
-    tx: PendingTx,
-    { log: _log, ..._evmCtx }: any,
-  ) => {
-    void _evmCtx;
+  const mockHandlePendingTx = async (tx: PendingTx) => {
     handledTxs.push(tx);
   };
   return { mockHandlePendingTx, handledTxs };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,6 @@
     "allowJs": true,
     "checkJs": true,
     // Strictness audit 2026-02-24 by scripts/maintenance/typecheck-flag-report.mjs
-    //  alwaysStrict                           27 errors
-    //  strictPropertyInitialization           29 errors
-    //  noFallthroughCasesInSwitch             30 errors
     //  noImplicitOverride                     30 errors
     //  strictBindCallApply                    32 errors
     //  noImplicitReturns                      47 errors
@@ -27,6 +24,11 @@
     "strict": false,
     "strictNullChecks": true,
     "noImplicitThis": true,
+    "alwaysStrict": true,
+    "strictPropertyInitialization": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "strictBindCallApply": true,
     "noUncheckedSideEffectImports": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "checkJs": true,
     // Strictness audit 2026-02-24 by scripts/maintenance/typecheck-flag-report.mjs
     //  useUnknownInCatchVariables            128 errors
-    //  noUnusedParameters                    175 errors
     //  exactOptionalPropertyTypes            221 errors
     //  noUnusedLocals                        590 errors
     //  noPropertyAccessFromIndexSignature    983 errors
@@ -25,6 +24,7 @@
     "strictPropertyInitialization": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
+    "noUnusedParameters": true,
     "strictBindCallApply": true,
     "noImplicitReturns": true,
     "noUncheckedSideEffectImports": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,6 @@
     "allowJs": true,
     "checkJs": true,
     // Strictness audit 2026-02-24 by scripts/maintenance/typecheck-flag-report.mjs
-    //  noImplicitOverride                     30 errors
-    //  strictBindCallApply                    32 errors
-    //  noImplicitReturns                      47 errors
     //  useUnknownInCatchVariables            128 errors
     //  noUnusedParameters                    175 errors
     //  exactOptionalPropertyTypes            221 errors
@@ -29,6 +26,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "strictBindCallApply": true,
+    "noImplicitReturns": true,
     "noUncheckedSideEffectImports": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,22 @@
     "skipLibCheck": true,
     "allowJs": true,
     "checkJs": true,
+    // Strictness audit 2026-02-24 by scripts/maintenance/typecheck-flag-report.mjs
+    //  alwaysStrict                           27 errors
+    //  strictPropertyInitialization           29 errors
+    //  noFallthroughCasesInSwitch             30 errors
+    //  noImplicitOverride                     30 errors
+    //  strictBindCallApply                    32 errors
+    //  noImplicitReturns                      47 errors
+    //  useUnknownInCatchVariables            128 errors
+    //  noUnusedParameters                    175 errors
+    //  exactOptionalPropertyTypes            221 errors
+    //  noUnusedLocals                        590 errors
+    //  noPropertyAccessFromIndexSignature    983 errors
+    //  noUncheckedIndexedAccess             1584 errors
+    //  strictFunctionTypes                  1717 errors
+    //  noImplicitAny                        8869 errors
+    //  strict                              10594 errors
     "strict": false,
     "strictNullChecks": true,
     "noImplicitThis": true,


### PR DESCRIPTION
refs: #5760 

## Description

Adds a script to count the number of violations of different TS config flags. Then it burns down the easiest ones.


There's also a small lint config change to disable `no-nested-ternary`.

### Security Considerations
none

### Scaling Considerations
n/a

### Documentation Considerations

What remains is kept in tsconfig.json:
```
    //  useUnknownInCatchVariables            128 errors
    //  exactOptionalPropertyTypes            221 errors
    //  noUnusedLocals                        590 errors
    //  noPropertyAccessFromIndexSignature    983 errors
    //  noUncheckedIndexedAccess             1584 errors
    //  strictFunctionTypes                  1717 errors
    //  noImplicitAny                        8869 errors
    //  strict                              10594 errors
```

### Testing Considerations
CI suffices

### Upgrade Considerations
n/a