### PR TITLE
feat(boot): snapshot fixtures and fast SwingSet test resume

### DIFF
--- a/packages/boot/test/bootstrapTests/ec-membership-update.test.ts
+++ b/packages/boot/test/bootstrapTests/ec-membership-update.test.ts
@@ -1,21 +1,13 @@
 import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
-import {
-  makeAgoricNamesRemotesFromFakeStorage,
-  slotToBoardRemote,
-  unmarshalFromVstorage,
-} from '@agoric/vats/tools/board-utils.js';
-import { makeMarshal, passStyleOf } from '@endo/marshal';
+import { passStyleOf } from '@endo/marshal';
 import type { TestFn } from 'ava';
-
 import {
-  makeGovernanceDriver,
-  makeWalletFactoryDriver,
-} from '../../tools/drivers.js';
-import { makeLiquidationTestKit } from '../../tools/liquidation.js';
-import { makeSwingsetTestKit } from '../../tools/supports.js';
-import { loadOrCreateRunUtilsSnapshot } from '../tools/runutils-snapshots.js';
+  makeBootTestContext,
+  withGovernance,
+  withLiquidation,
+  withWalletFactory,
+} from '../tools/boot-test-context.js';
 
 const wallets = [
   'agoric1gx9uu7y6c90rqruhesae2t7c2vlw4uyyxlqxrx',
@@ -43,67 +35,13 @@ const getQuestionId = id => `propose-question-${id}`;
 const getVoteId = id => `vote-${id}`;
 
 export const makeZoeTestContext = async t => {
-  console.time('ZoeTestContext');
-  const snapshot = await loadOrCreateRunUtilsSnapshot(
-    'main-vaults-base',
-    t.log,
-  );
-  const swingsetTestKit = await makeSwingsetTestKit(t.log, undefined, {
+  const bootCtx = await makeBootTestContext(t, {
     configSpecifier: '@agoric/vm-config/decentral-main-vaults-config.json',
-    snapshot,
+    snapshotName: 'main-vaults-base',
   });
-
-  const { runUtils, storage } = swingsetTestKit;
-  console.timeLog('DefaultTestContext', 'swingsetTestKit');
-  const { EV } = runUtils;
-
-  await eventLoopIteration();
-
-  // We don't need vaults, but this gets the brand, which is checked somewhere
-  // Wait for ATOM to make it into agoricNames
-  await EV.vat('bootstrap').consumeItem('vaultFactoryKit');
-  console.timeLog('DefaultTestContext', 'vaultFactoryKit');
-
-  // has to be late enough for agoricNames data to have been published
-  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
-  console.timeLog('DefaultTestContext', 'agoricNamesRemotes');
-
-  console.timeEnd('DefaultTestContext');
-  const walletFactoryDriver = await makeWalletFactoryDriver(
-    runUtils,
-    storage,
-    agoricNamesRemotes,
-  );
-
-  const { fromCapData } = makeMarshal(undefined, slotToBoardRemote);
-
-  const getVstorageData = (key: string) => {
-    const data = unmarshalFromVstorage(storage.data, key, fromCapData, -1);
-    return data;
-  };
-
-  const governanceDriver = await makeGovernanceDriver(
-    swingsetTestKit,
-    agoricNamesRemotes,
-    walletFactoryDriver,
-    wallets,
-  );
-
-  const liquidationTestKit = await makeLiquidationTestKit({
-    swingsetTestKit,
-    agoricNamesRemotes,
-    walletFactoryDriver,
-    governanceDriver,
-    t,
-  });
-
-  return {
-    ...swingsetTestKit,
-    ...liquidationTestKit,
-    storage,
-    getVstorageData,
-    governanceDriver,
-  };
+  const walletCtx = await withWalletFactory(bootCtx);
+  const governanceCtx = await withGovernance(walletCtx, { wallets });
+  return withLiquidation(governanceCtx, { t });
 };
 const test = anyTest as TestFn<Awaited<ReturnType<typeof makeZoeTestContext>>>;
 
@@ -114,10 +52,14 @@ test.before(async t => {
 test.after.always(t => t.context.shutdown?.());
 
 test.serial('normal running of committee', async t => {
-  const { advanceTimeBy, storage, getVstorageData, governanceDriver } =
-    t.context;
-
-  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
+  const {
+    advanceTimeBy,
+    agoricNamesRemotes,
+    expectParamValue,
+    expectProposalAccepted,
+    expectVoteAccepted,
+    governanceDriver,
+  } = t.context;
   const { VaultFactory } = agoricNamesRemotes.instance;
   const { ATOM: collateralBrand, IST: debtBrand } = agoricNamesRemotes.brand;
 
@@ -141,9 +83,7 @@ test.serial('normal running of committee', async t => {
   );
 
   t.log('Checking if question proposal passed');
-  t.like(committee[0].getLatestUpdateRecord(), {
-    status: { id: getQuestionId(1), numWantsSatisfied: 1 },
-  });
+  expectProposalAccepted(t, committee[0], getQuestionId(1));
 
   t.log('Voting on question using first 3 wallets');
   await governanceDriver.enactLatestProposal(
@@ -153,11 +93,7 @@ test.serial('normal running of committee', async t => {
   );
 
   t.log('Checking if votes passed');
-  for (const w of committee.slice(0, 3)) {
-    t.like(w.getLatestUpdateRecord(), {
-      status: { id: getVoteId(1), numWantsSatisfied: 1 },
-    });
-  }
+  expectVoteAccepted(t, committee.slice(0, 3), getVoteId(1));
 
   t.log('Waiting for period to end');
   await advanceTimeBy(1, 'minutes');
@@ -165,9 +101,12 @@ test.serial('normal running of committee', async t => {
   t.log('Verifying outcome');
 
   const lastOutcome = await governanceDriver.getLatestOutcome();
-  console.log(lastOutcome);
-  const managerParams = getVstorageData(managerGovernanceKey);
-  t.deepEqual(managerParams.current.DebtLimit.value.value, 100_000_000n);
+  expectParamValue(t, managerGovernanceKey, 100_000_000n, [
+    'current',
+    'DebtLimit',
+    'value',
+    'value',
+  ]);
   t.assert(lastOutcome.outcome === 'win');
 });
 
@@ -185,22 +124,20 @@ test.serial(
 );
 
 test.serial.failing('replace committee', async t => {
-  const { buildProposal, evalProposal, storage } = t.context;
+  const { agoricNamesRemotes, applyProposal, refreshAgoricNamesRemotes } =
+    t.context;
 
-  const preEvalAgoricNames = makeAgoricNamesRemotesFromFakeStorage(storage);
-  await evalProposal(
-    buildProposal(
-      '@agoric/builders/scripts/inter-protocol/replace-electorate-core.js',
-      ['BOOTSTRAP_TEST'],
-    ),
+  const preEvalEconomicCommittee =
+    agoricNamesRemotes.instance.economicCommittee;
+  await applyProposal(
+    '@agoric/builders/scripts/inter-protocol/replace-electorate-core.js',
+    ['BOOTSTRAP_TEST'],
   );
-  await eventLoopIteration();
-
-  const postEvalAgoricNames = makeAgoricNamesRemotesFromFakeStorage(storage);
+  refreshAgoricNamesRemotes();
 
   t.not(
-    preEvalAgoricNames.instance.economicCommittee,
-    postEvalAgoricNames.instance.economicCommittee,
+    preEvalEconomicCommittee,
+    agoricNamesRemotes.instance.economicCommittee,
   );
 });
 
@@ -220,11 +157,16 @@ test.serial(
 test.serial.failing(
   'successful proposal and vote by 2 continuing members',
   async t => {
-    const { storage, advanceTimeBy, getVstorageData, governanceDriver } =
-      t.context;
+    const {
+      advanceTimeBy,
+      agoricNamesRemotes,
+      expectParamValue,
+      expectProposalAccepted,
+      expectVoteAccepted,
+      governanceDriver,
+    } = t.context;
     const newCommittee = governanceDriver.ecMembers.slice(0, 3);
 
-    const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
     const { economicCommittee, econCommitteeCharter, VaultFactory } =
       agoricNamesRemotes.instance;
     const { ATOM: collateralBrand, IST: debtBrand } = agoricNamesRemotes.brand;
@@ -252,9 +194,7 @@ test.serial.failing(
       offerIds.propose.incoming,
     );
 
-    t.like(newCommittee[0].getLatestUpdateRecord(), {
-      status: { id: getQuestionId(2), numWantsSatisfied: 1 },
-    });
+    expectProposalAccepted(t, newCommittee[0], getQuestionId(2));
 
     t.log('Voting on question using first 2 wallets');
     await governanceDriver.enactLatestProposal(
@@ -262,29 +202,33 @@ test.serial.failing(
       getVoteId(2),
       offerIds.vote.incoming,
     );
-    for (const w of newCommittee.slice(0, 2)) {
-      t.like(w.getLatestUpdateRecord(), {
-        status: { id: getVoteId(2), numWantsSatisfied: 1 },
-      });
-    }
+    expectVoteAccepted(t, newCommittee.slice(0, 2), getVoteId(2));
 
     t.log('Waiting for period to end');
     await advanceTimeBy(1, 'minutes');
 
     t.log('Verifying outcome');
     const lastOutcome = await governanceDriver.getLatestOutcome();
-    const managerParams = getVstorageData(managerGovernanceKey);
-    t.deepEqual(managerParams.current.DebtLimit.value.value, 200_000_000n);
+    expectParamValue(t, managerGovernanceKey, 200_000_000n, [
+      'current',
+      'DebtLimit',
+      'value',
+      'value',
+    ]);
     t.assert(lastOutcome.outcome === 'win');
   },
 );
 
 test.serial('unsuccessful vote by 2 outgoing members', async t => {
-  const { governanceDriver, storage, advanceTimeBy, getVstorageData } =
-    t.context;
+  const {
+    advanceTimeBy,
+    agoricNamesRemotes,
+    expectProposalAccepted,
+    expectVoteAccepted,
+    governanceDriver,
+  } = t.context;
   const outgoingCommittee = governanceDriver.ecMembers.slice(3);
 
-  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
   const { VaultFactory } = agoricNamesRemotes.instance;
   const { ATOM: collateralBrand, IST: debtBrand } = agoricNamesRemotes.brand;
 
@@ -297,9 +241,7 @@ test.serial('unsuccessful vote by 2 outgoing members', async t => {
     getQuestionId(3),
     offerIds.propose.outgoing,
   );
-  t.like(outgoingCommittee[0].getLatestUpdateRecord(), {
-    status: { id: getQuestionId(3), numWantsSatisfied: 1 },
-  });
+  expectProposalAccepted(t, outgoingCommittee[0], getQuestionId(3));
 
   t.log('Voting on question using first 2 wallets');
   t.log('voting is done by invitations already present and should fail');
@@ -312,32 +254,39 @@ test.serial('unsuccessful vote by 2 outgoing members', async t => {
   await t.throwsAsync(votePromises[0]);
   await t.throwsAsync(votePromises[1]);
 
-  for (const w of outgoingCommittee.slice(0, 2)) {
-    t.like(w.getLatestUpdateRecord(), {
-      status: { id: getVoteId(3), numWantsSatisfied: 1 },
-    });
-  }
+  expectVoteAccepted(t, outgoingCommittee.slice(0, 2), getVoteId(3));
 
   t.log('Waiting for period to end');
   await advanceTimeBy(1, 'minutes');
 
   const lastOutcome = await governanceDriver.getLatestOutcome();
-  const managerParams = getVstorageData(managerGovernanceKey);
-  t.notDeepEqual(managerParams.current.DebtLimit.value.value, 300_000_000n);
+  t.notDeepEqual(
+    (
+      t.context.readPublished(
+        managerGovernanceKey.replace(/^published\./, ''),
+      ) as any
+    ).current.DebtLimit.value.value,
+    300_000_000n,
+  );
   t.assert(lastOutcome.outcome === 'fail');
 });
 
 test.serial(
   'successful vote by 2 continuing and 1 outgoing members',
   async t => {
-    const { storage, advanceTimeBy, getVstorageData, governanceDriver } =
-      t.context;
+    const {
+      advanceTimeBy,
+      agoricNamesRemotes,
+      expectParamValue,
+      expectProposalAccepted,
+      expectVoteAccepted,
+      governanceDriver,
+    } = t.context;
     const committee = [
       ...governanceDriver.ecMembers.slice(0, 2),
       governanceDriver.ecMembers[3],
     ];
 
-    const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
     const { VaultFactory } = agoricNamesRemotes.instance;
     const { ATOM: collateralBrand, IST: debtBrand } = agoricNamesRemotes.brand;
 
@@ -350,9 +299,7 @@ test.serial(
       getQuestionId(4),
       offerIds.propose.outgoing,
     );
-    t.like(committee[0].getLatestUpdateRecord(), {
-      status: { id: getQuestionId(4), numWantsSatisfied: 1 },
-    });
+    expectProposalAccepted(t, committee[0], getQuestionId(4));
 
     t.log('Voting on question using first all wallets');
     t.log('first 2 should pass, last should fail');
@@ -367,18 +314,18 @@ test.serial(
     await votePromises[1];
     await t.throwsAsync(votePromises[2]);
 
-    for (const w of committee) {
-      t.like(w.getLatestUpdateRecord(), {
-        status: { id: getVoteId(4), numWantsSatisfied: 1 },
-      });
-    }
+    expectVoteAccepted(t, committee, getVoteId(4));
 
     t.log('Waiting for period to end');
     await advanceTimeBy(1, 'minutes');
 
     const lastOutcome = await governanceDriver.getLatestOutcome();
-    const managerParams = getVstorageData(managerGovernanceKey);
-    t.deepEqual(managerParams.current.DebtLimit.value.value, 400_000_000n);
+    expectParamValue(t, managerGovernanceKey, 400_000_000n, [
+      'current',
+      'DebtLimit',
+      'value',
+      'value',
+    ]);
     t.assert(lastOutcome.outcome === 'win');
   },
 );
@@ -386,14 +333,18 @@ test.serial(
 test.serial(
   'unsuccessful vote by 1 continuing and 2 outgoing members',
   async t => {
-    const { storage, advanceTimeBy, getVstorageData, governanceDriver } =
-      t.context;
+    const {
+      advanceTimeBy,
+      agoricNamesRemotes,
+      expectProposalAccepted,
+      expectVoteAccepted,
+      governanceDriver,
+    } = t.context;
     const committee = [
       governanceDriver.ecMembers[0],
       ...governanceDriver.ecMembers.slice(3, 5),
     ];
 
-    const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
     const { VaultFactory } = agoricNamesRemotes.instance;
     const { ATOM: collateralBrand, IST: debtBrand } = agoricNamesRemotes.brand;
 
@@ -406,9 +357,7 @@ test.serial(
       getQuestionId(5),
       offerIds.propose.outgoing,
     );
-    t.like(committee[0].getLatestUpdateRecord(), {
-      status: { id: getQuestionId(5), numWantsSatisfied: 1 },
-    });
+    expectProposalAccepted(t, committee[0], getQuestionId(5));
 
     t.log('Voting on question using first all wallets');
     t.log('first 2 should fail, last should pass');
@@ -423,18 +372,20 @@ test.serial(
     await t.throwsAsync(votePromises[1]);
     await t.throwsAsync(votePromises[2]);
 
-    for (const w of committee) {
-      t.like(w.getLatestUpdateRecord(), {
-        status: { id: getVoteId(5), numWantsSatisfied: 1 },
-      });
-    }
+    expectVoteAccepted(t, committee, getVoteId(5));
 
     t.log('Waiting for period to end');
     await advanceTimeBy(1, 'minutes');
 
     const lastOutcome = await governanceDriver.getLatestOutcome();
-    const managerParams = getVstorageData(managerGovernanceKey);
-    t.notDeepEqual(managerParams.current.DebtLimit.value.value, 500_000_000n);
+    t.notDeepEqual(
+      (
+        t.context.readPublished(
+          managerGovernanceKey.replace(/^published\./, ''),
+        ) as any
+      ).current.DebtLimit.value.value,
+      500_000_000n,
+    );
     t.assert(lastOutcome.outcome === 'fail');
   },
 );
@@ -442,12 +393,16 @@ test.serial(
 // Will fail until https://github.com/Agoric/agoric-sdk/issues/10136 is completed
 test.failing('outgoing member should not be able to propose', async t => {
   // Ability to propose by outgoing member should still exist
-  const { storage, advanceTimeBy, getVstorageData, governanceDriver } =
-    t.context;
+  const {
+    advanceTimeBy,
+    agoricNamesRemotes,
+    expectProposalAccepted,
+    expectVoteAccepted,
+    governanceDriver,
+  } = t.context;
   const newCommittee = governanceDriver.ecMembers.slice(0, 3);
   const outgoingMember = governanceDriver.ecMembers[3];
 
-  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
   const { VaultFactory } = agoricNamesRemotes.instance;
   const { ATOM: collateralBrand, IST: debtBrand } = agoricNamesRemotes.brand;
 
@@ -461,9 +416,7 @@ test.failing('outgoing member should not be able to propose', async t => {
     offerIds.propose.outgoing,
   );
 
-  t.like(outgoingMember.getLatestUpdateRecord(), {
-    status: { id: getQuestionId(3), numWantsSatisfied: 1 },
-  });
+  expectProposalAccepted(t, outgoingMember, getQuestionId(3));
 
   t.log('Voting on question using first 2 wallets');
   await governanceDriver.enactLatestProposal(
@@ -471,28 +424,35 @@ test.failing('outgoing member should not be able to propose', async t => {
     getVoteId(3),
     offerIds.vote.incoming,
   );
-  for (const w of newCommittee.slice(0, 2)) {
-    t.like(w.getLatestUpdateRecord(), {
-      status: { id: getVoteId(3), numWantsSatisfied: 1 },
-    });
-  }
+  expectVoteAccepted(t, newCommittee.slice(0, 2), getVoteId(3));
 
   t.log('Waiting for period to end');
   await advanceTimeBy(1, 'minutes');
 
   t.log('Verifying outcome');
   const lastOutcome = await governanceDriver.getLatestOutcome();
-  const managerParams = getVstorageData(managerGovernanceKey);
-  t.notDeepEqual(managerParams.current.DebtLimit.value.value, 300_000_000n);
+  t.notDeepEqual(
+    (
+      t.context.readPublished(
+        managerGovernanceKey.replace(/^published\./, ''),
+      ) as any
+    ).current.DebtLimit.value.value,
+    300_000_000n,
+  );
   t.assert(lastOutcome.outcome === 'win');
 });
 
 test.serial.failing('EC can govern provisionPool parameter', async t => {
-  const { storage, advanceTimeBy, getVstorageData, governanceDriver } =
-    t.context;
+  const {
+    advanceTimeBy,
+    agoricNamesRemotes,
+    expectParamValue,
+    expectProposalAccepted,
+    expectVoteAccepted,
+    governanceDriver,
+  } = t.context;
   const newCommittee = governanceDriver.ecMembers.slice(0, 3);
 
-  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
   const { provisionPool } = agoricNamesRemotes.instance;
   const { IST } = agoricNamesRemotes.brand;
 
@@ -506,9 +466,7 @@ test.serial.failing('EC can govern provisionPool parameter', async t => {
     offerIds.propose.incoming,
   );
 
-  t.like(newCommittee[0].getLatestUpdateRecord(), {
-    status: { id: getQuestionId(5), numWantsSatisfied: 1 },
-  });
+  expectProposalAccepted(t, newCommittee[0], getQuestionId(5));
 
   t.log('Voting on question using first 2 wallets');
   await governanceDriver.enactLatestProposal(
@@ -516,31 +474,33 @@ test.serial.failing('EC can govern provisionPool parameter', async t => {
     getVoteId(5),
     offerIds.vote.incoming,
   );
-  for (const w of newCommittee.slice(0, 2)) {
-    t.like(w.getLatestUpdateRecord(), {
-      status: { id: getVoteId(5), numWantsSatisfied: 1 },
-    });
-  }
+  expectVoteAccepted(t, newCommittee.slice(0, 2), getVoteId(5));
 
   t.log('Waiting for period to end');
   await advanceTimeBy(1, 'minutes');
 
   t.log('Verifying outcome');
   const lastOutcome = await governanceDriver.getLatestOutcome();
-  const provisionPoolParams = getVstorageData(provisionPoolParamsKey);
-  t.deepEqual(
-    provisionPoolParams.current.PerAccountInitialAmount.value.value,
-    100_000_000n,
-  );
+  expectParamValue(t, provisionPoolParamsKey, 100_000_000n, [
+    'current',
+    'PerAccountInitialAmount',
+    'value',
+    'value',
+  ]);
   t.assert(lastOutcome.outcome === 'win');
 });
 
 test.serial.failing('EC can govern reserve parameter', async t => {
-  const { storage, advanceTimeBy, governanceDriver, getVstorageData } =
-    t.context;
+  const {
+    advanceTimeBy,
+    agoricNamesRemotes,
+    expectParamValue,
+    expectProposalAccepted,
+    expectVoteAccepted,
+    governanceDriver,
+  } = t.context;
   const newCommittee = governanceDriver.ecMembers.slice(0, 3);
 
-  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
   const { reserve } = agoricNamesRemotes.instance;
   const { IST } = agoricNamesRemotes.brand;
 
@@ -554,9 +514,7 @@ test.serial.failing('EC can govern reserve parameter', async t => {
     offerIds.propose.incoming,
   );
 
-  t.like(newCommittee[0].getLatestUpdateRecord(), {
-    status: { id: getQuestionId(6), numWantsSatisfied: 1 },
-  });
+  expectProposalAccepted(t, newCommittee[0], getQuestionId(6));
 
   t.log('Voting on question using first 2 wallets');
   await governanceDriver.enactLatestProposal(
@@ -564,11 +522,7 @@ test.serial.failing('EC can govern reserve parameter', async t => {
     getVoteId(6),
     offerIds.vote.incoming,
   );
-  for (const w of newCommittee.slice(0, 2)) {
-    t.like(w.getLatestUpdateRecord(), {
-      status: { id: getVoteId(6), numWantsSatisfied: 1 },
-    });
-  }
+  expectVoteAccepted(t, newCommittee.slice(0, 2), getVoteId(6));
 
   t.log('no oracle invitation should exist before vote passing');
   const oracleInvitation =
@@ -576,8 +530,7 @@ test.serial.failing('EC can govern reserve parameter', async t => {
   t.is(oracleInvitation, undefined);
 
   t.log('Checking params before passing proposal');
-  const reserveParams = getVstorageData(reserveParamsKey);
-  t.is(reserveParams.totalFeeBurned.value, 0n);
+  expectParamValue(t, reserveParamsKey, 0n, ['totalFeeBurned', 'value']);
 
   t.log('Waiting for period to end');
   await advanceTimeBy(1, 'minutes');
@@ -586,16 +539,20 @@ test.serial.failing('EC can govern reserve parameter', async t => {
   const lastOutcome = await governanceDriver.getLatestOutcome();
   t.assert(lastOutcome.outcome === 'win');
 
-  const reserveParamsPostUpdate = getVstorageData(reserveParamsKey);
-  t.is(reserveParamsPostUpdate.totalFeeBurned.value, 1000n);
+  expectParamValue(t, reserveParamsKey, 1000n, ['totalFeeBurned', 'value']);
 });
 
 test.serial.failing('EC can govern psm parameter', async t => {
-  const { storage, advanceTimeBy, getVstorageData, governanceDriver } =
-    t.context;
+  const {
+    advanceTimeBy,
+    agoricNamesRemotes,
+    expectParamValue,
+    expectProposalAccepted,
+    expectVoteAccepted,
+    governanceDriver,
+  } = t.context;
   const newCommittee = governanceDriver.ecMembers.slice(0, 3);
 
-  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
   const { IST } = agoricNamesRemotes.brand;
 
   const psmInstances = Object.keys(agoricNamesRemotes.instance)
@@ -619,9 +576,7 @@ test.serial.failing('EC can govern psm parameter', async t => {
       offerIds.propose.incoming,
     );
 
-    t.like(newCommittee[0].getLatestUpdateRecord(), {
-      status: { id: getQuestionId(instanceName), numWantsSatisfied: 1 },
-    });
+    expectProposalAccepted(t, newCommittee[0], getQuestionId(instanceName));
 
     t.log('Voting on question using first 2 wallets');
     await governanceDriver.enactLatestProposal(
@@ -629,19 +584,19 @@ test.serial.failing('EC can govern psm parameter', async t => {
       getVoteId(instanceName),
       offerIds.vote.incoming,
     );
-    for (const w of newCommittee.slice(0, 2)) {
-      t.like(w.getLatestUpdateRecord(), {
-        status: { id: getVoteId(instanceName), numWantsSatisfied: 1 },
-      });
-    }
+    expectVoteAccepted(t, newCommittee.slice(0, 2), getVoteId(instanceName));
 
     t.log('Waiting for period to end');
     await advanceTimeBy(1, 'minutes');
 
     t.log('Verifying outcome');
     const lastOutcome = await governanceDriver.getLatestOutcome();
-    const psmParams = getVstorageData(getPsmKey(brand));
-    t.deepEqual(psmParams.current.MintLimit.value.value, 100_000_000n);
+    expectParamValue(t, getPsmKey(brand), 100_000_000n, [
+      'current',
+      'MintLimit',
+      'value',
+      'value',
+    ]);
     t.assert(lastOutcome.outcome === 'win');
   }
 });
@@ -649,10 +604,14 @@ test.serial.failing('EC can govern psm parameter', async t => {
 test.serial.failing(
   'EC can make calls to price feed governed APIs',
   async t => {
-    const { storage, advanceTimeBy, governanceDriver } = t.context;
+    const {
+      advanceTimeBy,
+      agoricNamesRemotes,
+      expectProposalAccepted,
+      expectVoteAccepted,
+      governanceDriver,
+    } = t.context;
     const newCommittee = governanceDriver.ecMembers.slice(0, 3);
-
-    const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(storage);
 
     const priceFeedInstances = Object.keys(agoricNamesRemotes.instance).filter(
       instance => {
@@ -676,9 +635,7 @@ test.serial.failing(
         offerIds.propose.incoming,
       );
 
-      t.like(newCommittee[0].getLatestUpdateRecord(), {
-        status: { id: getQuestionId(instanceName), numWantsSatisfied: 1 },
-      });
+      expectProposalAccepted(t, newCommittee[0], getQuestionId(instanceName));
 
       t.log('Voting on question using first 2 wallets');
       await governanceDriver.enactLatestProposal(
@@ -686,11 +643,7 @@ test.serial.failing(
         getVoteId(instanceName),
         offerIds.vote.incoming,
       );
-      for (const w of newCommittee.slice(0, 2)) {
-        t.like(w.getLatestUpdateRecord(), {
-          status: { id: getVoteId(instanceName), numWantsSatisfied: 1 },
-        });
-      }
+      expectVoteAccepted(t, newCommittee.slice(0, 2), getVoteId(instanceName));
 
       t.log('no oracle invitation should exist before vote passing');
       const oracleInvitation =

--- a/packages/boot/test/bootstrapTests/terminate-governed.test.ts
+++ b/packages/boot/test/bootstrapTests/terminate-governed.test.ts
@@ -1,20 +1,15 @@
 import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import type { TestFn } from 'ava';
 import type { ZoeService } from '@agoric/zoe';
-import { makeSwingsetTestKit } from '../../tools/supports.js';
-import { loadOrCreateRunUtilsSnapshot } from '../tools/runutils-snapshots.js';
+import { makeBootTestContext } from '../tools/boot-test-context.js';
 
 // A more minimal set would be better. We need governance, but not econ vats.
 const PLATFORM_CONFIG = '@agoric/vm-config/decentral-main-vaults-config.json';
 
 const makeDefaultTestContext = async t => {
-  const snapshot = await loadOrCreateRunUtilsSnapshot(
-    'main-vaults-base',
-    t.log,
-  );
-  const swingsetTestKit = await makeSwingsetTestKit(t.log, undefined, {
+  const swingsetTestKit = await makeBootTestContext(t, {
     configSpecifier: PLATFORM_CONFIG,
-    snapshot,
+    snapshotName: 'main-vaults-base',
   });
   const { runUtils } = swingsetTestKit;
   const { EV } = runUtils;
@@ -40,15 +35,14 @@ test.after.always(t => {
 
 test(`Create a contract via core-eval and kill it via core-eval by boardID `, async t => {
   const TEST_CONTRACT_LABEL = 'testContractLabel';
-  const { runUtils, buildProposal, evalProposal, zoe } = t.context;
+  const { runUtils, applyProposal, zoe } = t.context;
   const { EV } = runUtils;
 
   // Create a contract via core-eval.
-  const creatorProposal = buildProposal(
+  await applyProposal(
     '@agoric/governance/test/swingsetTests/contractGovernor/add-governedContract.js',
     [TEST_CONTRACT_LABEL],
   );
-  await evalProposal(creatorProposal);
 
   const { boardID, governor, instance, publicFacet } = (await EV.vat(
     'bootstrap',
@@ -68,11 +62,10 @@ test(`Create a contract via core-eval and kill it via core-eval by boardID `, as
   t.is(governedInstance.getKref(), instance.getKref());
 
   // Terminate the pair via proposal.
-  const terminatorProposal = buildProposal(
+  await applyProposal(
     '@agoric/vats/src/proposals/terminate-governed-instance.js',
     [`${boardID}:${TEST_CONTRACT_LABEL}`],
   );
-  await evalProposal(terminatorProposal);
 
   // Confirm termination.
   const expectTerminationError = p =>

--- a/packages/boot/test/bootstrapTests/vats-restart.test.ts
+++ b/packages/boot/test/bootstrapTests/vats-restart.test.ts
@@ -5,27 +5,25 @@ import type { TestFn } from 'ava';
 import { Fail } from '@endo/errors';
 import { eventLoopIteration } from '@agoric/internal/src/testing-utils.js';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
-import { makeAgoricNamesRemotesFromFakeStorage } from '@agoric/vats/tools/board-utils.js';
 import type { ScopedBridgeManager } from '@agoric/vats';
-import { makeSwingsetTestKit } from '../../tools/supports.js';
-import { makeWalletFactoryDriver } from '../../tools/drivers.js';
-import { loadOrCreateRunUtilsSnapshot } from '../tools/runutils-snapshots.js';
+import {
+  makeBootTestContext,
+  withWalletFactory,
+} from '../tools/boot-test-context.js';
 
 // main/production config doesn't have initialPrice, upon which 'open vaults' depends
 const PLATFORM_CONFIG = '@agoric/vm-config/decentral-itest-vaults-config.json';
 
 export const makeTestContext = async t => {
   console.time('DefaultTestContext');
-  const snapshot = await loadOrCreateRunUtilsSnapshot(
-    'itest-vaults-base',
-    t.log,
+  const swingsetTestKit = await withWalletFactory(
+    await makeBootTestContext(t, {
+      configSpecifier: PLATFORM_CONFIG,
+      snapshotName: 'itest-vaults-base',
+    }),
   );
-  const swingsetTestKit = await makeSwingsetTestKit(t.log, undefined, {
-    configSpecifier: PLATFORM_CONFIG,
-    snapshot,
-  });
 
-  const { runUtils, storage } = swingsetTestKit;
+  const { runUtils } = swingsetTestKit;
   console.timeLog('DefaultTestContext', 'swingsetTestKit');
   const { EV } = runUtils;
 
@@ -35,18 +33,9 @@ export const makeTestContext = async t => {
 
   await eventLoopIteration();
 
-  // has to be late enough for agoricNames data to have been published
-  const agoricNamesRemotes = makeAgoricNamesRemotesFromFakeStorage(
-    swingsetTestKit.storage,
-  );
-  agoricNamesRemotes.brand.ATOM || Fail`ATOM brand not yet defined`;
+  swingsetTestKit.agoricNamesRemotes.brand.ATOM ||
+    Fail`ATOM brand not yet defined`;
   console.timeLog('DefaultTestContext', 'agoricNamesRemotes');
-
-  const walletFactoryDriver = await makeWalletFactoryDriver(
-    runUtils,
-    storage,
-    agoricNamesRemotes,
-  );
   console.timeLog('DefaultTestContext', 'walletFactoryDriver');
 
   console.timeEnd('DefaultTestContext');
@@ -55,8 +44,6 @@ export const makeTestContext = async t => {
 
   return {
     ...swingsetTestKit,
-    agoricNamesRemotes,
-    walletFactoryDriver,
     shared,
   };
 };
@@ -74,9 +61,9 @@ test.after.always(t => t.context.shutdown?.());
 const walletAddr = 'agoric1a';
 
 test.serial('open vault', async t => {
-  const { walletFactoryDriver } = t.context;
+  const { provideSmartWallet } = t.context;
 
-  const wd = await walletFactoryDriver.provideSmartWallet(walletAddr);
+  const wd = await provideSmartWallet(walletAddr);
   t.true(wd.isNew);
 
   await wd.executeOfferMaker(Offers.vaults.OpenVault, {
@@ -86,10 +73,7 @@ test.serial('open vault', async t => {
     giveCollateral: 9.0,
   });
 
-  t.like(wd.getLatestUpdateRecord(), {
-    updated: 'offerStatus',
-    status: { id: 'open1', numWantsSatisfied: 1 },
-  });
+  wd.expectStatus(t, { id: 'open1', numWantsSatisfied: 1 });
 });
 
 test.serial('make IBC callbacks before upgrade', async t => {
@@ -104,12 +88,10 @@ test.serial('make IBC callbacks before upgrade', async t => {
 });
 
 test.serial('run restart-vats proposal', async t => {
-  const { buildProposal, evalProposal } = t.context;
+  const { applyProposal } = t.context;
 
   t.log('building proposal');
-  await evalProposal(
-    buildProposal('@agoric/builders/scripts/vats/restart-vats.js'),
-  );
+  await applyProposal('@agoric/builders/scripts/vats/restart-vats.js');
 
   t.pass(); // reached here without throws
 });
@@ -147,9 +129,9 @@ test.serial('read metrics', async t => {
 });
 
 test.serial('open second vault', async t => {
-  const { walletFactoryDriver } = t.context;
+  const { provideSmartWallet } = t.context;
 
-  const wd = await walletFactoryDriver.provideSmartWallet(walletAddr);
+  const wd = await provideSmartWallet(walletAddr);
   t.false(wd.isNew);
 
   await wd.executeOfferMaker(Offers.vaults.OpenVault, {
@@ -159,8 +141,5 @@ test.serial('open second vault', async t => {
     giveCollateral: 9.0,
   });
 
-  t.like(wd.getLatestUpdateRecord(), {
-    updated: 'offerStatus',
-    status: { id: 'open2', numWantsSatisfied: 1 },
-  });
+  wd.expectStatus(t, { id: 'open2', numWantsSatisfied: 1 });
 });

--- a/packages/boot/test/bootstrapTests/vow-offer-results.test.ts
+++ b/packages/boot/test/bootstrapTests/vow-offer-results.test.ts
@@ -2,29 +2,26 @@ import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import type { TestFn } from 'ava';
 import {
-  makeWalletFactoryContext,
-  type WalletFactoryTestContext,
-} from './walletFactory.js';
-import { loadOrCreateRunUtilsSnapshot } from '../tools/runutils-snapshots.js';
+  makeBootTestContext,
+  withWalletFactory,
+  type WalletFactoryBootTestContext,
+} from '../tools/boot-test-context.js';
 
-const test: TestFn<WalletFactoryTestContext> = anyTest;
+const test: TestFn<WalletFactoryBootTestContext> = anyTest;
 
 test.before(async t => {
-  const snapshot = await loadOrCreateRunUtilsSnapshot(
-    'orchestration-base',
-    t.log,
-  );
-  t.context = await makeWalletFactoryContext(
-    t,
-    '@agoric/vm-config/decentral-itest-orchestration-config.json',
-    { snapshot },
+  t.context = await withWalletFactory(
+    await makeBootTestContext(t, {
+      configSpecifier:
+        '@agoric/vm-config/decentral-itest-orchestration-config.json',
+      snapshotName: 'orchestration-base',
+    }),
   );
 });
 test.after.always(t => t.context.shutdown?.());
 
 test('resolves', async t => {
-  const { walletFactoryDriver, buildProposal, evalProposal, runUtils } =
-    t.context;
+  const { applyProposal, provideSmartWallet, runUtils } = t.context;
   const flushKernel = () => runUtils.queueAndRun(() => undefined, true);
   const timeStep = async <T>(
     label: string,
@@ -39,16 +36,13 @@ test('resolves', async t => {
   };
 
   t.log('start valueVow');
-  const startProposal = await timeStep('build start-valueVow proposal', () =>
-    buildProposal('@agoric/builders/scripts/testing/start-valueVow.js'),
-  );
-  await timeStep('eval start-valueVow proposal', () =>
-    evalProposal(startProposal),
+  await timeStep('apply start-valueVow proposal', () =>
+    applyProposal('@agoric/builders/scripts/testing/start-valueVow.js'),
   );
 
   t.log('use wallet to get a vow');
   const getter = await timeStep('provide getter wallet', () =>
-    walletFactoryDriver.provideSmartWallet('agoric1getter'),
+    provideSmartWallet('agoric1getter'),
   );
   // *send* b/c execution doesn't resolve until even the vow resolves and that won't happen until the set-value
   await timeStep('send getter offer', () =>
@@ -67,32 +61,25 @@ test('resolves', async t => {
 
   t.log('confirm the value is not in offer results');
   {
-    const statusRecord = getter.getLatestUpdateRecord();
-    t.like(statusRecord, {
-      status: {
-        id: 'get-value',
-        numWantsSatisfied: 1,
-      },
-      updated: 'offerStatus',
+    const statusRecord = getter.expectStatus(t, {
+      id: 'get-value',
+      numWantsSatisfied: 1,
     });
+    t.is(statusRecord.updated, 'offerStatus');
     // narrow the type
     assert(statusRecord.updated === 'offerStatus');
     t.false('result' in statusRecord.status, 'no result yet');
   }
 
   t.log('restart valueVow');
-  const restartProposal = await timeStep(
-    'build restart-valueVow proposal',
-    () => buildProposal('@agoric/builders/scripts/testing/restart-valueVow.js'),
-  );
-  await timeStep('eval restart-valueVow proposal', () =>
-    evalProposal(restartProposal),
+  await timeStep('apply restart-valueVow proposal', () =>
+    applyProposal('@agoric/builders/scripts/testing/restart-valueVow.js'),
   );
 
   t.log('use wallet to set value');
   const offerArgs = { value: 'Ciao, mondo!' };
   const setter = await timeStep('provide setter wallet', () =>
-    walletFactoryDriver.provideSmartWallet('agoric1setter'),
+    provideSmartWallet('agoric1setter'),
   );
   await timeStep('execute setter offer', () =>
     setter.executeOffer({
@@ -106,27 +93,9 @@ test('resolves', async t => {
       proposal: {},
     }),
   );
-  t.like(setter.getLatestUpdateRecord(), {
-    updated: 'offerStatus',
-    status: {
-      id: 'set-value',
-      numWantsSatisfied: 1,
-    },
-  });
+  setter.expectStatus(t, { id: 'set-value', numWantsSatisfied: 1 });
 
   t.log('confirm the value is now in offer results');
   await timeStep('flush kernel after setter offer', flushKernel);
-  {
-    const statusRecord = getter.getLatestUpdateRecord();
-    // narrow the type
-    assert(statusRecord.updated === 'offerStatus');
-    t.true('result' in statusRecord.status, 'got result');
-    t.like(statusRecord, {
-      status: {
-        id: 'get-value',
-        result: offerArgs.value,
-      },
-      updated: 'offerStatus',
-    });
-  }
+  getter.expectResult(t, 'get-value', offerArgs.value);
 });

--- a/packages/boot/test/bootstrapTests/vtransfer.test.ts
+++ b/packages/boot/test/bootstrapTests/vtransfer.test.ts
@@ -8,17 +8,13 @@ import type { TransferVat } from '@agoric/vats/src/vat-transfer.js';
 import { BridgeId } from '@agoric/internal';
 import { VTRANSFER_IBC_EVENT } from '@agoric/internal/src/action-types.js';
 import type { ERef } from '@agoric/vow';
-import { makeSwingsetTestKit } from '../../tools/supports.js';
-import { loadOrCreateRunUtilsSnapshot } from '../tools/runutils-snapshots.js';
+import { makeBootTestContext } from '../tools/boot-test-context.js';
 
-const makeDefaultTestContext = async t => {
-  const snapshot = await loadOrCreateRunUtilsSnapshot('demo-base', t.log);
-  const swingsetTestKit = await makeSwingsetTestKit(t.log, undefined, {
+const makeDefaultTestContext = async t =>
+  makeBootTestContext(t, {
     configSpecifier: '@agoric/vm-config/decentral-demo-config.json',
-    snapshot,
+    snapshotName: 'demo-base',
   });
-  return swingsetTestKit;
-};
 type DefaultTestContext = Awaited<ReturnType<typeof makeDefaultTestContext>>;
 
 const test: TestFn<DefaultTestContext> = anyTest;
@@ -28,8 +24,7 @@ test.after.always(t => t.context.shutdown?.());
 
 test('vtransfer', async t => {
   const {
-    buildProposal,
-    evalProposal,
+    applyProposal,
     bridgeUtils: { getOutboundMessages },
     runUtils,
   } = t.context;
@@ -80,10 +75,7 @@ test('vtransfer', async t => {
   // 1 interceptors for target
 
   // Tap into VTRANSFER_IBC_EVENT messages
-  const testVtransferProposal = buildProposal(
-    '@agoric/builders/scripts/vats/test-vtransfer.js',
-  );
-  await evalProposal(testVtransferProposal);
+  await applyProposal('@agoric/builders/scripts/vats/test-vtransfer.js');
 
   // simulate a Golang upcall with arbitrary payload
   // note that property order matters!
@@ -112,7 +104,10 @@ test('vtransfer', async t => {
   ]);
 
   // test adding an interceptor for the same target, which should fail
-  await t.throwsAsync(() => evalProposal(testVtransferProposal), {
-    message: /Target.*already registered/,
-  });
+  await t.throwsAsync(
+    () => applyProposal('@agoric/builders/scripts/vats/test-vtransfer.js'),
+    {
+      message: /Target.*already registered/,
+    },
+  );
 });

--- a/packages/boot/test/bootstrapTests/wallet-fun.test.ts
+++ b/packages/boot/test/bootstrapTests/wallet-fun.test.ts
@@ -10,25 +10,23 @@ import bundleSource from '@endo/bundle-source';
 import type { ExecutionContext, TestFn } from 'ava';
 import { createRequire } from 'node:module';
 import {
-  makeWalletFactoryContext,
-  type WalletFactoryTestContext as TC,
-} from './walletFactory.ts';
-import { loadOrCreateRunUtilsSnapshot } from '../tools/runutils-snapshots.js';
+  makeBootTestContext,
+  withWalletFactory,
+  type WalletFactoryBootTestContext as TC,
+} from '../tools/boot-test-context.js';
 
 const nodeRequire = createRequire(import.meta.url);
 
 const test = anyTest as TestFn<TC>;
 
 test.before(async t => {
-  const snapshot = await loadOrCreateRunUtilsSnapshot(
-    'main-vaults-base',
-    t.log,
+  t.context = await withWalletFactory(
+    await makeBootTestContext(t, {
+      snapshotName: 'main-vaults-base',
+    }),
   );
-  t.context = await makeWalletFactoryContext(t, undefined, { snapshot });
 });
-test.after.always(t => {
-  return t.context.shutdown && t.context.shutdown();
-});
+test.after.always(t => t.context.shutdown?.());
 
 const startContract = async <SF>(
   t: ExecutionContext<TC>,
@@ -63,7 +61,7 @@ const showInvitationBalance = (addr: string, r: CurrentWalletRecord) => [
 ];
 
 test('use offer result without zoe', async t => {
-  const { walletFactoryDriver, agoricNamesRemotes } = t.context;
+  const { agoricNamesRemotes, provideSmartWallet } = t.context;
 
   const makeCoreCtx = (addr: string) => {
     const start = async () => {
@@ -92,14 +90,14 @@ test('use offer result without zoe', async t => {
 
   // client-side presence
   const addr = 'agoric1admin';
-  const wd = await walletFactoryDriver.provideSmartWallet(addr);
+  const wd = await provideSmartWallet(addr);
 
   const makePriceOracle = () => {
     const redeemInvitation = async () => {
       const { walletFun } = agoricNamesRemotes.instance;
       t.truthy(walletFun);
 
-      t.log(...showInvitationBalance(addr, wd.getCurrentWalletRecord()));
+      t.log(...showInvitationBalance(addr, wd.current()));
 
       await wd.executeOffer({
         id: 'redeemInvitation',
@@ -111,7 +109,7 @@ test('use offer result without zoe', async t => {
         proposal: {},
         saveResult: { name: 'priceSetter' },
       });
-      t.log('redeemInvitation last update', wd.getLatestUpdateRecord());
+      t.log('redeemInvitation last update', wd.latest());
     };
 
     const useOfferResult = () =>

--- a/packages/boot/test/bootstrapTests/walletFactory.ts
+++ b/packages/boot/test/bootstrapTests/walletFactory.ts
@@ -1,72 +1,25 @@
-import { Fail } from '@endo/errors';
 import {
-  type AgoricNamesRemotes,
-  makeAgoricNamesRemotesFromFakeStorage,
-} from '@agoric/vats/tools/board-utils.js';
-import {
-  fetchCoreEvalRelease,
-  makeSwingsetTestKit,
-} from '../../tools/supports.js';
-import { makeWalletFactoryDriver } from '../../tools/drivers.js';
+  makeBootTestContext,
+  withWalletFactory,
+  type WalletFactoryBootTestContext,
+} from '../tools/boot-test-context.js';
 
 export const makeWalletFactoryContext = async (
   t,
   configSpecifier = '@agoric/vm-config/decentral-main-vaults-config.json',
   opts = {},
 ) => {
-  const swingsetTestKit = await makeSwingsetTestKit(t.log, undefined, {
+  const ctx = await makeBootTestContext(t, {
     configSpecifier,
     ...opts,
   });
-
-  const { runUtils, storage } = swingsetTestKit;
-  console.timeLog('DefaultTestContext', 'swingsetTestKit');
-  const { EV } = runUtils;
-
-  // Wait for ATOM to make it into agoricNames
-  await EV.vat('bootstrap').consumeItem('vaultFactoryKit');
-  console.timeLog('DefaultTestContext', 'vaultFactoryKit');
-
-  // has to be late enough for agoricNames data to have been published
-  const agoricNamesRemotes: AgoricNamesRemotes =
-    makeAgoricNamesRemotesFromFakeStorage(swingsetTestKit.storage);
-  const refreshAgoricNamesRemotes = () => {
-    Object.assign(
-      agoricNamesRemotes,
-      makeAgoricNamesRemotesFromFakeStorage(swingsetTestKit.storage),
-    );
-  };
-  agoricNamesRemotes.brand.ATOM || Fail`ATOM missing from agoricNames`;
-  console.timeLog('DefaultTestContext', 'agoricNamesRemotes');
-
-  const evalReleasedProposal = async (release: string, name: string) => {
-    const materials = await fetchCoreEvalRelease({
-      repo: 'Agoric/agoric-sdk',
-      release,
-      name,
-    });
-    try {
-      await swingsetTestKit.evalProposal(materials);
-    } finally {
-      refreshAgoricNamesRemotes();
-    }
-  };
-
-  const walletFactoryDriver = await makeWalletFactoryDriver(
-    runUtils,
-    storage,
-    agoricNamesRemotes,
-  );
+  const walletCtx = await withWalletFactory(ctx);
   return {
-    ...swingsetTestKit,
-    swingsetTestKit,
-    agoricNamesRemotes,
-    evalReleasedProposal,
-    refreshAgoricNamesRemotes,
-    walletFactoryDriver,
+    ...walletCtx,
+    swingsetTestKit: walletCtx,
   };
 };
 
-export type WalletFactoryTestContext = Awaited<
-  ReturnType<typeof makeWalletFactoryContext>
->;
+export type WalletFactoryTestContext = WalletFactoryBootTestContext & {
+  swingsetTestKit: WalletFactoryBootTestContext;
+};

--- a/packages/boot/test/configs.test.js
+++ b/packages/boot/test/configs.test.js
@@ -38,6 +38,16 @@ const CONFIG_FILES = [
 
 const NON_UPGRADEABLE_VATS = ['pegasus', 'mints'];
 
+const makeMemoizedAsync = fn => {
+  const cache = new Map();
+  return key => {
+    if (!cache.has(key)) {
+      cache.set(key, fn(key));
+    }
+    return cache.get(key);
+  };
+};
+
 /**
  * @param {string} bin
  * @param {{ spawn: typeof spawn }} io
@@ -66,16 +76,48 @@ const makeTestContext = async () => {
   const pathname = new URL(import.meta.url).pathname;
   const dirname = path.dirname(pathname);
   const pathResolve = (...ps) => path.join(dirname, ...ps);
+  const configPaths = new Map();
 
   const bundleCache = await unsafeSharedBundleCache;
 
   const vizTool = pathResolve('..', 'tools', 'authorityViz.js');
   const runViz = pspawn(vizTool, { spawn: ambientSpawn });
 
+  const getConfigPath = makeMemoizedAsync(async configName => {
+    const fullPath = await importConfig(configName);
+    configPaths.set(configName, fullPath);
+    return fullPath;
+  });
+  const getConfigText = makeMemoizedAsync(async configName =>
+    fsPromises.readFile(await getConfigPath(configName), 'utf-8'),
+  );
+  const getProdConfig = makeMemoizedAsync(async configName => {
+    const config = await loadSwingsetConfigFile(
+      await getConfigPath(configName),
+    );
+    if (!config) {
+      throw Error(`missing config ${configName}`);
+    }
+    return config;
+  });
+  const getProposalBundles = makeMemoizedAsync(async configName => {
+    const config = await getProdConfig(configName);
+    const { coreProposals } = /** @type {any} */ (config);
+    const proposals = coreProposals || [];
+    return extractCoreProposalBundles(proposals);
+  });
+  const checkedBundles = new Map();
+
   return {
     bundleCache,
-    pathResolve,
+    checkedBundles,
     basename: path.basename,
+    configPaths,
+    getConfigPath,
+    getConfigText,
+    getProdConfig,
+    getProposalBundles,
+    pathResolve,
     runViz,
   };
 };
@@ -88,7 +130,7 @@ test.before(async t => {
 test('Bootstrap SwingSet config file syntax', async t => {
   await Promise.all(
     CONFIG_FILES.map(async f => {
-      const txt = await fsPromises.readFile(await importConfig(f), 'utf-8');
+      const txt = await t.context.getConfigText(f);
       const config = harden(JSON.parse(txt));
       t.notThrows(() => mustMatch(config, ssShape.SwingSetConfig), f);
     }),
@@ -113,7 +155,7 @@ const hashCode = s => {
 };
 
 const checkBundle = async (t, sourceSpec, seen, name, configSpec) => {
-  const { bundleCache, basename } = t.context;
+  const { bundleCache, basename, checkedBundles } = t.context;
 
   const targetName = `${hashCode(sourceSpec)}-${basename(sourceSpec, '.js')}`;
 
@@ -126,16 +168,27 @@ const checkBundle = async (t, sourceSpec, seen, name, configSpec) => {
 
   if (!seen.has(targetName)) {
     seen.add(targetName);
+    if (!checkedBundles.has(targetName)) {
+      checkedBundles.set(
+        targetName,
+        (async () => {
+          t.log(configSpec, ': check bundle:', name, basename(sourceSpec));
+          const meta = await bundleCache.validateOrAdd(
+            sourceSpec,
+            targetName,
+            noLog,
+          );
+          t.truthy(meta, name);
 
-    t.log(configSpec, ': check bundle:', name, basename(sourceSpec));
-    const meta = await bundleCache.validateOrAdd(sourceSpec, targetName, noLog);
-    t.truthy(meta, name);
-
-    for (const item of meta.contents) {
-      if (item.relativePath.includes('magic-cookie-test-only')) {
-        t.fail(`${configSpec} bundle ${name}: ${item.relativePath}`);
-      }
+          for (const item of meta.contents) {
+            if (item.relativePath.includes('magic-cookie-test-only')) {
+              t.fail(`${configSpec} bundle ${name}: ${item.relativePath}`);
+            }
+          }
+        })(),
+      );
     }
+    await checkedBundles.get(targetName);
   }
 };
 
@@ -144,43 +197,39 @@ test('no test-only code is in production configs', async t => {
 
   const seen = new Set();
 
-  for await (const configSpec of PROD_CONFIG_FILES) {
-    t.log('checking config', configSpec);
-    const fullPath = await importConfig(configSpec);
-    const config = await loadSwingsetConfigFile(fullPath);
-    if (!config) throw t.truthy(config, configSpec); // if/throw refines type
-    const { bundles } = config;
-    if (!bundles) throw t.truthy(bundles, configSpec);
+  await Promise.all(
+    PROD_CONFIG_FILES.map(async configSpec => {
+      t.log('checking config', configSpec);
+      const config = await t.context.getProdConfig(configSpec);
+      const { bundles } = config;
+      if (!bundles) throw t.truthy(bundles, configSpec);
 
-    for await (const [name, spec] of entries(bundles)) {
-      if (!('sourceSpec' in spec)) throw t.fail();
+      await Promise.all(
+        entries(bundles).map(async ([name, spec]) => {
+          if (!('sourceSpec' in spec)) throw t.fail();
 
-      await checkBundle(t, spec.sourceSpec, seen, name, configSpec);
-    }
-  }
+          await checkBundle(t, spec.sourceSpec, seen, name, configSpec);
+        }),
+      );
+    }),
+  );
 });
 
 test('no test-only code is in production proposals', async t => {
   const seen = new Set();
 
-  for await (const configSpec of PROD_CONFIG_FILES) {
-    t.log('checking config', configSpec);
-    const getProposals = async () => {
-      const fullPath = await importConfig(configSpec);
-      const config = await loadSwingsetConfigFile(fullPath);
-      if (!config) throw t.truthy(config, configSpec); // if/throw refines type
-      const { coreProposals } = /** @type {any} */ (config);
-      return coreProposals || [];
-    };
-
-    const coreProposals = await getProposals();
-    const { bundles } = await extractCoreProposalBundles(coreProposals);
-
-    const { entries } = Object;
-    for await (const [name, spec] of entries(bundles)) {
-      await checkBundle(t, spec.sourceSpec, seen, name, configSpec);
-    }
-  }
+  await Promise.all(
+    PROD_CONFIG_FILES.map(async configSpec => {
+      t.log('checking config', configSpec);
+      const { bundles } = await t.context.getProposalBundles(configSpec);
+      const { entries } = Object;
+      await Promise.all(
+        entries(bundles).map(async ([name, spec]) =>
+          checkBundle(t, spec.sourceSpec, seen, name, configSpec),
+        ),
+      );
+    }),
+  );
 });
 
 test('bootstrap permit visualization snapshot', async t => {

--- a/packages/boot/test/configs.test.js
+++ b/packages/boot/test/configs.test.js
@@ -38,11 +38,18 @@ const CONFIG_FILES = [
 
 const NON_UPGRADEABLE_VATS = ['pegasus', 'mints'];
 
-const makeMemoizedAsync = fn => {
+// Like `makeAtomicProvider`, but tolerates non-Passable cached values
+// (e.g. Maps from `extractCoreProposalBundles`). Rejected promises are
+// evicted so the next call retries instead of replaying the failure.
+const makeMemoizedPromise = makeFn => {
   const cache = new Map();
   return key => {
     if (!cache.has(key)) {
-      cache.set(key, fn(key));
+      const p = makeFn(key).catch(err => {
+        cache.delete(key);
+        throw err;
+      });
+      cache.set(key, p);
     }
     return cache.get(key);
   };
@@ -83,15 +90,15 @@ const makeTestContext = async () => {
   const vizTool = pathResolve('..', 'tools', 'authorityViz.js');
   const runViz = pspawn(vizTool, { spawn: ambientSpawn });
 
-  const getConfigPath = makeMemoizedAsync(async configName => {
+  const getConfigPath = makeMemoizedPromise(async configName => {
     const fullPath = await importConfig(configName);
     configPaths.set(configName, fullPath);
     return fullPath;
   });
-  const getConfigText = makeMemoizedAsync(async configName =>
+  const getConfigText = makeMemoizedPromise(async configName =>
     fsPromises.readFile(await getConfigPath(configName), 'utf-8'),
   );
-  const getProdConfig = makeMemoizedAsync(async configName => {
+  const getProdConfig = makeMemoizedPromise(async configName => {
     const config = await loadSwingsetConfigFile(
       await getConfigPath(configName),
     );
@@ -100,7 +107,7 @@ const makeTestContext = async () => {
     }
     return config;
   });
-  const getProposalBundles = makeMemoizedAsync(async configName => {
+  const getProposalBundles = makeMemoizedPromise(async configName => {
     const config = await getProdConfig(configName);
     const { coreProposals } = /** @type {any} */ (config);
     const proposals = coreProposals || [];

--- a/packages/boot/test/orchestration/axelar-gmp.test.ts
+++ b/packages/boot/test/orchestration/axelar-gmp.test.ts
@@ -9,8 +9,12 @@ import type { ExecutionContext, TestFn } from 'ava';
 import { encodeAbiParameters } from 'viem';
 import { makeReceiveUpCallPayload } from '../../tools/axelar-supports.js';
 import { makeWalletFactoryDriver } from '../../tools/drivers.js';
-import { makeWalletFactoryContext } from '../bootstrapTests/walletFactory.js';
-import { loadOrCreateRunUtilsSnapshot } from '../tools/runutils-snapshots.js';
+import {
+  makeBootTestContext,
+  withWalletFactory,
+  type TestWalletDriver,
+  type WalletFactoryBootTestContext,
+} from '../tools/boot-test-context.js';
 
 export type WalletFactoryDriver = Awaited<
   ReturnType<typeof makeWalletFactoryDriver>
@@ -21,8 +25,7 @@ export type SmartWalletDriver = Awaited<
 >;
 
 type MakeEVMTransactionParams = {
-  wallet: SmartWalletDriver;
-  previousOffer: string;
+  wallet: TestWalletDriver;
   methodName: string;
   offerArgs: any;
   proposal: any;
@@ -35,52 +38,58 @@ type AxelarGmpMemo = {
   type: 1 | 2 | 3;
 };
 
-const test = anyTest as TestFn<Awaited<ReturnType<typeof makeTestContext>>>;
+type AxelarGmpTestContext = WalletFactoryBootTestContext & {
+  axelarLog: ReturnType<WalletFactoryBootTestContext['makePublishedLog']>;
+  flow: {
+    evmTransactionCounter: number;
+    previousOffer: string;
+    lcaAddress: string;
+  };
+  wallet: TestWalletDriver;
+};
+
+const test = anyTest as TestFn<AxelarGmpTestContext>;
 
 const makeTestContext = async (t: ExecutionContext) => {
-  const snapshot = await loadOrCreateRunUtilsSnapshot(
-    'orchestration-base',
-    t.log,
-  );
-  const ctx = await makeWalletFactoryContext(
-    t,
-    '@agoric/vm-config/decentral-itest-orchestration-config.json',
-    { snapshot },
+  const ctx = await withWalletFactory(
+    await makeBootTestContext(t, {
+      configSpecifier:
+        '@agoric/vm-config/decentral-itest-orchestration-config.json',
+      snapshotName: 'orchestration-base',
+    }),
   );
 
-  const wallet =
-    await ctx.walletFactoryDriver.provideSmartWallet('agoric1makeAccount');
+  const wallet = await ctx.provideSmartWallet('agoric1makeAccount');
 
-  const fullCtx = {
+  return {
     ...ctx,
+    axelarLog: ctx.makePublishedLog('axelarGmp.log'),
+    flow: {
+      evmTransactionCounter: 0,
+      previousOffer: '',
+      lcaAddress: '',
+    },
     wallet,
   };
-
-  return fullCtx;
 };
 
 const agoricToAxelarChannel = 'channel-9';
 const axelarToAgoricChannel = 'channel-41';
-let evmTransactionCounter = 0;
-let previousOffer = '';
-let lcaAddress = '';
 
-const makeEVMTransaction = async ({
-  wallet,
-  methodName,
-  offerArgs,
-  proposal,
-}: MakeEVMTransactionParams) => {
-  const id = `evmTransaction${evmTransactionCounter}`;
+const makeEVMTransaction = async (
+  t: ExecutionContext<AxelarGmpTestContext>,
+  { wallet, methodName, offerArgs, proposal }: MakeEVMTransactionParams,
+) => {
+  const id = `evmTransaction${t.context.flow.evmTransactionCounter}`;
 
   const proposeInvitationSpec: ContinuingInvitationSpec = {
     source: 'continuing',
-    previousOffer,
+    previousOffer: t.context.flow.previousOffer,
     invitationMakerName: 'makeEVMTransactionInvitation',
     invitationArgs: harden([methodName, offerArgs]),
   };
 
-  evmTransactionCounter += 1;
+  t.context.flow.evmTransactionCounter += 1;
 
   await wallet.executeOffer({
     id,
@@ -94,12 +103,11 @@ const makeEVMTransaction = async ({
 test.before(async t => {
   t.context = await makeTestContext(t);
 
-  const { evalProposal, buildProposal } = t.context;
-  // Register AXL in vbankAssets
-  await evalProposal(
-    buildProposal(
-      '../../../multichain-testing/src/register-interchain-bank-assets.builder.js',
-      [
+  await t.context.applyProposals([
+    {
+      builderPath:
+        '../../../multichain-testing/src/register-interchain-bank-assets.builder.js',
+      args: [
         '--assets',
         JSON.stringify([
           {
@@ -110,25 +118,27 @@ test.before(async t => {
           },
         ]),
       ],
-    ),
-  );
-
-  await evalProposal(
-    buildProposal(
-      '@agoric/builders/scripts/orchestration/axelar-gmp.build.js',
-      ['--net', 'bootstrap', '--peer', 'axelar:connection-0:channel-41:uaxl'],
-    ),
-  );
+    },
+    {
+      builderPath: '@agoric/builders/scripts/orchestration/axelar-gmp.build.js',
+      args: [
+        '--net',
+        'bootstrap',
+        '--peer',
+        'axelar:connection-0:channel-41:uaxl',
+      ],
+    },
+  ]);
 });
 
 test.beforeEach(t => {
-  t.context.storage.data.delete('published.axelarGmp.log');
+  t.context.axelarLog.reset();
 });
 
 test.serial('makeAccount via axelarGmp', async t => {
   const {
-    storage,
     wallet,
+    axelarLog,
     bridgeUtils: { runInbound },
   } = t.context;
 
@@ -148,10 +158,7 @@ test.serial('makeAccount via axelarGmp', async t => {
     },
   });
 
-  const getLogged = () =>
-    JSON.parse(storage.data.get('published.axelarGmp.log')!).values;
-
-  t.deepEqual(getLogged(), [
+  axelarLog.expect(t, [
     'Inside createAndMonitorLCA',
     'localAccount created successfully',
     'tap created successfully',
@@ -170,7 +177,7 @@ test.serial('makeAccount via axelarGmp', async t => {
     }),
   );
 
-  t.deepEqual(getLogged(), [
+  axelarLog.expect(t, [
     'Inside createAndMonitorLCA',
     'localAccount created successfully',
     'tap created successfully',
@@ -179,28 +186,32 @@ test.serial('makeAccount via axelarGmp', async t => {
     'Done',
   ]);
 
-  previousOffer = wallet.getCurrentWalletRecord().offerToUsedInvitation[0][0];
+  t.context.flow.previousOffer = wallet.current().offerToUsedInvitation[0][0];
 });
 
 test.serial('get lca address', async t => {
   const { wallet } = t.context;
 
-  await makeEVMTransaction({
+  await makeEVMTransaction(t, {
     wallet,
-    previousOffer,
     methodName: 'getLocalAddress',
     offerArgs: [],
     proposal: {},
   });
 
-  // @ts-expect-error
-  lcaAddress = wallet.getLatestUpdateRecord().status.result;
-  t.truthy(lcaAddress);
-  t.like(wallet.getLatestUpdateRecord(), {
+  t.context.flow.lcaAddress = `${wallet.expectResult(
+    t,
+    `evmTransaction${t.context.flow.evmTransactionCounter - 1}`,
+  )}`;
+  t.truthy(t.context.flow.lcaAddress);
+  wallet.expectStatus(t, {
+    id: `evmTransaction${t.context.flow.evmTransactionCounter - 1}`,
+    numWantsSatisfied: 1,
+    result: t.context.flow.lcaAddress,
+  });
+  t.like(wallet.latest(), {
     status: {
-      id: `evmTransaction${evmTransactionCounter - 1}`,
-      numWantsSatisfied: 1,
-      result: lcaAddress,
+      id: `evmTransaction${t.context.flow.evmTransactionCounter - 1}`,
     },
   });
 });
@@ -223,8 +234,8 @@ test.serial('receiveUpCall test', async t => {
       amount: 1n,
       denom: 'uaxl',
       sender: makeTestAddress(),
-      target: lcaAddress as `${string}1${string}`,
-      receiver: lcaAddress as `${string}1${string}`,
+      target: t.context.flow.lcaAddress as `${string}1${string}`,
+      receiver: t.context.flow.lcaAddress as `${string}1${string}`,
       sourceChannel: axelarToAgoricChannel,
       destinationChannel: agoricToAxelarChannel,
       memo: JSON.stringify({
@@ -244,23 +255,27 @@ test.serial('receiveUpCall test', async t => {
     }),
   );
 
-  await makeEVMTransaction({
+  await makeEVMTransaction(t, {
     wallet,
-    previousOffer,
     methodName: 'getRemoteAddress',
     offerArgs: [],
     proposal: {},
   });
 
-  // @ts-expect-error
-  const evmSmartWalletAddress = wallet.getLatestUpdateRecord().status.result;
+  const evmSmartWalletAddress = wallet.expectResult(
+    t,
+    `evmTransaction${t.context.flow.evmTransactionCounter - 1}`,
+  );
   t.truthy(evmSmartWalletAddress);
 
-  t.like(wallet.getLatestUpdateRecord(), {
+  wallet.expectStatus(t, {
+    id: `evmTransaction${t.context.flow.evmTransactionCounter - 1}`,
+    numWantsSatisfied: 1,
+    result: evmSmartWalletAddress,
+  });
+  t.like(wallet.latest(), {
     status: {
-      id: `evmTransaction${evmTransactionCounter - 1}`,
-      numWantsSatisfied: 1,
-      result: evmSmartWalletAddress,
+      id: `evmTransaction${t.context.flow.evmTransactionCounter - 1}`,
     },
   });
 });
@@ -268,9 +283,8 @@ test.serial('receiveUpCall test', async t => {
 test.serial('make offers using the lca', async t => {
   const { wallet } = t.context;
 
-  await makeEVMTransaction({
+  await makeEVMTransaction(t, {
     wallet,
-    previousOffer,
     methodName: 'send',
     offerArgs: [
       {
@@ -283,22 +297,19 @@ test.serial('make offers using the lca', async t => {
     proposal: {},
   });
 
-  t.like(wallet.getLatestUpdateRecord(), {
-    status: {
-      id: `evmTransaction${evmTransactionCounter - 1}`,
-      numWantsSatisfied: 1,
-      result: 'transfer success',
-    },
-  });
+  wallet.expectResult(
+    t,
+    `evmTransaction${t.context.flow.evmTransactionCounter - 1}`,
+    'transfer success',
+  );
 });
 
 test.serial('token transfers using lca', async t => {
-  const { storage, wallet } = t.context;
+  const { axelarLog, wallet } = t.context;
   const { BLD } = t.context.agoricNamesRemotes.brand;
 
-  await makeEVMTransaction({
+  await makeEVMTransaction(t, {
     wallet,
-    previousOffer,
     methodName: 'sendGmp',
     offerArgs: [
       {
@@ -312,10 +323,7 @@ test.serial('token transfers using lca', async t => {
     },
   });
 
-  const getLogged = () =>
-    JSON.parse(storage.data.get('published.axelarGmp.log')!).values;
-
-  t.deepEqual(getLogged(), [
+  axelarLog.expect(t, [
     'Inside sendGmp',
     'Payload: null',
     'Initiating IBC Transfer...',
@@ -323,19 +331,17 @@ test.serial('token transfers using lca', async t => {
     'sendGmp successful',
   ]);
 
-  t.like(wallet.getLatestUpdateRecord(), {
-    status: {
-      id: `evmTransaction${evmTransactionCounter - 1}`,
-      result: 'sendGmp successful',
-    },
-  });
+  wallet.expectResult(
+    t,
+    `evmTransaction${t.context.flow.evmTransactionCounter - 1}`,
+    'sendGmp successful',
+  );
 
   t.log('make offer with 0 amount');
 
   await t.throwsAsync(
-    makeEVMTransaction({
+    makeEVMTransaction(t, {
       wallet,
-      previousOffer,
       methodName: 'sendGmp',
       offerArgs: [
         {
@@ -353,7 +359,7 @@ test.serial('token transfers using lca', async t => {
 });
 
 test.serial('make contract calls using lca', async t => {
-  const { wallet, storage } = t.context;
+  const { axelarLog, wallet } = t.context;
   const { BLD } = t.context.agoricNamesRemotes.brand;
 
   const factoryContractAddress: `0x${string}` =
@@ -366,9 +372,8 @@ test.serial('make contract calls using lca', async t => {
     },
   ];
 
-  await makeEVMTransaction({
+  await makeEVMTransaction(t, {
     wallet,
-    previousOffer,
     methodName: 'sendGmp',
     offerArgs: [
       {
@@ -384,10 +389,7 @@ test.serial('make contract calls using lca', async t => {
     },
   });
 
-  const getLogged = () =>
-    JSON.parse(storage.data.get('published.axelarGmp.log')!).values;
-
-  t.deepEqual(getLogged(), [
+  axelarLog.expect(t, [
     'Inside sendGmp',
     `Payload: ${JSON.stringify(buildGMPPayload(contractInvocationData))}`,
     'Fee object {"amount":"20000","recipient":"axelar1zl3rxpp70lmte2xr6c4lgske2fyuj3hupcsvcd"}',
@@ -396,19 +398,17 @@ test.serial('make contract calls using lca', async t => {
     'sendGmp successful',
   ]);
 
-  t.like(wallet.getLatestUpdateRecord(), {
-    status: {
-      id: `evmTransaction${evmTransactionCounter - 1}`,
-      result: 'sendGmp successful',
-    },
-  });
+  wallet.expectResult(
+    t,
+    `evmTransaction${t.context.flow.evmTransactionCounter - 1}`,
+    'sendGmp successful',
+  );
 
   t.log('make offer without contractInvocationData');
 
   await t.throwsAsync(
-    makeEVMTransaction({
+    makeEVMTransaction(t, {
       wallet,
-      previousOffer,
       methodName: 'sendGmp',
       offerArgs: [
         {
@@ -430,9 +430,8 @@ test.serial('make contract calls using lca', async t => {
   t.log('make offer without passing gas amount');
 
   await t.throwsAsync(
-    makeEVMTransaction({
+    makeEVMTransaction(t, {
       wallet,
-      previousOffer,
       methodName: 'sendGmp',
       offerArgs: [
         {
@@ -459,36 +458,28 @@ test.serial('make contract calls using lca', async t => {
 test.serial('restart axelarGmp', async t => {
   t.log('restart axelar-gmp');
 
-  const { evalProposal, buildProposal, wallet } = t.context;
-  await evalProposal(
-    buildProposal('@agoric/builders/scripts/testing/restart-axelar-gmp.js'),
-  );
+  const { applyProposal, wallet } = t.context;
+  await applyProposal('@agoric/builders/scripts/testing/restart-axelar-gmp.js');
 
   t.log(
     'check if the LCA address remains durable after restarting the contract',
   );
-  await makeEVMTransaction({
+  await makeEVMTransaction(t, {
     wallet,
-    previousOffer,
     methodName: 'getLocalAddress',
     offerArgs: [],
     proposal: {},
   });
 
-  // @ts-expect-error
-  lcaAddress = wallet.getLatestUpdateRecord().status.result;
-  t.truthy(lcaAddress);
-  t.like(wallet.getLatestUpdateRecord(), {
-    status: {
-      id: `evmTransaction${evmTransactionCounter - 1}`,
-      numWantsSatisfied: 1,
-      result: lcaAddress,
-    },
-  });
+  t.context.flow.lcaAddress = `${wallet.expectResult(
+    t,
+    `evmTransaction${t.context.flow.evmTransactionCounter - 1}`,
+  )}`;
+  t.truthy(t.context.flow.lcaAddress);
 });
 
 test.serial('make contract calls after contract restart', async t => {
-  const { wallet, storage } = t.context;
+  const { axelarLog, wallet } = t.context;
   const { BLD } = t.context.agoricNamesRemotes.brand;
 
   const factoryContractAddress: `0x${string}` =
@@ -501,9 +492,8 @@ test.serial('make contract calls after contract restart', async t => {
     },
   ];
 
-  await makeEVMTransaction({
+  await makeEVMTransaction(t, {
     wallet,
-    previousOffer,
     methodName: 'sendGmp',
     offerArgs: [
       {
@@ -519,10 +509,7 @@ test.serial('make contract calls after contract restart', async t => {
     },
   });
 
-  const getLogged = () =>
-    JSON.parse(storage.data.get('published.axelarGmp.log')!).values;
-
-  t.deepEqual(getLogged(), [
+  axelarLog.expect(t, [
     'Inside sendGmp',
     `Payload: ${JSON.stringify(buildGMPPayload(contractInvocationData))}`,
     'Fee object {"amount":"50000","recipient":"axelar1zl3rxpp70lmte2xr6c4lgske2fyuj3hupcsvcd"}',
@@ -531,10 +518,9 @@ test.serial('make contract calls after contract restart', async t => {
     'sendGmp successful',
   ]);
 
-  t.like(wallet.getLatestUpdateRecord(), {
-    status: {
-      id: `evmTransaction${evmTransactionCounter - 1}`,
-      result: 'sendGmp successful',
-    },
-  });
+  wallet.expectResult(
+    t,
+    `evmTransaction${t.context.flow.evmTransactionCounter - 1}`,
+    'sendGmp successful',
+  );
 });

--- a/packages/boot/test/orchestration/contract-upgrade.test.ts
+++ b/packages/boot/test/orchestration/contract-upgrade.test.ts
@@ -7,22 +7,20 @@ import { buildVTransferEvent } from '@agoric/orchestration/tools/ibc-mocks.js';
 import { withChainCapabilities } from '@agoric/orchestration';
 import { makeTestAddress } from '@agoric/orchestration/tools/make-test-address.js';
 import {
-  makeWalletFactoryContext,
-  type WalletFactoryTestContext,
-} from '../bootstrapTests/walletFactory.js';
+  makeBootTestContext,
+  withWalletFactory,
+  type WalletFactoryBootTestContext,
+} from '../tools/boot-test-context.js';
 import { minimalChainInfos } from '../tools/chainInfo.js';
-import { loadOrCreateRunUtilsSnapshot } from '../tools/runutils-snapshots.js';
 
-const test: TestFn<WalletFactoryTestContext> = anyTest;
+const test: TestFn<WalletFactoryBootTestContext> = anyTest;
 test.before(async t => {
-  const snapshot = await loadOrCreateRunUtilsSnapshot(
-    'orchestration-base',
-    t.log,
-  );
-  t.context = await makeWalletFactoryContext(
-    t,
-    '@agoric/vm-config/decentral-itest-orchestration-config.json',
-    { snapshot },
+  t.context = await withWalletFactory(
+    await makeBootTestContext(t, {
+      configSpecifier:
+        '@agoric/vm-config/decentral-itest-orchestration-config.json',
+      snapshotName: 'orchestration-base',
+    }),
   );
 });
 test.after.always(t => t.context.shutdown?.());
@@ -38,18 +36,18 @@ test.after.always(t => t.context.shutdown?.());
  */
 test('resume', async t => {
   const {
-    walletFactoryDriver,
+    applyProposal,
     bridgeUtils: { runInbound },
-    buildProposal,
-    evalProposal,
-    storage,
+    provideSmartWallet,
   } = t.context;
 
   const { IST } = t.context.agoricNamesRemotes.brand;
+  const sendAnywhereLog = t.context.makePublishedLog('send-anywhere.log');
 
   t.log('start sendAnywhere');
-  await evalProposal(
-    buildProposal('@agoric/builders/scripts/testing/init-send-anywhere.js', [
+  await applyProposal(
+    '@agoric/builders/scripts/testing/init-send-anywhere.js',
+    [
       '--chainInfo',
       JSON.stringify(withChainCapabilities(minimalChainInfos)),
       '--assetInfo',
@@ -64,11 +62,11 @@ test('resume', async t => {
           },
         ],
       ]),
-    ]),
+    ],
   );
 
   t.log('making offer');
-  const wallet = await walletFactoryDriver.provideSmartWallet('agoric1test');
+  const wallet = await provideSmartWallet('agoric1test');
   // no money in wallet to actually send
   const zero = { brand: IST, value: 0n };
   // send because it won't resolve
@@ -86,20 +84,16 @@ test('resume', async t => {
     offerArgs: { destAddr: 'cosmos1whatever', chainName: 'cosmoshub' },
   });
 
-  // XXX golden test
-  const getLogged = () =>
-    JSON.parse(storage.data.get('published.send-anywhere.log')!).values;
-
   // This log shows the flow started, but didn't get past the IBC Transfer settlement
-  t.deepEqual(getLogged(), [
+  sendAnywhereLog.expect(t, [
     'sending {0} from cosmoshub to cosmos1whatever',
     'got info for chain: cosmoshub cosmoshub-4',
     'completed transfer to localAccount',
   ]);
 
   t.log('null upgrading sendAnywhere');
-  await evalProposal(
-    buildProposal('@agoric/builders/scripts/testing/upgrade-send-anywhere.js'),
+  await applyProposal(
+    '@agoric/builders/scripts/testing/upgrade-send-anywhere.js',
   );
 
   // simulate ibc/MsgTransfer ack from remote chain, enabling `.transfer()` promise
@@ -114,7 +108,7 @@ test('resume', async t => {
     }),
   );
 
-  t.deepEqual(getLogged(), [
+  sendAnywhereLog.expect(t, [
     'sending {0} from cosmoshub to cosmos1whatever',
     'got info for chain: cosmoshub cosmoshub-4',
     'completed transfer to localAccount',

--- a/packages/boot/test/orchestration/lca.test.ts
+++ b/packages/boot/test/orchestration/lca.test.ts
@@ -7,52 +7,41 @@ import type { start as stakeBldStart } from '@agoric/orchestration/src/examples/
 import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
 import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
 import {
-  makeWalletFactoryContext,
-  type WalletFactoryTestContext,
-} from '../bootstrapTests/walletFactory.js';
-import { loadOrCreateRunUtilsSnapshot } from '../tools/runutils-snapshots.js';
+  makeBootTestContext,
+  withWalletFactory,
+  type WalletFactoryBootTestContext,
+} from '../tools/boot-test-context.js';
 
-const test: TestFn<WalletFactoryTestContext> = anyTest;
+const test: TestFn<WalletFactoryBootTestContext> = anyTest;
 
 test.before(async t => {
-  const snapshot = await loadOrCreateRunUtilsSnapshot(
-    'orchestration-base',
-    t.log,
-  );
-  t.context = await makeWalletFactoryContext(
-    t,
-    '@agoric/vm-config/decentral-itest-orchestration-config.json',
-    { snapshot },
+  t.context = await withWalletFactory(
+    await makeBootTestContext(t, {
+      configSpecifier:
+        '@agoric/vm-config/decentral-itest-orchestration-config.json',
+      snapshotName: 'orchestration-base',
+    }),
   );
 });
 test.after.always(t => t.context.shutdown?.());
 
 test.serial('stakeBld', async t => {
-  const {
-    agoricNamesRemotes,
-    buildProposal,
-    evalProposal,
-    refreshAgoricNamesRemotes,
-  } = t.context;
+  const { agoricNamesRemotes, applyProposal, provideSmartWallet } = t.context;
 
   // start-stakeBld depends on this. Sanity check in case the context changes.
   const { BLD } = agoricNamesRemotes.brand;
   BLD || Fail`BLD missing from agoricNames`;
 
-  await evalProposal(
-    buildProposal('@agoric/builders/scripts/orchestration/init-stakeBld.js'),
+  await applyProposal(
+    '@agoric/builders/scripts/orchestration/init-stakeBld.js',
   );
-  // update now that stakeBld is instantiated
-  refreshAgoricNamesRemotes();
 
   const stakeBld = agoricNamesRemotes.instance.stakeBld as Instance<
     typeof stakeBldStart
   >;
   t.truthy(stakeBld);
 
-  const wd = await t.context.walletFactoryDriver.provideSmartWallet(
-    'agoric1testStakeBld',
-  );
+  const wd = await provideSmartWallet('agoric1testStakeBld');
 
   await wd.executeOffer({
     id: 'request-stake',
@@ -69,8 +58,8 @@ test.serial('stakeBld', async t => {
     },
   });
 
-  const current = wd.getCurrentWalletRecord();
-  const latest = wd.getLatestUpdateRecord();
+  const current = wd.current();
+  const latest = wd.latest();
   t.like(current, {
     offerToPublicSubscriberPaths: [
       // TODO publish something useful
@@ -96,9 +85,7 @@ test.serial('stakeBld', async t => {
       },
     },
   });
-  t.like(wd.getLatestUpdateRecord(), {
-    status: { id: 'request-delegate', numWantsSatisfied: 1 },
-  });
+  wd.expectStatus(t, { id: 'request-delegate', numWantsSatisfied: 1 });
 
   await t.throwsAsync(
     wd.executeOffer({
@@ -141,9 +128,7 @@ test.serial('stakeBld', async t => {
       amount: { denom: 'ibc/1234', value: 10n },
     },
   });
-  t.like(wd.getLatestUpdateRecord(), {
-    status: { id: 'bank-send', numWantsSatisfied: 1 },
-  });
+  wd.expectStatus(t, { id: 'bank-send', numWantsSatisfied: 1 });
 
   await wd.executeOffer({
     id: 'bank-sendAll',
@@ -165,9 +150,7 @@ test.serial('stakeBld', async t => {
       ],
     },
   });
-  t.like(wd.getLatestUpdateRecord(), {
-    status: { id: 'bank-sendAll', numWantsSatisfied: 1 },
-  });
+  wd.expectStatus(t, { id: 'bank-sendAll', numWantsSatisfied: 1 });
 
   await t.throwsAsync(
     wd.executeOffer({

--- a/packages/boot/test/orchestration/orchestration.test.ts
+++ b/packages/boot/test/orchestration/orchestration.test.ts
@@ -9,23 +9,23 @@ import type { start as startStakeIca } from '@agoric/orchestration/src/examples/
 import { buildVTransferEvent } from '@agoric/orchestration/tools/ibc-mocks.js';
 import { makeTestAddress } from '@agoric/orchestration/tools/make-test-address.js';
 import { SIMULATED_ERRORS } from '@agoric/vats/tools/fake-bridge.js';
+import type { ZoeService } from '@agoric/zoe';
 import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
 import { Fail } from '@endo/errors';
 import type { TestFn } from 'ava';
-import type { ZoeService } from '@agoric/zoe';
 import {
   insistManagerType,
   makeSwingsetHarness,
 } from '../../tools/supports.js';
 import {
-  makeWalletFactoryContext,
-  type WalletFactoryTestContext,
-} from '../bootstrapTests/walletFactory.js';
+  makeBootTestContext,
+  withWalletFactory,
+  type WalletFactoryBootTestContext,
+} from '../tools/boot-test-context.js';
 import { minimalChainInfos } from '../tools/chainInfo.js';
-import { loadOrCreateRunUtilsSnapshot } from '../tools/runutils-snapshots.js';
 
 const test: TestFn<
-  WalletFactoryTestContext & {
+  WalletFactoryBootTestContext & {
     harness?: ReturnType<typeof makeSwingsetHarness>;
   }
 > = anyTest;
@@ -47,14 +47,15 @@ test.before(async t => {
   insistManagerType(defaultManagerType);
   const harness =
     defaultManagerType === 'xsnap' ? makeSwingsetHarness() : undefined;
-  const snapshot = await loadOrCreateRunUtilsSnapshot(
-    'orchestration-base',
-    t.log,
-  );
-  const ctx = await makeWalletFactoryContext(
-    t,
-    '@agoric/vm-config/decentral-itest-orchestration-config.json',
-    { slogFile, defaultManagerType, harness, snapshot },
+  const ctx = await withWalletFactory(
+    await makeBootTestContext(t, {
+      configSpecifier:
+        '@agoric/vm-config/decentral-itest-orchestration-config.json',
+      snapshotName: 'orchestration-base',
+      slogFile,
+      defaultManagerType,
+      harness,
+    }),
   );
   t.context = { ...ctx, harness };
 });
@@ -62,15 +63,12 @@ test.after.always(t => t.context.shutdown?.());
 
 test.skip('stakeOsmo - queries', async t => {
   const {
-    buildProposal,
-    evalProposal,
+    applyProposal,
     runUtils: { EV },
   } = t.context;
-  await evalProposal(
-    buildProposal('@agoric/builders/scripts/orchestration/init-stakeOsmo.js', [
-      '--chainInfo',
-      JSON.stringify(withChainCapabilities(minimalChainInfos)),
-    ]),
+  await applyProposal(
+    '@agoric/builders/scripts/orchestration/init-stakeOsmo.js',
+    ['--chainInfo', JSON.stringify(withChainCapabilities(minimalChainInfos))],
   );
 
   const agoricNames = await EV.vat('bootstrap').consumeItem('agoricNames');
@@ -101,24 +99,18 @@ test.skip('stakeOsmo - queries', async t => {
 
 test.serial('stakeAtom - smart wallet', async t => {
   const {
-    buildProposal,
-    evalProposal,
+    applyProposal,
     agoricNamesRemotes,
     bridgeUtils: { flushInboundQueue },
-    readPublished,
     harness,
   } = t.context;
 
-  await evalProposal(
-    buildProposal('@agoric/builders/scripts/orchestration/init-stakeAtom.js', [
-      '--chainInfo',
-      JSON.stringify(withChainCapabilities(minimalChainInfos)),
-    ]),
+  await applyProposal(
+    '@agoric/builders/scripts/orchestration/init-stakeAtom.js',
+    ['--chainInfo', JSON.stringify(withChainCapabilities(minimalChainInfos))],
   );
 
-  const wd = await t.context.walletFactoryDriver.provideSmartWallet(
-    'agoric1testStakAtom',
-  );
+  const wd = await t.context.provideSmartWallet('agoric1testStakAtom');
 
   harness?.useRunPolicy(true);
   await wd.sendOffer({
@@ -134,20 +126,11 @@ test.serial('stakeAtom - smart wallet', async t => {
   harness?.useRunPolicy(false);
 
   await flushInboundQueue();
-  t.like(wd.getCurrentWalletRecord(), {
-    offerToPublicSubscriberPaths: [
-      [
-        'request-account',
-        {
-          account: 'published.stakeAtom.accounts.cosmos1test',
-        },
-      ],
-    ],
+  wd.expectInvitationPath(t, 'request-account', {
+    account: 'published.stakeAtom.accounts.cosmos1test',
   });
-  t.like(wd.getLatestUpdateRecord(), {
-    status: { id: 'request-account', numWantsSatisfied: 1 },
-  });
-  t.deepEqual(readPublished('stakeAtom.accounts.cosmos1test'), {
+  wd.expectStatus(t, { id: 'request-account', numWantsSatisfied: 1 });
+  t.context.expectPublished(t, 'stakeAtom.accounts.cosmos1test', {
     localAddress:
       '/ibc-port/icacontroller-1/ordered/{"version":"ics27-1","controllerConnectionId":"connection-8","hostConnectionId":"connection-649","address":"cosmos1test","encoding":"proto3","txType":"sdk_multi_msg"}/ibc-channel/channel-1',
     remoteAddress:
@@ -169,8 +152,9 @@ test.serial('stakeAtom - smart wallet', async t => {
     },
     proposal: {},
   });
-  t.like(wd.getLatestUpdateRecord(), {
-    status: { id: 'request-delegate-success', numWantsSatisfied: 1 },
+  wd.expectStatus(t, {
+    id: 'request-delegate-success',
+    numWantsSatisfied: 1,
   });
 
   const validatorAddressFail: CosmosValidatorAddress = {
@@ -227,45 +211,38 @@ test.todo('withdraw reward wallet offer');
 
 test.serial('basic-flows', async t => {
   const {
-    buildProposal,
-    evalProposal,
-    readPublished,
+    applyProposal,
     bridgeUtils: { flushInboundQueue, runInbound },
   } = t.context;
 
-  await evalProposal(
-    buildProposal(
-      '@agoric/builders/scripts/orchestration/init-basic-flows.js',
-      [
-        '--chainInfo',
-        JSON.stringify(withChainCapabilities(minimalChainInfos)),
-        '--assetInfo',
-        JSON.stringify([
-          [
-            'ibc/uusdconagoric',
-            {
-              chainName: 'agoric',
-              baseName: 'noble',
-              baseDenom: 'uusdc',
-            },
-          ],
-          // not tested until #10006. consider renaming to ibc/uusdconcosmos
-          // and updating boot/tools/ibc/mocks.ts
-          [
-            'ibc/uusdchash',
-            {
-              chainName: 'cosmoshub',
-              baseName: 'noble',
-              baseDenom: 'uusdc',
-            },
-          ],
-        ]),
-      ],
-    ),
+  await applyProposal(
+    '@agoric/builders/scripts/orchestration/init-basic-flows.js',
+    [
+      '--chainInfo',
+      JSON.stringify(withChainCapabilities(minimalChainInfos)),
+      '--assetInfo',
+      JSON.stringify([
+        [
+          'ibc/uusdconagoric',
+          {
+            chainName: 'agoric',
+            baseName: 'noble',
+            baseDenom: 'uusdc',
+          },
+        ],
+        [
+          'ibc/uusdchash',
+          {
+            chainName: 'cosmoshub',
+            baseName: 'noble',
+            baseDenom: 'uusdc',
+          },
+        ],
+      ]),
+    ],
   );
 
-  const wd =
-    await t.context.walletFactoryDriver.provideSmartWallet('agoric1test');
+  const wd = await t.context.provideSmartWallet('agoric1test');
 
   // create a cosmos orchestration account
   await wd.sendOffer({
@@ -281,20 +258,11 @@ test.serial('basic-flows', async t => {
     proposal: {},
   });
   await flushInboundQueue();
-  t.like(wd.getCurrentWalletRecord(), {
-    offerToPublicSubscriberPaths: [
-      [
-        'request-coa',
-        {
-          account: 'published.basicFlows.cosmos1test1',
-        },
-      ],
-    ],
+  wd.expectInvitationPath(t, 'request-coa', {
+    account: 'published.basicFlows.cosmos1test1',
   });
-  t.like(wd.getLatestUpdateRecord(), {
-    status: { id: 'request-coa', numWantsSatisfied: 1 },
-  });
-  t.deepEqual(readPublished('basicFlows.cosmos1test1'), {
+  wd.expectStatus(t, { id: 'request-coa', numWantsSatisfied: 1 });
+  t.context.expectPublished(t, 'basicFlows.cosmos1test1', {
     localAddress:
       '/ibc-port/icacontroller-2/ordered/{"version":"ics27-1","controllerConnectionId":"connection-8","hostConnectionId":"connection-649","address":"cosmos1test1","encoding":"proto3","txType":"sdk_multi_msg"}/ibc-channel/channel-2',
     remoteAddress:
@@ -315,16 +283,11 @@ test.serial('basic-flows', async t => {
     proposal: {},
   });
 
-  const publicSubscriberPaths = Object.fromEntries(
-    wd.getCurrentWalletRecord().offerToPublicSubscriberPaths,
-  );
   const expectedAddress = makeTestAddress();
-  t.deepEqual(publicSubscriberPaths['request-loa'], {
+  wd.expectInvitationPath(t, 'request-loa', {
     account: `published.basicFlows.${expectedAddress}`,
   });
-  t.like(wd.getLatestUpdateRecord(), {
-    status: { id: 'request-loa', numWantsSatisfied: 1 },
-  });
+  wd.expectStatus(t, { id: 'request-loa', numWantsSatisfied: 1 });
 
   await wd.sendOffer({
     id: 'transfer-to-noble-from-cosmos',
@@ -343,11 +306,9 @@ test.serial('basic-flows', async t => {
       },
     },
   });
-  t.like(wd.getLatestUpdateRecord(), {
-    status: {
-      id: 'transfer-to-noble-from-cosmos',
-      error: undefined,
-    },
+  wd.expectStatus(t, {
+    id: 'transfer-to-noble-from-cosmos',
+    error: undefined,
   });
 
   await wd.sendOffer({
@@ -367,12 +328,9 @@ test.serial('basic-flows', async t => {
       },
     },
   });
-  t.like(wd.getLatestUpdateRecord(), {
-    status: {
-      id: 'transfer-to-noble-from-cosmos-timeout',
-      error:
-        'Error: ABCI code: 5: error handling packet: see events for details',
-    },
+  wd.expectStatus(t, {
+    id: 'transfer-to-noble-from-cosmos-timeout',
+    error: 'Error: ABCI code: 5: error handling packet: see events for details',
   });
 
   await wd.sendOffer({
@@ -404,7 +362,7 @@ test.serial('basic-flows', async t => {
   );
 
   const latestOfferStatus = () => {
-    const curr = wd.getLatestUpdateRecord();
+    const curr = wd.latest();
     if (curr.updated === 'offerStatus') {
       return curr.status;
     }
@@ -440,51 +398,42 @@ test.serial('basic-flows', async t => {
 });
 
 test.serial('auto-stake-it - proposal', async t => {
-  const { buildProposal, evalProposal } = t.context;
-
   await t.notThrowsAsync(
-    evalProposal(
-      buildProposal('@agoric/builders/scripts/testing/init-auto-stake-it.js', [
-        '--chainInfo',
-        JSON.stringify(withChainCapabilities(minimalChainInfos)),
-      ]),
+    t.context.applyProposal(
+      '@agoric/builders/scripts/testing/init-auto-stake-it.js',
+      ['--chainInfo', JSON.stringify(withChainCapabilities(minimalChainInfos))],
     ),
   );
 });
 
 test.serial('basic-flows - portfolio holder', async t => {
   const {
-    buildProposal,
-    evalProposal,
-    readPublished,
+    applyProposal,
     agoricNamesRemotes,
     bridgeUtils: { flushInboundQueue },
   } = t.context;
 
-  await evalProposal(
-    buildProposal(
-      '@agoric/builders/scripts/orchestration/init-basic-flows.js',
-      [
-        '--chainInfo',
-        JSON.stringify(withChainCapabilities(minimalChainInfos)),
-        '--assetInfo',
-        JSON.stringify([
-          [
-            'ubld',
-            {
-              baseDenom: 'ubld',
-              baseName: 'agoric',
-              chainName: 'agoric',
-              brandKey: 'BLD',
-            },
-          ],
-        ]),
-      ],
-    ),
+  await applyProposal(
+    '@agoric/builders/scripts/orchestration/init-basic-flows.js',
+    [
+      '--chainInfo',
+      JSON.stringify(withChainCapabilities(minimalChainInfos)),
+      '--assetInfo',
+      JSON.stringify([
+        [
+          'ubld',
+          {
+            baseDenom: 'ubld',
+            baseName: 'agoric',
+            chainName: 'agoric',
+            brandKey: 'BLD',
+          },
+        ],
+      ]),
+    ],
   );
 
-  const wd =
-    await t.context.walletFactoryDriver.provideSmartWallet('agoric1test2');
+  const wd = await t.context.provideSmartWallet('agoric1test2');
 
   // create a cosmos orchestration account
   await wd.sendOffer({
@@ -499,41 +448,30 @@ test.serial('basic-flows - portfolio holder', async t => {
     },
     proposal: {},
   });
-  t.like(
-    wd.getLatestUpdateRecord(),
-    {
-      status: { id: 'request-portfolio-acct', numWantsSatisfied: 1 },
-    },
+  wd.expectStatus(
+    t,
+    { id: 'request-portfolio-acct', numWantsSatisfied: 1 },
     'trivially satisfied',
   );
   await flushInboundQueue();
-  t.like(wd.getCurrentWalletRecord(), {
-    offerToPublicSubscriberPaths: [
-      [
-        'request-portfolio-acct',
-        {
-          agoric:
-            'published.basicFlows.agoric1qyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc09z0g',
-          cosmoshub: 'published.basicFlows.cosmos1test2',
-          osmosis: 'published.basicFlows.cosmos1test3',
-        },
-      ],
-    ],
+  wd.expectInvitationPath(t, 'request-portfolio-acct', {
+    agoric:
+      'published.basicFlows.agoric1qyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc09z0g',
+    cosmoshub: 'published.basicFlows.cosmos1test2',
+    osmosis: 'published.basicFlows.cosmos1test3',
   });
-  t.like(wd.getLatestUpdateRecord(), {
-    status: { id: 'request-portfolio-acct', numWantsSatisfied: 1 },
-  });
+  wd.expectStatus(t, { id: 'request-portfolio-acct', numWantsSatisfied: 1 });
 
-  t.deepEqual(readPublished('basicFlows.cosmos1test3'), {
+  t.context.expectPublished(t, 'basicFlows.cosmos1test3', {
     localAddress:
       '/ibc-port/icacontroller-4/ordered/{"version":"ics27-1","controllerConnectionId":"connection-1","hostConnectionId":"connection-1649","address":"cosmos1test3","encoding":"proto3","txType":"sdk_multi_msg"}/ibc-channel/channel-4',
     remoteAddress:
       '/ibc-hop/connection-1/ibc-port/icahost/ordered/{"version":"ics27-1","controllerConnectionId":"connection-1","hostConnectionId":"connection-1649","address":"cosmos1test3","encoding":"proto3","txType":"sdk_multi_msg"}/ibc-channel/channel-4',
   });
   t.is(
-    readPublished(
+    t.context.readPublished(
       'basicFlows.agoric1qyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc09z0g',
-    ) as any,
+    ) as unknown,
     '',
   );
 
@@ -554,9 +492,7 @@ test.serial('basic-flows - portfolio holder', async t => {
     },
     proposal: {},
   });
-  t.like(wd.getLatestUpdateRecord(), {
-    status: { id: 'delegate-cosmoshub', numWantsSatisfied: 1 },
-  });
+  wd.expectStatus(t, { id: 'delegate-cosmoshub', numWantsSatisfied: 1 });
 
   await wd.sendOffer({
     id: 'delegate-agoric',
@@ -573,9 +509,7 @@ test.serial('basic-flows - portfolio holder', async t => {
     },
     proposal: {},
   });
-  t.like(wd.getLatestUpdateRecord(), {
-    status: { id: 'delegate-agoric', numWantsSatisfied: 1 },
-  });
+  wd.expectStatus(t, { id: 'delegate-agoric', numWantsSatisfied: 1 });
 
   await t.throwsAsync(
     wd.executeOffer({

--- a/packages/boot/test/orchestration/restart-contracts.test.ts
+++ b/packages/boot/test/orchestration/restart-contracts.test.ts
@@ -15,14 +15,14 @@ import { buildVTransferEvent } from '@agoric/orchestration/tools/ibc-mocks.js';
 import type { UpdateRecord } from '@agoric/smart-wallet/src/smartWallet.js';
 import { makeTestAddress } from '@agoric/orchestration/tools/make-test-address.js';
 import {
-  makeWalletFactoryContext,
-  type WalletFactoryTestContext,
-} from '../bootstrapTests/walletFactory.js';
+  makeBootTestContext,
+  withWalletFactory,
+  type WalletFactoryBootTestContext,
+} from '../tools/boot-test-context.js';
 import { minimalChainInfos } from '../tools/chainInfo.js';
-import { loadOrCreateRunUtilsSnapshot } from '../tools/runutils-snapshots.js';
 
 const test: TestFn<
-  WalletFactoryTestContext & {
+  WalletFactoryBootTestContext & {
     assertInboundQueueLength: (
       phase: 'before' | 'after',
       label: string,
@@ -63,14 +63,12 @@ const wrapSteps = <S extends TestStep[]>(
   ) as unknown as S;
 
 test.before(async t => {
-  const snapshot = await loadOrCreateRunUtilsSnapshot(
-    'orchestration-base',
-    t.log,
-  );
-  const context = await makeWalletFactoryContext(
-    t,
-    '@agoric/vm-config/decentral-itest-orchestration-config.json',
-    { snapshot },
+  const context = await withWalletFactory(
+    await makeBootTestContext(t, {
+      configSpecifier:
+        '@agoric/vm-config/decentral-itest-orchestration-config.json',
+      snapshotName: 'orchestration-base',
+    }),
   );
 
   const { getInboundQueueLength } = context.bridgeUtils;
@@ -93,18 +91,18 @@ test.after.always(t => t.context.shutdown?.());
 
 test.serial('send-anywhere', async t => {
   const {
-    walletFactoryDriver,
-    buildProposal,
-    evalProposal,
+    applyProposal,
     bridgeUtils: { runInbound, flushInboundQueue },
     assertInboundQueueLength,
+    provideSmartWallet,
   } = t.context;
 
   const { IST } = t.context.agoricNamesRemotes.brand;
 
   t.log('start send-anywhere');
-  await evalProposal(
-    buildProposal('@agoric/builders/scripts/testing/init-send-anywhere.js', [
+  await applyProposal(
+    '@agoric/builders/scripts/testing/init-send-anywhere.js',
+    [
       '--chainInfo',
       JSON.stringify(withChainCapabilities(minimalChainInfos)),
       '--assetInfo',
@@ -119,7 +117,7 @@ test.serial('send-anywhere', async t => {
           },
         ],
       ]),
-    ]),
+    ],
   );
 
   // This test consumes a channel and a test Id.
@@ -136,9 +134,7 @@ test.serial('send-anywhere', async t => {
       makeWallet: async (_opts, label) => {
         lastWalletId += 1;
         const walletId = lastWalletId;
-        const wallet = await walletFactoryDriver.provideSmartWallet(
-          `agoric1test${walletId}`,
-        );
+        const wallet = await provideSmartWallet(`agoric1test${walletId}`);
         // no money in wallet to actually send
         const zero = { brand: IST, value: 0n };
         // send because it won't resolve
@@ -162,7 +158,7 @@ test.serial('send-anywhere', async t => {
         });
 
         t.like(
-          wallet.getCurrentWalletRecord(),
+          wallet.current(),
           { liveOffers: [['send-somewhere']] },
           `${label} live offer until we simulate the transfer ack`,
         );
@@ -171,7 +167,7 @@ test.serial('send-anywhere', async t => {
       },
       checkEmptyBalance: async (opts, label) => {
         t.like(
-          opts.wallet.getLatestUpdateRecord(),
+          opts.wallet.latest(),
           {
             updated: 'balance',
             currentAmount: { value: [] },
@@ -195,7 +191,7 @@ test.serial('send-anywhere', async t => {
         return opts;
       },
       checkTransferSettled: async (opts, label) => {
-        const conclusion = opts.wallet.getLatestUpdateRecord();
+        const conclusion = opts.wallet.latest();
         t.like(conclusion, {
           updated: 'offerStatus',
           status: {
@@ -211,7 +207,7 @@ test.serial('send-anywhere', async t => {
       finalFlush: async (opts, label) => {
         await flushInboundQueue();
         t.like(
-          opts.wallet.getLatestUpdateRecord(),
+          opts.wallet.latest(),
           {
             status: {
               error: undefined,
@@ -227,10 +223,8 @@ test.serial('send-anywhere', async t => {
 
   await testInterruptedSteps(t, allSteps, async () => {
     t.log('restart send-anywhere');
-    await evalProposal(
-      buildProposal(
-        '@agoric/builders/scripts/testing/restart-send-anywhere.js',
-      ),
+    await applyProposal(
+      '@agoric/builders/scripts/testing/restart-send-anywhere.js',
     );
   });
 
@@ -253,18 +247,15 @@ const hasResult = (r: UpdateRecord) => {
 // Tests restart but not of an orchestration() flow
 test.serial('stakeAtom', async t => {
   const {
-    buildProposal,
-    evalProposal,
+    applyProposal,
     agoricNamesRemotes,
     bridgeUtils: { flushInboundQueue },
     readLatest,
   } = t.context;
 
-  await evalProposal(
-    buildProposal('@agoric/builders/scripts/orchestration/init-stakeAtom.js', [
-      '--chainInfo',
-      JSON.stringify(withChainCapabilities(minimalChainInfos)),
-    ]),
+  await applyProposal(
+    '@agoric/builders/scripts/orchestration/init-stakeAtom.js',
+    ['--chainInfo', JSON.stringify(withChainCapabilities(minimalChainInfos))],
   );
 
   await flushInboundQueue(); // establish baseline
@@ -291,7 +282,7 @@ test.serial('stakeAtom', async t => {
         t.context.num.channel += 1;
         const channel = t.context.num.channel;
 
-        const wallet = await t.context.walletFactoryDriver.provideSmartWallet(
+        const wallet = await t.context.provideSmartWallet(
           `agoric1testStakeAtom${walletId}`,
         );
 
@@ -312,8 +303,7 @@ test.serial('stakeAtom', async t => {
         // no result yet because the IBC incoming messages haven't arrived
         // and won't until we flush.
         await flushInboundQueue();
-        const latest = readLatest(accountPath);
-        t.deepEqual(latest, {
+        t.context.expectPublished(t, accountPath, {
           localAddress: `/ibc-port/icacontroller-${ica}/ordered/{"version":"ics27-1","controllerConnectionId":"connection-8","hostConnectionId":"connection-649","address":"${testAccount}","encoding":"proto3","txType":"sdk_multi_msg"}/ibc-channel/channel-${channel}`,
           remoteAddress: `/ibc-hop/connection-8/ibc-port/icahost/ordered/{"version":"ics27-1","controllerConnectionId":"connection-8","hostConnectionId":"connection-649","address":"${testAccount}","encoding":"proto3","txType":"sdk_multi_msg"}/ibc-channel/channel-${channel}`,
         });
@@ -339,10 +329,10 @@ test.serial('stakeAtom', async t => {
         });
         // no result yet because the IBC incoming messages haven't arrived
         // and won't until we flush.
-        t.false(hasResult(opts.wallet!.getLatestUpdateRecord()));
+        t.false(hasResult(opts.wallet!.latest()));
         await flushInboundQueue();
         // now the offer has resolved
-        t.true(hasResult(opts.wallet!.getLatestUpdateRecord()));
+        t.true(hasResult(opts.wallet!.latest()));
         return opts;
       },
     } satisfies Record<string, TestStep<Input>[1]>),
@@ -350,8 +340,8 @@ test.serial('stakeAtom', async t => {
 
   await testInterruptedSteps(t, allSteps, async () => {
     t.log('restart stakeAtom');
-    await evalProposal(
-      buildProposal('@agoric/builders/scripts/testing/restart-stakeAtom.js'),
+    await applyProposal(
+      '@agoric/builders/scripts/testing/restart-stakeAtom.js',
     );
     await flushInboundQueue();
   });
@@ -369,22 +359,19 @@ test.serial('stakeAtom', async t => {
 // the two core-eval functions.
 test.serial('basicFlows', async t => {
   const {
-    walletFactoryDriver,
-    buildProposal,
-    evalProposal,
+    applyProposal,
     bridgeUtils: { getInboundQueueLength, flushInboundQueue },
+    provideSmartWallet,
   } = t.context;
 
   t.log('start basicFlows');
-  await evalProposal(
-    buildProposal(
-      '@agoric/builders/scripts/orchestration/init-basic-flows.js',
-      ['--chainInfo', JSON.stringify(withChainCapabilities(minimalChainInfos))],
-    ),
+  await applyProposal(
+    '@agoric/builders/scripts/orchestration/init-basic-flows.js',
+    ['--chainInfo', JSON.stringify(withChainCapabilities(minimalChainInfos))],
   );
 
   t.log('making offer');
-  const wallet = await walletFactoryDriver.provideSmartWallet('agoric1test');
+  const wallet = await provideSmartWallet('agoric1test');
   const id1 = 'make-orch-account';
   // send because it won't resolve
   await wallet.sendOffer({
@@ -400,7 +387,7 @@ test.serial('basicFlows', async t => {
     },
   });
   // no errors and no result yet
-  t.like(wallet.getLatestUpdateRecord(), {
+  t.like(wallet.latest(), {
     status: {
       id: id1,
       error: undefined,
@@ -412,18 +399,18 @@ test.serial('basicFlows', async t => {
   // 1x ICQ Channel Open
   t.is(getInboundQueueLength(), 1);
   t.log('flush and verify results');
-  const beforeFlush = wallet.getLatestUpdateRecord();
+  const beforeFlush = wallet.latest();
   t.like(beforeFlush, {
     status: {
       result: undefined,
     },
   });
   t.is(await flushInboundQueue(1), 1);
-  t.like(wallet.getLatestUpdateRecord(), {
+  wallet.expectResult(t, id1, 'UNPUBLISHED');
+  t.like(wallet.latest(), {
     status: {
       id: id1,
       error: undefined,
-      result: 'UNPUBLISHED',
     },
   });
 
@@ -441,7 +428,7 @@ test.serial('basicFlows', async t => {
     },
   });
   // no errors and no result yet
-  t.like(wallet.getLatestUpdateRecord(), {
+  t.like(wallet.latest(), {
     status: {
       id: id2,
       error: undefined,
@@ -454,16 +441,16 @@ test.serial('basicFlows', async t => {
   t.is(getInboundQueueLength(), 3);
 
   t.log('restart basicFlows');
-  await evalProposal(
-    buildProposal('@agoric/builders/scripts/testing/restart-basic-flows.js'),
+  await applyProposal(
+    '@agoric/builders/scripts/testing/restart-basic-flows.js',
   );
 
   t.is(await flushInboundQueue(3), 3);
-  t.like(wallet.getLatestUpdateRecord(), {
+  wallet.expectResult(t, id2, 'UNPUBLISHED');
+  t.like(wallet.latest(), {
     status: {
       id: id2,
       error: undefined,
-      result: 'UNPUBLISHED',
     },
   });
 });

--- a/packages/boot/test/orchestration/vstorage-chain-info.test.ts
+++ b/packages/boot/test/orchestration/vstorage-chain-info.test.ts
@@ -15,9 +15,10 @@ import {
   makeSwingsetHarness,
 } from '../../tools/supports.js';
 import {
-  makeWalletFactoryContext,
-  type WalletFactoryTestContext,
-} from '../bootstrapTests/walletFactory.js';
+  makeBootTestContext,
+  withWalletFactory,
+  type WalletFactoryBootTestContext,
+} from '../tools/boot-test-context.js';
 
 type ChainInfoState = {
   bootReady: Promise<void>;
@@ -31,7 +32,7 @@ type ChainInfoContext = {
   markConfigVerified: (error?: unknown) => void;
   makeBootContext: (
     t: ExecutionContext<unknown>,
-  ) => Promise<WalletFactoryTestContext>;
+  ) => Promise<WalletFactoryBootTestContext>;
 };
 
 const test: TestFn<ChainInfoContext> = anyTest;
@@ -65,15 +66,15 @@ test.before(async t => {
     };
   });
 
-  const makeBootContext = (t0: ExecutionContext<unknown>) =>
-    makeWalletFactoryContext(
-      t0,
-      '@agoric/vm-config/decentral-itest-orchestration-chains-config.json',
-      {
+  const makeBootContext = async (t0: ExecutionContext<unknown>) =>
+    withWalletFactory(
+      await makeBootTestContext(t0, {
+        configSpecifier:
+          '@agoric/vm-config/decentral-itest-orchestration-chains-config.json',
         slogFile,
         defaultManagerType: managerType,
         harness,
-      },
+      }),
     );
 
   t.context = {
@@ -93,7 +94,7 @@ test.before(async t => {
  */
 test('config', async t => {
   await t.context.state.bootReady;
-  let ctx: WalletFactoryTestContext | undefined;
+  let ctx: WalletFactoryBootTestContext | undefined;
   t.teardown(() => t.context.markConfigVerified());
   try {
     ctx = await t.context.makeBootContext(t);
@@ -172,14 +173,11 @@ test('revise chain info', async t => {
   t.teardown(async () => ctx.shutdown());
 
   const {
-    buildProposal,
-    evalProposal,
+    applyProposal,
     runUtils: { EV },
   } = ctx;
 
-  await evalProposal(
-    buildProposal('@agoric/builders/scripts/testing/append-chain-info.js'),
-  );
+  await applyProposal('@agoric/builders/scripts/testing/append-chain-info.js');
 
   const agoricNames = await EV.vat('bootstrap').consumeItem('agoricNames');
 

--- a/packages/boot/test/tools/boot-test-context.test.ts
+++ b/packages/boot/test/tools/boot-test-context.test.ts
@@ -1,0 +1,136 @@
+import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import type { TestFn } from 'ava';
+
+import {
+  attachBootContextHelpers,
+  enhanceSmartWalletDriver,
+  makeBootTestContext,
+} from './boot-test-context.js';
+import { makeSwingsetTestKit } from '../../tools/supports.js';
+import { loadOrCreateRunUtilsSnapshot } from './runutils-snapshots.js';
+
+const test = anyTest as TestFn;
+
+const makeFakeBootCtx = () =>
+  ({
+    buildProposal: async (builderPath: string, args: string[] = []) => ({
+      bundles: [],
+      evals: [{ builderPath, args }],
+    }),
+    evalProposal: async () => undefined,
+    readPublished: (path: string) => ({ path }),
+    runUtils: {},
+    storage: {
+      data: new Map<string, string>(),
+    },
+  }) as any;
+
+test('snapshotName boot context matches manual snapshot loading', async t => {
+  const manualSnapshot = await loadOrCreateRunUtilsSnapshot('demo-base', t.log);
+  const manual = await makeSwingsetTestKit(t.log, undefined, {
+    configSpecifier: '@agoric/vm-config/decentral-demo-config.json',
+    snapshot: manualSnapshot,
+  });
+  t.teardown(() => manual.shutdown());
+
+  const viaSnapshot = await makeBootTestContext(t, {
+    configSpecifier: '@agoric/vm-config/decentral-demo-config.json',
+    snapshotName: 'demo-base',
+  });
+  t.teardown(() => viaSnapshot.shutdown());
+
+  t.deepEqual(
+    Object.keys(viaSnapshot.readPublished('agoricNames.brand')).sort(),
+    Object.keys(manual.readPublished('agoricNames.brand')).sort(),
+  );
+  t.deepEqual(
+    [...viaSnapshot.storage.data.entries()].slice(0, 10),
+    [...manual.storage.data.entries()].slice(0, 10),
+  );
+});
+
+test('attachBootContextHelpers applies proposals and runs afterProposal once', async t => {
+  const calls: string[] = [];
+  let refreshCount = 0;
+  const ctx = attachBootContextHelpers(
+    {
+      ...makeFakeBootCtx(),
+      buildProposal: async (builderPath: string, args: string[] = []) => {
+        calls.push(`build:${builderPath}:${args.join(',')}`);
+        return { bundles: [], evals: [] };
+      },
+      evalProposal: async () => {
+        calls.push('eval');
+      },
+    },
+    () => {
+      refreshCount += 1;
+    },
+  );
+
+  await ctx.applyProposal('builder.js', ['--x'], {
+    refreshAgoricNames: true,
+  });
+  await ctx.applyProposals([
+    { builderPath: 'first.js' },
+    { builderPath: 'second.js', refreshAgoricNames: true },
+  ]);
+
+  t.deepEqual(calls, [
+    'build:builder.js:--x',
+    'eval',
+    'build:first.js:',
+    'eval',
+    'build:second.js:',
+    'eval',
+  ]);
+  t.is(refreshCount, 2);
+});
+
+test('published log helper reads resets and expects values', t => {
+  const ctx = attachBootContextHelpers(makeFakeBootCtx());
+  ctx.storage.data.set(
+    'published.axelarGmp.log',
+    JSON.stringify({ values: ['hello', 'world'] }),
+  );
+
+  const log = ctx.makePublishedLog('axelarGmp.log');
+  t.deepEqual(log.read(), ['hello', 'world']);
+  log.expect(t, ['hello', 'world']);
+  log.reset();
+  t.deepEqual(log.read(), []);
+});
+
+test('wallet assertion helpers fail with readable messages', t => {
+  const wallet = enhanceSmartWalletDriver({
+    getCurrentWalletRecord: () => ({
+      offerToPublicSubscriberPaths: [],
+      offerToUsedInvitation: [],
+      purses: [],
+    }),
+    getLatestUpdateRecord: () =>
+      ({
+        updated: 'offerStatus',
+        status: {
+          id: 'missing-result',
+          numWantsSatisfied: 1,
+        },
+      }) as any,
+  } as any);
+
+  const fakeT = {
+    deepEqual: () => undefined,
+    is: () => undefined,
+    like: () => undefined,
+    true(condition: unknown, message?: string) {
+      if (!condition) {
+        throw new Error(String(message));
+      }
+    },
+  };
+
+  t.throws(() => wallet.expectResult(fakeT as any, 'missing-result'), {
+    message: 'Expected offer missing-result to have a result',
+  });
+});

--- a/packages/boot/test/tools/boot-test-context.ts
+++ b/packages/boot/test/tools/boot-test-context.ts
@@ -1,0 +1,422 @@
+import {
+  type AgoricNamesRemotes,
+  makeAgoricNamesRemotesFromFakeStorage,
+} from '@agoric/vats/tools/board-utils.js';
+import { Fail } from '@endo/errors';
+
+import type { ExecutionContext } from 'ava';
+
+import {
+  type GovernanceDriver,
+  type SmartWalletDriver,
+  type WalletFactoryDriver,
+  makeGovernanceDriver,
+  makeWalletFactoryDriver,
+} from '../../tools/drivers.js';
+import { makeLiquidationTestKit } from '../../tools/liquidation.js';
+import {
+  fetchCoreEvalRelease,
+  makeSwingsetTestKit,
+  type MakeSwingsetTestKitOptions,
+  type SwingsetTestKit,
+} from '../../tools/supports.js';
+import {
+  loadOrCreateRunUtilsSnapshot,
+  type RunUtilsSnapshotName,
+} from './runutils-snapshots.js';
+
+type LoggerLike = Pick<ExecutionContext, 'log'> | ((...args: any[]) => void);
+
+type ProposalStep = {
+  builderPath: string;
+  args?: string[];
+  refreshAgoricNames?: boolean;
+};
+
+type ApplyProposalOptions = Pick<ProposalStep, 'refreshAgoricNames'>;
+
+const runProposalSteps = async <M>(
+  applyProposal: (
+    builderPath: string,
+    args?: string[],
+    opts?: ApplyProposalOptions,
+  ) => Promise<M>,
+  steps: ProposalStep[],
+) => {
+  const materials: M[] = [];
+  for (const { builderPath, args = [], refreshAgoricNames } of steps) {
+    materials.push(
+      await applyProposal(builderPath, args, { refreshAgoricNames }),
+    );
+  }
+  return materials;
+};
+
+type TestLike = Pick<ExecutionContext, 'deepEqual' | 'is' | 'like' | 'true'>;
+
+export type TestWalletDriver = SmartWalletDriver & {
+  current: () => ReturnType<SmartWalletDriver['getCurrentWalletRecord']>;
+  latest: () => ReturnType<SmartWalletDriver['getLatestUpdateRecord']>;
+  expectStatus: (
+    t: TestLike,
+    partial: Record<string, unknown>,
+    message?: string,
+  ) => ReturnType<SmartWalletDriver['getLatestUpdateRecord']>;
+  expectResult: (
+    t: TestLike,
+    offerId: string,
+    result?: unknown,
+    message?: string,
+  ) => unknown;
+  expectInvitationPath: (
+    t: TestLike,
+    offerId: string,
+    path: unknown,
+    message?: string,
+  ) => unknown;
+};
+
+export type TestWalletFactoryDriver = Omit<
+  WalletFactoryDriver,
+  'provideSmartWallet'
+> & {
+  provideSmartWallet: (
+    walletAddress: string,
+    myMarshaller?: Parameters<WalletFactoryDriver['provideSmartWallet']>[1],
+  ) => Promise<TestWalletDriver>;
+};
+
+type BootContextHelpers = {
+  applyProposal: (
+    builderPath: string,
+    args?: string[],
+    opts?: ApplyProposalOptions,
+  ) => Promise<Awaited<ReturnType<SwingsetTestKit['buildProposal']>>>;
+  applyProposals: (
+    steps: ProposalStep[],
+  ) => Promise<Awaited<ReturnType<SwingsetTestKit['buildProposal']>>[]>;
+  expectPublished: (
+    t: Pick<ExecutionContext, 'deepEqual'>,
+    path: string,
+    expected: unknown,
+  ) => unknown;
+  makePublishedLog: (path: string) => {
+    read: () => any[];
+    reset: () => void;
+    expect: (
+      t: Pick<ExecutionContext, 'deepEqual'>,
+      values: unknown[],
+    ) => unknown;
+  };
+};
+
+export type BootTestContext = SwingsetTestKit & BootContextHelpers;
+
+export type WalletFactoryBootTestContext = BootTestContext & {
+  agoricNamesRemotes: AgoricNamesRemotes;
+  refreshAgoricNamesRemotes: () => AgoricNamesRemotes;
+  evalReleasedProposal: (release: string, name: string) => Promise<void>;
+  provideSmartWallet: TestWalletFactoryDriver['provideSmartWallet'];
+  walletFactoryDriver: TestWalletFactoryDriver;
+};
+
+export type GovernanceBootTestContext = WalletFactoryBootTestContext & {
+  governanceDriver: GovernanceDriver;
+  expectProposalAccepted: (
+    t: TestLike,
+    member: GovernanceDriver['ecMembers'][number],
+    questionId: string,
+  ) => unknown;
+  expectVoteAccepted: (
+    t: TestLike,
+    members: GovernanceDriver['ecMembers'][number][],
+    voteId: string,
+  ) => unknown;
+  expectParamValue: (
+    t: Pick<ExecutionContext, 'deepEqual'>,
+    key: string,
+    expected: unknown,
+    valuePath?: (string | number)[],
+  ) => unknown;
+};
+
+const NO_EXPECTED_RESULT = Symbol('no-expected-result');
+
+const getLog = (input: LoggerLike) =>
+  typeof input === 'function' ? input : input.log.bind(input);
+
+const normalizePublishedPath = (path: string) =>
+  path.startsWith('published.') ? path : `published.${path}`;
+
+const toPublishedSubpath = (path: string) =>
+  normalizePublishedPath(path).replace(/^published\./, '');
+
+const readPublishedLogValues = (
+  storage: BootTestContext['storage'],
+  path: string,
+) => {
+  const raw = storage.data.get(normalizePublishedPath(path));
+  if (!raw) {
+    return [];
+  }
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed) ? parsed : parsed.values || [];
+};
+
+const assertResultPresent = (
+  t: Pick<ExecutionContext, 'true'>,
+  record: ReturnType<SmartWalletDriver['getLatestUpdateRecord']>,
+  offerId: string,
+) => {
+  t.true(
+    record.updated === 'offerStatus' && 'result' in record.status,
+    `Expected offer ${offerId} to have a result`,
+  );
+  if (record.updated !== 'offerStatus' || !('result' in record.status)) {
+    throw Fail`offer ${offerId} did not produce a result`;
+  }
+  return record.status.result;
+};
+
+export const enhanceSmartWalletDriver = (
+  wallet: SmartWalletDriver,
+): TestWalletDriver => ({
+  ...wallet,
+  current: () => wallet.getCurrentWalletRecord(),
+  latest: () => wallet.getLatestUpdateRecord(),
+  expectStatus: (t, partial, message) => {
+    const latest = wallet.getLatestUpdateRecord();
+    t.like(latest, { status: partial }, message);
+    return latest;
+  },
+  expectResult: (t, offerId, result = NO_EXPECTED_RESULT, message) => {
+    const latest = wallet.getLatestUpdateRecord();
+    t.like(
+      latest,
+      {
+        updated: 'offerStatus',
+        status: {
+          id: offerId,
+          numWantsSatisfied: 1,
+        },
+      },
+      message,
+    );
+    const actual = assertResultPresent(t, latest, offerId);
+    if (result !== NO_EXPECTED_RESULT) {
+      t.is(actual, result, message);
+    }
+    return actual;
+  },
+  expectInvitationPath: (t, offerId, path, message) => {
+    const current = wallet.getCurrentWalletRecord();
+    const paths = Object.fromEntries(
+      current.offerToPublicSubscriberPaths || [],
+    );
+    t.deepEqual(paths[offerId], path, message);
+    return paths[offerId];
+  },
+});
+
+export const attachBootContextHelpers = <T extends SwingsetTestKit>(
+  ctx: T,
+  afterProposal?: () => unknown,
+): T & BootContextHelpers => {
+  const applyProposal = async (
+    builderPath: string,
+    args: string[] = [],
+    opts: ApplyProposalOptions = {},
+  ) => {
+    const materials = await ctx.buildProposal(builderPath, args);
+    try {
+      await ctx.evalProposal(materials);
+    } finally {
+      if (opts.refreshAgoricNames ?? false) {
+        await afterProposal?.();
+      }
+    }
+    return materials;
+  };
+
+  return {
+    ...ctx,
+    applyProposal,
+    applyProposals: steps => runProposalSteps(applyProposal, steps),
+    expectPublished: (t, path, expected) =>
+      t.deepEqual(ctx.readPublished(toPublishedSubpath(path)), expected),
+    makePublishedLog: path => ({
+      read: () => readPublishedLogValues(ctx.storage, path),
+      reset: () => {
+        ctx.storage.data.delete(normalizePublishedPath(path));
+      },
+      expect: (t, values) =>
+        t.deepEqual(readPublishedLogValues(ctx.storage, path), values),
+    }),
+  };
+};
+
+export const makeBootTestContext = async (
+  tOrLog: LoggerLike,
+  {
+    bundleDir,
+    snapshotName,
+    snapshot,
+    ...options
+  }: MakeSwingsetTestKitOptions & {
+    bundleDir?: string;
+    snapshotName?: RunUtilsSnapshotName;
+  } = {},
+): Promise<BootTestContext> => {
+  const log = getLog(tOrLog);
+  const resolvedSnapshot = snapshotName
+    ? await loadOrCreateRunUtilsSnapshot(snapshotName, log)
+    : snapshot;
+  const ctx = await makeSwingsetTestKit(log, bundleDir, {
+    ...options,
+    snapshot: resolvedSnapshot,
+  });
+  return attachBootContextHelpers(ctx);
+};
+
+export const withWalletFactory = async <T extends BootTestContext>(
+  ctx: T,
+): Promise<T & WalletFactoryBootTestContext> => {
+  const { EV } = ctx.runUtils;
+  await EV.vat('bootstrap').consumeItem('vaultFactoryKit');
+
+  const agoricNamesRemotes: AgoricNamesRemotes =
+    makeAgoricNamesRemotesFromFakeStorage(ctx.storage);
+  const refreshAgoricNamesRemotes = () => {
+    Object.assign(
+      agoricNamesRemotes,
+      makeAgoricNamesRemotesFromFakeStorage(ctx.storage),
+    );
+    return agoricNamesRemotes;
+  };
+
+  agoricNamesRemotes.brand.ATOM || Fail`ATOM missing from agoricNames`;
+
+  const baseDriver = await makeWalletFactoryDriver(
+    ctx.runUtils,
+    ctx.storage,
+    agoricNamesRemotes,
+  );
+  const walletFactoryDriver: TestWalletFactoryDriver = {
+    ...baseDriver,
+    provideSmartWallet: async (walletAddress, myMarshaller) =>
+      enhanceSmartWalletDriver(
+        await baseDriver.provideSmartWallet(walletAddress, myMarshaller),
+      ),
+  };
+
+  const walletCtx = attachBootContextHelpers(ctx, refreshAgoricNamesRemotes);
+
+  const evalReleasedProposal = async (release: string, name: string) => {
+    const materials = await fetchCoreEvalRelease({
+      repo: 'Agoric/agoric-sdk',
+      release,
+      name,
+    });
+    await ctx.evalProposal(materials);
+    refreshAgoricNamesRemotes();
+  };
+
+  const applyProposal: WalletFactoryBootTestContext['applyProposal'] = async (
+    builderPath,
+    args = [],
+    opts = {},
+  ) =>
+    walletCtx.applyProposal(builderPath, args, {
+      ...opts,
+      refreshAgoricNames: opts.refreshAgoricNames ?? true,
+    });
+
+  const applyProposals: WalletFactoryBootTestContext['applyProposals'] =
+    steps => runProposalSteps(applyProposal, steps);
+
+  return {
+    ...walletCtx,
+    applyProposal,
+    applyProposals,
+    agoricNamesRemotes,
+    refreshAgoricNamesRemotes,
+    evalReleasedProposal,
+    provideSmartWallet: walletFactoryDriver.provideSmartWallet,
+    walletFactoryDriver,
+  };
+};
+
+export const withGovernance = async <T extends WalletFactoryBootTestContext>(
+  ctx: T,
+  { wallets }: { wallets: string[] },
+): Promise<T & GovernanceBootTestContext> => {
+  const governanceDriver = await makeGovernanceDriver(
+    ctx,
+    ctx.agoricNamesRemotes,
+    ctx.walletFactoryDriver,
+    wallets,
+  );
+
+  const expectProposalAccepted = (
+    t: TestLike,
+    member: GovernanceDriver['ecMembers'][number],
+    questionId: string,
+  ) => {
+    const latest = member.getLatestUpdateRecord();
+    t.like(latest, { status: { id: questionId, numWantsSatisfied: 1 } });
+    return latest;
+  };
+
+  const expectVoteAccepted = (
+    t: TestLike,
+    members: GovernanceDriver['ecMembers'][number][],
+    voteId: string,
+  ) =>
+    members.map(member => {
+      const latest = member.getLatestUpdateRecord();
+      t.like(latest, { status: { id: voteId, numWantsSatisfied: 1 } });
+      return latest;
+    });
+
+  const expectParamValue = (
+    t: Pick<ExecutionContext, 'deepEqual'>,
+    key: string,
+    expected: unknown,
+    valuePath: (string | number)[] = [],
+  ) => {
+    const actual = valuePath.reduce(
+      (value, segment) => value?.[segment],
+      ctx.readPublished(toPublishedSubpath(key)),
+    );
+    return t.deepEqual(actual, expected);
+  };
+
+  return {
+    ...ctx,
+    governanceDriver,
+    expectProposalAccepted,
+    expectVoteAccepted,
+    expectParamValue,
+  };
+};
+
+export const withLiquidation = async <
+  T extends WalletFactoryBootTestContext & {
+    governanceDriver: GovernanceDriver;
+  },
+>(
+  ctx: T,
+  { t }: { t: ExecutionContext },
+) => {
+  const liquidation = await makeLiquidationTestKit({
+    swingsetTestKit: ctx,
+    agoricNamesRemotes: ctx.agoricNamesRemotes,
+    walletFactoryDriver: ctx.walletFactoryDriver,
+    governanceDriver: ctx.governanceDriver,
+    t,
+  });
+  return {
+    ...ctx,
+    ...liquidation,
+  };
+};

--- a/packages/boot/test/tools/controller-fixture.test.ts
+++ b/packages/boot/test/tools/controller-fixture.test.ts
@@ -1,0 +1,64 @@
+import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import type { TestFn } from 'ava';
+
+import type { SwingSetConfig } from '@agoric/swingset-vat';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
+import {
+  forkScenario,
+  makeControllerFixture,
+  type ControllerFixture,
+} from './controller-fixture.js';
+
+const test = anyTest as TestFn<ControllerFixture>;
+
+const importSpec = async spec =>
+  new URL(importMetaResolve(spec, import.meta.url)).pathname;
+
+const makeConfig = async (): Promise<SwingSetConfig> =>
+  harden({
+    bootstrap: 'bootstrap',
+    defaultReapInterval: 'never',
+    vats: {
+      bootstrap: {
+        sourceSpec: await importSpec(
+          '@agoric/swingset-vat/tools/bootstrap-relay.js',
+        ),
+      },
+    },
+    bundles: {
+      board: {
+        sourceSpec: await importSpec('@agoric/vats/src/vat-board.js'),
+      },
+    },
+    bundleCachePath: 'bundles',
+  });
+
+test.before(async t => {
+  t.context = await makeControllerFixture({
+    config: await makeConfig(),
+  });
+});
+
+test('forkScenario produces isolated controller forks', async t => {
+  const forkA = await forkScenario(t);
+  const forkB = await t.context.forkController();
+  t.teardown(() => forkB.shutdown());
+
+  const crank0 = forkA.getCrankNumber();
+  t.is(forkB.getCrankNumber(), crank0);
+
+  const boardVatConfig = {
+    name: 'board',
+    bundleCapName: 'board',
+  };
+  const boardRootA =
+    await forkA.runUtils.EV.vat('bootstrap').createVat(boardVatConfig);
+  t.truthy(boardRootA);
+  t.true(forkA.getCrankNumber() > crank0);
+  t.is(forkB.getCrankNumber(), crank0);
+
+  const boardRootB =
+    await forkB.runUtils.EV.vat('bootstrap').createVat(boardVatConfig);
+  t.truthy(boardRootB);
+});

--- a/packages/boot/test/tools/controller-fixture.test.ts
+++ b/packages/boot/test/tools/controller-fixture.test.ts
@@ -2,41 +2,20 @@ import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava
 
 import type { TestFn } from 'ava';
 
-import type { SwingSetConfig } from '@agoric/swingset-vat';
-import { resolve as importMetaResolve } from 'import-meta-resolve';
 import {
   forkScenario,
-  makeControllerFixture,
+  makeBootControllerFixture,
   type ControllerFixture,
 } from './controller-fixture.js';
 
 const test = anyTest as TestFn<ControllerFixture>;
 
-const importSpec = async spec =>
-  new URL(importMetaResolve(spec, import.meta.url)).pathname;
-
-const makeConfig = async (): Promise<SwingSetConfig> =>
-  harden({
-    bootstrap: 'bootstrap',
-    defaultReapInterval: 'never',
-    vats: {
-      bootstrap: {
-        sourceSpec: await importSpec(
-          '@agoric/swingset-vat/tools/bootstrap-relay.js',
-        ),
-      },
-    },
-    bundles: {
-      board: {
-        sourceSpec: await importSpec('@agoric/vats/src/vat-board.js'),
-      },
-    },
-    bundleCachePath: 'bundles',
-  });
-
 test.before(async t => {
-  t.context = await makeControllerFixture({
-    config: await makeConfig(),
+  t.context = await makeBootControllerFixture({
+    testModuleUrl: import.meta.url,
+    bundles: {
+      board: '@agoric/vats/src/vat-board.js',
+    },
   });
 });
 

--- a/packages/boot/test/tools/controller-fixture.ts
+++ b/packages/boot/test/tools/controller-fixture.ts
@@ -1,6 +1,7 @@
 import { initSwingStore } from '@agoric/swing-store';
 import { buildVatController, type SwingSetConfig } from '@agoric/swingset-vat';
 import { makeRunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
 
 import type { ExecutionContext } from 'ava';
 
@@ -31,6 +32,49 @@ export type BridgeHarness = {
 
 export type BridgeBackend = (obj: any) => unknown;
 
+type SourceSpecEntry =
+  | string
+  | {
+      sourceSpec: string;
+    };
+
+type ResolvedSourceSpecEntry = {
+  sourceSpec: string;
+};
+
+type SourceSpecEntries = Record<string, SourceSpecEntry>;
+
+type SetupBase = (context: {
+  controller: BuiltController;
+  runUtils: RunUtils;
+}) => Promise<void>;
+
+type ControllerFixtureOptions = {
+  bootstrapArgs?: unknown[];
+  config: SwingSetConfig;
+  pinVatRoots?: string[];
+  baseDeviceEndowments?: Record<string, unknown>;
+  setupBase?: SetupBase;
+};
+
+type BootControllerFixtureOptions = Omit<ControllerFixtureOptions, 'config'> & {
+  testModuleUrl: string;
+  bootstrap?: string;
+  bootstrapSourceSpec?: string;
+  vats?: SourceSpecEntries;
+  /**
+   * Bundles available to forked scenarios. Must declare the union of bundles
+   * used by every test sharing this base, because the base controller is built
+   * once and its kernel state is snapshot-serialized for per-test forks; forks
+   * cannot add bundles that weren't registered before the snapshot.
+   */
+  bundles?: SourceSpecEntries;
+  devices?: SourceSpecEntries;
+  bundleCachePath?: string;
+  defaultReapInterval?: number | 'never';
+  includeDevDependencies?: boolean;
+};
+
 export const makeBridgeDeviceEndowments = (
   t: BridgeHarness,
   bridgeBackends: Record<string, BridgeBackend> = {},
@@ -52,27 +96,75 @@ export const makeThrowingBridgeHarness = (): BridgeHarness => ({
   },
 });
 
+const isRelativeSourceSpec = (sourceSpec: string) =>
+  sourceSpec.startsWith('./') || sourceSpec.startsWith('../');
+
+export const resolveSourceSpec = async (
+  testModuleUrl: string,
+  entry: SourceSpecEntry,
+): Promise<ResolvedSourceSpecEntry> => {
+  const sourceSpec = typeof entry === 'string' ? entry : entry.sourceSpec;
+  return {
+    sourceSpec: isRelativeSourceSpec(sourceSpec)
+      ? new URL(sourceSpec, testModuleUrl).pathname
+      : new URL(importMetaResolve(sourceSpec, testModuleUrl)).pathname,
+  };
+};
+
+const resolveSourceSpecEntries = async (
+  testModuleUrl: string,
+  entries: SourceSpecEntries = {},
+) => {
+  const resolvedEntries = await Promise.all(
+    Object.entries(entries).map(async ([name, entry]) => [
+      name,
+      await resolveSourceSpec(testModuleUrl, entry),
+    ]),
+  );
+  return Object.fromEntries(resolvedEntries);
+};
+
+export const makeBootSwingSetConfig = async ({
+  testModuleUrl,
+  bootstrap = 'bootstrap',
+  bootstrapSourceSpec = '@agoric/swingset-vat/tools/bootstrap-relay.js',
+  vats = {},
+  bundles = {},
+  devices = {},
+  bundleCachePath = 'bundles',
+  defaultReapInterval = 'never',
+  includeDevDependencies = false,
+}: {
+  testModuleUrl: string;
+  bootstrap?: string;
+  bootstrapSourceSpec?: string;
+  vats?: SourceSpecEntries;
+  bundles?: SourceSpecEntries;
+  devices?: SourceSpecEntries;
+  bundleCachePath?: string;
+  defaultReapInterval?: number | 'never';
+  includeDevDependencies?: boolean;
+}): Promise<SwingSetConfig> =>
+  harden({
+    bootstrap,
+    bundleCachePath,
+    defaultReapInterval,
+    includeDevDependencies,
+    vats: {
+      [bootstrap]: await resolveSourceSpec(testModuleUrl, bootstrapSourceSpec),
+      ...(await resolveSourceSpecEntries(testModuleUrl, vats)),
+    },
+    bundles: await resolveSourceSpecEntries(testModuleUrl, bundles),
+    devices: await resolveSourceSpecEntries(testModuleUrl, devices),
+  });
+
 export const makeControllerFixture = async ({
   bootstrapArgs = [],
   config,
   pinVatRoots = ['bootstrap'],
   baseDeviceEndowments = {},
-  setupBase = undefined as
-    | ((context: {
-        controller: BuiltController;
-        runUtils: RunUtils;
-      }) => Promise<void>)
-    | undefined,
-}: {
-  bootstrapArgs?: unknown[];
-  config: SwingSetConfig;
-  pinVatRoots?: string[];
-  baseDeviceEndowments?: Record<string, unknown>;
-  setupBase?: (context: {
-    controller: BuiltController;
-    runUtils: RunUtils;
-  }) => Promise<void>;
-}): Promise<ControllerFixture> => {
+  setupBase,
+}: ControllerFixtureOptions): Promise<ControllerFixture> => {
   const swingStore = initSwingStore();
   const controller = await buildVatController(
     config,
@@ -134,6 +226,39 @@ export const makeControllerFixture = async ({
     await swingStore.hostStorage.close();
   }
 };
+
+export const makeBootControllerFixture = async ({
+  testModuleUrl,
+  bootstrap,
+  bootstrapSourceSpec,
+  vats,
+  bundles,
+  devices,
+  bundleCachePath,
+  defaultReapInterval,
+  includeDevDependencies,
+  bootstrapArgs,
+  pinVatRoots,
+  baseDeviceEndowments,
+  setupBase,
+}: BootControllerFixtureOptions) =>
+  makeControllerFixture({
+    bootstrapArgs,
+    pinVatRoots,
+    baseDeviceEndowments,
+    setupBase,
+    config: await makeBootSwingSetConfig({
+      testModuleUrl,
+      bootstrap,
+      bootstrapSourceSpec,
+      vats,
+      bundles,
+      devices,
+      bundleCachePath,
+      defaultReapInterval,
+      includeDevDependencies,
+    }),
+  });
 
 export const forkScenario = async (
   t: ExecutionContext<{ forkController: ControllerFixture['forkController'] }>,

--- a/packages/boot/test/tools/controller-fixture.ts
+++ b/packages/boot/test/tools/controller-fixture.ts
@@ -1,0 +1,145 @@
+import { initSwingStore } from '@agoric/swing-store';
+import { buildVatController, type SwingSetConfig } from '@agoric/swingset-vat';
+import { makeRunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
+
+import type { ExecutionContext } from 'ava';
+
+type BuiltController = Awaited<ReturnType<typeof buildVatController>>;
+type RunUtils = ReturnType<typeof makeRunUtils>;
+
+export type ForkedController = {
+  controller: BuiltController;
+  EV: RunUtils['EV'];
+  getCrankNumber: () => number;
+  runUtils: RunUtils;
+  shutdown: () => Promise<void>;
+};
+
+export type ControllerFixture = {
+  forkController: (
+    options?: Partial<{
+      deviceEndowments: Record<string, unknown>;
+      pinVatRoots: string[];
+    }>,
+  ) => Promise<ForkedController>;
+};
+
+export type BridgeHarness = {
+  assert: (condition: unknown, message?: string) => void;
+  fail: (message?: string) => never;
+};
+
+export type BridgeBackend = (obj: any) => unknown;
+
+export const makeBridgeDeviceEndowments = (
+  t: BridgeHarness,
+  bridgeBackends: Record<string, BridgeBackend> = {},
+) => ({
+  bridge: {
+    t,
+    bridgeBackends,
+  },
+});
+
+export const makeThrowingBridgeHarness = (): BridgeHarness => ({
+  assert(condition, message) {
+    if (!condition) {
+      throw new Error(String(message));
+    }
+  },
+  fail(message) {
+    throw new Error(String(message));
+  },
+});
+
+export const makeControllerFixture = async ({
+  bootstrapArgs = [],
+  config,
+  pinVatRoots = ['bootstrap'],
+  baseDeviceEndowments = {},
+  setupBase = undefined as
+    | ((context: {
+        controller: BuiltController;
+        runUtils: RunUtils;
+      }) => Promise<void>)
+    | undefined,
+}: {
+  bootstrapArgs?: unknown[];
+  config: SwingSetConfig;
+  pinVatRoots?: string[];
+  baseDeviceEndowments?: Record<string, unknown>;
+  setupBase?: (context: {
+    controller: BuiltController;
+    runUtils: RunUtils;
+  }) => Promise<void>;
+}): Promise<ControllerFixture> => {
+  const swingStore = initSwingStore();
+  const controller = await buildVatController(
+    config,
+    bootstrapArgs,
+    { kernelStorage: swingStore.kernelStorage },
+    baseDeviceEndowments,
+  );
+
+  try {
+    for (const vatName of pinVatRoots) {
+      controller.pinVatRoot(vatName);
+    }
+    await controller.run();
+    const runUtils = makeRunUtils(controller);
+    if (setupBase) {
+      await setupBase({ controller, runUtils });
+    }
+    const serialized = swingStore.debug.serialize();
+
+    return {
+      // `deviceEndowments` is per-fork by design and does NOT inherit from
+      // `baseDeviceEndowments`: the base typically boots with a tripwire
+      // harness (e.g. `makeThrowingBridgeHarness()`) so that any device
+      // activity during a test must be wired to that test's own `t` and
+      // backends post-fork. Inheriting or merging base endowments would
+      // route per-fork device calls to the wrong context.
+      forkController: async ({
+        deviceEndowments = {},
+        pinVatRoots: forkPinVatRoots = pinVatRoots,
+      } = {}) => {
+        const forkStore = initSwingStore(null, { serialized });
+        const forkController = await buildVatController(
+          config,
+          bootstrapArgs,
+          { kernelStorage: forkStore.kernelStorage },
+          deviceEndowments,
+        );
+        for (const vatName of forkPinVatRoots) {
+          forkController.pinVatRoot(vatName);
+        }
+        await forkController.run();
+
+        const forkRunUtils = makeRunUtils(forkController);
+        return {
+          controller: forkController,
+          EV: forkRunUtils.EV,
+          getCrankNumber: () =>
+            Number(forkStore.kernelStorage.kvStore.get('crankNumber')),
+          runUtils: forkRunUtils,
+          shutdown: async () => {
+            await forkController.shutdown();
+            await forkStore.hostStorage.close();
+          },
+        };
+      },
+    };
+  } finally {
+    await controller.shutdown();
+    await swingStore.hostStorage.close();
+  }
+};
+
+export const forkScenario = async (
+  t: ExecutionContext<{ forkController: ControllerFixture['forkController'] }>,
+  options?: Parameters<ControllerFixture['forkController']>[0],
+) => {
+  const scenario = await t.context.forkController(options);
+  t.teardown(() => scenario.shutdown());
+  return scenario;
+};

--- a/packages/boot/test/tools/runutils-snapshots.ts
+++ b/packages/boot/test/tools/runutils-snapshots.ts
@@ -15,6 +15,10 @@ const SNAPSHOT_LOCK_WAIT_MS = 15 * 60_000;
 const here = dirname(fileURLToPath(import.meta.url));
 const snapshotDir = resolve(here, '../cache/runutils');
 
+let kernelBundleP: ReturnType<typeof buildKernelBundle> | undefined;
+// Bundling `kernel.js` takes ~1s; reuse the result across snapshot ops.
+const getKernelBundle = () => (kernelBundleP ??= buildKernelBundle());
+
 export const RUNUTILS_SNAPSHOT_SPECS = {
   'demo-base': {
     configSpecifier: '@agoric/vm-config/decentral-demo-config.json',
@@ -107,7 +111,7 @@ export const availableRunUtilsSnapshotNames = (): RunUtilsSnapshotName[] =>
  * direct dependency on `@agoric/swingset-vat`.
  */
 export const getCurrentKernelBundleSha512 = async (): Promise<string> =>
-  (await buildKernelBundle()).endoZipBase64Sha512;
+  (await getKernelBundle()).endoZipBase64Sha512;
 
 const getSnapshotSpec = (name: RunUtilsSnapshotName): RunUtilsSnapshotSpec =>
   RUNUTILS_SNAPSHOT_SPECS[name];
@@ -146,20 +150,21 @@ export const computeRunUtilsSnapshotFingerprint = async (
   hash.update(`snapshot-version:${SNAPSHOT_VERSION}\n`);
   hash.update(`snapshot-name:${name}\n`);
   const effectiveKernelBundleSha512 =
-    kernelBundleSha512 || (await buildKernelBundle()).endoZipBase64Sha512;
+    kernelBundleSha512 || (await getKernelBundle()).endoZipBase64Sha512;
   hash.update(`kernel-bundle:${effectiveKernelBundleSha512}\n`);
 
   const inputPaths = getSnapshotInputPaths(name);
-  for (const inputPath of inputPaths) {
+  const fileHashes = await Promise.all(inputPaths.map(hashFile));
+  for (const [i, inputPath] of inputPaths.entries()) {
     hash.update(`path:${inputPath}\n`);
-    hash.update(`hash:${await hashFile(inputPath)}\n`);
+    hash.update(`hash:${fileHashes[i]}\n`);
   }
 
   return hash.digest('hex');
 };
 
 export const computeRunUtilsSnapshotFingerprints = async () => {
-  const kernelBundleSha512 = (await buildKernelBundle()).endoZipBase64Sha512;
+  const kernelBundleSha512 = (await getKernelBundle()).endoZipBase64Sha512;
   const names = availableRunUtilsSnapshotNames().sort();
   return Object.fromEntries(
     await Promise.all(
@@ -187,7 +192,7 @@ export const createRunUtilsSnapshot = async (
   const spec = getSnapshotSpec(name);
   const path = snapshotPath(name);
   const swingStorePath = snapshotSwingStorePath(name);
-  const kernelBundle = await buildKernelBundle();
+  const kernelBundle = await getKernelBundle();
   const snapshotFingerprint = await computeRunUtilsSnapshotFingerprint(
     name,
     kernelBundle.endoZipBase64Sha512,
@@ -239,7 +244,7 @@ export const loadRunUtilsSnapshot = async (
       `Unsupported snapshot version ${metadata.version}, expected ${SNAPSHOT_VERSION}`,
     );
   }
-  const currentKernelBundleSha512 = (await buildKernelBundle())
+  const currentKernelBundleSha512 = (await getKernelBundle())
     .endoZipBase64Sha512;
   const expectedSnapshotFingerprint = await computeRunUtilsSnapshotFingerprint(
     name,

--- a/packages/boot/test/upgrading/upgrade-contracts.test.js
+++ b/packages/boot/test/upgrading/upgrade-contracts.test.js
@@ -4,6 +4,7 @@
  */
 import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
+import { initSwingStore } from '@agoric/swing-store';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { buildVatController } from '@agoric/swingset-vat';
 
@@ -13,7 +14,16 @@ import { buildVatController } from '@agoric/swingset-vat';
  */
 
 /**
- * @type {TestFn<{}>}
+ * @typedef {{
+ *   forkController: () => Promise<{
+ *     controller: Awaited<ReturnType<typeof buildVatController>>;
+ *     shutdown: () => Promise<void>;
+ *   }>;
+ * }} TestContext
+ */
+
+/**
+ * @type {TestFn<TestContext>}
  */
 const test = anyTest;
 
@@ -21,9 +31,8 @@ const bfile = name => new URL(name, import.meta.url).pathname;
 const importSpec = async spec =>
   new URL(importMetaResolve(spec, import.meta.url)).pathname;
 
-test('upgrade mintHolder', async t => {
-  /** @type {SwingSetConfig} */
-  const config = harden({
+const makeBaseConfig = async () =>
+  harden({
     bootstrap: 'bootstrap',
     vats: {
       // TODO refactor to use bootstrap-relay.js
@@ -39,12 +48,54 @@ test('upgrade mintHolder', async t => {
       },
     },
   });
-  // console.debug('config', JSON.stringify(config, null, 2));
 
-  const c = await buildVatController(config);
-  t.teardown(c.shutdown);
+let baseContextP;
+const getBaseContext = () => {
+  if (!baseContextP) {
+    baseContextP = (async () => {
+      const config = await makeBaseConfig();
+      const swingStore = initSwingStore();
+      const controller = await buildVatController(config, undefined, {
+        kernelStorage: swingStore.kernelStorage,
+      });
+      try {
+        controller.pinVatRoot('bootstrap');
+        await controller.run();
+        const serialized = swingStore.debug.serialize();
+        return {
+          forkController: async () => {
+            const forkStore = initSwingStore(null, { serialized });
+            const forkController = await buildVatController(config, undefined, {
+              kernelStorage: forkStore.kernelStorage,
+            });
+            forkController.pinVatRoot('bootstrap');
+            await forkController.run();
+            return {
+              controller: forkController,
+              shutdown: async () => {
+                await forkController.shutdown();
+                await forkStore.hostStorage.close();
+              },
+            };
+          },
+        };
+      } finally {
+        await controller.shutdown();
+        await swingStore.hostStorage.close();
+      }
+    })();
+  }
+  return baseContextP;
+};
+
+test.before(async t => {
+  t.context = await getBaseContext();
+});
+
+test('upgrade mintHolder', async t => {
+  const { controller: c, shutdown } = await t.context.forkController();
+  t.teardown(shutdown);
   c.pinVatRoot('bootstrap');
-  await c.run();
 
   const run = async (name, args = []) => {
     assert(Array.isArray(args));

--- a/packages/boot/test/upgrading/upgrade-contracts.test.js
+++ b/packages/boot/test/upgrading/upgrade-contracts.test.js
@@ -4,22 +4,20 @@
  */
 import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { initSwingStore } from '@agoric/swing-store';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
-import { buildVatController } from '@agoric/swingset-vat';
+import {
+  forkScenario,
+  makeControllerFixture,
+} from '../tools/controller-fixture.js';
 
 /**
  * @import {TestFn} from 'ava';
+ * @import {ControllerFixture} from '../tools/controller-fixture.js';
  * @import {SwingSetConfig} from '@agoric/swingset-vat';
  */
 
 /**
- * @typedef {{
- *   forkController: () => Promise<{
- *     controller: Awaited<ReturnType<typeof buildVatController>>;
- *     shutdown: () => Promise<void>;
- *   }>;
- * }} TestContext
+ * @typedef {ControllerFixture} TestContext
  */
 
 /**
@@ -52,38 +50,9 @@ const makeBaseConfig = async () =>
 let baseContextP;
 const getBaseContext = () => {
   if (!baseContextP) {
-    baseContextP = (async () => {
-      const config = await makeBaseConfig();
-      const swingStore = initSwingStore();
-      const controller = await buildVatController(config, undefined, {
-        kernelStorage: swingStore.kernelStorage,
-      });
-      try {
-        controller.pinVatRoot('bootstrap');
-        await controller.run();
-        const serialized = swingStore.debug.serialize();
-        return {
-          forkController: async () => {
-            const forkStore = initSwingStore(null, { serialized });
-            const forkController = await buildVatController(config, undefined, {
-              kernelStorage: forkStore.kernelStorage,
-            });
-            forkController.pinVatRoot('bootstrap');
-            await forkController.run();
-            return {
-              controller: forkController,
-              shutdown: async () => {
-                await forkController.shutdown();
-                await forkStore.hostStorage.close();
-              },
-            };
-          },
-        };
-      } finally {
-        await controller.shutdown();
-        await swingStore.hostStorage.close();
-      }
-    })();
+    baseContextP = makeBaseConfig().then(config =>
+      makeControllerFixture({ config }),
+    );
   }
   return baseContextP;
 };
@@ -93,9 +62,7 @@ test.before(async t => {
 });
 
 test('upgrade mintHolder', async t => {
-  const { controller: c, shutdown } = await t.context.forkController();
-  t.teardown(shutdown);
-  c.pinVatRoot('bootstrap');
+  const { controller: c } = await forkScenario(t);
 
   const run = async (name, args = []) => {
     assert(Array.isArray(args));

--- a/packages/boot/test/upgrading/upgrade-contracts.test.js
+++ b/packages/boot/test/upgrading/upgrade-contracts.test.js
@@ -4,16 +4,14 @@
  */
 import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { resolve as importMetaResolve } from 'import-meta-resolve';
 import {
   forkScenario,
-  makeControllerFixture,
+  makeBootControllerFixture,
 } from '../tools/controller-fixture.js';
 
 /**
  * @import {TestFn} from 'ava';
  * @import {ControllerFixture} from '../tools/controller-fixture.js';
- * @import {SwingSetConfig} from '@agoric/swingset-vat';
  */
 
 /**
@@ -25,34 +23,20 @@ import {
  */
 const test = anyTest;
 
-const bfile = name => new URL(name, import.meta.url).pathname;
-const importSpec = async spec =>
-  new URL(importMetaResolve(spec, import.meta.url)).pathname;
-
-const makeBaseConfig = async () =>
-  harden({
-    bootstrap: 'bootstrap',
-    vats: {
-      // TODO refactor to use bootstrap-relay.js
-      bootstrap: { sourceSpec: bfile('./bootstrap.js') },
-      zoe: { sourceSpec: await importSpec('@agoric/vats/src/vat-zoe.js') },
-    },
-    bundles: {
-      zcf: {
-        sourceSpec: await importSpec('@agoric/zoe/contractFacet.js'),
-      },
-      mintHolder: {
-        sourceSpec: await importSpec('@agoric/vats/src/mintHolder.js'),
-      },
-    },
-  });
-
 let baseContextP;
 const getBaseContext = () => {
   if (!baseContextP) {
-    baseContextP = makeBaseConfig().then(config =>
-      makeControllerFixture({ config }),
-    );
+    baseContextP = makeBootControllerFixture({
+      testModuleUrl: import.meta.url,
+      bootstrapSourceSpec: './bootstrap.js',
+      vats: {
+        zoe: '@agoric/vats/src/vat-zoe.js',
+      },
+      bundles: {
+        zcf: '@agoric/zoe/contractFacet.js',
+        mintHolder: '@agoric/vats/src/mintHolder.js',
+      },
+    });
   }
   return baseContextP;
 };

--- a/packages/boot/test/upgrading/upgrade-vats.test.ts
+++ b/packages/boot/test/upgrading/upgrade-vats.test.ts
@@ -1,6 +1,9 @@
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import type { ExecutionContext, TestFn } from 'ava';
 
 import { BridgeId, deepCopyJsonable } from '@agoric/internal';
+import { initSwingStore } from '@agoric/swing-store';
 import { buildVatController, type SwingSetConfig } from '@agoric/swingset-vat';
 import { sharedBundleCachePath } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { makeRunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
@@ -18,17 +21,31 @@ const bfile = name => new URL(name, import.meta.url).pathname;
 const importSpec = async spec =>
   new URL(importMetaResolve(spec, import.meta.url)).pathname;
 
-const makeCallOutbound = t => (srcID, obj) => {
-  t.log(`callOutbound(${srcID}, ${obj})`);
-  return obj;
+type RunUtils = ReturnType<typeof makeRunUtils>;
+type Scenario = {
+  EV: RunUtils['EV'];
+  getCrankNumber: () => number;
+  runUtils: RunUtils;
+  shutdown: () => Promise<void>;
+};
+type BridgeBackend = (obj: any) => unknown;
+type BridgeHarness = {
+  assert: (condition: unknown, message?: string) => void;
+  fail: (message?: string) => never;
+};
+type BaseSetup = {
+  forkScenario: (
+    t: ExecutionContext,
+    options?: {
+      bridgeBackends?: Record<string, BridgeBackend>;
+    },
+  ) => Promise<Scenario>;
 };
 
-const makeScenario = async (
-  t: any,
-  kernelConfigOverrides: Partial<SwingSetConfig> = {},
-  deviceEndowments: Record<string, unknown> = {},
-) => {
-  const config: SwingSetConfig = {
+const test = anyTest as TestFn<BaseSetup>;
+
+const makeBaseConfig = async (): Promise<SwingSetConfig> =>
+  harden({
     includeDevDependencies: true, // for vat-data
     bootstrap: 'bootstrap',
     defaultReapInterval: 'never',
@@ -39,32 +56,151 @@ const makeScenario = async (
         ),
       },
     },
+    bundles: {
+      bank: {
+        sourceSpec: await importSpec('@agoric/vats/src/vat-bank.js'),
+      },
+      board: {
+        sourceSpec: await importSpec('@agoric/vats/src/vat-board.js'),
+      },
+      bridge: {
+        sourceSpec: await importSpec('@agoric/vats/src/vat-bridge.js'),
+      },
+      chain: {
+        sourceSpec: await importSpec('@agoric/vats/src/core/boot-chain.js'),
+      },
+      mint: {
+        sourceSpec: bfile('./vat-mint.js'),
+      },
+      priceAuthority: {
+        sourceSpec: await importSpec('@agoric/vats/src/vat-priceAuthority.js'),
+      },
+      vow: {
+        sourceSpec: bfile('./vat-vow.js'),
+      },
+    },
+    devices: {
+      bridge: {
+        sourceSpec: bfile('./device-bridge.js'),
+      },
+    },
     bundleCachePath: sharedBundleCachePath,
-    ...kernelConfigOverrides,
-  };
+  });
 
-  const c = await buildVatController(
+const makeBridgeDeviceEndowments = (
+  t: BridgeHarness,
+  bridgeBackends: Record<string, BridgeBackend> = {},
+) => ({
+  bridge: {
+    t,
+    bridgeBackends,
+  },
+});
+
+const makeBaseBridgeHarness = (): BridgeHarness => ({
+  assert(condition, message) {
+    if (!condition) {
+      throw new Error(String(message));
+    }
+  },
+  fail(message) {
+    throw new Error(String(message));
+  },
+});
+
+const makeBaseSetup = async (): Promise<BaseSetup> => {
+  const config = await makeBaseConfig();
+  const swingStore = initSwingStore();
+  const controller = await buildVatController(
     config,
     undefined,
-    undefined,
-    deviceEndowments,
+    { kernelStorage: swingStore.kernelStorage },
+    makeBridgeDeviceEndowments(makeBaseBridgeHarness()),
   );
-  t.teardown(c.shutdown);
-  c.pinVatRoot('bootstrap');
 
-  await c.run();
-  const runUtils = makeRunUtils(c);
-  return runUtils;
+  try {
+    controller.pinVatRoot('bootstrap');
+    await controller.run();
+    const serialized = swingStore.debug.serialize();
+
+    return {
+      forkScenario: async (t, { bridgeBackends = {} } = {}) => {
+        const forkStore = initSwingStore(null, { serialized });
+        const forkController = await buildVatController(
+          config,
+          undefined,
+          { kernelStorage: forkStore.kernelStorage },
+          makeBridgeDeviceEndowments(t, bridgeBackends),
+        );
+
+        forkController.pinVatRoot('bootstrap');
+        await forkController.run();
+
+        const runUtils = makeRunUtils(forkController);
+        const { EV } = runUtils;
+        return {
+          EV,
+          getCrankNumber: () =>
+            Number(forkStore.kernelStorage.kvStore.get('crankNumber')),
+          runUtils,
+          shutdown: async () => {
+            await forkController.shutdown();
+            await forkStore.hostStorage.close();
+          },
+        };
+      },
+    };
+  } finally {
+    await controller.shutdown();
+    await swingStore.hostStorage.close();
+  }
 };
 
-test('upgrade vat-board', async t => {
-  const bundles = {
-    board: {
-      sourceSpec: await importSpec('@agoric/vats/src/vat-board.js'),
-    },
-  };
+let baseSetupP: Promise<BaseSetup> | undefined;
+const getBaseSetup = () => {
+  if (!baseSetupP) {
+    baseSetupP = makeBaseSetup();
+  }
+  return baseSetupP;
+};
 
-  const { EV } = await makeScenario(t, { bundles });
+const makeScenario = async (
+  t: ExecutionContext<BaseSetup>,
+  options?: {
+    bridgeBackends?: Record<string, BridgeBackend>;
+  },
+) => {
+  const scenario = await t.context.forkScenario(t, options);
+  t.teardown(() => scenario.shutdown());
+  return scenario;
+};
+
+test.before(async t => {
+  t.context = await getBaseSetup();
+});
+
+test('forked scenarios start equivalent and isolated', async t => {
+  const forkA = await makeScenario(t);
+  const forkB = await t.context.forkScenario(t);
+  t.teardown(() => forkB.shutdown());
+
+  const crank0 = forkA.getCrankNumber();
+  t.is(forkB.getCrankNumber(), crank0);
+
+  const boardVatConfig = {
+    name: 'board',
+    bundleCapName: 'board',
+  };
+  await forkA.EV.vat('bootstrap').createVat(boardVatConfig);
+  t.true(forkA.getCrankNumber() > crank0);
+  t.is(forkB.getCrankNumber(), crank0);
+
+  const boardRoot = await forkB.EV.vat('bootstrap').createVat(boardVatConfig);
+  t.truthy(boardRoot);
+});
+
+test('upgrade vat-board', async t => {
+  const { EV } = await makeScenario(t);
 
   t.log('create initial version');
   const boardVatConfig = {
@@ -88,13 +224,7 @@ test('upgrade vat-board', async t => {
 });
 
 test.failing('upgrade bootstrap vat', async t => {
-  const bundles = {
-    chain: {
-      sourceSpec: await importSpec('@agoric/vats/src/core/boot-chain.js'),
-    },
-  };
-  // @ts-expect-error error in skipped test
-  const { EV } = await makeScenario(t, bundles);
+  const { EV } = await makeScenario(t);
 
   t.log('create initial version');
   const chainVatConfig = {
@@ -114,32 +244,17 @@ test.failing('upgrade bootstrap vat', async t => {
 });
 
 test('upgrade vat-bridge', async t => {
-  const bundles = {
-    bridge: { sourceSpec: await importSpec('@agoric/vats/src/vat-bridge.js') },
-  };
-  const devices = {
-    bridge: { sourceSpec: bfile('./device-bridge.js') },
-  };
-
   const expectedStorageValues = ['abc', 'def'];
-  const { EV } = await makeScenario(
-    t,
-    { bundles, devices },
-    {
-      bridge: {
-        t,
-        callOutbound: makeCallOutbound(t),
-        bridgeBackends: {
-          [BridgeId.STORAGE](obj) {
-            const { method, args } = obj;
-            t.is(method, 'set', `storage bridge method must be 'set'`);
-            t.deepEqual(args, [['root1', expectedStorageValues.shift()]]);
-            return undefined;
-          },
-        },
+  const { EV } = await makeScenario(t, {
+    bridgeBackends: {
+      [BridgeId.STORAGE](obj) {
+        const { method, args } = obj;
+        t.is(method, 'set', `storage bridge method must be 'set'`);
+        t.deepEqual(args, [['root1', expectedStorageValues.shift()]]);
+        return undefined;
       },
     },
-  );
+  });
 
   t.log('create initial version');
   const bridgeVatConfig = {
@@ -223,36 +338,19 @@ test('upgrade vat-bridge', async t => {
 });
 
 test('upgrade vat-bank', async t => {
-  const bundles = {
-    bank: { sourceSpec: await importSpec('@agoric/vats/src/vat-bank.js') },
-    bridge: { sourceSpec: await importSpec('@agoric/vats/src/vat-bridge.js') },
-    mint: { sourceSpec: bfile('./vat-mint.js') },
-  };
-  const devices = {
-    bridge: { sourceSpec: bfile('./device-bridge.js') },
-  };
-
-  const { EV } = await makeScenario(
-    t,
-    { bundles, devices },
-    {
-      bridge: {
-        t,
-        callOutbound: makeCallOutbound(t),
-        bridgeBackends: {
-          [BridgeId.BANK](obj) {
-            switch (obj.type) {
-              case 'VBANK_GET_BALANCE': {
-                return '1000';
-              }
-              default:
-                throw Fail`unexpected call to bank handler ${obj}`;
-            }
-          },
-        },
+  const { EV } = await makeScenario(t, {
+    bridgeBackends: {
+      [BridgeId.BANK](obj) {
+        switch (obj.type) {
+          case 'VBANK_GET_BALANCE': {
+            return '1000';
+          }
+          default:
+            Fail`unexpected call to bank handler ${obj}`;
+        }
       },
     },
-  );
+  });
 
   t.log('create initial version');
   const bridgeVatConfig = {
@@ -400,13 +498,7 @@ test('upgrade vat-bank', async t => {
 });
 
 test('upgrade vat-priceAuthority', async t => {
-  const bundles = {
-    priceAuthority: {
-      sourceSpec: await importSpec('@agoric/vats/src/vat-priceAuthority.js'),
-    },
-  };
-
-  const { EV } = await makeScenario(t, { bundles });
+  const { EV } = await makeScenario(t);
 
   t.log('create initial version');
   const priceAuthorityVatConfig = {
@@ -438,13 +530,7 @@ test('upgrade vat-priceAuthority', async t => {
 });
 
 test('upgrade vat-vow', async t => {
-  const bundles = {
-    vow: {
-      sourceSpec: bfile('./vat-vow.js'),
-    },
-  };
-
-  const { EV } = await makeScenario(t, { bundles });
+  const { EV } = await makeScenario(t);
 
   t.log('create initial version, metered');
   const vatAdmin = await EV.vat('bootstrap').getVatAdmin();

--- a/packages/boot/test/upgrading/upgrade-vats.test.ts
+++ b/packages/boot/test/upgrading/upgrade-vats.test.ts
@@ -2,18 +2,24 @@ import { test as anyTest } from '@agoric/swingset-vat/tools/prepare-test-env-ava
 
 import type { ExecutionContext, TestFn } from 'ava';
 
+import type { IssuerKit } from '@agoric/ertp/src/types.js';
 import { BridgeId, deepCopyJsonable } from '@agoric/internal';
-import { initSwingStore } from '@agoric/swing-store';
-import { buildVatController, type SwingSetConfig } from '@agoric/swingset-vat';
+import { type SwingSetConfig } from '@agoric/swingset-vat';
 import { sharedBundleCachePath } from '@agoric/swingset-vat/tools/bundleTool.js';
-import { makeRunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
+import type { BankVat } from '@agoric/vats/src/vat-bank.js';
+import type { PriceAuthorityVat } from '@agoric/vats/src/vat-priceAuthority.js';
 import { Fail } from '@endo/errors';
 import { makeTagged } from '@endo/marshal';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
-import type { IssuerKit } from '@agoric/ertp/src/types.js';
-import type { BankVat } from '@agoric/vats/src/vat-bank.js';
-import type { PriceAuthorityVat } from '@agoric/vats/src/vat-priceAuthority.js';
 import { matchAmount, matchIter, matchRef } from '../../tools/supports.js';
+import {
+  forkScenario,
+  makeBridgeDeviceEndowments,
+  makeControllerFixture,
+  makeThrowingBridgeHarness,
+  type BridgeBackend,
+  type ControllerFixture,
+} from '../tools/controller-fixture.js';
 
 import type { buildRootObject as buildTestMintVat } from './vat-mint.js';
 
@@ -21,26 +27,7 @@ const bfile = name => new URL(name, import.meta.url).pathname;
 const importSpec = async spec =>
   new URL(importMetaResolve(spec, import.meta.url)).pathname;
 
-type RunUtils = ReturnType<typeof makeRunUtils>;
-type Scenario = {
-  EV: RunUtils['EV'];
-  getCrankNumber: () => number;
-  runUtils: RunUtils;
-  shutdown: () => Promise<void>;
-};
-type BridgeBackend = (obj: any) => unknown;
-type BridgeHarness = {
-  assert: (condition: unknown, message?: string) => void;
-  fail: (message?: string) => never;
-};
-type BaseSetup = {
-  forkScenario: (
-    t: ExecutionContext,
-    options?: {
-      bridgeBackends?: Record<string, BridgeBackend>;
-    },
-  ) => Promise<Scenario>;
-};
+type BaseSetup = Pick<ControllerFixture, 'forkController'>;
 
 const test = anyTest as TestFn<BaseSetup>;
 
@@ -87,73 +74,14 @@ const makeBaseConfig = async (): Promise<SwingSetConfig> =>
     bundleCachePath: sharedBundleCachePath,
   });
 
-const makeBridgeDeviceEndowments = (
-  t: BridgeHarness,
-  bridgeBackends: Record<string, BridgeBackend> = {},
-) => ({
-  bridge: {
-    t,
-    bridgeBackends,
-  },
-});
-
-const makeBaseBridgeHarness = (): BridgeHarness => ({
-  assert(condition, message) {
-    if (!condition) {
-      throw new Error(String(message));
-    }
-  },
-  fail(message) {
-    throw new Error(String(message));
-  },
-});
-
 const makeBaseSetup = async (): Promise<BaseSetup> => {
   const config = await makeBaseConfig();
-  const swingStore = initSwingStore();
-  const controller = await buildVatController(
+  return makeControllerFixture({
     config,
-    undefined,
-    { kernelStorage: swingStore.kernelStorage },
-    makeBridgeDeviceEndowments(makeBaseBridgeHarness()),
-  );
-
-  try {
-    controller.pinVatRoot('bootstrap');
-    await controller.run();
-    const serialized = swingStore.debug.serialize();
-
-    return {
-      forkScenario: async (t, { bridgeBackends = {} } = {}) => {
-        const forkStore = initSwingStore(null, { serialized });
-        const forkController = await buildVatController(
-          config,
-          undefined,
-          { kernelStorage: forkStore.kernelStorage },
-          makeBridgeDeviceEndowments(t, bridgeBackends),
-        );
-
-        forkController.pinVatRoot('bootstrap');
-        await forkController.run();
-
-        const runUtils = makeRunUtils(forkController);
-        const { EV } = runUtils;
-        return {
-          EV,
-          getCrankNumber: () =>
-            Number(forkStore.kernelStorage.kvStore.get('crankNumber')),
-          runUtils,
-          shutdown: async () => {
-            await forkController.shutdown();
-            await forkStore.hostStorage.close();
-          },
-        };
-      },
-    };
-  } finally {
-    await controller.shutdown();
-    await swingStore.hostStorage.close();
-  }
+    baseDeviceEndowments: makeBridgeDeviceEndowments(
+      makeThrowingBridgeHarness(),
+    ),
+  });
 };
 
 let baseSetupP: Promise<BaseSetup> | undefined;
@@ -169,11 +97,10 @@ const makeScenario = async (
   options?: {
     bridgeBackends?: Record<string, BridgeBackend>;
   },
-) => {
-  const scenario = await t.context.forkScenario(t, options);
-  t.teardown(() => scenario.shutdown());
-  return scenario;
-};
+) =>
+  forkScenario(t, {
+    deviceEndowments: makeBridgeDeviceEndowments(t, options?.bridgeBackends),
+  });
 
 test.before(async t => {
   t.context = await getBaseSetup();
@@ -181,7 +108,9 @@ test.before(async t => {
 
 test('forked scenarios start equivalent and isolated', async t => {
   const forkA = await makeScenario(t);
-  const forkB = await t.context.forkScenario(t);
+  const forkB = await t.context.forkController({
+    deviceEndowments: makeBridgeDeviceEndowments(t),
+  });
   t.teardown(() => forkB.shutdown());
 
   const crank0 = forkA.getCrankNumber();

--- a/packages/boot/test/upgrading/upgrade-vats.test.ts
+++ b/packages/boot/test/upgrading/upgrade-vats.test.ts
@@ -4,18 +4,15 @@ import type { ExecutionContext, TestFn } from 'ava';
 
 import type { IssuerKit } from '@agoric/ertp/src/types.js';
 import { BridgeId, deepCopyJsonable } from '@agoric/internal';
-import { type SwingSetConfig } from '@agoric/swingset-vat';
-import { sharedBundleCachePath } from '@agoric/swingset-vat/tools/bundleTool.js';
 import type { BankVat } from '@agoric/vats/src/vat-bank.js';
 import type { PriceAuthorityVat } from '@agoric/vats/src/vat-priceAuthority.js';
 import { Fail } from '@endo/errors';
 import { makeTagged } from '@endo/marshal';
-import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { matchAmount, matchIter, matchRef } from '../../tools/supports.js';
 import {
   forkScenario,
+  makeBootControllerFixture,
   makeBridgeDeviceEndowments,
-  makeControllerFixture,
   makeThrowingBridgeHarness,
   type BridgeBackend,
   type ControllerFixture,
@@ -23,61 +20,26 @@ import {
 
 import type { buildRootObject as buildTestMintVat } from './vat-mint.js';
 
-const bfile = name => new URL(name, import.meta.url).pathname;
-const importSpec = async spec =>
-  new URL(importMetaResolve(spec, import.meta.url)).pathname;
-
 type BaseSetup = Pick<ControllerFixture, 'forkController'>;
 
 const test = anyTest as TestFn<BaseSetup>;
 
-const makeBaseConfig = async (): Promise<SwingSetConfig> =>
-  harden({
+const makeBaseSetup = async (): Promise<BaseSetup> => {
+  return makeBootControllerFixture({
+    testModuleUrl: import.meta.url,
     includeDevDependencies: true, // for vat-data
-    bootstrap: 'bootstrap',
-    defaultReapInterval: 'never',
-    vats: {
-      bootstrap: {
-        sourceSpec: await importSpec(
-          '@agoric/swingset-vat/tools/bootstrap-relay.js',
-        ),
-      },
-    },
     bundles: {
-      bank: {
-        sourceSpec: await importSpec('@agoric/vats/src/vat-bank.js'),
-      },
-      board: {
-        sourceSpec: await importSpec('@agoric/vats/src/vat-board.js'),
-      },
-      bridge: {
-        sourceSpec: await importSpec('@agoric/vats/src/vat-bridge.js'),
-      },
-      chain: {
-        sourceSpec: await importSpec('@agoric/vats/src/core/boot-chain.js'),
-      },
-      mint: {
-        sourceSpec: bfile('./vat-mint.js'),
-      },
-      priceAuthority: {
-        sourceSpec: await importSpec('@agoric/vats/src/vat-priceAuthority.js'),
-      },
-      vow: {
-        sourceSpec: bfile('./vat-vow.js'),
-      },
+      bank: '@agoric/vats/src/vat-bank.js',
+      board: '@agoric/vats/src/vat-board.js',
+      bridge: '@agoric/vats/src/vat-bridge.js',
+      chain: '@agoric/vats/src/core/boot-chain.js',
+      mint: './vat-mint.js',
+      priceAuthority: '@agoric/vats/src/vat-priceAuthority.js',
+      vow: './vat-vow.js',
     },
     devices: {
-      bridge: {
-        sourceSpec: bfile('./device-bridge.js'),
-      },
+      bridge: './device-bridge.js',
     },
-    bundleCachePath: sharedBundleCachePath,
-  });
-
-const makeBaseSetup = async (): Promise<BaseSetup> => {
-  const config = await makeBaseConfig();
-  return makeControllerFixture({
-    config,
     baseDeviceEndowments: makeBridgeDeviceEndowments(
       makeThrowingBridgeHarness(),
     ),
@@ -275,7 +237,7 @@ test('upgrade vat-bank', async t => {
             return '1000';
           }
           default:
-            Fail`unexpected call to bank handler ${obj}`;
+            throw Fail`unexpected call to bank handler ${obj}`;
         }
       },
     },

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -1456,6 +1456,13 @@ export const makeSwingsetTestKit = async <
     evals: materials.flatMap(e => e.evals),
     bundles: materials.flatMap(e => e.bundles),
   });
+  const installedProposalBundleIDs = new Set<string>();
+  let coreEvalBridgeHandlerP: Promise<BridgeHandler> | undefined;
+
+  const getProposalBundleID = (bundle: ProposalMaterials['bundles'][number]) =>
+    'endoZipBase64Sha512' in bundle
+      ? `b1-${bundle.endoZipBase64Sha512}`
+      : JSON.stringify(bundle);
 
   const evalProposal = async (proposalP: ERef<ProposalMaterials>) => {
     const { EV } = runUtils;
@@ -1467,22 +1474,30 @@ export const makeSwingsetTestKit = async <
       ),
     );
 
-    await profiler.measure(
+    const installedBundleCount = await profiler.measure(
       'makeSwingsetTestKit.proposal.installBundles',
       async () => {
-        const seenBundleHashes = new Set<string>();
+        let installed = 0;
         for (const bundle of proposal.bundles) {
-          const bundleHash = bundle.endoZipBase64Sha512 ?? bundle.endoZipBase64;
-          if (seenBundleHashes.has(bundleHash)) {
+          const bundleID = getProposalBundleID(bundle);
+          if (installedProposalBundleIDs.has(bundleID)) {
             continue;
           }
-          seenBundleHashes.add(bundleHash);
           await controller.validateAndInstallBundle(bundle);
+          installedProposalBundleIDs.add(bundleID);
+          installed += 1;
         }
+        return installed;
       },
       { bundleCount: proposal.bundles.length },
     );
-    log('installed', proposal.bundles.length, 'bundles');
+    log(
+      'installed',
+      installedBundleCount,
+      'new bundles from',
+      proposal.bundles.length,
+      'proposal bundles',
+    );
 
     log('executing proposal');
     const bridgeMessage = {
@@ -1490,9 +1505,13 @@ export const makeSwingsetTestKit = async <
       evals: proposal.evals,
     };
     log({ bridgeMessage });
-    const coreEvalBridgeHandler = await EV.vat('bootstrap').consumeItem(
-      'coreEvalBridgeHandler',
-    );
+    if (!coreEvalBridgeHandlerP) {
+      coreEvalBridgeHandlerP = profiler.measure(
+        'makeSwingsetTestKit.proposal.getCoreEvalBridgeHandler',
+        () => EV.vat('bootstrap').consumeItem('coreEvalBridgeHandler'),
+      );
+    }
+    const coreEvalBridgeHandler = await coreEvalBridgeHandlerP;
     await profiler.measure(
       'makeSwingsetTestKit.proposal.executeCoreEval',
       () => EV(coreEvalBridgeHandler).fromBridge(bridgeMessage),

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -1048,6 +1048,23 @@ const restoreFakeStorage = (
  * @param options.swingStorePath - Optional persistent swing-store directory path
  * @returns A test kit with various utilities for interacting with the SwingSet
  */
+export type MakeSwingsetTestKitOptions = {
+  configSpecifier?: string;
+  label?: string | undefined;
+  storage?: FakeStorage | undefined;
+  verbose?: boolean;
+  slogFile?: string | undefined;
+  profileVats?: string[];
+  debugVats?: string[];
+  defaultManagerType?: ManagerType;
+  harness?: RunHarness | undefined;
+  proposalBuildMode?: ProposalBuildMode;
+  resolveBase?: string;
+  configOverrides?: Partial<SwingSetConfig>;
+  snapshot?: SwingsetTestKitSnapshot | undefined;
+  swingStorePath?: string | undefined;
+};
+
 export const makeSwingsetTestKit = async <
   PublishedPathTypes extends ClientPublishedPathTypes =
     BootstrapPublishedPathTypes,
@@ -1071,7 +1088,7 @@ export const makeSwingsetTestKit = async <
     configOverrides = {} as Partial<SwingSetConfig>,
     snapshot = undefined as SwingsetTestKitSnapshot | undefined,
     swingStorePath = undefined as string | undefined,
-  } = {},
+  }: MakeSwingsetTestKitOptions = {},
 ) => {
   const storage = storageOpt || restoreFakeStorage(snapshot?.storageSnapshot);
   const importSpec = createRequire(resolveBase).resolve;

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -120,18 +120,14 @@ const makeConfigCacheKey = ({
   defaultManagerType: ManagerType;
   discriminator: string;
   configOverrides: Partial<SwingSetConfig>;
-}) => {
-  const normalizedOverrides = JSON.parse(
-    JSON.stringify(configOverrides ?? {}),
-  ) as Partial<SwingSetConfig>;
-  return JSON.stringify({
+}) =>
+  JSON.stringify({
     bundleDir,
     configPath,
     defaultManagerType,
     discriminator,
-    configOverrides: normalizedOverrides,
+    configOverrides: configOverrides ?? {},
   });
-};
 
 // Releases are immutable, so we can cache them.
 // Doesn't help in CI but speeds up local development.
@@ -187,10 +183,6 @@ const keysToObject = <K extends PropertyKey, V>(
   return Object.fromEntries(keys.map((key, i) => [key, valueMaker(key, i)]));
 };
 
-/**
- * AVA's default t.deepEqual() is nearly unreadable for sorted arrays of
- * strings.
- */
 /**
  * Compare two arrays of property keys for equality in a way that's more readable
  * in AVA test output than the default t.deepEqual().

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -74,7 +74,7 @@ import type { GovernancePublishedPathTypes } from '@agoric/governance';
 import type { EconomyBootstrapPowers } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
 import { base64ToBytes } from '@agoric/network';
 import type { SwingsetController } from '@agoric/swingset-vat/src/controller/controller.js';
-import type { IBCDowncallMethod, IBCMethod } from '@agoric/vats';
+import type { BridgeHandler, IBCDowncallMethod, IBCMethod } from '@agoric/vats';
 import type { BootstrapRootObject } from '@agoric/vats/src/core/lib-boot.js';
 import type { ERef } from '@agoric/vow';
 import type { EProxy } from '@endo/eventual-send';
@@ -1468,9 +1468,8 @@ export const makeSwingsetTestKit = async <
     const { EV } = runUtils;
 
     const proposal = harden(
-      await profiler.measure(
-        'makeSwingsetTestKit.proposal.resolve',
-        () => proposalP,
+      await profiler.measure('makeSwingsetTestKit.proposal.resolve', () =>
+        Promise.resolve(proposalP),
       ),
     );
 
@@ -1736,17 +1735,12 @@ export const makeSwingsetHarness = ({
 };
 
 /**
- *
- * @param {string} mt
- * @returns {asserts mt is ManagerType}
- */
-/**
  * Validates that a string is a valid SwingSet manager type.
  *
  * @param mt - The manager type string to validate
  * @throws If the string is not a valid manager type
  */
-export function insistManagerType(mt) {
+export function insistManagerType(mt: string): asserts mt is ManagerType {
   assert(['local', 'node-subprocess', 'xsnap', 'xs-worker'].includes(mt));
 }
 


### PR DESCRIPTION
refs: #12489

## Description

Adds shared boot-test scaffolding and migrates packages/boot tests onto it, along with several perf wins on top of the existing runutils snapshot cache on master. Pure test-infrastructure change — no production code is touched.

Most critical files to review:

- `packages/boot/test/tools/controller-fixture.ts` — builds a base SwingSet controller once, serializes its swing-store state, and forks isolated controllers for individual scenarios; adds bridge device endowment helpers and source-spec resolution for boot-style controller fixtures.
- `packages/boot/test/tools/boot-test-context.ts` — wraps `makeSwingsetTestKit` with `snapshotName` support backed by `loadOrCreateRunUtilsSnapshot(name, log)`; adds shared proposal helpers, published-log assertions, and wallet-factory / governance / liquidation context helpers; adds wallet assertion helpers for status, result, and invitation path checks.
- `packages/boot/tools/supports.ts` — exports `MakeSwingsetTestKitOptions` for shared helper composition; avoids reinstalling proposal bundles already installed by the same test kit; caches the `coreEvalBridgeHandler` lookup across proposal applications; tightens `insistManagerType` typing; memoizes config-file loading and config cache-key construction.
- `packages/boot/test/tools/runutils-snapshots.ts` — memoizes `buildKernelBundle()` per process and parallelizes input-file hashing during fingerprint computation.
- Migrated tests under `packages/boot/test/{bootstrapTests,orchestration,upgrading}/**` — moved onto the shared context helpers; `vow-offer-results` continues to use the existing `orchestration-base` runutils snapshot from master.

This branch no longer introduces a `runutils-fixtures` module. The runutils snapshot cache and `loadOrCreateCachedSnapshot` options-bag API are already on master; `loadOrCreateRunUtilsSnapshot` remains the public positional wrapper. `packages/portfolio-deploy/test/portfolio-snapshots.ts` is unchanged from master by this PR.

## Performance impact

### Local dev (warm cache, single-file `yarn ava` runs)

| Scenario | Master | This PR | Δ |
|---|---|---|---|
| `upgrade-vats.test.ts` (multi-scenario fork-based file) | 45.3s | **30.7s** | **−32%** |
| `contract-upgrade.test.ts` | 9.3s | 9.2s | ~0% |
| `lca.test.ts` | 7.5s | 7.2s | −4% |
| `vow-offer-results.test.ts` | 6.0s | 6.2s | +3% |
| `vtransfer.test.ts` (very small file) | 4.6s | 5.1s | +11% (~+0.5s wrapper overhead) |
| AVA `--watch` reload cycle on a heavy test | ~60–90s | **~10s** | snapshot reuse |

The biggest dev-loop win is **watch mode**: `loadOrCreateRunUtilsSnapshot` plus the in-process `buildKernelBundle()` memoization brings a watch-mode reload on a heavy test (e.g. `orchestration.test.ts`) from ~60–90s of full bootstrap down to ~10s of snapshot restore. Multi-scenario files using the new `controller-fixture` fork pattern (e.g. `upgrade-vats`) see a real ~32% file-level speedup from sharing the base controller across scenarios. Tiny test files pay a ~0.2–0.5s wrapper overhead, which is noticeable only when a file already finishes in under 10s.

### CI (`test-boot` job matrix, 3 engines × 4 shards)

| Metric | Master (run 25756405151) | This PR (run 25819403493) | Δ |
|---|---|---|---|
| **Max-shard wall time** (sets the workflow's wall) | 1576s | **1347s** | **−15%** |
| Total CPU across 12 shards | 8778s | 9406s | +7% |
| Slowest shard moved from | `node-new 2` | `xs 2` | (distribution shifted) |

The wall-time win is real, but **mostly attributable to incidental resharding rather than per-file speedups**: adding two new `tools/*.test.ts` files perturbed AVA's alphabetical `CI_NODE_INDEX` split, shedding work from the previously-overloaded shard 2 onto shards 0 and 1 and flattening the per-shard distribution. The per-file speedups on heavy files (notably `upgrade-vats` locally) contribute a smaller share. Total CI CPU rises ~7% from the two new test files plus modest per-file wrapper overhead on bootstrap tests; in a parallel matrix this doesn't affect wall time.

### Security Considerations

None. Changes are confined to test infrastructure under `packages/boot/test/**` and the test-support module `packages/boot/tools/supports.ts`. No new authorities or trust boundaries are introduced.

### Scaling Considerations

See *Performance impact* above. Net-positive for local dev (watch-mode is qualitatively better; multi-scenario files run ~32% faster). For CI, max-shard wall time drops ~15% (mostly from resharding); cumulative CPU rises ~7% but doesn't affect parallel wall time. No effect on production runtime resource usage.

### Documentation Considerations

None. No user-visible APIs change.

### Testing Considerations

This PR *is* test infrastructure; correctness is exercised by the migrated suites continuing to pass:

- `cd packages/boot && yarn run -T tsc --noEmit --incremental`
- `yarn typecheck-quick`
- `cd packages/boot && yarn test test/tools/boot-test-context.test.ts test/tools/controller-fixture.test.ts`
- Full bootstrap, orchestration, and upgrade suites under `packages/boot/test/**` exercised in CI.

### Upgrade Considerations

None. Test-only.