### PR TITLE
ci(github): autosquash fixup commits when PR is enqueued

### DIFF
--- a/.github/workflows/autosquash-on-enqueue.yml
+++ b/.github/workflows/autosquash-on-enqueue.yml
@@ -1,0 +1,112 @@
+name: Autosquash on queue enqueue
+
+on:
+  pull_request_target:
+    types:
+      - enqueued
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: autosquash-on-enqueue-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  autosquash:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.base.ref == 'master' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+    steps:
+      - name: Check out PR branch
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Fetch base branch
+        run: git fetch origin "${BASE_REF}"
+
+      - name: Detect fixup commits
+        id: detect
+        run: |
+          set -euo pipefail
+          count=$(git rev-list "origin/${BASE_REF}..HEAD" --grep='^\(fixup\|squash\|amend\)! ' --count)
+          echo "count=${count}" >>"${GITHUB_OUTPUT}"
+          if [ "${count}" -gt 0 ]; then
+            echo 'Found fixup/squash/amend commits:'
+            git log --format='%h %s' --reverse "origin/${BASE_REF}..HEAD" --grep='^\(fixup\|squash\|amend\)! '
+          else
+            echo 'No fixup/squash/amend commits found.'
+          fi
+
+      - name: Autosquash commits
+        id: autosquash
+        if: steps.detect.outputs.count != '0'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash "origin/${BASE_REF}"
+
+      - name: Push rewritten branch
+        if: steps.detect.outputs.count != '0' && steps.autosquash.outcome == 'success'
+        run: git push --force-with-lease origin "HEAD:${HEAD_REF}"
+
+      - name: Re-enable auto-merge
+        if: steps.detect.outputs.count != '0' && steps.autosquash.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr merge "${PR_URL}" --auto --merge
+
+      - name: Comment on autosquash conflict
+        if: steps.detect.outputs.count != '0' && steps.autosquash.outcome != 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                'Autosquash failed while this PR was entering the merge queue.',
+                '',
+                'The branch history could not be rewritten cleanly with `git rebase --autosquash`.',
+                'Please run autosquash locally, resolve conflicts, and push. Then enqueue again.',
+              ].join('\n'),
+            });
+
+      - name: Fail on autosquash conflict
+        if: steps.detect.outputs.count != '0' && steps.autosquash.outcome != 'success'
+        run: exit 1
+
+  skip-forks:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.base.ref == 'master' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Comment for fork PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                'Autosquash-on-enqueue skipped: this PR branch is in a fork.',
+                '',
+                'For safety, the workflow only rewrites branches in this repository.',
+                'Please autosquash locally and push, then enqueue again.',
+              ].join('\n'),
+            });

--- a/docs/architecture/0002-autosquash-on-merge-queue-enqueue.md
+++ b/docs/architecture/0002-autosquash-on-merge-queue-enqueue.md
@@ -1,0 +1,95 @@
+# ADR 2: Autosquash fixup commits when PR is enqueued to merge queue
+
+## Status
+
+Accepted 2026-02-18.
+
+## Context
+
+We are removing dependence on Mergify while preserving this behavior:
+
+- PRs can be merged to `master` using merge commits (`--merge`), including merge queue.
+- `fixup!`, `squash!`, and `amend!` commits should be collapsed automatically.
+- Developers should have one primary action for intent: "get this into master".
+
+GitHub merge queue does not perform `git rebase --autosquash` on PR branches. It validates and merges, but does not rewrite commit history before merge.
+
+## Requirements
+
+Functional requirements:
+
+1. Preserve merge-commit integration strategy on `master`.
+2. Autosquash fixup-style commits before final merge.
+3. Trigger from queue entry so users do not need a separate manual cleanup step.
+4. Re-queue automatically after rewrite when possible.
+
+Non-functional requirements:
+
+1. Keep repository security posture: do not rewrite untrusted fork branches with write token.
+2. Make failures explicit in PR conversation.
+3. Keep behavior deterministic and auditable in Actions logs.
+
+## Decision
+
+Add a GitHub Actions workflow at `.github/workflows/autosquash-on-enqueue.yml` that runs on:
+
+- `pull_request_target` with `types: [enqueued]`.
+
+Behavior:
+
+1. Only run for PRs targeting `master`.
+2. Only rewrite same-repository branches (`head.repo.full_name == github.repository`).
+3. Detect fixup commits in `origin/master..HEAD` matching `^(fixup|squash|amend)! `.
+4. If none exist, no-op.
+5. If present, run non-interactive autosquash:
+   - `GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash origin/<base>`
+6. Force-push rewritten branch with `--force-with-lease`.
+7. Re-enable auto-merge with merge method:
+   - `gh pr merge <pr-url> --auto --merge`
+8. On rebase conflict, comment on PR and fail the workflow.
+9. For fork PRs, add a comment explaining that autosquash-on-enqueue is skipped.
+
+This provides the "one action" flow:
+
+- user requests queue merge once,
+- workflow performs history cleanup if needed,
+- workflow re-applies merge queue intent after rewrite.
+
+## Ruled out
+
+1. Use merge queue alone
+- Rejected because merge queue does not autosquash fixup commits.
+
+2. Switch to squash merges
+- Rejected because requirement is to keep merge commits for PR integration.
+
+3. Keep a required `no-fixup-commits` blocking check only
+- Rejected as primary mechanism because it forces a second user action and breaks the desired one-step intent.
+
+4. Rewrite history on `merge_group` branches
+- Rejected because merge-group refs are ephemeral queue branches, not the PR branch of record.
+
+5. Rewrite fork branches from `pull_request_target`
+- Rejected for security and trust-boundary reasons.
+
+6. Full agentic merge bot outside Actions
+- Rejected for now: higher operational complexity, additional credentials/runtime, and little gain over native Actions for this specific task.
+
+## Consequences
+
+Positive:
+
+- Maintains merge-commit strategy while cleaning fixup commits automatically.
+- Keeps user interaction simple.
+- Centralizes behavior in auditable repository automation.
+
+Tradeoffs:
+
+- Queue entry may briefly dequeue/requeue when branch history is rewritten.
+- Autosquash can fail on conflict and requires manual intervention.
+- Fork PRs require manual autosquash by contributor/maintainer.
+
+Operational notes:
+
+1. Branch protection should require checks compatible with this flow; avoid requiring a check that always fails on fixup commits before enqueue.
+2. Team guidance should encourage `fixup!` workflows and rely on enqueue-time autosquash.


### PR DESCRIPTION
## Summary
- add a new workflow that triggers on pull_request_target enqueued
- autosquash fixup/squash/amend commits on same-repo PR branches targeting master
- force-push rewritten history and re-enable queue auto-merge with merge commits
- add ADR documenting requirements, design rationale, and ruled-out alternatives

## Why
- we want to remove Mergify dependency while keeping merge commits for PR integration
- we still want automatic cleanup of fixup commits with a single user action: enqueue for merge

## Safety and behavior notes
- skips rewriting fork PR branches and leaves a comment
- comments and fails when autosquash rebase conflicts
- queue entry may briefly dequeue/requeue when history is rewritten
