### PR TITLE
feat(ymax-planner): "no-planner"/"no-resolver" feature flags

### DIFF
--- a/services/ymax-planner/README.md
+++ b/services/ymax-planner/README.md
@@ -165,6 +165,7 @@ Environment variables:
 - `CONTRACT_INSTANCE`: Contract instance identifier, either "ymax0" (dev) or "ymax1" (prod) (required)
 - `ALCHEMY_API_KEY`: API key for accessing Alchemy's RPC endpoint (required, but not verified at startup)
   - **Important**: For all EVM chains in `AxelarChain` (see `packages/portfolio-api/src/constants.js`), ensure they are enabled in your Alchemy dashboard.
+- `FEATURE_FLAGS`: For selectively disabling resolver or planner, until they are fully separated (optional, valid comma-separated values are "no-planner" and "no-resolver")
 - `GCP_PROJECT_ID`: For fetching an unset `MNEMONIC` from the Google Cloud Secret Manager (default "simulationlab")
 - `GCP_SECRET_NAME`: For fetching an unset `MNEMONIC` from the Google Cloud Secret Manager (default "YMAX_CONTROL_MNEMONIC")
 - `MNEMONIC`: For the private key used to sign transactions (optional, but if not provided then it will be retrieved from the Google Cloud Secret Manager using `GCP_PROJECT_ID` and `GCP_SECRET_NAME`)

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -330,6 +330,7 @@ export const main = async (
     });
     await startEngine(powers, {
       isDryRun,
+      featureFlags: config.featureFlags,
       contractInstance: config.contractInstance,
       depositBrandName: env.DEPOSIT_BRAND_NAME || 'USDC',
       feeBrandName: env.FEE_BRAND_NAME || 'BLD',


### PR DESCRIPTION
## Description
For selectively disabling resolver or planner, until they are fully separated, the process pays attention to "no-planner" and "no-resolver" values in an optional comma-separated FEATURE_FLAGS environment variable.

### Security Considerations
We obviously don't want to run production without both components, at least outside of incident response.

### Scaling Considerations
n/a

### Documentation Considerations
Described in README.md.

### Testing Considerations
Tested manually; this is not worth unit test coverage IMO.

### Upgrade Considerations
Safe for immediate deployment.