### PR TITLE
fast test builds

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -88,9 +88,17 @@
     "example": "examples"
   },
   "ava": {
+    "extensions": {
+      "js": true,
+      "ts": "module"
+    },
     "workerThreads": false,
     "files": [
       "test/**/*.test.*"
+    ],
+    "nodeArguments": [
+      "--import=ts-blank-space/register",
+      "--no-warnings"
     ],
     "require": [
       "@agoric/internal/src/ava-force-exit.mjs",

--- a/packages/SwingSet/test/bundleTool.test.ts
+++ b/packages/SwingSet/test/bundleTool.test.ts
@@ -185,8 +185,8 @@ test.serial('load() rebuilds when dependency file changes', async t => {
     s => import(s),
     testPowers,
   );
-  await cache.load(sourcePath, 'toy');
-  const bundlePath = path.join(bundlesDir, 'bundle-toy.js');
+  const { bundleFileName } = await cache.validateOrAdd(sourcePath, 'toy');
+  const bundlePath = path.join(bundlesDir, bundleFileName);
   const before = await readFile(bundlePath, 'utf8');
 
   // Ensure mtime differences are observable on coarser filesystems.

--- a/packages/SwingSet/test/bundleTool.test.ts
+++ b/packages/SwingSet/test/bundleTool.test.ts
@@ -93,7 +93,7 @@ test.serial('failed load does not poison later load for same key', async t => {
 test('makeNodeBundleCache returns independent cache instances', async t => {
   const { bundlesDir, sourcePath } = await setupFixture(t);
   const loadModule = specifier => import(specifier);
-  const opts = { format: 'endoZipBase64', dev: false };
+  const opts = { format: 'endoZipBase64' as const, dev: false };
 
   const cacheAP = makeNodeBundleCache(bundlesDir, opts, loadModule, testPowers);
   const cacheBP = makeNodeBundleCache(bundlesDir, opts, loadModule, testPowers);

--- a/packages/SwingSet/test/bundleTool.test.ts
+++ b/packages/SwingSet/test/bundleTool.test.ts
@@ -5,9 +5,8 @@ import { setTimeout as delay } from 'timers/promises';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 import {
+  makeAmbientBundleToolPowers,
   makeNodeBundleCache,
-  provideBundleCache,
-  sharedBundleCachePath,
 } from '../tools/bundleTool.js';
 
 // Use a directory ignored by AVA watch mode (via ignore-by-default).
@@ -16,6 +15,9 @@ const watchIgnoredTmpRoot = path.join(
   fileURLToPath(new URL('../', import.meta.url)),
   '.sass-cache',
 );
+const testPowers = makeAmbientBundleToolPowers({
+  eventSink: { onBundleToolEvent: () => {} },
+});
 
 const setupFixture = async (t: ExecutionContext) => {
   await mkdir(watchIgnoredTmpRoot, { recursive: true });
@@ -54,7 +56,12 @@ test.serial('load() breaks stale lock from dead owner pid', async t => {
     'utf8',
   );
 
-  const cache = await makeNodeBundleCache(bundlesDir, {}, s => import(s));
+  const cache = await makeNodeBundleCache(
+    bundlesDir,
+    {},
+    s => import(s),
+    testPowers,
+  );
   const loaded = await cache.load(sourcePath, 'toy');
   t.truthy(loaded);
 });
@@ -67,7 +74,12 @@ test.serial('failed load does not poison later load for same key', async t => {
   const fixtureSource = await readFile(fixtureSourcePath, 'utf8');
   await rm(sourcePath, { force: true });
 
-  const cache = await makeNodeBundleCache(bundlesDir, {}, s => import(s));
+  const cache = await makeNodeBundleCache(
+    bundlesDir,
+    {},
+    s => import(s),
+    testPowers,
+  );
   await t.throwsAsync(() => cache.load(sourcePath, 'toy'), {
     message:
       /no such file or directory|Cannot find module|Failed to load module|Cannot find file/i,
@@ -78,16 +90,16 @@ test.serial('failed load does not poison later load for same key', async t => {
   t.truthy(loaded);
 });
 
-test('provideBundleCache returns shared cache for same key', async t => {
+test('makeNodeBundleCache returns independent cache instances', async t => {
   const { bundlesDir, sourcePath } = await setupFixture(t);
   const loadModule = specifier => import(specifier);
   const opts = { format: 'endoZipBase64', dev: false };
 
-  const cacheAP = provideBundleCache(bundlesDir, opts, loadModule);
-  const cacheBP = provideBundleCache(bundlesDir, opts, loadModule);
-  t.is(cacheAP, cacheBP, 'cache promises are the same');
+  const cacheAP = makeNodeBundleCache(bundlesDir, opts, loadModule, testPowers);
+  const cacheBP = makeNodeBundleCache(bundlesDir, opts, loadModule, testPowers);
+  t.not(cacheAP, cacheBP, 'cache promises are distinct');
   const [cacheA, cacheB] = await Promise.all([cacheAP, cacheBP]);
-  t.is(cacheA, cacheB, 'cache fulfilments are the same');
+  t.not(cacheA, cacheB, 'cache fulfilments are distinct');
 
   const [bundleA, bundleB] = await Promise.all([
     cacheA.load(sourcePath, 'toy'),
@@ -101,14 +113,14 @@ test('provideBundleCache returns shared cache for same key', async t => {
   );
 });
 
-test('sharedBundleCachePath resolves from the repo root', t => {
-  const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
-  t.is(sharedBundleCachePath, path.join(repoRoot, 'bundles'));
-});
-
 test('concurrent load() calls for same key settle without hanging', async t => {
   const { bundlesDir, sourcePath } = await setupFixture(t);
-  const cache = await makeNodeBundleCache(bundlesDir, {}, s => import(s));
+  const cache = await makeNodeBundleCache(
+    bundlesDir,
+    {},
+    s => import(s),
+    testPowers,
+  );
   const loads = Array.from({ length: 24 }, () => cache.load(sourcePath, 'toy'));
   const bundles = await Promise.all(loads);
   t.is(bundles.length, 24);
@@ -120,7 +132,12 @@ test('concurrent load() calls for same key settle without hanging', async t => {
 
 test('load() accepts file URL source specs', async t => {
   const { bundlesDir, sourcePath } = await setupFixture(t);
-  const cache = await makeNodeBundleCache(bundlesDir, {}, s => import(s));
+  const cache = await makeNodeBundleCache(
+    bundlesDir,
+    {},
+    s => import(s),
+    testPowers,
+  );
   const sourceURL = pathToFileURL(sourcePath).href;
   const loaded = await cache.load(sourceURL, 'toy');
   t.truthy(loaded);
@@ -153,7 +170,12 @@ test.serial('load() rebuilds when dependency file changes', async t => {
     'utf8',
   );
 
-  const cache = await makeNodeBundleCache(bundlesDir, {}, s => import(s));
+  const cache = await makeNodeBundleCache(
+    bundlesDir,
+    {},
+    s => import(s),
+    testPowers,
+  );
   await cache.load(sourcePath, 'toy');
   const bundlePath = path.join(bundlesDir, 'bundle-toy.js');
   const before = await readFile(bundlePath, 'utf8');
@@ -171,7 +193,12 @@ test.serial(
   'add() and validateOrAdd() accept relative and absolute specs',
   async t => {
     const { bundlesDir, sourcePath } = await setupFixture(t);
-    const cache = await makeNodeBundleCache(bundlesDir, {}, s => import(s));
+    const cache = await makeNodeBundleCache(
+      bundlesDir,
+      {},
+      s => import(s),
+      testPowers,
+    );
 
     const originalCwd = process.cwd();
     const relDir = path.dirname(sourcePath);
@@ -217,7 +244,12 @@ test.serial(
     const staleTime = Date.now() - 120_000;
     await utimes(malformedLock, staleTime / 1000, staleTime / 1000);
 
-    const cache = await makeNodeBundleCache(bundlesDir, {}, s => import(s));
+    const cache = await makeNodeBundleCache(
+      bundlesDir,
+      {},
+      s => import(s),
+      testPowers,
+    );
     const loaded = await cache.load(sourcePath, 'toy');
     t.truthy(loaded);
     const loadedBad = await cache.load(sourcePath, 'toy-bad');
@@ -244,14 +276,24 @@ test.serial('load() handles missing lock path', async t => {
     void rm(brokenLock, { recursive: true, force: true });
   }, 0);
 
-  const cache = await makeNodeBundleCache(bundlesDir, {}, s => import(s));
+  const cache = await makeNodeBundleCache(
+    bundlesDir,
+    {},
+    s => import(s),
+    testPowers,
+  );
   const loaded = await cache.load(sourcePath, 'toy-broken');
   t.truthy(loaded);
 });
 
 test.serial('loadRegistry() loads bundles and validates entries', async t => {
   const { bundlesDir, sourcePath } = await setupFixture(t);
-  const cache = await makeNodeBundleCache(bundlesDir, {}, s => import(s));
+  const cache = await makeNodeBundleCache(
+    bundlesDir,
+    {},
+    s => import(s),
+    testPowers,
+  );
 
   const registry = {
     demo: {

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -8,9 +8,12 @@ import { makeDirectoryLock } from '@agoric/internal/src/build-cache.js';
 
 /**
  * @import {EReturn} from '@endo/far';
+ * @import {BuildCacheEvent} from '@agoric/internal/src/build-cache-types.js';
+ * @import {BundleOptions, ModuleFormat} from '@endo/bundle-source';
  */
 
 /** @typedef {EReturn<typeof wrappedMaker>} WrappedBundleCache */
+/** @typedef {BundleOptions<ModuleFormat> & Parameters<typeof wrappedMaker>[1]} BundleCacheOptions */
 /**
  * @typedef {{
  *   sourceSpec?: string;
@@ -34,8 +37,28 @@ import { makeDirectoryLock } from '@agoric/internal/src/build-cache.js';
  */
 /**
  * @typedef {{
- *   onBundleToolEvent?: (event: Record<string, unknown>) => void,
+ *   onBundleToolEvent?: (event: BundleToolEvent) => void,
  * }} BundleToolEventSink
+ */
+/**
+ * @typedef {{
+ *   type: 'bundle-source-log';
+ *   args: unknown[];
+ *   phase: string;
+ *   timestamp: number;
+ * }} BundleSourceLogEvent
+ */
+/**
+ * @typedef {{
+ *   type: 'registry-loaded';
+ *   args: string[];
+ *   phase: '[registry]';
+ *   elapsedMs: number;
+ *   bundleCount: number;
+ * }} RegistryLoadedEvent
+ */
+/**
+ * @typedef {BundleSourceLogEvent | RegistryLoadedEvent | BuildCacheEvent} BundleToolEvent
  */
 /**
  * @typedef {{
@@ -50,7 +73,7 @@ import { makeDirectoryLock } from '@agoric/internal/src/build-cache.js';
 
 /**
  * @param {string} dest
- * @param {Parameters<typeof wrappedMaker>[1]} options
+ * @param {BundleCacheOptions} options
  * @param {Parameters<typeof wrappedMaker>[2]} loadModule
  * @param {BundleToolPowers} powers
  * @returns {Promise<BundleCache>}
@@ -140,7 +163,7 @@ harden(makeAmbientBundleToolPowers);
 
 /**
  * @param {string} dest
- * @param {Parameters<typeof wrappedMaker>[1]} options
+ * @param {BundleCacheOptions} options
  * @param {Parameters<typeof wrappedMaker>[2]} loadModule
  * @param {BundleToolPowers} powers
  * @returns {Promise<BundleCache>}

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -66,6 +66,7 @@ import { makeDirectoryLock } from '@agoric/internal/src/build-cache.js';
  *   delayMs: (ms: number) => Promise<unknown>,
  *   eventSink?: BundleToolEventSink,
  *   isPidAlive: (pid: number) => boolean,
+ *   loadModule: Parameters<typeof wrappedMaker>[2],
  *   monotonicNow: () => number,
  *   now: () => number,
  *   pid: number,
@@ -114,14 +115,7 @@ const inferLogPhase = args => {
 harden(inferLogPhase);
 
 /**
- * @param {{
- *   delayMs?: (ms: number) => Promise<unknown>,
- *   eventSink?: BundleToolEventSink,
- *   isPidAlive?: (pid: number) => boolean,
- *   monotonicNow?: () => number,
- *   now?: () => number,
- *   pid?: number,
- * }} [options]
+ * @param {Partial<BundleToolPowers>} [options]
  * @returns {BundleToolPowers}
  * @alpha
  */
@@ -140,6 +134,7 @@ export const makeAmbientBundleToolPowers = (options = {}) => {
         return false;
       }
     },
+    loadModule = specifier => import(specifier),
     monotonicNow = () => performance.now(),
     now = () => Date.now(),
     pid = process.pid,
@@ -148,6 +143,7 @@ export const makeAmbientBundleToolPowers = (options = {}) => {
     delayMs,
     eventSink,
     isPidAlive,
+    loadModule,
     monotonicNow,
     now,
     pid,
@@ -156,23 +152,18 @@ export const makeAmbientBundleToolPowers = (options = {}) => {
 harden(makeAmbientBundleToolPowers);
 
 /**
- * @param {string} dest
- * @param {BundleCacheOptions} options
- * @param {Parameters<typeof wrappedMaker>[2]} loadModule
+ * @param {string} destPath
  * @param {BundleToolPowers} powers
+ * @param {BundleCacheOptions} [options]
  * @returns {Promise<BundleCache>}
  * @alpha
  */
-export const makeNodeBundleCache = async (
-  dest,
-  options,
-  loadModule,
-  powers,
-) => {
+export const makeNodeBundleCache = async (destPath, powers, options = {}) => {
   const {
     delayMs,
     eventSink = defaultBundleToolEventSink,
     isPidAlive,
+    loadModule,
     monotonicNow,
     now,
     pid,
@@ -234,12 +225,12 @@ export const makeNodeBundleCache = async (
   };
 
   const rawCache = await wrappedMaker(
-    dest,
+    destPath,
     { log, ...options },
     loadModule,
     pid,
   );
-  const lockRoot = path.resolve(dest, '.bundle-locks');
+  const lockRoot = path.resolve(destPath, '.bundle-locks');
   /** @type {Map<string, Promise<unknown>>} */
   const inProcessLoads = new Map();
   const { withLock } = makeDirectoryLock({
@@ -299,7 +290,7 @@ export const makeNodeBundleCache = async (
           log0,
           options0,
         );
-        const bundlePath = path.resolve(dest, bundleFileName);
+        const bundlePath = path.resolve(destPath, bundleFileName);
         return import(bundlePath).then(m => harden(m.default));
       });
       inProcessLoads.set(key, pending);
@@ -366,12 +357,7 @@ export const makeNodeBundleCache = async (
  * @alpha
  */
 export const unsafeMakeBundleCache = (dest, pid = process.pid) =>
-  makeNodeBundleCache(
-    dest,
-    {},
-    s => import(s),
-    makeAmbientBundleToolPowers({ pid }),
-  );
+  makeNodeBundleCache(dest, makeAmbientBundleToolPowers({ pid }));
 
 /**
  * This is a hack to share bundles across multiple SwingSet instances. It is

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -1,9 +1,10 @@
 import { makeNodeBundleCache as wrappedMaker } from '@endo/bundle-source/cache.js';
 import styles from 'ansi-styles'; // less authority than 'chalk'
-import { mkdir, readFile, rm, stat, writeFile } from 'fs/promises';
+import * as fsPromises from 'fs/promises';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import { setTimeout as delay } from 'timers/promises';
+import { makeDirectoryLock } from '@agoric/internal/src/build-cache.js';
 
 /**
  * @import {EReturn} from '@endo/far';
@@ -31,18 +32,135 @@ import { setTimeout as delay } from 'timers/promises';
  *   loadRegistry: <T extends Record<string, BundleRegistryEntry>>(registry: T) => Promise<LoadedRegistryBundles<T>>;
  * }} BundleCache
  */
-
-const BUNDLE_LOCK_ACQUIRE_TIMEOUT_MS = 5 * 60_000;
-const BUNDLE_STALE_LOCK_MS = 60_000;
+/**
+ * @typedef {{
+ *   onBundleToolEvent?: (event: Record<string, unknown>) => void,
+ * }} BundleToolEventSink
+ */
+/**
+ * @typedef {{
+ *   delayMs: (ms: number) => Promise<unknown>,
+ *   eventSink?: BundleToolEventSink,
+ *   isPidAlive: (pid: number) => boolean,
+ *   monotonicNow: () => number,
+ *   now: () => number,
+ *   pid: number,
+ * }} BundleToolPowers
+ */
 
 /**
  * @param {string} dest
  * @param {Parameters<typeof wrappedMaker>[1]} options
  * @param {Parameters<typeof wrappedMaker>[2]} loadModule
- * @param {number} [pid]
+ * @param {BundleToolPowers} powers
  * @returns {Promise<BundleCache>}
  */
-export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
+const BUNDLE_LOCK_ACQUIRE_TIMEOUT_MS = 5 * 60_000;
+const BUNDLE_STALE_LOCK_MS = 60_000;
+
+const defaultBundleToolEventSink = {
+  onBundleToolEvent: event => {
+    if (
+      event.type !== 'bundle-source-log' &&
+      event.type !== 'registry-loaded'
+    ) {
+      return;
+    }
+    const { args = [], phase = '[check]', type } = event;
+    if (type === 'bundle-source-log') {
+      const joined = args.map(arg => String(arg)).join(' ');
+      if (joined.includes(' valid:')) {
+        return;
+      }
+    }
+    const flattened = args.map(arg =>
+      // Don't print stack traces.
+      arg instanceof Error ? arg.message : arg,
+    );
+    console.log(
+      `${styles.dim.open}[bundleTool]${phase}`,
+      ...flattened,
+      styles.dim.close,
+    );
+  },
+};
+harden(defaultBundleToolEventSink);
+
+const inferLogPhase = args => {
+  const joined = args.map(arg => String(arg)).join(' ');
+  let phase = '[check]';
+  if (joined.includes(' add:') || joined.includes(' bundled ')) {
+    phase = '[rebuilt]';
+  }
+  return phase;
+};
+harden(inferLogPhase);
+
+/**
+ * @param {{
+ *   delayMs?: (ms: number) => Promise<unknown>,
+ *   eventSink?: BundleToolEventSink,
+ *   isPidAlive?: (pid: number) => boolean,
+ *   monotonicNow?: () => number,
+ *   now?: () => number,
+ *   pid?: number,
+ * }} [options]
+ * @returns {BundleToolPowers}
+ * @alpha
+ */
+export const makeAmbientBundleToolPowers = (options = {}) => {
+  const {
+    delayMs = ms => delay(ms),
+    eventSink = defaultBundleToolEventSink,
+    isPidAlive = lockPid => {
+      if (!Number.isInteger(lockPid) || lockPid <= 0) {
+        return false;
+      }
+      try {
+        process.kill(lockPid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    monotonicNow = () => performance.now(),
+    now = () => Date.now(),
+    pid = process.pid,
+  } = options;
+  return harden({
+    delayMs,
+    eventSink,
+    isPidAlive,
+    monotonicNow,
+    now,
+    pid,
+  });
+};
+harden(makeAmbientBundleToolPowers);
+
+/**
+ * @param {string} dest
+ * @param {Parameters<typeof wrappedMaker>[1]} options
+ * @param {Parameters<typeof wrappedMaker>[2]} loadModule
+ * @param {BundleToolPowers} powers
+ * @returns {Promise<BundleCache>}
+ * @alpha
+ */
+export const makeNodeBundleCache = async (
+  dest,
+  options,
+  loadModule,
+  powers,
+) => {
+  const {
+    delayMs,
+    eventSink = defaultBundleToolEventSink,
+    isPidAlive,
+    monotonicNow,
+    now,
+    pid,
+  } = powers;
+
   /** @param {string} sourceSpec */
   const canonicalizeSourceSpec = sourceSpec => {
     if (sourceSpec.startsWith('file:')) {
@@ -66,27 +184,16 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
     }
   };
 
+  const onEvent = eventSink.onBundleToolEvent || (() => {});
   const log = (...args) => {
-    const joined = args.map(arg => String(arg)).join(' ');
-    const isCacheHit = joined.includes(' valid:');
-    if (isCacheHit) {
-      return;
-    }
-    let phase = '[check]';
-    if (joined.includes(' add:') || joined.includes(' bundled ')) {
-      phase = '[rebuilt]';
-    }
-    const flattened = args.map(arg =>
-      // Don't print stack traces.
-      arg instanceof Error ? arg.message : arg,
-    );
-    console.log(
-      // Make all messages prefixed and dim.
-      `${styles.dim.open}[bundleTool]${phase}`,
-      ...flattened,
-      styles.dim.close,
-    );
+    onEvent({
+      type: 'bundle-source-log',
+      args,
+      phase: inferLogPhase(args),
+      timestamp: now(),
+    });
   };
+
   const rawCache = await wrappedMaker(
     dest,
     { log, ...options },
@@ -96,98 +203,17 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
   const lockRoot = path.resolve(dest, '.bundle-locks');
   /** @type {Map<string, Promise<unknown>>} */
   const inProcessLoads = new Map();
-
-  /**
-   * @param {string} targetName
-   * @param {() => Promise<any>} duringLock
-   */
-  const withBundleLock = async (targetName, duringLock) => {
-    const lockName = `${encodeURIComponent(targetName)}.lock`;
-    const lockPath = path.resolve(lockRoot, lockName);
-    const ownerPath = path.resolve(lockPath, 'owner.json');
-    await mkdir(lockRoot, { recursive: true });
-    const started = performance.now();
-
-    const isPidAlive = lockPid => {
-      if (!Number.isInteger(lockPid) || lockPid <= 0) {
-        return false;
-      }
-      try {
-        process.kill(lockPid, 0);
-        return true;
-      } catch {
-        return false;
-      }
-    };
-
-    const maybeBreakStaleLock = async () => {
-      const ownerTxt = await readFile(ownerPath, 'utf8').catch(() => undefined);
-      let lockInfo;
-      if (typeof ownerTxt === 'string') {
-        try {
-          lockInfo = JSON.parse(ownerTxt);
-        } catch {
-          // Another process may be in the middle of writing owner.json.
-          // Treat malformed data as unknown owner and rely on age checks below.
-          lockInfo = undefined;
-        }
-      }
-      if (
-        lockInfo &&
-        Number.isInteger(lockInfo.pid) &&
-        !isPidAlive(lockInfo.pid)
-      ) {
-        await rm(lockPath, { recursive: true, force: true });
-        return true;
-      }
-      try {
-        const st = await stat(lockPath);
-        const ageMs = Date.now() - st.mtimeMs;
-        if (ageMs >= BUNDLE_STALE_LOCK_MS) {
-          await rm(lockPath, { recursive: true, force: true });
-          return true;
-        }
-      } catch {
-        return true;
-      }
-      return false;
-    };
-
-    // Cross-process lock via mkdir(). Retriable on EEXIST.
-    for (;;) {
-      try {
-        await mkdir(lockPath);
-        await writeFile(
-          ownerPath,
-          JSON.stringify({ pid: process.pid, createdAt: Date.now() }),
-          'utf8',
-        );
-        break;
-      } catch (e) {
-        if (e && typeof e === 'object' && 'code' in e && e.code === 'EEXIST') {
-          const brokeStaleLock = await maybeBreakStaleLock();
-          if (brokeStaleLock) {
-            continue;
-          }
-          const waitedMs = performance.now() - started;
-          if (waitedMs >= BUNDLE_LOCK_ACQUIRE_TIMEOUT_MS) {
-            throw Error(
-              `Timed out waiting for bundle lock ${lockPath} after ${waitedMs}ms`,
-            );
-          }
-          await delay(20);
-          continue;
-        }
-        throw e;
-      }
-    }
-
-    try {
-      return await duringLock();
-    } finally {
-      await rm(lockPath, { recursive: true, force: true });
-    }
-  };
+  const { withLock } = makeDirectoryLock({
+    fs: fsPromises,
+    delayMs,
+    now,
+    pid,
+    isPidAlive,
+    lockRoot,
+    staleLockMs: BUNDLE_STALE_LOCK_MS,
+    acquireTimeoutMs: BUNDLE_LOCK_ACQUIRE_TIMEOUT_MS,
+    onEvent,
+  });
 
   const cache = harden({
     ...rawCache,
@@ -195,7 +221,7 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
       const canonicalRootPath = canonicalizeSourceSpec(rootPath);
       const resolvedTargetName =
         targetName || path.basename(canonicalRootPath, '.js');
-      return withBundleLock(resolvedTargetName, () =>
+      return withLock(resolvedTargetName, () =>
         rawCache.add(canonicalRootPath, resolvedTargetName, log0, options0),
       );
     },
@@ -203,7 +229,7 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
       const canonicalRootPath = canonicalizeSourceSpec(rootPath);
       const resolvedTargetName =
         targetName || path.basename(canonicalRootPath, '.js');
-      return withBundleLock(resolvedTargetName, () =>
+      return withLock(resolvedTargetName, () =>
         rawCache.validateOrAdd(
           canonicalRootPath,
           resolvedTargetName,
@@ -223,7 +249,7 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
       if (found) {
         return found;
       }
-      const pending = withBundleLock(resolvedTargetName, async () => {
+      const pending = withLock(resolvedTargetName, async () => {
         const { bundleFileName } = await rawCache.validateOrAdd(
           canonicalRootPath,
           resolvedTargetName,
@@ -250,7 +276,7 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
    * @returns {Promise<LoadedRegistryBundles<T>>}
    */
   const loadRegistry = async registry => {
-    const started = performance.now();
+    const started = monotonicNow();
     await null;
     try {
       const loaded = await Promise.all(
@@ -270,11 +296,16 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
         harden(Object.fromEntries(loaded))
       );
     } finally {
-      const elapsedMs = performance.now() - started;
-      console.log(
-        `${styles.dim.open}[bundleTool][registry] loaded ${Object.keys(registry).length} bundle(s) in ${elapsedMs}ms`,
-        styles.dim.close,
-      );
+      const elapsedMs = monotonicNow() - started;
+      onEvent({
+        type: 'registry-loaded',
+        phase: '[registry]',
+        args: [
+          `loaded ${Object.keys(registry).length} bundle(s) in ${elapsedMs}ms`,
+        ],
+        elapsedMs,
+        bundleCount: Object.keys(registry).length,
+      });
     }
   };
   return /** @type {BundleCache} */ (
@@ -285,41 +316,19 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
   );
 };
 
-/** @type {Map<string, Promise<BundleCache>>} */
-const providedCaches = new Map();
-
 /**
- * Make a new bundle cache for the destination. If there is already one for that
- * destination, return it.
- *
  * @param {string} dest
- * @param {object} options
- * @param {string} [options.format]
- * @param {boolean} [options.dev]
- * @param {number} [options.byteLimit=490_000] - Maximum bundle size in bytes before
- *   falling back to optimizations that may reduce legibility.
- * @param {(id: string) => Promise<any>} loadModule
  * @param {number} [pid]
  * @returns {Promise<BundleCache>}
+ * @alpha
  */
-export const provideBundleCache = (dest, options, loadModule, pid) => {
-  const uniqueDest = [dest, options.format, options.dev].join('-');
-  // store the promise instead of awaiting to prevent a race
-  let bundleCache = providedCaches.get(uniqueDest);
-  if (!bundleCache) {
-    bundleCache = makeNodeBundleCache(dest, options, loadModule, pid);
-    providedCaches.set(uniqueDest, bundleCache);
-  }
-  return bundleCache;
-};
-harden(provideBundleCache);
-
-/**
- * @param {string} dest
- * @returns {Promise<BundleCache>}
- */
-export const unsafeMakeBundleCache = dest =>
-  makeNodeBundleCache(dest, {}, s => import(s));
+export const unsafeMakeBundleCache = (dest, pid = process.pid) =>
+  makeNodeBundleCache(
+    dest,
+    {},
+    s => import(s),
+    makeAmbientBundleToolPowers({ pid }),
+  );
 
 /**
  * This is a hack to share bundles across multiple SwingSet instances. It is
@@ -344,6 +353,7 @@ export const sharedBundleCachePath = fileURLToPath(
  * separately for use in other contexts that need to know where the shared
  * bundles are located, but that also makes it more likely to cause conflicts if
  * used in multiple places at once.
+ * @alpha
  */
 export const unsafeSharedBundleCache = unsafeMakeBundleCache(
   sharedBundleCachePath,

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -1,6 +1,7 @@
 import { makeNodeBundleCache as wrappedMaker } from '@endo/bundle-source/cache.js';
 import styles from 'ansi-styles'; // less authority than 'chalk'
 import * as fsPromises from 'fs/promises';
+import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import { setTimeout as delay } from 'timers/promises';
@@ -71,13 +72,6 @@ import { makeDirectoryLock } from '@agoric/internal/src/build-cache.js';
  * }} BundleToolPowers
  */
 
-/**
- * @param {string} dest
- * @param {BundleCacheOptions} options
- * @param {Parameters<typeof wrappedMaker>[2]} loadModule
- * @param {BundleToolPowers} powers
- * @returns {Promise<BundleCache>}
- */
 const BUNDLE_LOCK_ACQUIRE_TIMEOUT_MS = 5 * 60_000;
 const BUNDLE_STALE_LOCK_MS = 60_000;
 
@@ -208,6 +202,28 @@ export const makeNodeBundleCache = async (
   };
 
   const onEvent = eventSink.onBundleToolEvent || (() => {});
+  const optionsKeyFor = options0 => {
+    // Include options in the key on purpose: bundle output may differ by
+    // bundle-source options, and correctness prefers over-segmentation over
+    // accidental cache aliasing.
+    try {
+      return JSON.stringify(options0 || {});
+    } catch {
+      return '[unstringifiable-options]';
+    }
+  };
+  const sanitizeName = name => name.replace(/[^a-zA-Z0-9._-]/g, '-');
+  const getTargetNames = (canonicalRootPath, targetName, options0) => {
+    const requestedTargetName =
+      targetName || path.basename(canonicalRootPath, '.js');
+    const optionsKey = optionsKeyFor(options0);
+    const hashKey = createHash('sha256')
+      .update(`${canonicalRootPath}\n${optionsKey}`)
+      .digest('hex')
+      .slice(0, 12);
+    const cacheTargetName = `${sanitizeName(requestedTargetName)}-${hashKey}`;
+    return harden({ requestedTargetName, cacheTargetName, optionsKey });
+  };
   const log = (...args) => {
     onEvent({
       type: 'bundle-source-log',
@@ -242,20 +258,26 @@ export const makeNodeBundleCache = async (
     ...rawCache,
     add: (rootPath, targetName, log0, options0) => {
       const canonicalRootPath = canonicalizeSourceSpec(rootPath);
-      const resolvedTargetName =
-        targetName || path.basename(canonicalRootPath, '.js');
-      return withLock(resolvedTargetName, () =>
-        rawCache.add(canonicalRootPath, resolvedTargetName, log0, options0),
+      const { requestedTargetName, cacheTargetName } = getTargetNames(
+        canonicalRootPath,
+        targetName,
+        options0,
+      );
+      return withLock(requestedTargetName, () =>
+        rawCache.add(canonicalRootPath, cacheTargetName, log0, options0),
       );
     },
     validateOrAdd: (rootPath, targetName, log0, options0) => {
       const canonicalRootPath = canonicalizeSourceSpec(rootPath);
-      const resolvedTargetName =
-        targetName || path.basename(canonicalRootPath, '.js');
-      return withLock(resolvedTargetName, () =>
+      const { requestedTargetName, cacheTargetName } = getTargetNames(
+        canonicalRootPath,
+        targetName,
+        options0,
+      );
+      return withLock(requestedTargetName, () =>
         rawCache.validateOrAdd(
           canonicalRootPath,
-          resolvedTargetName,
+          cacheTargetName,
           log0,
           options0,
         ),
@@ -263,19 +285,17 @@ export const makeNodeBundleCache = async (
     },
     load: async (rootPath, targetName, log0, options0) => {
       const canonicalRootPath = canonicalizeSourceSpec(rootPath);
-      const resolvedTargetName =
-        targetName || path.basename(canonicalRootPath, '.js');
-      const key = `${resolvedTargetName}:${canonicalRootPath}:${JSON.stringify(
-        options0 || {},
-      )}`;
+      const { requestedTargetName, cacheTargetName, optionsKey } =
+        getTargetNames(canonicalRootPath, targetName, options0);
+      const key = `${cacheTargetName}:${canonicalRootPath}:${optionsKey}`;
       const found = inProcessLoads.get(key);
       if (found) {
         return found;
       }
-      const pending = withLock(resolvedTargetName, async () => {
+      const pending = withLock(requestedTargetName, async () => {
         const { bundleFileName } = await rawCache.validateOrAdd(
           canonicalRootPath,
-          resolvedTargetName,
+          cacheTargetName,
           log0,
           options0,
         );

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -11,7 +11,8 @@
   "exports": {
     "./src/entrypoint.js": "./src/entrypoint.js",
     "./src/helpers.js": "./src/helpers.js",
-    "./src/lib/index.js": "./src/lib/index.js"
+    "./src/lib/index.js": "./src/lib/index.js",
+    "./src/proposals.js": "./src/proposals.js"
   },
   "files": [
     "src",

--- a/packages/agoric-cli/src/lib/bundles.js
+++ b/packages/agoric-cli/src/lib/bundles.js
@@ -96,7 +96,9 @@ export const statPlans = async path => {
     const plan = JSON.parse(fs.readFileSync(join(path, planfile), 'utf8'));
     console.log('\n**\nPLAN', plan.name);
     for (const bundle of plan.bundles) {
-      await statBundle(bundle.fileName);
+      if (bundle.fileName) {
+        await statBundle(bundle.fileName);
+      }
     }
   }
 };

--- a/packages/agoric-cli/src/proposals.js
+++ b/packages/agoric-cli/src/proposals.js
@@ -1,0 +1,393 @@
+/* eslint-env node */
+// @ts-check
+
+import childProcessAmbient from 'node:child_process';
+import fsRaw from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+import makeScratchPad from '@agoric/internal/src/scratch.js';
+
+import { makeScriptLoader } from './scripts.js';
+
+/** @import {promises as FsPromises} from 'node:fs' */
+/** @import {EndoZipBase64Bundle} from '@agoric/swingset-vat' */
+/** @import {CoreEvalSDKType} from '@agoric/cosmic-proto/swingset/swingset.js' */
+/** @import {CoreEvalMaterialRecord} from '@agoric/deploy-script-support/src/writeCoreEvalParts.js' */
+
+const consoleThis = console;
+const require = createRequire(import.meta.url);
+
+/**
+ * @typedef {'prefer-in-process' | 'in-process-only' | 'shell-only'} ProposalBuildMode
+ */
+
+/**
+ * @typedef {{
+ *   evals: CoreEvalSDKType[];
+ *   bundles: EndoZipBase64Bundle[];
+ *   dependencies: string[];
+ *   resolvedBuilderPath: string;
+ *   modeUsed: 'in-process' | 'shell';
+ * }} ProposalBuildResult
+ */
+
+/**
+ * @param {string} moduleSpecifier
+ * @param {string[]} paths
+ */
+const resolveModuleSpecifier = (moduleSpecifier, paths) => {
+  try {
+    // Use Node's CJS resolver semantics for parity with agoric script loading.
+    // This can differ from strict ESM resolution behavior.
+    return require.resolve(moduleSpecifier, { paths });
+  } catch (_err) {
+    if (path.isAbsolute(moduleSpecifier)) {
+      return path.normalize(moduleSpecifier);
+    }
+    return path.resolve(paths[0] || process.cwd(), moduleSpecifier);
+  }
+};
+
+/**
+ * @param {FsPromises} fs
+ * @param {string} filePath
+ */
+const readJSONFile = async (fs, filePath) =>
+  harden(JSON.parse(await fs.readFile(filePath, 'utf8')));
+
+/**
+ * @param {string} agoricRunOutput
+ */
+const parseProposalParts = agoricRunOutput => {
+  const evals = [
+    ...agoricRunOutput.matchAll(
+      /swingset-core-eval (?<permit>\S+) (?<script>\S+)/g,
+    ),
+  ].map(m => {
+    if (!m.groups) {
+      throw Error(`Invalid proposal output ${m[0]}`);
+    }
+    const { permit, script } = m.groups;
+    return { permit, script };
+  });
+
+  if (!evals.length) {
+    throw Error(
+      `No swingset-core-eval found in proposal output: ${agoricRunOutput}`,
+    );
+  }
+
+  const bundles = [
+    ...agoricRunOutput.matchAll(/swingset install-bundle @([^\n]+)/g),
+  ].map(([, bundle]) => bundle);
+  if (!bundles.length) {
+    throw Error(`No bundles found in proposal output: ${agoricRunOutput}`);
+  }
+
+  return { evals, bundles };
+};
+
+/**
+ * Resolve a file path relative to a working directory.
+ *
+ * @param {string | number} filePath
+ * @param {string} cwd
+ */
+const resolveFromCwd = (filePath, cwd) => path.resolve(cwd, String(filePath));
+
+/**
+ * @param {FsPromises} fs
+ * @param {string} cwd
+ * @param {string | number} filePath
+ */
+const readTextFromCwd = (fs, cwd, filePath) =>
+  fs.readFile(resolveFromCwd(filePath, cwd), 'utf8');
+
+/**
+ * @param {FsPromises} fs
+ * @param {string} cwd
+ * @param {string | number} filePath
+ */
+const readJSONFromCwd = (fs, cwd, filePath) =>
+  readJSONFile(fs, resolveFromCwd(filePath, cwd));
+
+/**
+ * Materialize in-memory proposal output from writeCoreEval callback records.
+ *
+ * @param {CoreEvalMaterialRecord[]} records
+ * @param {string} resolvedBuilderPath
+ * @param {string} cwd
+ */
+const materializeFromRecords = (records, resolvedBuilderPath, cwd) => {
+  if (!records.length) {
+    return undefined;
+  }
+  const dependencySet = new Set([resolvedBuilderPath]);
+  /** @type {CoreEvalSDKType[]} */
+  const evals = [];
+  /** @type {EndoZipBase64Bundle[]} */
+  const bundles = [];
+
+  for (const record of records) {
+    evals.push(record.eval);
+    for (const bundleInfo of record.bundles) {
+      bundles.push(bundleInfo.bundle);
+      const resolvedEntrypoint = resolveModuleSpecifier(bundleInfo.entrypoint, [
+        path.dirname(resolvedBuilderPath),
+        cwd,
+      ]);
+      dependencySet.add(resolvedEntrypoint);
+    }
+  }
+
+  return harden({
+    evals,
+    bundles,
+    dependencies: [...dependencySet].sort(),
+  });
+};
+
+/**
+ * @param {FsPromises} fs
+ * @param {string} outputDir
+ * @param {string} resolvedBuilderPath
+ */
+const readProposalMaterialsFromPlans = async (
+  fs,
+  outputDir,
+  resolvedBuilderPath,
+) => {
+  const files = await fs.readdir(outputDir);
+  const planFiles = files.filter(f => f.endsWith('-plan.json')).sort();
+
+  // TODO: Replace this with metadata capture during writeCoreEval execution.
+  if (!planFiles.length) {
+    throw Error(`No core-eval plan files found in ${outputDir}`);
+  }
+
+  const dependencySet = new Set([resolvedBuilderPath]);
+
+  /** @type {CoreEvalSDKType[]} */
+  const evals = [];
+  /** @type {EndoZipBase64Bundle[]} */
+  const bundles = [];
+
+  for (const planFile of planFiles) {
+    /**
+     * @type {{
+     *   permit: string;
+     *   script: string;
+     *   bundles: Array<{ entrypoint: string; fileName: string }>;
+     * }}
+     */
+    const plan = await readJSONFile(fs, path.join(outputDir, planFile));
+
+    const [jsonPermits, jsCode] = await Promise.all([
+      readTextFromCwd(fs, outputDir, plan.permit),
+      readTextFromCwd(fs, outputDir, plan.script),
+    ]);
+    evals.push({ json_permits: jsonPermits, js_code: jsCode });
+
+    for (const bundleInfo of plan.bundles) {
+      bundles.push(await readJSONFromCwd(fs, outputDir, bundleInfo.fileName));
+
+      const resolvedEntrypoint = resolveModuleSpecifier(bundleInfo.entrypoint, [
+        path.dirname(resolvedBuilderPath),
+        outputDir,
+      ]);
+      dependencySet.add(resolvedEntrypoint);
+    }
+  }
+
+  return harden({
+    evals,
+    bundles,
+    dependencies: [...dependencySet].sort(),
+  });
+};
+
+/**
+ * @param {{ fs: FsPromises; cwd: string; }} param0
+ */
+const makeScopedWriteFile = ({ fs, cwd }) => {
+  /** @type {typeof fs.writeFile} */
+  return async (filePath, data, options) => {
+    const abs = resolveFromCwd(String(filePath), cwd);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    return fs.writeFile(abs, data, options);
+  };
+};
+
+/**
+ * @param {{
+ *   fs: FsPromises;
+ *   cwd: string;
+ *   resolvedBuilderPath: string;
+ *   args: string[];
+ *   now: () => number;
+ *   cacheDir: string;
+ *   console: Console;
+ * }} param0
+ */
+const runInProcess = async ({
+  fs,
+  cwd,
+  resolvedBuilderPath,
+  args,
+  now,
+  cacheDir,
+  console,
+}) => {
+  const endowments = {
+    cacheDir,
+    now,
+    scriptArgs: args,
+    writeFile: makeScopedWriteFile({ fs, cwd }),
+  };
+
+  const runScript = makeScriptLoader(
+    [resolvedBuilderPath],
+    {
+      progname: 'agoric',
+      rawArgs: ['run', resolvedBuilderPath, ...args],
+      endowments,
+    },
+    { fs, console },
+  );
+
+  const homeP = Promise.resolve({ scratch: Promise.resolve(makeScratchPad()) });
+  await runScript({ home: homeP });
+
+  return readProposalMaterialsFromPlans(fs, cwd, resolvedBuilderPath);
+};
+
+/**
+ * @param {{
+ *   fs: FsPromises;
+ *   cwd: string;
+ *   resolvedBuilderPath: string;
+ *   args: string[];
+ *   childProcess: Pick<typeof import('node:child_process'), 'execFileSync'>;
+ * }} param0
+ */
+const runWithShell = async ({
+  fs,
+  cwd,
+  resolvedBuilderPath,
+  args,
+  childProcess,
+}) => {
+  const agoricEntrypoint = require.resolve('agoric/src/entrypoint.js');
+  const agoricRunOutput = childProcess.execFileSync(
+    agoricEntrypoint,
+    ['run', resolvedBuilderPath, ...args],
+    { cwd },
+  );
+
+  const built = parseProposalParts(agoricRunOutput.toString());
+
+  const evals = await Promise.all(
+    built.evals.map(async ({ permit, script }) => {
+      const [permits, code] = await Promise.all(
+        [permit, script].map(filePath => readTextFromCwd(fs, cwd, filePath)),
+      );
+      return { json_permits: permits, js_code: code };
+    }),
+  );
+
+  const bundles = await Promise.all(
+    built.bundles.map(async filePath => readJSONFromCwd(fs, cwd, filePath)),
+  );
+
+  return harden({
+    evals,
+    bundles,
+    dependencies: [resolvedBuilderPath],
+  });
+};
+
+/**
+ * @param {{
+ *   builderPath: string;
+ *   args?: string[];
+ *   cwd?: string;
+ *   mode?: ProposalBuildMode;
+ *   cacheDir?: string;
+ *   fs?: FsPromises;
+ *   now?: () => number;
+ *   console?: Console;
+ *   childProcess?: Pick<typeof import('node:child_process'), 'execFileSync'>;
+ * }} opts
+ * @returns {Promise<ProposalBuildResult>}
+ */
+export const buildCoreEvalProposal = async ({
+  builderPath,
+  args = [],
+  cwd = process.cwd(),
+  mode = 'prefer-in-process',
+  cacheDir = path.join(os.homedir(), '.agoric', 'cache'),
+  fs = fsRaw.promises,
+  now = Date.now,
+  console = globalThis.console,
+  childProcess = childProcessAmbient,
+}) => {
+  if (!builderPath) {
+    throw Error('builderPath is required');
+  }
+
+  const resolvedBuilderPath = resolveModuleSpecifier(builderPath, [cwd]);
+
+  const inProcess = async () =>
+    runInProcess({
+      fs,
+      cwd,
+      resolvedBuilderPath,
+      args,
+      now,
+      cacheDir,
+      console,
+    }).then(result => ({
+      ...result,
+      modeUsed: /** @type {const} */ ('in-process'),
+    }));
+
+  const shell = async () =>
+    runWithShell({
+      fs,
+      cwd,
+      resolvedBuilderPath,
+      args,
+      childProcess,
+    }).then(result => ({
+      ...result,
+      modeUsed: /** @type {const} */ ('shell'),
+    }));
+
+  switch (mode) {
+    case 'in-process-only': {
+      const result = await inProcess();
+      return harden({ ...result, resolvedBuilderPath });
+    }
+    case 'shell-only': {
+      const result = await shell();
+      return harden({ ...result, resolvedBuilderPath });
+    }
+    case 'prefer-in-process': {
+      try {
+        const result = await inProcess();
+        return harden({ ...result, resolvedBuilderPath });
+      } catch (err) {
+        console.warn(
+          `in-process proposal build failed, falling back to shell for ${resolvedBuilderPath}`,
+          err,
+        );
+        const result = await shell();
+        return harden({ ...result, resolvedBuilderPath });
+      }
+    }
+    default:
+      throw Error(`Invalid proposal build mode: ${mode}`);
+  }
+};

--- a/packages/agoric-cli/src/proposals.js
+++ b/packages/agoric-cli/src/proposals.js
@@ -54,8 +54,11 @@ const resolveModuleSpecifier = (moduleSpecifier, paths) => {
  * @param {FsPromises} fs
  * @param {string} filePath
  */
-const readJSONFile = async (fs, filePath) =>
-  harden(JSON.parse(await fs.readFile(filePath, 'utf8')));
+const readJSONFile = async (fs, filePath) => {
+  await null;
+  const data = await fs.readFile(filePath, 'utf8');
+  return harden(JSON.parse(data));
+};
 
 /**
  * @param {string} agoricRunOutput
@@ -240,9 +243,14 @@ const runInProcess = async ({
   cacheDir,
   console,
 }) => {
+  /** @type {CoreEvalMaterialRecord[]} */
+  const coreEvalRecords = [];
   const endowments = {
     cacheDir,
     now,
+    onWriteCoreEval: record => {
+      coreEvalRecords.push(record);
+    },
     scriptArgs: args,
     writeFile: makeScopedWriteFile({ fs, cwd }),
   };
@@ -259,6 +267,15 @@ const runInProcess = async ({
 
   const homeP = Promise.resolve({ scratch: Promise.resolve(makeScratchPad()) });
   await runScript({ home: homeP });
+
+  const materialized = materializeFromRecords(
+    coreEvalRecords,
+    resolvedBuilderPath,
+    cwd,
+  );
+  if (materialized) {
+    return materialized;
+  }
 
   return readProposalMaterialsFromPlans(fs, cwd, resolvedBuilderPath);
 };
@@ -330,12 +347,13 @@ export const buildCoreEvalProposal = async ({
   cacheDir = path.join(os.homedir(), '.agoric', 'cache'),
   fs = fsRaw.promises,
   now = Date.now,
-  console = globalThis.console,
+  console = consoleThis,
   childProcess = childProcessAmbient,
 }) => {
   if (!builderPath) {
     throw Error('builderPath is required');
   }
+  await null;
 
   const resolvedBuilderPath = resolveModuleSpecifier(builderPath, [cwd]);
 

--- a/packages/boot/README.md
+++ b/packages/boot/README.md
@@ -1,0 +1,58 @@
+# @aglocal/boot
+
+Bootstrap configuration and test utilities for Agoric chain tests.
+
+## Test Profiling
+
+`makeSwingsetTestKit` supports opt-in profiling for hotspot analysis.
+
+- Set `AGORIC_BOOT_TEST_PROFILE=1` to enable profiling.
+- Optionally set `AGORIC_BOOT_TEST_PROFILE_FILE=/absolute/path/trace.json` to control output location.
+
+If `AGORIC_BOOT_TEST_PROFILE_FILE` is not set, the trace is written to:
+
+`<cwd>/.cache/boot-test-profiles/bootstrap-supports-<pid>.trace.json`
+
+where `<cwd>` is the process working directory for the test run (often `packages/boot` for `yarn workspace @aglocal/boot test ...`).
+
+When profiling is disabled, no profiling file is written.
+
+### Trace Schema
+The profiling file is a [Chrome Trace Event JSON Object](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#heading=h.q8di1j2nawlp):
+
+```json
+{
+  "displayTimeUnit": "ms",
+  "traceEvents": [
+    {
+      "name": "process_name",
+      "ph": "M",
+      "pid": 12345,
+      "tid": 0,
+      "ts": 0,
+      "args": {
+        "name": "agoric-boot-tests"
+      }
+    },
+    {
+      "name": "makeSwingsetTestKit.buildSwingset",
+      "cat": "agoric.boot.test-supports",
+      "ph": "X",
+      "pid": 12345,
+      "tid": 0,
+      "ts": 8710.2,
+      "dur": 6215905.4,
+      "args": {
+        "configPath": "bundles/config....json",
+        "verbose": false
+      }
+    }
+  ]
+}
+```
+Notes:
+- `"displayTimeUnit": "ms"` is a viewer hint.
+- `cat` is a comma-separated list of categories that can be used for filtering.
+- `"ph": "M"` designates a [Metadata event](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#heading=h.xqopa5m0e28f); `"ph": "X"` designates a [Complete event](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#heading=h.lpfof2aylapb).
+- `ts` and `dur` indicate start time and duration (respectively) in microseconds as measured on a monotonic clock.
+Further reading is available at [The Trace Event Profiling Tool (about:tracing)](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool/) and [Trace Event Best Practices](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/trace_events.md).

--- a/packages/boot/test/configs.test.js
+++ b/packages/boot/test/configs.test.js
@@ -128,8 +128,7 @@ const checkBundle = async (t, sourceSpec, seen, name, configSpec) => {
     seen.add(targetName);
 
     t.log(configSpec, ': check bundle:', name, basename(sourceSpec));
-    await bundleCache.load(sourceSpec, targetName, noLog);
-    const meta = await bundleCache.validate(targetName);
+    const meta = await bundleCache.validateOrAdd(sourceSpec, targetName, noLog);
     t.truthy(meta, name);
 
     for (const item of meta.contents) {

--- a/packages/boot/test/tools/proposal-extractor-cache.test.ts
+++ b/packages/boot/test/tools/proposal-extractor-cache.test.ts
@@ -1,0 +1,223 @@
+/* eslint-env node */
+
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { createHash } from 'node:crypto';
+import * as fsPromises from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { makeProposalExtractor } from '../../tools/supports.js';
+
+const sha256 = (value: string) =>
+  createHash('sha256').update(value).digest('hex');
+const importSpec = createRequire(import.meta.url).resolve;
+
+const makeFixture = async t => {
+  const root = await mkdtemp(join(os.tmpdir(), 'boot-proposal-cache-'));
+  t.teardown(async () => rm(root, { recursive: true, force: true }));
+
+  const builderPath = join(root, 'builder.js');
+  const dependencyPath = join(root, 'dependency.txt');
+  await writeFile(builderPath, 'export default null;\n', 'utf8');
+  await writeFile(dependencyPath, 'v1\n', 'utf8');
+
+  const cacheRoot = join(root, '.cache');
+  await mkdir(cacheRoot, { recursive: true });
+
+  return { root, builderPath, dependencyPath, cacheRoot };
+};
+
+test('proposal extractor caches materials on disk and reuses across instances', async t => {
+  const { builderPath, dependencyPath, cacheRoot } = await makeFixture(t);
+
+  let builds = 0;
+  const fakeBuilder: any = async ({ mode }) => {
+    builds += 1;
+    return harden({
+      bundles: [{ moduleFormat: 'endoZipBase64', endoZipBase64: 'AAAA' }],
+      dependencies: [dependencyPath],
+      evals: [
+        {
+          json_permits: '{"consume":{}}',
+          js_code: 'harden({});',
+        },
+      ],
+      modeUsed: mode === 'shell-only' ? 'shell' : 'in-process',
+      resolvedBuilderPath: builderPath,
+    });
+  };
+
+  const extractorA = makeProposalExtractor(
+    {
+      buildCoreEvalProposal: fakeBuilder,
+      childProcess: {
+        execFileSync: () => {
+          throw Error('shell path should not be used');
+        },
+      },
+      fs: fsPromises,
+    },
+    import.meta.url,
+    { cacheRoot },
+  );
+
+  const first = await extractorA(builderPath, ['--example']);
+  const second = await extractorA(builderPath, ['--example']);
+  t.is(builds, 1);
+  t.deepEqual(second, first);
+
+  const extractorB = makeProposalExtractor(
+    {
+      buildCoreEvalProposal: fakeBuilder,
+      childProcess: {
+        execFileSync: () => {
+          throw Error('shell path should not be used');
+        },
+      },
+      fs: fsPromises,
+    },
+    import.meta.url,
+    { cacheRoot },
+  );
+
+  const third = await extractorB(builderPath, ['--example']);
+  t.is(builds, 1);
+  t.deepEqual(third, first);
+});
+
+test('proposal extractor invalidates cache when dependency content changes', async t => {
+  const { builderPath, dependencyPath, cacheRoot } = await makeFixture(t);
+
+  let builds = 0;
+  const fakeBuilder: any = async () => {
+    builds += 1;
+    return harden({
+      bundles: [{ moduleFormat: 'endoZipBase64', endoZipBase64: 'AAAA' }],
+      dependencies: [dependencyPath],
+      evals: [{ json_permits: '{}', js_code: `harden({ build: ${builds} });` }],
+      modeUsed: 'in-process',
+      resolvedBuilderPath: builderPath,
+    });
+  };
+
+  const extractor = makeProposalExtractor(
+    {
+      buildCoreEvalProposal: fakeBuilder,
+      childProcess: {
+        execFileSync: () => {
+          throw Error('shell path should not be used');
+        },
+      },
+      fs: fsPromises,
+    },
+    import.meta.url,
+    { cacheRoot },
+  );
+
+  await extractor(builderPath, []);
+  await writeFile(dependencyPath, 'v2\n', 'utf8');
+  await extractor(builderPath, []);
+
+  t.is(builds, 2);
+});
+
+test('prefer-in-process falls back to shell-only mode when builder throws', async t => {
+  const { builderPath, dependencyPath, cacheRoot } = await makeFixture(t);
+
+  const modes: string[] = [];
+  const fakeBuilder: any = async ({ mode }) => {
+    modes.push(mode || 'missing');
+    if (mode !== 'shell-only') {
+      throw Error('simulate in-process failure');
+    }
+    return harden({
+      bundles: [{ moduleFormat: 'endoZipBase64', endoZipBase64: 'AAAA' }],
+      dependencies: [dependencyPath],
+      evals: [{ json_permits: '{}', js_code: 'harden({ fallback: true });' }],
+      modeUsed: 'shell',
+      resolvedBuilderPath: builderPath,
+    });
+  };
+
+  const extractor = makeProposalExtractor(
+    {
+      buildCoreEvalProposal: fakeBuilder,
+      childProcess: {
+        execFileSync: () => {
+          throw Error('shell child process should not run in this unit test');
+        },
+      },
+      fs: fsPromises,
+    },
+    import.meta.url,
+    { cacheRoot, mode: 'prefer-in-process' },
+  );
+
+  const materials = await extractor(builderPath, []);
+  t.true(materials.evals[0]?.js_code.includes('fallback'));
+  t.deepEqual(modes, ['prefer-in-process', 'shell-only']);
+});
+
+test('stale/dead lock is recovered before building', async t => {
+  const { builderPath, dependencyPath, cacheRoot } = await makeFixture(t);
+
+  const args = ['--recover-lock'];
+  const mode = 'prefer-in-process';
+  const schemaVersion = 'v1';
+  const resolvedBuilderPath = importSpec(builderPath);
+  const cacheKey = sha256(
+    JSON.stringify({
+      args,
+      builderPath: resolvedBuilderPath,
+      mode,
+      schemaVersion,
+    }),
+  );
+  const lockPath = join(
+    cacheRoot,
+    '.locks',
+    `${encodeURIComponent(cacheKey)}.lock`,
+  );
+  await mkdir(lockPath, { recursive: true });
+  await writeFile(
+    join(lockPath, 'owner.json'),
+    JSON.stringify({ pid: 999_999_999, createdAt: Date.now() }),
+    'utf8',
+  );
+
+  let builds = 0;
+  const fakeBuilder: any = async () => {
+    builds += 1;
+    return harden({
+      bundles: [{ moduleFormat: 'endoZipBase64', endoZipBase64: 'AAAA' }],
+      dependencies: [dependencyPath],
+      evals: [
+        { json_permits: '{}', js_code: 'harden({ lockRecovered: true });' },
+      ],
+      modeUsed: 'in-process',
+      resolvedBuilderPath: builderPath,
+    });
+  };
+
+  const extractor = makeProposalExtractor(
+    {
+      buildCoreEvalProposal: fakeBuilder,
+      childProcess: {
+        execFileSync: () => {
+          throw Error('shell path should not be used');
+        },
+      },
+      fs: fsPromises,
+    },
+    import.meta.url,
+    { cacheRoot },
+  );
+
+  await extractor(builderPath, args);
+  t.is(builds, 1);
+
+  const lockStats = await stat(lockPath).catch(() => undefined);
+  t.is(lockStats, undefined);
+});

--- a/packages/boot/test/tools/proposal-extractor-cache.test.ts
+++ b/packages/boot/test/tools/proposal-extractor-cache.test.ts
@@ -31,6 +31,7 @@ const makeFixture = async t => {
 
 test('proposal extractor caches materials on disk and reuses across instances', async t => {
   const { builderPath, dependencyPath, cacheRoot } = await makeFixture(t);
+  const cacheEvents: Array<{ type: string; reason?: string }> = [];
 
   let builds = 0;
   const fakeBuilder: any = async ({ mode }) => {
@@ -54,13 +55,16 @@ test('proposal extractor caches materials on disk and reuses across instances', 
       buildCoreEvalProposal: fakeBuilder,
       childProcess: {
         execFileSync: () => {
-          throw Error('shell path should not be used');
+          throw Error('shell mode should not be used');
         },
       },
       fs: fsPromises,
     },
     import.meta.url,
-    { cacheRoot },
+    {
+      cacheRoot,
+      onCacheEvent: event => cacheEvents.push(event),
+    },
   );
 
   const first = await extractorA(builderPath, ['--example']);
@@ -73,7 +77,7 @@ test('proposal extractor caches materials on disk and reuses across instances', 
       buildCoreEvalProposal: fakeBuilder,
       childProcess: {
         execFileSync: () => {
-          throw Error('shell path should not be used');
+          throw Error('shell mode should not be used');
         },
       },
       fs: fsPromises,
@@ -85,8 +89,78 @@ test('proposal extractor caches materials on disk and reuses across instances', 
   const third = await extractorB(builderPath, ['--example']);
   t.is(builds, 1);
   t.deepEqual(third, first);
+  t.true(cacheEvents.some(event => event.type === 'proposal-cache-miss'));
+  t.true(cacheEvents.some(event => event.type === 'proposal-cache-hit'));
 });
 
+test('proposal cache key and on-disk cache contents are explicit', async t => {
+  const { builderPath, dependencyPath, cacheRoot } = await makeFixture(t);
+  const args = ['--key-shape'];
+  const mode = 'prefer-in-process';
+  const schemaVersion = 'v1';
+  const resolvedBuilderPath = importSpec(builderPath);
+  const expectedCacheKey = sha256(
+    JSON.stringify({
+      args,
+      builderPath: resolvedBuilderPath,
+      mode,
+      schemaVersion,
+    }),
+  );
+  const builtMaterials: ProposalBuilderResult = harden({
+    bundles: [
+      {
+        moduleFormat: 'endoZipBase64',
+        endoZipBase64: 'AAAA',
+        endoZipBase64Sha512: 'fake-sha512-for-test',
+      },
+    ],
+    dependencies: [dependencyPath],
+    evals: [{ json_permits: '{}', js_code: 'harden({ cached: true });' }],
+    modeUsed: 'in-process',
+    resolvedBuilderPath,
+  });
+
+  const extractor = makeProposalExtractor(
+    {
+      buildCoreEvalProposal: async () => builtMaterials,
+      childProcess: {
+        execFileSync: () => {
+          throw Error('shell mode should not be used');
+        },
+      },
+      fs: fsPromises,
+    },
+    import.meta.url,
+    { cacheRoot },
+  );
+
+  await extractor(builderPath, args);
+
+  const cacheEntryDir = join(cacheRoot, expectedCacheKey);
+  const metadataPath = join(cacheEntryDir, 'metadata.json');
+  const materialsPath = join(cacheEntryDir, 'materials.json');
+  const metadata = JSON.parse(await fsPromises.readFile(metadataPath, 'utf8'));
+  const materials = JSON.parse(
+    await fsPromises.readFile(materialsPath, 'utf8'),
+  );
+
+  t.like(metadata, {
+    args,
+    builderPath: resolvedBuilderPath,
+    mode,
+    schemaVersion,
+    toolVersion: 'boot-proposal-cache-v1',
+  });
+  t.deepEqual(
+    metadata.dependencies.map(dep => dep.path).sort(),
+    [resolvedBuilderPath, dependencyPath].sort(),
+  );
+  t.deepEqual(materials, {
+    evals: builtMaterials.evals,
+    bundles: builtMaterials.bundles,
+  });
+});
 test('proposal extractor invalidates cache when dependency content changes', async t => {
   const { builderPath, dependencyPath, cacheRoot } = await makeFixture(t);
 
@@ -107,7 +181,7 @@ test('proposal extractor invalidates cache when dependency content changes', asy
       buildCoreEvalProposal: fakeBuilder,
       childProcess: {
         execFileSync: () => {
-          throw Error('shell path should not be used');
+          throw Error('shell mode should not be used');
         },
       },
       fs: fsPromises,
@@ -145,9 +219,7 @@ test('prefer-in-process falls back to shell-only mode when builder throws', asyn
     {
       buildCoreEvalProposal: fakeBuilder,
       childProcess: {
-        execFileSync: () => {
-          throw Error('shell child process should not run in this unit test');
-        },
+        execFileSync: (() => t.fail('shell mode should not be used')) as any,
       },
       fs: fsPromises,
     },
@@ -162,6 +234,7 @@ test('prefer-in-process falls back to shell-only mode when builder throws', asyn
 
 test('stale/dead lock is recovered before building', async t => {
   const { builderPath, dependencyPath, cacheRoot } = await makeFixture(t);
+  const cacheEvents: Array<{ type: string; reason?: string }> = [];
 
   const args = ['--recover-lock'];
   const mode = 'prefer-in-process';
@@ -206,17 +279,25 @@ test('stale/dead lock is recovered before building', async t => {
       buildCoreEvalProposal: fakeBuilder,
       childProcess: {
         execFileSync: () => {
-          throw Error('shell path should not be used');
+          throw Error('shell mode should not be used');
         },
       },
       fs: fsPromises,
     },
     import.meta.url,
-    { cacheRoot },
+    {
+      cacheRoot,
+      onCacheEvent: event => cacheEvents.push(event),
+    },
   );
 
   await extractor(builderPath, args);
   t.is(builds, 1);
+  t.true(
+    cacheEvents.some(
+      event => event.type === 'lock-broken' && event.reason === 'dead-owner',
+    ),
+  );
 
   const lockStats = await stat(lockPath).catch(() => undefined);
   t.is(lockStats, undefined);

--- a/packages/boot/test/tools/proposal-extractor-cache.test.ts
+++ b/packages/boot/test/tools/proposal-extractor-cache.test.ts
@@ -3,12 +3,15 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { createHash } from 'node:crypto';
 import * as fsPromises from 'node:fs/promises';
-import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import { join } from 'node:path';
 
-import { makeProposalExtractor } from '../../tools/supports.js';
+import {
+  makeProposalExtractor,
+  type ProposalBuilderResult,
+} from '../../tools/supports.js';
 
 const sha256 = (value: string) =>
   createHash('sha256').update(value).digest('hex');

--- a/packages/boot/tools/profiling-types.ts
+++ b/packages/boot/tools/profiling-types.ts
@@ -1,0 +1,124 @@
+/**
+ * @file Chromium Trace Event format types
+ * @see {@link https://chromium.googlesource.com/catapult/+/HEAD/tracing/README.md}
+ * @see {@link https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview}
+ */
+
+/**
+ * Common fields for all trace events.
+ */
+export interface TraceEventBase {
+  /** The process ID for the event. */
+  pid: number;
+  /** The thread ID for the event. */
+  tid: number;
+  /**
+   * The tracing clock timestamp of the event in microseconds.
+   * For metadata events, this is typically 0.
+   */
+  ts: number;
+  /**
+   * The event phase. This is a single character that determines
+   * how the event is interpreted.
+   */
+  ph: string;
+  /** The name of the event, shown in the trace viewer. */
+  name: string;
+  /**
+   * The event categories. This is a comma-separated list of categories
+   * used for filtering.
+   */
+  cat?: string;
+  /**
+   * Any arguments provided for the event. Some phases have
+   * specific argument requirements.
+   */
+  args?: Record<string, unknown>;
+  /**
+   * A fixed color name to use for the event.
+   * @see {@link https://github.com/catapult-project/catapult/blob/master/tracing/tracing/base/color_scheme.html}
+   */
+  cname?: string;
+  /**
+   * A thread-local ID used for associating events with each other.
+   * Typically used for async events.
+   */
+  id?: string | number;
+  /**
+   * A globally unique ID used for associating events across processes.
+   */
+  id2?: { global: string | number } | { local: string | number };
+  /**
+   * The scope of the event ID.
+   */
+  scope?: string;
+  /**
+   * The thread-local timestamp of the event in microseconds.
+   */
+  tts?: number;
+}
+
+/**
+ * Complete Event ('X'): Combined duration events.
+ */
+export interface TraceCompleteEvent extends TraceEventBase {
+  ph: 'X';
+  /** The duration of the event in microseconds. */
+  dur: number;
+  /** The thread-local duration of the event in microseconds. */
+  tdur?: number;
+}
+
+/**
+ * Instant Event ('i'): Events with no duration.
+ */
+export interface TraceInstantEvent extends TraceEventBase {
+  ph: 'i';
+  /** The scope of the instant event. */
+  s?: 'g' | 'p' | 't';
+}
+
+/**
+ * Metadata Event ('M'): Events used to annotate the trace.
+ */
+export interface TraceMetadataEvent extends TraceEventBase {
+  ph: 'M';
+  name:
+    | 'process_name'
+    | 'thread_name'
+    | 'process_labels'
+    | 'process_sort_index'
+    | 'thread_sort_index';
+}
+
+/**
+ * Async Event: Events that can overlap and occur on different threads.
+ * Uses 'b' (begin), 'n' (nestable begin), 'e' (end), 'f' (nestable end).
+ */
+export interface TraceAsyncEvent extends TraceEventBase {
+  ph: 'b' | 'n' | 'e' | 'f' | 'S' | 'T' | 'p' | 'F';
+}
+
+/**
+ * The root object of a Chromium Trace File.
+ */
+export interface TraceFile {
+  /**
+   * The list of trace events.
+   */
+  traceEvents: Array<
+    | TraceEventBase
+    | TraceCompleteEvent
+    | TraceMetadataEvent
+    | TraceInstantEvent
+    | TraceAsyncEvent
+  >;
+  /**
+   * A hint for the viewer about the time unit to use.
+   */
+  displayTimeUnit?: 'ms' | 'ns';
+  /**
+   * Other key-value pairs allowed at the root level.
+   */
+  [key: string]: unknown;
+}

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -501,9 +501,8 @@ const makeProposalCacheStore = ({
     if (!bundleCacheP) {
       bundleCacheP = makeNodeBundleCache(
         depFingerprintCacheDir,
-        {},
-        s => import(s),
         makeAmbientBundleToolPowers({
+          loadModule: s => import(s),
           eventSink: { onBundleToolEvent: () => {} },
         }),
       );

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -5,7 +5,7 @@ import childProcessAmbient from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { promises as fsAmbientPromises } from 'node:fs';
 import { createRequire } from 'node:module';
-import { basename, join, resolve as pathResolve } from 'node:path';
+import { basename, dirname, join, resolve as pathResolve } from 'node:path';
 import { inspect } from 'node:util';
 import tmp from 'tmp';
 
@@ -78,6 +78,11 @@ import type { ERef } from '@agoric/vow';
 import type { EProxy } from '@endo/eventual-send';
 import { FileSystemCache, NodeFetchCache } from 'node-fetch-cache';
 import { icaMocks, protoMsgMockMap, protoMsgMocks } from './ibc/mocks.js';
+import {
+  type TraceCompleteEvent,
+  type TraceFile,
+  type TraceMetadataEvent,
+} from './profiling-types.js';
 
 const tmpDir = makeTempDirFactory(tmp);
 
@@ -284,6 +289,146 @@ type ProposalExtractorEvent =
     };
 
 const PROPOSAL_CACHE_TOOL_VERSION = 'boot-proposal-cache-v1';
+// Profiling env vars are documented in packages/boot/README.md.
+const BOOT_PROFILE_ENV = 'AGORIC_BOOT_TEST_PROFILE';
+const BOOT_PROFILE_FILE_ENV = 'AGORIC_BOOT_TEST_PROFILE_FILE';
+
+// Chrome Trace Event format:
+// https://chromium.googlesource.com/catapult/+/HEAD/tracing/README.md
+interface BootProfileCompleteEvent extends TraceCompleteEvent {
+  cat: 'agoric.boot.test-supports';
+}
+
+interface BootProfileMetadataEvent extends TraceMetadataEvent {
+  args: { name: string };
+  pid: number;
+  tid: number;
+  ts: 0;
+}
+
+interface BootProfileTraceFile extends TraceFile {
+  displayTimeUnit: 'ms';
+  traceEvents: Array<BootProfileMetadataEvent | BootProfileCompleteEvent>;
+}
+
+interface BootProfiler {
+  measure: <T>(
+    name: string,
+    op: () => Promise<T> | T,
+    args?: Record<string, unknown>,
+  ) => Promise<T>;
+}
+
+const bootProfileSessions = new Map<
+  string,
+  {
+    events: BootProfileCompleteEvent[];
+    writeQueue: Promise<void>;
+  }
+>();
+
+const isEnabledProfileSetting = (value: string | undefined) => {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized !== '0' && normalized !== 'false' && normalized !== 'off';
+};
+
+const makeBootProfiler = ({
+  cwd = process.cwd(),
+  env = process.env,
+  fs = fsAmbientPromises,
+  pid = process.pid,
+}: {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  fs?: typeof import('node:fs/promises');
+  pid?: number;
+} = {}): BootProfiler => {
+  const enabled = isEnabledProfileSetting(env[BOOT_PROFILE_ENV]);
+  if (!enabled) {
+    return harden({
+      measure: async (_name, op) => op(),
+    });
+  }
+
+  const configuredPath = env[BOOT_PROFILE_FILE_ENV];
+  const profilePath = configuredPath
+    ? pathResolve(configuredPath)
+    : join(
+        cwd,
+        '.cache',
+        'boot-test-profiles',
+        `bootstrap-supports-${pid}.trace.json`,
+      );
+  const session =
+    bootProfileSessions.get(profilePath) ||
+    (() => {
+      const next = { events: [], writeQueue: Promise.resolve() };
+      bootProfileSessions.set(profilePath, next);
+      return next;
+    })();
+  const origin = performance.now();
+
+  const queueWrite = () => {
+    session.writeQueue = session.writeQueue
+      .catch(() => {})
+      .then(async () => {
+        const metadataEvents: BootProfileMetadataEvent[] = [
+          {
+            name: 'process_name',
+            ph: 'M',
+            pid,
+            tid: 0,
+            ts: 0,
+            args: { name: 'agoric-boot-tests' },
+          },
+          {
+            name: 'thread_name',
+            ph: 'M',
+            pid,
+            tid: 0,
+            ts: 0,
+            args: { name: 'main' },
+          },
+        ];
+        const traceFile: BootProfileTraceFile = {
+          displayTimeUnit: 'ms',
+          traceEvents: [...metadataEvents, ...session.events],
+        };
+        await fs.mkdir(dirname(profilePath), { recursive: true });
+        await fs.writeFile(
+          `${profilePath}`,
+          `${JSON.stringify(traceFile, null, 2)}\n`,
+          'utf8',
+        );
+      })
+      .catch(() => {});
+  };
+
+  return harden({
+    measure: async (name, op, args) => {
+      const start = performance.now();
+      try {
+        return await op();
+      } finally {
+        const end = performance.now();
+        session.events.push({
+          name,
+          args,
+          cat: 'agoric.boot.test-supports',
+          ph: 'X',
+          pid,
+          tid: 0,
+          ts: (start - origin) * 1000,
+          dur: (end - start) * 1000,
+        });
+        queueWrite();
+      }
+    },
+  });
+};
 
 const hashText = (text: string) =>
   createHash('sha256').update(text).digest('hex');
@@ -831,14 +976,24 @@ export const makeSwingsetTestKit = async <
   } = {},
 ) => {
   const importSpec = createRequire(resolveBase).resolve;
-  console.time('makeBaseSwingsetTestKit');
-  const configPath = await getNodeTestVaultsConfig({
-    bundleDir,
-    configPath: importSpec(configSpecifier),
-    discriminator: label,
-    defaultManagerType,
-    configOverrides,
-  });
+  const profiler = makeBootProfiler();
+  const configPath = await profiler.measure(
+    'makeSwingsetTestKit.getNodeTestVaultsConfig',
+    () =>
+      getNodeTestVaultsConfig({
+        bundleDir,
+        configPath: importSpec(configSpecifier),
+        discriminator: label,
+        defaultManagerType,
+        configOverrides,
+      }),
+    {
+      bundleDir,
+      configSpecifier,
+      defaultManagerType,
+      label,
+    },
+  );
   const swingStore = initSwingStore();
   const { kernelStorage, hostStorage } = swingStore;
   const { fromCapData } = boardSlottingMarshaller(slotToBoardRemote);
@@ -1103,33 +1258,46 @@ export const makeSwingsetTestKit = async <
     : undefined;
 
   const mailboxStorage = new Map();
-  const { controller, timer, bridgeInbound } = await buildSwingset(
-    // @ts-expect-error missing method 'getNextKey'
-    mailboxStorage,
-    bridgeOutbound,
-    kernelStorage,
-    configPath,
-    [],
-    {},
+  const { controller, timer, bridgeInbound } = await profiler.measure(
+    'makeSwingsetTestKit.buildSwingset',
+    () =>
+      buildSwingset(
+        // @ts-expect-error missing method 'getNextKey'
+        mailboxStorage,
+        bridgeOutbound,
+        kernelStorage,
+        configPath,
+        [],
+        {},
+        {
+          callerWillEvaluateCoreProposals: false,
+          debugName: 'TESTBOOT',
+          verbose,
+          slogSender,
+          profileVats,
+          debugVats,
+        },
+      ),
     {
-      callerWillEvaluateCoreProposals: false,
-      debugName: 'TESTBOOT',
+      configPath,
+      debugVatsCount: debugVats.length,
+      profileVatsCount: profileVats.length,
       verbose,
-      slogSender,
-      profileVats,
-      debugVats,
     },
   );
-
-  console.timeLog('makeBaseSwingsetTestKit', 'buildSwingset');
 
   // XXX This initial run() might not be necessary. Tests pass without it as of
   // 2025-02, but we suspect that `makeSwingsetTestKit` just isn't being
   // exercised in the right way.
-  await controller.run();
-  const runUtils = makeBootstrapRunUtils(controller, harness);
+  await profiler.measure('makeSwingsetTestKit.controller.run.initial', () =>
+    controller.run(),
+  );
+  const runUtils = makeBootstrapRunUtils<BootstrapVatItems>(
+    controller,
+    harness,
+  );
 
-  const buildProposal = makeProposalExtractor(
+  const extractProposal = makeProposalExtractor(
     {
       childProcess: childProcessAmbient,
       fs: fsAmbientPromises,
@@ -1141,6 +1309,12 @@ export const makeSwingsetTestKit = async <
       mode: proposalBuildMode,
     },
   );
+  const buildProposal = (builderPath: string, args: string[] = []) =>
+    profiler.measure(
+      'makeSwingsetTestKit.proposal.extract',
+      () => extractProposal(builderPath, args),
+      { argsCount: args.length, builderPath, mode: proposalBuildMode },
+    );
 
   type ProposalMaterials = Awaited<ReturnType<typeof buildProposal>>;
 
@@ -1154,9 +1328,15 @@ export const makeSwingsetTestKit = async <
 
     const proposal = harden(await proposalP);
 
-    for await (const bundle of proposal.bundles) {
-      await controller.validateAndInstallBundle(bundle);
-    }
+    await profiler.measure(
+      'makeSwingsetTestKit.proposal.installBundles',
+      async () => {
+        for (const bundle of proposal.bundles) {
+          await controller.validateAndInstallBundle(bundle);
+        }
+      },
+      { bundleCount: proposal.bundles.length },
+    );
     log('installed', proposal.bundles.length, 'bundles');
 
     log('executing proposal');
@@ -1168,11 +1348,13 @@ export const makeSwingsetTestKit = async <
     const coreEvalBridgeHandler = await EV.vat('bootstrap').consumeItem(
       'coreEvalBridgeHandler',
     );
-    await EV(coreEvalBridgeHandler).fromBridge(bridgeMessage);
+    await profiler.measure(
+      'makeSwingsetTestKit.proposal.executeCoreEval',
+      () => EV(coreEvalBridgeHandler).fromBridge(bridgeMessage),
+      { evalCount: proposal.evals.length },
+    );
     log(`proposal executed`);
   };
-
-  console.timeEnd('makeBaseSwingsetTestKit');
 
   let currentTime = 0n;
   const updateTimer = async time => {

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -1385,7 +1385,13 @@ export const makeSwingsetTestKit = async <
     await profiler.measure(
       'makeSwingsetTestKit.proposal.installBundles',
       async () => {
+        const seenBundleHashes = new Set<string>();
         for (const bundle of proposal.bundles) {
+          const bundleHash = bundle.endoZipBase64Sha512 ?? bundle.endoZipBase64;
+          if (seenBundleHashes.has(bundleHash)) {
+            continue;
+          }
+          seenBundleHashes.add(bundleHash);
           await controller.validateAndInstallBundle(bundle);
         }
       },

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -28,7 +28,6 @@ import {
   writeFileAtomic,
 } from '@agoric/internal/src/build-cache.js';
 import { unmarshalFromVstorage } from '@agoric/internal/src/marshal/board-client-utils.js';
-import { makeReadJsonFile } from '@agoric/internal/src/node/read-json.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { makeTempDirFactory } from '@agoric/internal/src/tmpDir.js';
 import { krefOf } from '@agoric/kmarshal';
@@ -36,7 +35,6 @@ import { makeTestAddress } from '@agoric/orchestration/tools/make-test-address.j
 import { decodeProtobufBase64 } from '@agoric/orchestration/tools/protobuf-decoder.js';
 import { initSwingStore } from '@agoric/swing-store';
 import { loadSwingsetConfigFile } from '@agoric/swingset-vat';
-import { sharedBundleCachePath } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { makeSlogSender } from '@agoric/telemetry';
 import { TimeMath, type Timestamp } from '@agoric/time';
 import {
@@ -70,7 +68,7 @@ import type { ExecutionContext as AvaT } from 'ava';
 import type { CoreEvalSDKType } from '@agoric/cosmic-proto/swingset/swingset.js';
 import { computronCounter } from '@agoric/cosmic-swingset/src/computron-counter.js';
 import { defaultBeansPerVatCreation } from '@agoric/cosmic-swingset/src/sim-params.js';
-import type { GovernancePublishedPathTypes } from '@agoric/governance/src/types.js';
+import type { GovernancePublishedPathTypes } from '@agoric/governance';
 import type { EconomyBootstrapPowers } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
 import { base64ToBytes } from '@agoric/network';
 import type { SwingsetController } from '@agoric/swingset-vat/src/controller/controller.js';
@@ -132,7 +130,6 @@ const makeBootstrapRunUtils = <
   makeRunUtils(controller, harness) as Omit<RunUtils, 'EV'> & {
     EV: BootstrapEV<BootstrapVatItems>;
   };
-
 const keysToObject = <K extends PropertyKey, V>(
   keys: K[],
   valueMaker: (key: K, i: number) => V,
@@ -286,59 +283,74 @@ type ProposalExtractorEvent =
       type: 'proposal-cache-hit' | 'proposal-cache-miss';
     };
 
-/**
- * Creates a function that can build and extract proposal data from package scripts.
- *
- * @param powers - Object containing required capabilities
- * @param powers.childProcess - Node child_process module for executing commands
- * @param powers.fs - Node fs/promises module for file operations
- * @param powers.now - Optional wall-clock function used for cache metadata and lock timing
- * @param powers.buildCoreEvalProposal - Optional in-process proposal builder implementation
- * @returns A function that builds and extracts proposal data
- */
-export const makeProposalExtractor = (
-  { childProcess, fs, now = Date.now, buildCoreEvalProposal }: Powers,
-  resolveBase = import.meta.url,
-  options: ProposalExtractorOptions = {},
-) => {
-  const importSpec = createRequire(resolveBase).resolve;
-  const readJSONFile = makeReadJsonFile(fs, harden);
-  const mode = options.mode || 'prefer-in-process';
-  const onCacheEvent = options.onCacheEvent || (() => {});
-  const schemaVersion = options.schemaVersion || 'v1';
-  const cacheRoot =
-    options.cacheRoot ||
-    join(process.cwd(), '.cache', 'boot-proposal-build', schemaVersion);
-  const scriptCacheDir = join(cacheRoot, 'script-bundle-cache');
-  const depFingerprintCacheDir = join(
-    cacheRoot,
-    'dependency-fingerprint-cache',
-  );
-  const cacheToolVersion = 'boot-proposal-cache-v1';
-  const dedupe = new Map<string, Promise<ProposalBuilderResult>>();
-  const buildProposal =
-    buildCoreEvalProposal ||
-    (async (opts: {
-      args?: string[];
-      builderPath: string;
-      cacheDir?: string;
-      childProcess?: Pick<typeof import('node:child_process'), 'execFileSync'>;
-      console?: Pick<Console, 'warn'>;
-      cwd?: string;
-      fs?: typeof import('node:fs/promises');
-      mode?: ProposalBuildMode;
-      now?: () => number;
-    }) => {
-      const proposalsMod = (await import(
-        importSpec('agoric/src/proposals.js')
-      )) as {
-        buildCoreEvalProposal: (
-          o: typeof opts,
-        ) => Promise<ProposalBuilderResult>;
-      };
-      return proposalsMod.buildCoreEvalProposal(opts);
-    });
+const PROPOSAL_CACHE_TOOL_VERSION = 'boot-proposal-cache-v1';
 
+const hashText = (text: string) =>
+  createHash('sha256').update(text).digest('hex');
+
+const hashBuffer = (content: string | Uint8Array) =>
+  createHash('sha256').update(content).digest('hex');
+
+const isPidAlive = (pid: number) => {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const cachePathsForKey = (cacheRoot: string, key: string) => {
+  const entryDir = join(cacheRoot, key);
+  return {
+    entryDir,
+    metadataPath: join(entryDir, 'metadata.json'),
+    materialsPath: join(entryDir, 'materials.json'),
+  };
+};
+
+interface ProposalCacheStore {
+  ensureBuildDirs: () => Promise<void>;
+  fingerprintDependencies: (
+    dependencyPaths: string[],
+  ) => Promise<ProposalCacheDependency[]>;
+  loadCachedMaterials: (
+    cacheKey: string,
+  ) => Promise<ProposalBuilderResult | undefined>;
+  normalizeDependencyPaths: (dependencyPaths: string[]) => string[];
+  persistMaterials: (
+    cacheKey: string,
+    metadata: ProposalCacheMetadata,
+    materials: ProposalBuilderResult,
+  ) => Promise<void>;
+  withCacheLock: <T>(cacheKey: string, body: () => Promise<T>) => Promise<T>;
+}
+
+const makeProposalCacheStore = ({
+  cacheRoot,
+  depFingerprintCacheDir,
+  fs,
+  mode,
+  now,
+  onCacheEvent,
+  schemaVersion,
+  scriptCacheDir,
+}: {
+  cacheRoot: string;
+  depFingerprintCacheDir: string;
+  fs: typeof import('node:fs/promises');
+  mode: ProposalBuildMode;
+  now: () => number;
+  onCacheEvent: (event: ProposalExtractorEvent) => void;
+  schemaVersion: string;
+  scriptCacheDir: string;
+}): ProposalCacheStore => {
+  const lockAcquireTimeoutMs = 5 * 60_000;
+  const staleLockMs = 60_000;
+  const lockRoot = join(cacheRoot, '.locks');
   let bundleCacheP: ReturnType<typeof makeNodeBundleCache> | undefined;
   const getBundleCache = () => {
     if (!bundleCacheP) {
@@ -353,16 +365,14 @@ export const makeProposalExtractor = (
     }
     return bundleCacheP;
   };
-
-  const hashText = (text: string) =>
-    createHash('sha256').update(text).digest('hex');
-
-  const hashBuffer = (content: string | Uint8Array) =>
-    createHash('sha256').update(content).digest('hex');
-
+  const readJSONFile = async <T>(filePath: string) =>
+    harden(JSON.parse(await fs.readFile(filePath, 'utf8')) as T);
+  const sameDependencies = (
+    a: ProposalCacheDependency[],
+    b: ProposalCacheDependency[],
+  ) => JSON.stringify(a) === JSON.stringify(b);
   const normalizeDependencyPaths = (dependencyPaths: string[]) =>
     [...new Set(dependencyPaths.map(spec => pathResolve(spec)))].sort();
-
   const fingerprintDependency = async (
     dependencyPath: string,
   ): Promise<ProposalCacheDependency> => {
@@ -391,27 +401,8 @@ export const makeProposalExtractor = (
       };
     }
   };
-
   const fingerprintDependencies = async (dependencyPaths: string[]) =>
     Promise.all(dependencyPaths.map(path => fingerprintDependency(path)));
-
-  const sameDependencies = (
-    a: ProposalCacheDependency[],
-    b: ProposalCacheDependency[],
-  ) => JSON.stringify(a) === JSON.stringify(b);
-
-  const isPidAlive = (pid: number) => {
-    if (!Number.isInteger(pid) || pid <= 0) {
-      return false;
-    }
-    try {
-      process.kill(pid, 0);
-      return true;
-    } catch {
-      return false;
-    }
-  };
-
   const { withLock } = makeDirectoryLock({
     fs,
     delayMs: ms => new Promise(resolve => setTimeout(resolve, ms)),
@@ -423,20 +414,13 @@ export const makeProposalExtractor = (
     acquireTimeoutMs: lockAcquireTimeoutMs,
     onEvent: onCacheEvent,
   });
-
-  const cachePathsForKey = (key: string) => {
-    const entryDir = join(cacheRoot, key);
-    return {
-      entryDir,
-      metadataPath: join(entryDir, 'metadata.json'),
-      materialsPath: join(entryDir, 'materials.json'),
-    };
-  };
-
   const loadCachedMaterials = async (
     cacheKey: string,
   ): Promise<ProposalBuilderResult | undefined> => {
-    const { metadataPath, materialsPath } = cachePathsForKey(cacheKey);
+    const { metadataPath, materialsPath } = cachePathsForKey(
+      cacheRoot,
+      cacheKey,
+    );
     try {
       const [metadata, materials] = await Promise.all([
         readJSONFile<ProposalCacheMetadata>(metadataPath),
@@ -445,7 +429,7 @@ export const makeProposalExtractor = (
 
       if (
         metadata.schemaVersion !== schemaVersion ||
-        metadata.toolVersion !== cacheToolVersion ||
+        metadata.toolVersion !== PROPOSAL_CACHE_TOOL_VERSION ||
         metadata.mode !== mode
       ) {
         return undefined;
@@ -463,14 +447,15 @@ export const makeProposalExtractor = (
       return undefined;
     }
   };
-
   const persistMaterials = async (
     cacheKey: string,
     metadata: ProposalCacheMetadata,
     materials: ProposalBuilderResult,
   ) => {
-    const { entryDir, metadataPath, materialsPath } =
-      cachePathsForKey(cacheKey);
+    const { entryDir, metadataPath, materialsPath } = cachePathsForKey(
+      cacheRoot,
+      cacheKey,
+    );
     await fs.mkdir(entryDir, { recursive: true });
     await Promise.all([
       writeFileAtomic({
@@ -496,6 +481,81 @@ export const makeProposalExtractor = (
       }),
     ]);
   };
+  const ensureBuildDirs = async () => {
+    await fs.mkdir(cacheRoot, { recursive: true });
+    await fs.mkdir(scriptCacheDir, { recursive: true });
+  };
+
+  return harden({
+    ensureBuildDirs,
+    fingerprintDependencies,
+    loadCachedMaterials,
+    normalizeDependencyPaths,
+    persistMaterials,
+    withCacheLock: withLock,
+  });
+};
+
+/**
+ * Creates a function that can build and extract proposal data from package scripts.
+ *
+ * @param powers - Object containing required capabilities
+ * @param powers.childProcess - Node child_process module for executing commands
+ * @param powers.fs - Node fs/promises module for file operations
+ * @param powers.now - Optional wall-clock function used for cache metadata and lock timing
+ * @param powers.buildCoreEvalProposal - Optional in-process proposal builder implementation
+ * @returns A function that builds and extracts proposal data
+ */
+export const makeProposalExtractor = (
+  { childProcess, fs, now = Date.now, buildCoreEvalProposal }: Powers,
+  resolveBase = import.meta.url,
+  options: ProposalExtractorOptions = {},
+) => {
+  const importSpec = createRequire(resolveBase).resolve;
+  const mode = options.mode || 'prefer-in-process';
+  const onCacheEvent = options.onCacheEvent || (() => {});
+  const schemaVersion = options.schemaVersion || 'v1';
+  const cacheRoot =
+    options.cacheRoot ||
+    join(process.cwd(), '.cache', 'boot-proposal-build', schemaVersion);
+  const scriptCacheDir = join(cacheRoot, 'script-bundle-cache');
+  const depFingerprintCacheDir = join(
+    cacheRoot,
+    'dependency-fingerprint-cache',
+  );
+  const dedupe = new Map<string, Promise<ProposalBuilderResult>>();
+  const cacheStore = makeProposalCacheStore({
+    cacheRoot,
+    depFingerprintCacheDir,
+    fs,
+    mode,
+    now,
+    onCacheEvent,
+    schemaVersion,
+    scriptCacheDir,
+  });
+  const buildProposal =
+    buildCoreEvalProposal ||
+    (async (opts: {
+      args?: string[];
+      builderPath: string;
+      cacheDir?: string;
+      childProcess?: Pick<typeof import('node:child_process'), 'execFileSync'>;
+      console?: Pick<Console, 'warn'>;
+      cwd?: string;
+      fs?: typeof import('node:fs/promises');
+      mode?: ProposalBuildMode;
+      now?: () => number;
+    }) => {
+      const proposalsMod = (await import(
+        importSpec('agoric/src/proposals.js')
+      )) as {
+        buildCoreEvalProposal: (
+          o: typeof opts,
+        ) => Promise<ProposalBuilderResult>;
+      };
+      return proposalsMod.buildCoreEvalProposal(opts);
+    });
 
   const buildAndExtract = async (builderPath: string, args: string[] = []) => {
     const scriptPath = importSpec(builderPath);
@@ -512,8 +572,8 @@ export const makeProposalExtractor = (
       return found;
     }
 
-    const pending = withLock(cacheKey, async () => {
-      const cached = await loadCachedMaterials(cacheKey);
+    const pending = cacheStore.withCacheLock(cacheKey, async () => {
+      const cached = await cacheStore.loadCachedMaterials(cacheKey);
       if (cached) {
         onCacheEvent({
           type: 'proposal-cache-hit',
@@ -531,8 +591,7 @@ export const makeProposalExtractor = (
       });
 
       const [builtDir, cleanup] = tmpDir('agoric-proposal');
-      await fs.mkdir(cacheRoot, { recursive: true });
-      await fs.mkdir(scriptCacheDir, { recursive: true });
+      await cacheStore.ensureBuildDirs();
 
       try {
         const built = await buildProposal({
@@ -546,11 +605,12 @@ export const makeProposalExtractor = (
           mode,
           now,
         });
-        const dependencyPaths = normalizeDependencyPaths([
+        const dependencyPaths = cacheStore.normalizeDependencyPaths([
           scriptPath,
           ...(built.dependencies || []),
         ]);
-        const dependencies = await fingerprintDependencies(dependencyPaths);
+        const dependencies =
+          await cacheStore.fingerprintDependencies(dependencyPaths);
         const metadata: ProposalCacheMetadata = {
           args: [...args],
           builderPath: built.resolvedBuilderPath || scriptPath,
@@ -558,14 +618,14 @@ export const makeProposalExtractor = (
           dependencies,
           mode,
           schemaVersion,
-          toolVersion: cacheToolVersion,
+          toolVersion: PROPOSAL_CACHE_TOOL_VERSION,
         };
         const materials = harden({
           evals: built.evals,
           bundles: built.bundles,
         });
 
-        await persistMaterials(cacheKey, metadata, materials);
+        await cacheStore.persistMaterials(cacheKey, metadata, materials);
         return materials;
       } finally {
         await cleanup();
@@ -573,12 +633,13 @@ export const makeProposalExtractor = (
     });
 
     dedupe.set(cacheKey, pending);
-    const cleanupPending = pending.finally(() => {
-      if (dedupe.get(cacheKey) === pending) {
-        dedupe.delete(cacheKey);
-      }
-    });
-    void cleanupPending.catch(() => {});
+    void pending
+      .finally(() => {
+        if (dedupe.get(cacheKey) === pending) {
+          dedupe.delete(cacheKey);
+        }
+      })
+      .catch(() => {});
     return pending;
   };
 
@@ -753,7 +814,7 @@ export const makeSwingsetTestKit = async <
     EconomyBootstrapPowers['consume'],
 >(
   log: (..._: any[]) => void,
-  bundleDir = sharedBundleCachePath,
+  bundleDir = 'bundles',
   {
     configSpecifier = '@agoric/vm-config/decentral-itest-vaults-config.json',
     label = undefined as string | undefined,
@@ -801,7 +862,6 @@ export const makeSwingsetTestKit = async <
       T,
       PublishedPathTypes
     >;
-
   let lastBankNonce = 0n;
   let ibcSequenceNonce = 0;
   let lcaSequenceNonce = 0;
@@ -1067,10 +1127,7 @@ export const makeSwingsetTestKit = async <
   // 2025-02, but we suspect that `makeSwingsetTestKit` just isn't being
   // exercised in the right way.
   await controller.run();
-  const runUtils = makeBootstrapRunUtils<BootstrapVatItems>(
-    controller,
-    harness,
-  );
+  const runUtils = makeBootstrapRunUtils(controller, harness);
 
   const buildProposal = makeProposalExtractor(
     {

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -27,8 +27,8 @@ import {
   makeDirectoryLock,
   writeFileAtomic,
 } from '@agoric/internal/src/build-cache.js';
-import { makeReadJsonFile } from '@agoric/internal/src/node/read-json.js';
 import { unmarshalFromVstorage } from '@agoric/internal/src/marshal/board-client-utils.js';
+import { makeReadJsonFile } from '@agoric/internal/src/node/read-json.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { makeTempDirFactory } from '@agoric/internal/src/tmpDir.js';
 import { krefOf } from '@agoric/kmarshal';
@@ -36,9 +36,9 @@ import { makeTestAddress } from '@agoric/orchestration/tools/make-test-address.j
 import { decodeProtobufBase64 } from '@agoric/orchestration/tools/protobuf-decoder.js';
 import { initSwingStore } from '@agoric/swing-store';
 import { loadSwingsetConfigFile } from '@agoric/swingset-vat';
+import { sharedBundleCachePath } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { makeSlogSender } from '@agoric/telemetry';
 import { TimeMath, type Timestamp } from '@agoric/time';
-import { sharedBundleCachePath } from '@agoric/swingset-vat/tools/bundleTool.js';
 import {
   fakeLocalChainBridgeQueryHandler,
   fakeLocalChainBridgeTxMsgHandler,
@@ -76,9 +76,9 @@ import { base64ToBytes } from '@agoric/network';
 import type { SwingsetController } from '@agoric/swingset-vat/src/controller/controller.js';
 import type { IBCDowncallMethod, IBCMethod } from '@agoric/vats';
 import type { BootstrapRootObject } from '@agoric/vats/src/core/lib-boot.js';
+import type { ERef } from '@agoric/vow';
 import type { EProxy } from '@endo/eventual-send';
 import { FileSystemCache, NodeFetchCache } from 'node-fetch-cache';
-import type { ERef } from '@agoric/vow';
 import { icaMocks, protoMsgMockMap, protoMsgMocks } from './ibc/mocks.js';
 
 const tmpDir = makeTempDirFactory(tmp);
@@ -273,8 +273,18 @@ interface ProposalCacheMetadata {
 interface ProposalExtractorOptions {
   cacheRoot?: string;
   mode?: ProposalBuildMode;
+  onCacheEvent?: (event: ProposalExtractorEvent) => void;
   schemaVersion?: string;
 }
+
+type ProposalExtractorEvent =
+  | BuildCacheEvent
+  | {
+      args: string[];
+      builderPath: string;
+      cacheKey: string;
+      type: 'proposal-cache-hit' | 'proposal-cache-miss';
+    };
 
 /**
  * Creates a function that can build and extract proposal data from package scripts.
@@ -294,6 +304,7 @@ export const makeProposalExtractor = (
   const importSpec = createRequire(resolveBase).resolve;
   const readJSONFile = makeReadJsonFile(fs, harden);
   const mode = options.mode || 'prefer-in-process';
+  const onCacheEvent = options.onCacheEvent || (() => {});
   const schemaVersion = options.schemaVersion || 'v1';
   const cacheRoot =
     options.cacheRoot ||
@@ -399,9 +410,10 @@ export const makeProposalExtractor = (
     now,
     pid: process.pid,
     isPidAlive,
-    lockRoot: join(cacheRoot, '.locks'),
-    staleLockMs: 60_000,
-    acquireTimeoutMs: 5 * 60_000,
+    lockRoot,
+    staleLockMs,
+    acquireTimeoutMs: lockAcquireTimeoutMs,
+    onEvent: onCacheEvent,
   });
 
   const cachePathsForKey = (key: string) => {
@@ -453,31 +465,27 @@ export const makeProposalExtractor = (
       cachePathsForKey(cacheKey);
     await fs.mkdir(entryDir, { recursive: true });
     await Promise.all([
-      writeFileAtomic(
-        {
-          fs,
-          filePath: `${metadataPath}`,
-          data: `${JSON.stringify(metadata, null, 2)}\n`,
-          now,
-          pid: process.pid,
-        },
-      ),
-      writeFileAtomic(
-        {
-          fs,
-          filePath: `${materialsPath}`,
-          data: `${JSON.stringify(
-            {
-              evals: materials.evals,
-              bundles: materials.bundles,
-            },
-            null,
-            2,
-          )}\n`,
-          now,
-          pid: process.pid,
-        },
-      ),
+      writeFileAtomic({
+        fs,
+        filePath: `${metadataPath}`,
+        data: `${JSON.stringify(metadata, null, 2)}\n`,
+        now,
+        pid: process.pid,
+      }),
+      writeFileAtomic({
+        fs,
+        filePath: `${materialsPath}`,
+        data: `${JSON.stringify(
+          {
+            evals: materials.evals,
+            bundles: materials.bundles,
+          },
+          null,
+          2,
+        )}\n`,
+        now,
+        pid: process.pid,
+      }),
     ]);
   };
 
@@ -499,9 +507,20 @@ export const makeProposalExtractor = (
     const pending = withLock(cacheKey, async () => {
       const cached = await loadCachedMaterials(cacheKey);
       if (cached) {
-        console.info('proposal cache hit:', scriptPath, args);
+        onCacheEvent({
+          type: 'proposal-cache-hit',
+          builderPath: scriptPath,
+          args: [...args],
+          cacheKey,
+        });
         return cached;
       }
+      onCacheEvent({
+        type: 'proposal-cache-miss',
+        builderPath: scriptPath,
+        args: [...args],
+        cacheKey,
+      });
 
       const [builtDir, cleanup] = tmpDir('agoric-proposal');
       await fs.mkdir(cacheRoot, { recursive: true });

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -2,9 +2,11 @@
 /* eslint-env node */
 
 import childProcessAmbient from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { promises as fsAmbientPromises } from 'node:fs';
 import { createRequire } from 'node:module';
-import { basename, join } from 'node:path';
+import { basename, join, resolve as pathResolve } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 import { inspect } from 'node:util';
 import tmp from 'tmp';
 
@@ -45,6 +47,10 @@ import type {
   ManagerType,
   SwingSetConfig,
 } from '@agoric/swingset-vat';
+import {
+  makeAmbientBundleToolPowers,
+  makeNodeBundleCache,
+} from '@agoric/swingset-vat/tools/bundleTool.js';
 import {
   makeRunUtils,
   type RunHarness,
@@ -217,9 +223,53 @@ export const getNodeTestVaultsConfig = async ({
   return testConfigPath;
 };
 
+type ProposalBuildMode = 'prefer-in-process' | 'in-process-only' | 'shell-only';
+
+interface ProposalBuilderResult {
+  bundles: EndoZipBase64Bundle[];
+  dependencies?: string[];
+  evals: CoreEvalSDKType[];
+  modeUsed?: 'in-process' | 'shell';
+  resolvedBuilderPath?: string;
+}
+
 interface Powers {
+  buildCoreEvalProposal?: (opts: {
+    args?: string[];
+    builderPath: string;
+    cacheDir?: string;
+    childProcess?: Pick<typeof import('node:child_process'), 'execFileSync'>;
+    console?: Pick<Console, 'warn'>;
+    cwd?: string;
+    fs?: typeof import('node:fs/promises');
+    mode?: ProposalBuildMode;
+    now?: () => number;
+  }) => Promise<ProposalBuilderResult>;
   childProcess: Pick<typeof import('node:child_process'), 'execFileSync'>;
   fs: typeof import('node:fs/promises');
+  now?: () => number;
+}
+
+interface ProposalCacheDependency {
+  fingerprint: string;
+  path: string;
+  source: 'bundle-cache' | 'file';
+}
+
+interface ProposalCacheMetadata {
+  args: string[];
+  builderPath: string;
+  createdAt: string;
+  dependencies: ProposalCacheDependency[];
+  mode: ProposalBuildMode;
+  schemaVersion: string;
+  toolVersion: string;
+}
+
+interface ProposalExtractorOptions {
+  cacheRoot?: string;
+  mode?: ProposalBuildMode;
+  schemaVersion?: string;
 }
 
 /**
@@ -228,86 +278,363 @@ interface Powers {
  * @param powers - Object containing required capabilities
  * @param powers.childProcess - Node child_process module for executing commands
  * @param powers.fs - Node fs/promises module for file operations
+ * @param powers.now - Optional wall-clock function used for cache metadata and lock timing
+ * @param powers.buildCoreEvalProposal - Optional in-process proposal builder implementation
  * @returns A function that builds and extracts proposal data
  */
 export const makeProposalExtractor = (
-  { childProcess, fs }: Powers,
+  { childProcess, fs, now = Date.now, buildCoreEvalProposal }: Powers,
   resolveBase = import.meta.url,
+  options: ProposalExtractorOptions = {},
 ) => {
   const importSpec = createRequire(resolveBase).resolve;
-
   const readJSONFile = makeReadJsonFile(fs, harden);
-
-  // XXX parses the output to find the files but could write them to a path that can be traversed
-  const parseProposalParts = (agoricRunOutput: string) => {
-    const evals = [
-      ...agoricRunOutput.matchAll(
-        /swingset-core-eval (?<permit>\S+) (?<script>\S+)/g,
-      ),
-    ].map(m => {
-      if (!m.groups) throw Fail`Invalid proposal output ${m[0]}`;
-      const { permit, script } = m.groups;
-      return { permit, script };
+  const mode = options.mode || 'prefer-in-process';
+  const schemaVersion = options.schemaVersion || 'v1';
+  const cacheRoot =
+    options.cacheRoot ||
+    join(process.cwd(), '.cache', 'boot-proposal-build', schemaVersion);
+  const scriptCacheDir = join(cacheRoot, 'script-bundle-cache');
+  const depFingerprintCacheDir = join(
+    cacheRoot,
+    'dependency-fingerprint-cache',
+  );
+  const lockRoot = join(cacheRoot, '.locks');
+  const cacheToolVersion = 'boot-proposal-cache-v1';
+  const lockAcquireTimeoutMs = 5 * 60_000;
+  const staleLockMs = 60_000;
+  const dedupe = new Map<string, Promise<ProposalBuilderResult>>();
+  const buildProposal =
+    buildCoreEvalProposal ||
+    (async (opts: {
+      args?: string[];
+      builderPath: string;
+      cacheDir?: string;
+      childProcess?: Pick<typeof import('node:child_process'), 'execFileSync'>;
+      console?: Pick<Console, 'warn'>;
+      cwd?: string;
+      fs?: typeof import('node:fs/promises');
+      mode?: ProposalBuildMode;
+      now?: () => number;
+    }) => {
+      const proposalsMod = (await import(
+        importSpec('agoric/src/proposals.js')
+      )) as {
+        buildCoreEvalProposal: (
+          o: typeof opts,
+        ) => Promise<ProposalBuilderResult>;
+      };
+      return proposalsMod.buildCoreEvalProposal(opts);
     });
-    evals.length ||
-      Fail`No swingset-core-eval found in proposal output: ${agoricRunOutput}`;
 
-    const bundles = [
-      ...agoricRunOutput.matchAll(/swingset install-bundle @([^\n]+)/g),
-    ].map(([, bundle]) => bundle);
-    bundles.length ||
-      Fail`No bundles found in proposal output: ${agoricRunOutput}`;
+  const bundleCacheP = makeNodeBundleCache(
+    depFingerprintCacheDir,
+    {},
+    s => import(s),
+    makeAmbientBundleToolPowers({ log: () => {} }),
+  );
 
-    return { evals, bundles };
+  const hashText = (text: string) =>
+    createHash('sha256').update(text).digest('hex');
+
+  const hashBuffer = (content: string | Uint8Array) =>
+    createHash('sha256').update(content).digest('hex');
+
+  const writeFileAtomic = async (filePath: string, data: string) => {
+    const tempPath = `${filePath}.${process.pid}.${now()}.tmp`;
+    await fs.writeFile(tempPath, data, { flag: 'wx' });
+    await fs.rename(tempPath, filePath);
   };
 
-  // XXX rebuilds every time
-  const buildAndExtract = async (builderPath: string, args: string[] = []) => {
-    const [builtDir, cleanup] = tmpDir('agoric-proposal');
+  const normalizeDependencyPaths = (dependencyPaths: string[]) =>
+    [...new Set(dependencyPaths.map(spec => pathResolve(spec)))].sort();
 
-    const readPkgFile = fileName =>
-      fs.readFile(join(builtDir, fileName), 'utf8');
-
-    await null;
+  const fingerprintDependency = async (
+    dependencyPath: string,
+  ): Promise<ProposalCacheDependency> => {
     try {
-      const scriptPath = importSpec(builderPath);
-
-      console.info('running package script:', scriptPath);
-      const agoricRunOutput = childProcess.execFileSync(
-        importSpec('agoric/src/entrypoint.js'),
-        ['run', scriptPath, ...args],
-        { cwd: builtDir },
+      const bundleCache = await bundleCacheP;
+      const targetName = `dep-${hashText(dependencyPath).slice(0, 16)}`;
+      const { bundleFileName } = await bundleCache.validateOrAdd(
+        dependencyPath,
+        targetName,
       );
-      const built = parseProposalParts(agoricRunOutput.toString());
-
-      const evalsP = Promise.all(
-        built.evals.map(async ({ permit, script }) => {
-          const [permits, code] = await Promise.all(
-            [permit, script].map(path => readPkgFile(path)),
-          );
-          return { json_permits: permits, js_code: code } as CoreEvalSDKType;
-        }),
+      const bundleText = await fs.readFile(
+        join(depFingerprintCacheDir, bundleFileName),
+        'utf8',
       );
-
-      const bundlesP = Promise.all(
-        built.bundles.map(
-          async path => readJSONFile(path) as Promise<EndoZipBase64Bundle>,
-        ),
-      );
-
-      const [evals, bundles] = await Promise.all([evalsP, bundlesP]);
-      return { evals, bundles };
-    } finally {
-      // Defer `cleanup` and ignore any exception; spurious test failures would
-      // be worse than the minor inconvenience of manual temp dir removal.
-      const cleanupP = Promise.resolve().then(() => cleanup());
-      cleanupP.catch(err => {
-        console.error(err);
-        throw err; // unhandled rejection
-      });
+      return {
+        path: dependencyPath,
+        fingerprint: hashText(bundleText),
+        source: 'bundle-cache',
+      };
+    } catch {
+      const fileContent = await fs.readFile(dependencyPath);
+      return {
+        path: dependencyPath,
+        fingerprint: hashBuffer(fileContent),
+        source: 'file',
+      };
     }
   };
-  return buildAndExtract;
+
+  const fingerprintDependencies = async (dependencyPaths: string[]) =>
+    Promise.all(dependencyPaths.map(path => fingerprintDependency(path)));
+
+  const sameDependencies = (
+    a: ProposalCacheDependency[],
+    b: ProposalCacheDependency[],
+  ) => JSON.stringify(a) === JSON.stringify(b);
+
+  const isPidAlive = (pid: unknown) => {
+    if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) {
+      return false;
+    }
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const maybeBreakStaleLock = async (lockPath: string) => {
+    const ownerPath = join(lockPath, 'owner.json');
+    const ownerText = await fs.readFile(ownerPath, 'utf8').catch(() => '');
+    if (ownerText) {
+      try {
+        const ownerInfo = JSON.parse(ownerText) as { pid?: number };
+        if (ownerInfo.pid && !isPidAlive(ownerInfo.pid)) {
+          await fs.rm(lockPath, { recursive: true, force: true });
+          return true;
+        }
+      } catch {
+        // rely on age-based lock breaking for malformed owner files
+      }
+    }
+
+    try {
+      const lockStats = await fs.stat(lockPath);
+      if (now() - lockStats.mtimeMs >= staleLockMs) {
+        await fs.rm(lockPath, { recursive: true, force: true });
+        return true;
+      }
+    } catch {
+      return true;
+    }
+
+    return false;
+  };
+
+  const withLock = async <T>(key: string, body: () => Promise<T>) => {
+    const lockPath = join(lockRoot, `${encodeURIComponent(key)}.lock`);
+    const ownerPath = join(lockPath, 'owner.json');
+    const started = now();
+    await fs.mkdir(lockRoot, { recursive: true });
+
+    for (;;) {
+      try {
+        await fs.mkdir(lockPath);
+        await fs.writeFile(
+          ownerPath,
+          JSON.stringify({ pid: process.pid, createdAt: now() }),
+          'utf8',
+        );
+        break;
+      } catch (err) {
+        const e = err as NodeJS.ErrnoException;
+        if (e.code !== 'EEXIST') {
+          throw err;
+        }
+        const recovered = await maybeBreakStaleLock(lockPath);
+        if (recovered) {
+          continue;
+        }
+        if (now() - started >= lockAcquireTimeoutMs) {
+          throw Error(`Timed out waiting for proposal cache lock ${lockPath}`);
+        }
+        await delay(20);
+      }
+    }
+
+    try {
+      return await body();
+    } finally {
+      await fs.rm(lockPath, { recursive: true, force: true });
+    }
+  };
+
+  const cachePathsForKey = (key: string) => {
+    const entryDir = join(cacheRoot, key);
+    return {
+      entryDir,
+      metadataPath: join(entryDir, 'metadata.json'),
+      materialsPath: join(entryDir, 'materials.json'),
+    };
+  };
+
+  const loadCachedMaterials = async (
+    cacheKey: string,
+  ): Promise<ProposalBuilderResult | undefined> => {
+    const { metadataPath, materialsPath } = cachePathsForKey(cacheKey);
+    try {
+      const [metadata, materials] = await Promise.all([
+        readJSONFile<ProposalCacheMetadata>(metadataPath),
+        readJSONFile<ProposalBuilderResult>(materialsPath),
+      ]);
+
+      if (
+        metadata.schemaVersion !== schemaVersion ||
+        metadata.toolVersion !== cacheToolVersion ||
+        metadata.mode !== mode
+      ) {
+        return undefined;
+      }
+
+      const dependencyPaths = metadata.dependencies.map(dep => dep.path);
+      const currentDependencies =
+        await fingerprintDependencies(dependencyPaths);
+      if (!sameDependencies(metadata.dependencies, currentDependencies)) {
+        return undefined;
+      }
+
+      return harden(materials);
+    } catch {
+      return undefined;
+    }
+  };
+
+  const persistMaterials = async (
+    cacheKey: string,
+    metadata: ProposalCacheMetadata,
+    materials: ProposalBuilderResult,
+  ) => {
+    const { entryDir, metadataPath, materialsPath } =
+      cachePathsForKey(cacheKey);
+    await fs.mkdir(entryDir, { recursive: true });
+    await Promise.all([
+      writeFileAtomic(
+        `${metadataPath}`,
+        `${JSON.stringify(metadata, null, 2)}\n`,
+      ),
+      writeFileAtomic(
+        `${materialsPath}`,
+        `${JSON.stringify(
+          {
+            evals: materials.evals,
+            bundles: materials.bundles,
+          },
+          null,
+          2,
+        )}\n`,
+      ),
+    ]);
+  };
+
+  const buildAndExtract = async (builderPath: string, args: string[] = []) => {
+    const scriptPath = importSpec(builderPath);
+    const cacheKeyPayload = {
+      args,
+      builderPath: scriptPath,
+      mode,
+      schemaVersion,
+    };
+    const cacheKey = hashText(JSON.stringify(cacheKeyPayload));
+
+    const found = dedupe.get(cacheKey);
+    if (found) {
+      return found;
+    }
+
+    const pending = withLock(cacheKey, async () => {
+      const cached = await loadCachedMaterials(cacheKey);
+      if (cached) {
+        console.info('proposal cache hit:', scriptPath, args);
+        return cached;
+      }
+
+      const [builtDir, cleanup] = tmpDir('agoric-proposal');
+      await fs.mkdir(cacheRoot, { recursive: true });
+      await fs.mkdir(scriptCacheDir, { recursive: true });
+
+      try {
+        const built = await buildProposal({
+          builderPath: scriptPath,
+          args,
+          cacheDir: scriptCacheDir,
+          childProcess,
+          console,
+          cwd: builtDir,
+          fs,
+          mode,
+          now,
+        });
+        const dependencyPaths = normalizeDependencyPaths([
+          scriptPath,
+          ...(built.dependencies || []),
+        ]);
+        const dependencies = await fingerprintDependencies(dependencyPaths);
+        const metadata: ProposalCacheMetadata = {
+          args: [...args],
+          builderPath: built.resolvedBuilderPath || scriptPath,
+          createdAt: new Date(now()).toISOString(),
+          dependencies,
+          mode,
+          schemaVersion,
+          toolVersion: cacheToolVersion,
+        };
+        const materials = harden({
+          evals: built.evals,
+          bundles: built.bundles,
+        });
+
+        await persistMaterials(cacheKey, metadata, materials);
+        return materials;
+      } finally {
+        await cleanup();
+      }
+    });
+
+    dedupe.set(cacheKey, pending);
+    const cleanupPending = pending.finally(() => {
+      if (dedupe.get(cacheKey) === pending) {
+        dedupe.delete(cacheKey);
+      }
+    });
+    void cleanupPending.catch(() => {});
+    return pending;
+  };
+
+  return async (builderPath: string, args: string[] = []) => {
+    try {
+      return await buildAndExtract(builderPath, args);
+    } catch (err) {
+      if (mode !== 'prefer-in-process') {
+        throw err;
+      }
+      console.warn(
+        'proposal extraction failed in cache/in-process path, retrying shell-only build',
+        err,
+      );
+      const [builtDir, cleanup] = tmpDir('agoric-proposal');
+      try {
+        const fallback = await buildProposal({
+          builderPath: importSpec(builderPath),
+          args,
+          cacheDir: scriptCacheDir,
+          childProcess,
+          console,
+          cwd: builtDir,
+          fs,
+          mode: 'shell-only',
+          now,
+        });
+        return harden({ evals: fallback.evals, bundles: fallback.bundles });
+      } finally {
+        await cleanup();
+      }
+    }
+  };
 };
 harden(makeProposalExtractor);
 
@@ -415,6 +742,7 @@ type AckBehaviorType = (typeof AckBehavior)[keyof typeof AckBehavior];
  * @param [options.debugVats]
  * @param [options.defaultManagerType]
  * @param [options.harness]
+ * @param [options.proposalBuildMode]
  */
 /**
  * Creates a SwingSet test environment with various utilities for testing.
@@ -434,6 +762,7 @@ type AckBehaviorType = (typeof AckBehavior)[keyof typeof AckBehavior];
  * @param options.debugVats - Array of vat names to debug
  * @param options.defaultManagerType - SwingSet manager type to use
  * @param options.harness - Optional run harness
+ * @param options.proposalBuildMode - Proposal extraction mode
  * @param options.resolveBase - Base URL or path for resolving module paths
  * @param options.configOverrides - Other SwingSet options to set in the config
    (may be overridden by more specific options such as `bundleDir` and
@@ -458,6 +787,7 @@ export const makeSwingsetTestKit = async <
     debugVats = [] as string[],
     defaultManagerType = 'local' as ManagerType,
     harness = undefined as RunHarness | undefined,
+    proposalBuildMode = 'prefer-in-process' as ProposalBuildMode,
     resolveBase = import.meta.url,
     configOverrides = {} as Partial<SwingSetConfig>,
   } = {},
@@ -765,10 +1095,18 @@ export const makeSwingsetTestKit = async <
     harness,
   );
 
-  const buildProposal = makeProposalExtractor({
-    childProcess: childProcessAmbient,
-    fs: fsAmbientPromises,
-  });
+  const buildProposal = makeProposalExtractor(
+    {
+      childProcess: childProcessAmbient,
+      fs: fsAmbientPromises,
+      now: Date.now,
+      // keep default proposal builder implementation
+    },
+    resolveBase,
+    {
+      mode: proposalBuildMode,
+    },
+  );
 
   type ProposalMaterials = Awaited<ReturnType<typeof buildProposal>>;
 

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -52,6 +52,7 @@ import type {
 import {
   makeAmbientBundleToolPowers,
   makeNodeBundleCache,
+  sharedBundleCachePath,
 } from '@agoric/swingset-vat/tools/bundleTool.js';
 import {
   makeRunUtils,
@@ -181,7 +182,7 @@ export const keyArrayEqual = (
  * @returns Path to the generated config file
  */
 export const getNodeTestVaultsConfig = async ({
-  bundleDir,
+  bundleDir = sharedBundleCachePath,
   configPath,
   defaultManagerType = 'local' as ManagerType,
   discriminator = '',
@@ -958,7 +959,7 @@ export const makeSwingsetTestKit = async <
     EconomyBootstrapPowers['consume'],
 >(
   log: (..._: any[]) => void,
-  bundleDir = 'bundles',
+  bundleDir = sharedBundleCachePath,
   {
     configSpecifier = '@agoric/vm-config/decentral-itest-vaults-config.json',
     label = undefined as string | undefined,
@@ -1285,9 +1286,9 @@ export const makeSwingsetTestKit = async <
     },
   );
 
-  // XXX This initial run() might not be necessary. Tests pass without it as of
-  // 2025-02, but we suspect that `makeSwingsetTestKit` just isn't being
-  // exercised in the right way.
+  // Make sure the kernel has progressed past its initial startup work before
+  // handing the harness back to test suites so that bootstrap vats and core
+  // proposals have result slots ready right away.
   await profiler.measure('makeSwingsetTestKit.controller.run.initial', () =>
     controller.run(),
   );

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -89,6 +89,33 @@ const tmpDir = makeTempDirFactory(tmp);
 
 const trace = makeTracer('BSTSupport', false);
 
+const configCache = new Map<string, string>();
+
+const makeConfigCacheKey = ({
+  bundleDir,
+  configPath,
+  defaultManagerType,
+  discriminator,
+  configOverrides,
+}: {
+  bundleDir: string;
+  configPath: string;
+  defaultManagerType: ManagerType;
+  discriminator: string;
+  configOverrides: Partial<SwingSetConfig>;
+}) => {
+  const normalizedOverrides = JSON.parse(
+    JSON.stringify(configOverrides ?? {}),
+  ) as Partial<SwingSetConfig>;
+  return JSON.stringify({
+    bundleDir,
+    configPath,
+    defaultManagerType,
+    discriminator,
+    configOverrides: normalizedOverrides,
+  });
+};
+
 // Releases are immutable, so we can cache them.
 // Doesn't help in CI but speeds up local development.
 // CI is on Github Actions, so fetching is reliable.
@@ -188,6 +215,17 @@ export const getNodeTestVaultsConfig = async ({
   discriminator = '',
   configOverrides = {},
 }) => {
+  const cacheKey = makeConfigCacheKey({
+    bundleDir,
+    configPath,
+    defaultManagerType,
+    discriminator,
+    configOverrides,
+  });
+  const cached = configCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
   const configFromFile: SwingSetConfig & { coreProposals?: any[] } = NonNullish(
     await loadSwingsetConfigFile(configPath),
   );
@@ -227,6 +265,7 @@ export const getNodeTestVaultsConfig = async ({
     JSON.stringify(config),
     'utf-8',
   );
+  configCache.set(cacheKey, testConfigPath);
   return testConfigPath;
 };
 

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -231,7 +231,7 @@ export const getNodeTestVaultsConfig = async ({
 
 type ProposalBuildMode = 'prefer-in-process' | 'in-process-only' | 'shell-only';
 
-interface ProposalBuilderResult {
+export interface ProposalBuilderResult {
   bundles: EndoZipBase64Bundle[];
   dependencies?: string[];
   evals: CoreEvalSDKType[];

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -89,6 +89,22 @@ const tmpDir = makeTempDirFactory(tmp);
 
 const trace = makeTracer('BSTSupport', false);
 
+const configFileCache = new Map<
+  string,
+  SwingSetConfig & { coreProposals?: any[] }
+>();
+
+const loadCachedSwingsetConfig = async (
+  path: string,
+): Promise<SwingSetConfig & { coreProposals?: any[] }> => {
+  let cached = configFileCache.get(path);
+  if (!cached) {
+    cached = NonNullish(await loadSwingsetConfigFile(path));
+    configFileCache.set(path, harden(cached));
+  }
+  return structuredClone(cached);
+};
+
 const configCache = new Map<string, string>();
 
 const makeConfigCacheKey = ({
@@ -226,9 +242,8 @@ export const getNodeTestVaultsConfig = async ({
   if (cached) {
     return cached;
   }
-  const configFromFile: SwingSetConfig & { coreProposals?: any[] } = NonNullish(
-    await loadSwingsetConfigFile(configPath),
-  );
+  const configFromFile: SwingSetConfig & { coreProposals?: any[] } =
+    await loadCachedSwingsetConfig(configPath);
 
   const config: SwingSetConfig & { coreProposals?: any[] } = {
     ...configFromFile,

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -6,7 +6,6 @@ import { createHash } from 'node:crypto';
 import { promises as fsAmbientPromises } from 'node:fs';
 import { createRequire } from 'node:module';
 import { basename, join, resolve as pathResolve } from 'node:path';
-import { setTimeout as delay } from 'node:timers/promises';
 import { inspect } from 'node:util';
 import tmp from 'tmp';
 
@@ -23,6 +22,11 @@ import {
   VBankAccount,
   type Remote,
 } from '@agoric/internal';
+import type { BuildCacheEvent } from '@agoric/internal/src/build-cache-types.js';
+import {
+  makeDirectoryLock,
+  writeFileAtomic,
+} from '@agoric/internal/src/build-cache.js';
 import { makeReadJsonFile } from '@agoric/internal/src/node/read-json.js';
 import { unmarshalFromVstorage } from '@agoric/internal/src/marshal/board-client-utils.js';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
@@ -299,10 +303,7 @@ export const makeProposalExtractor = (
     cacheRoot,
     'dependency-fingerprint-cache',
   );
-  const lockRoot = join(cacheRoot, '.locks');
   const cacheToolVersion = 'boot-proposal-cache-v1';
-  const lockAcquireTimeoutMs = 5 * 60_000;
-  const staleLockMs = 60_000;
   const dedupe = new Map<string, Promise<ProposalBuilderResult>>();
   const buildProposal =
     buildCoreEvalProposal ||
@@ -331,7 +332,7 @@ export const makeProposalExtractor = (
     depFingerprintCacheDir,
     {},
     s => import(s),
-    makeAmbientBundleToolPowers({ log: () => {} }),
+    makeAmbientBundleToolPowers({ eventSink: { onBundleToolEvent: () => {} } }),
   );
 
   const hashText = (text: string) =>
@@ -339,12 +340,6 @@ export const makeProposalExtractor = (
 
   const hashBuffer = (content: string | Uint8Array) =>
     createHash('sha256').update(content).digest('hex');
-
-  const writeFileAtomic = async (filePath: string, data: string) => {
-    const tempPath = `${filePath}.${process.pid}.${now()}.tmp`;
-    await fs.writeFile(tempPath, data, { flag: 'wx' });
-    await fs.rename(tempPath, filePath);
-  };
 
   const normalizeDependencyPaths = (dependencyPaths: string[]) =>
     [...new Set(dependencyPaths.map(spec => pathResolve(spec)))].sort();
@@ -386,8 +381,8 @@ export const makeProposalExtractor = (
     b: ProposalCacheDependency[],
   ) => JSON.stringify(a) === JSON.stringify(b);
 
-  const isPidAlive = (pid: unknown) => {
-    if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) {
+  const isPidAlive = (pid: number) => {
+    if (!Number.isInteger(pid) || pid <= 0) {
       return false;
     }
     try {
@@ -398,71 +393,16 @@ export const makeProposalExtractor = (
     }
   };
 
-  const maybeBreakStaleLock = async (lockPath: string) => {
-    const ownerPath = join(lockPath, 'owner.json');
-    const ownerText = await fs.readFile(ownerPath, 'utf8').catch(() => '');
-    if (ownerText) {
-      try {
-        const ownerInfo = JSON.parse(ownerText) as { pid?: number };
-        if (ownerInfo.pid && !isPidAlive(ownerInfo.pid)) {
-          await fs.rm(lockPath, { recursive: true, force: true });
-          return true;
-        }
-      } catch {
-        // rely on age-based lock breaking for malformed owner files
-      }
-    }
-
-    try {
-      const lockStats = await fs.stat(lockPath);
-      if (now() - lockStats.mtimeMs >= staleLockMs) {
-        await fs.rm(lockPath, { recursive: true, force: true });
-        return true;
-      }
-    } catch {
-      return true;
-    }
-
-    return false;
-  };
-
-  const withLock = async <T>(key: string, body: () => Promise<T>) => {
-    const lockPath = join(lockRoot, `${encodeURIComponent(key)}.lock`);
-    const ownerPath = join(lockPath, 'owner.json');
-    const started = now();
-    await fs.mkdir(lockRoot, { recursive: true });
-
-    for (;;) {
-      try {
-        await fs.mkdir(lockPath);
-        await fs.writeFile(
-          ownerPath,
-          JSON.stringify({ pid: process.pid, createdAt: now() }),
-          'utf8',
-        );
-        break;
-      } catch (err) {
-        const e = err as NodeJS.ErrnoException;
-        if (e.code !== 'EEXIST') {
-          throw err;
-        }
-        const recovered = await maybeBreakStaleLock(lockPath);
-        if (recovered) {
-          continue;
-        }
-        if (now() - started >= lockAcquireTimeoutMs) {
-          throw Error(`Timed out waiting for proposal cache lock ${lockPath}`);
-        }
-        await delay(20);
-      }
-    }
-
-    try {
-      return await body();
-    } finally {
-      await fs.rm(lockPath, { recursive: true, force: true });
-    }
-  };
+  const { withLock } = makeDirectoryLock({
+    fs,
+    delayMs: ms => new Promise(resolve => setTimeout(resolve, ms)),
+    now,
+    pid: process.pid,
+    isPidAlive,
+    lockRoot: join(cacheRoot, '.locks'),
+    staleLockMs: 60_000,
+    acquireTimeoutMs: 5 * 60_000,
+  });
 
   const cachePathsForKey = (key: string) => {
     const entryDir = join(cacheRoot, key);
@@ -514,19 +454,29 @@ export const makeProposalExtractor = (
     await fs.mkdir(entryDir, { recursive: true });
     await Promise.all([
       writeFileAtomic(
-        `${metadataPath}`,
-        `${JSON.stringify(metadata, null, 2)}\n`,
+        {
+          fs,
+          filePath: `${metadataPath}`,
+          data: `${JSON.stringify(metadata, null, 2)}\n`,
+          now,
+          pid: process.pid,
+        },
       ),
       writeFileAtomic(
-        `${materialsPath}`,
-        `${JSON.stringify(
-          {
-            evals: materials.evals,
-            bundles: materials.bundles,
-          },
-          null,
-          2,
-        )}\n`,
+        {
+          fs,
+          filePath: `${materialsPath}`,
+          data: `${JSON.stringify(
+            {
+              evals: materials.evals,
+              bundles: materials.bundles,
+            },
+            null,
+            2,
+          )}\n`,
+          now,
+          pid: process.pid,
+        },
       ),
     ]);
   };

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -339,12 +339,20 @@ export const makeProposalExtractor = (
       return proposalsMod.buildCoreEvalProposal(opts);
     });
 
-  const bundleCacheP = makeNodeBundleCache(
-    depFingerprintCacheDir,
-    {},
-    s => import(s),
-    makeAmbientBundleToolPowers({ eventSink: { onBundleToolEvent: () => {} } }),
-  );
+  let bundleCacheP: ReturnType<typeof makeNodeBundleCache> | undefined;
+  const getBundleCache = () => {
+    if (!bundleCacheP) {
+      bundleCacheP = makeNodeBundleCache(
+        depFingerprintCacheDir,
+        {},
+        s => import(s),
+        makeAmbientBundleToolPowers({
+          eventSink: { onBundleToolEvent: () => {} },
+        }),
+      );
+    }
+    return bundleCacheP;
+  };
 
   const hashText = (text: string) =>
     createHash('sha256').update(text).digest('hex');
@@ -359,7 +367,7 @@ export const makeProposalExtractor = (
     dependencyPath: string,
   ): Promise<ProposalCacheDependency> => {
     try {
-      const bundleCache = await bundleCacheP;
+      const bundleCache = await getBundleCache();
       const targetName = `dep-${hashText(dependencyPath).slice(0, 16)}`;
       const { bundleFileName } = await bundleCache.validateOrAdd(
         dependencyPath,

--- a/packages/deploy-script-support/src/cachedBundleSpec.js
+++ b/packages/deploy-script-support/src/cachedBundleSpec.js
@@ -1,4 +1,5 @@
 import { Fail } from '@endo/errors';
+import { writeFileAtomic } from '@agoric/internal/src/build-cache.js';
 
 /**
  * @import {promises} from 'fs';
@@ -30,11 +31,13 @@ export const makeCacheAndGetBundleSpec =
       if (e.code !== 'ENOENT') {
         throw e;
       }
-      const tmpFile = `${cacheFile}.${pid}.${now()}.${Math.random().toString(16).slice(2)}.tmp`;
-      await fs.writeFile(tmpFile, JSON.stringify(bundle, null, 2), {
-        flag: 'wx',
+      await writeFileAtomic({
+        fs,
+        filePath: cacheFile,
+        data: JSON.stringify(bundle, null, 2),
+        now,
+        pid,
       });
-      await fs.rename(tmpFile, cacheFile);
     }
     return harden({ bundleID, fileName: cacheFile });
   };

--- a/packages/deploy-script-support/src/externalTypes.js
+++ b/packages/deploy-script-support/src/externalTypes.js
@@ -5,8 +5,10 @@ export {};
  * @import {NameHub} from '@agoric/vats';
  * @import {ZoeService} from '@agoric/zoe';
  * @import {BundleSource} from '@endo/bundle-source';
+ * @import {writeFile as WriteFile} from 'node:fs/promises';
  * @import {ERef} from '@agoric/vow';
  * @import {ScratchPad} from '@agoric/internal/src/scratch.js';
+ * @import {CoreEvalMaterialRecord} from './writeCoreEvalParts.js';
  * @import {Bank} from '@agoric/vats/src/vat-bank.js';
  * @import {Board} from '@agoric/vats';
  * @import {NameAdmin} from '@agoric/vats';
@@ -66,10 +68,11 @@ export {};
  *  lookup: (...path: string[]) => unknown,
  *  log?: typeof console.log,
  *  now: () => number,
+ *  onWriteCoreEval?: (record: CoreEvalMaterialRecord) => void | Promise<void>,
  *  pathResolve: (...path: string[]) => string,
  *  publishBundle: PublishBundleRef,
  *  scriptArgs?: string[],
- *  writeFile?: import('node:fs/promises').writeFile,
+ *  writeFile?: WriteFile,
  * }} DeployScriptEndownments
  */
 

--- a/packages/deploy-script-support/src/externalTypes.js
+++ b/packages/deploy-script-support/src/externalTypes.js
@@ -64,10 +64,12 @@ export {};
  *  bundleSource: BundleSource,
  *  cacheDir: string,
  *  lookup: (...path: string[]) => unknown,
+ *  log?: typeof console.log,
  *  now: () => number,
  *  pathResolve: (...path: string[]) => string,
  *  publishBundle: PublishBundleRef,
  *  scriptArgs?: string[],
+ *  writeFile?: import('node:fs/promises').writeFile,
  * }} DeployScriptEndownments
  */
 

--- a/packages/deploy-script-support/src/helpers.js
+++ b/packages/deploy-script-support/src/helpers.js
@@ -70,6 +70,7 @@ export const makeHelpers = async (homePromise, endowments) => {
     publishBundle,
     pathResolve,
     cacheDir = pathResolve(os.homedir(), '.agoric/cache'),
+    onWriteCoreEval,
     writeFile,
     log,
   } = endowments;
@@ -158,6 +159,7 @@ export const makeHelpers = async (homePromise, endowments) => {
       return makeWriteCoreEval(homePromise, endowments, {
         getBundleSpec: deps.cacheAndGetBundleSpec,
         getBundlerMaker: helpers.getBundlerMaker,
+        ...(onWriteCoreEval && { onWriteCoreEval }),
         ...(log && { log }),
         ...(writeFile && { writeFile }),
       });
@@ -167,6 +169,7 @@ export const makeHelpers = async (homePromise, endowments) => {
       return makeWriteCoreEval(homePromise, endowments, {
         getBundleSpec: deps.cacheAndGetBundleSpec,
         getBundlerMaker: helpers.getBundlerMaker,
+        ...(onWriteCoreEval && { onWriteCoreEval }),
         ...(log && { log }),
         ...(writeFile && { writeFile }),
       });

--- a/packages/deploy-script-support/src/helpers.js
+++ b/packages/deploy-script-support/src/helpers.js
@@ -70,6 +70,8 @@ export const makeHelpers = async (homePromise, endowments) => {
     publishBundle,
     pathResolve,
     cacheDir = pathResolve(os.homedir(), '.agoric/cache'),
+    writeFile,
+    log,
   } = endowments;
 
   // Internal-to-this-function lazy dependencies.
@@ -156,6 +158,8 @@ export const makeHelpers = async (homePromise, endowments) => {
       return makeWriteCoreEval(homePromise, endowments, {
         getBundleSpec: deps.cacheAndGetBundleSpec,
         getBundlerMaker: helpers.getBundlerMaker,
+        ...(log && { log }),
+        ...(writeFile && { writeFile }),
       });
     },
     /** @deprecated use writeCoreEval */
@@ -163,6 +167,8 @@ export const makeHelpers = async (homePromise, endowments) => {
       return makeWriteCoreEval(homePromise, endowments, {
         getBundleSpec: deps.cacheAndGetBundleSpec,
         getBundlerMaker: helpers.getBundlerMaker,
+        ...(log && { log }),
+        ...(writeFile && { writeFile }),
       });
     },
   });

--- a/packages/internal/src/build-cache-types.ts
+++ b/packages/internal/src/build-cache-types.ts
@@ -1,0 +1,42 @@
+export interface LockLifecycleEvent {
+  key: string;
+  lockPath: string;
+  type: 'lock-acquired' | 'lock-released';
+}
+
+export interface LockWaitingEvent {
+  key: string;
+  lockPath: string;
+  type: 'lock-waiting';
+  waitedMs: number;
+}
+
+export interface LockBrokenEvent {
+  ageMs?: number;
+  key: string;
+  lockPath: string;
+  ownerPid?: number;
+  reason: 'dead-owner' | 'stale-age';
+  staleLockMs?: number;
+  type: 'lock-broken';
+}
+
+export type BuildCacheEvent =
+  | LockLifecycleEvent
+  | LockWaitingEvent
+  | LockBrokenEvent;
+
+export interface DirectoryLockPowers {
+  acquireTimeoutMs: number;
+  delayMs: (ms: number) => Promise<unknown>;
+  fs: Pick<
+    typeof import('node:fs/promises'),
+    'mkdir' | 'readFile' | 'rm' | 'stat' | 'writeFile'
+  >;
+  isPidAlive: (pid: number) => boolean;
+  lockRoot: string;
+  now: () => number;
+  onEvent?: (event: BuildCacheEvent) => void;
+  pid: number;
+  staleLockMs: number;
+}

--- a/packages/internal/src/build-cache.js
+++ b/packages/internal/src/build-cache.js
@@ -2,17 +2,7 @@
 import path from 'node:path';
 
 /**
- * @typedef {{
- *   fs: Pick<import('node:fs/promises'), 'mkdir' | 'readFile' | 'rm' | 'stat' | 'writeFile'>;
- *   delayMs: (ms: number) => Promise<unknown>;
- *   now: () => number;
- *   pid: number;
- *   isPidAlive: (pid: number) => boolean;
- *   lockRoot: string;
- *   staleLockMs: number;
- *   acquireTimeoutMs: number;
- *   onEvent?: (event: Record<string, unknown>) => void;
- * }} DirectoryLockPowers
+ * @import {BuildCacheEvent, DirectoryLockPowers} from './build-cache-types.js';
  */
 
 /**

--- a/packages/internal/src/build-cache.js
+++ b/packages/internal/src/build-cache.js
@@ -1,0 +1,191 @@
+/* eslint-env node */
+import path from 'node:path';
+
+/**
+ * @typedef {{
+ *   fs: Pick<import('node:fs/promises'), 'mkdir' | 'readFile' | 'rm' | 'stat' | 'writeFile'>;
+ *   delayMs: (ms: number) => Promise<unknown>;
+ *   now: () => number;
+ *   pid: number;
+ *   isPidAlive: (pid: number) => boolean;
+ *   lockRoot: string;
+ *   staleLockMs: number;
+ *   acquireTimeoutMs: number;
+ *   onEvent?: (event: Record<string, unknown>) => void;
+ * }} DirectoryLockPowers
+ */
+
+/**
+ * @param {DirectoryLockPowers} powers
+ */
+export const makeDirectoryLock = powers => {
+  const {
+    fs,
+    delayMs,
+    now,
+    pid,
+    isPidAlive,
+    lockRoot,
+    staleLockMs,
+    acquireTimeoutMs,
+    onEvent = () => {},
+  } = powers;
+  const safeEmit = event => {
+    try {
+      onEvent(event);
+    } catch {
+      // Event sinks must not interfere with cache lock correctness.
+    }
+  };
+
+  /** @param {string} dpath */
+  const mkdirUnlessExists = async dpath => {
+    await null; // avoid accidentally catching synchronous exceptions
+    try {
+      await fs.mkdir(dpath);
+      return true;
+    } catch (err) {
+      const e = /** @type {NodeJS.ErrnoException} */ (err);
+      if (e.code === 'EEXIST') {
+        return false;
+      }
+      throw err;
+    }
+  };
+
+  /** @param {string} fpath */
+  const statUnlessMissing = async fpath => {
+    await null; // avoid accidentally catching synchronous exceptions
+    try {
+      return await fs.stat(fpath);
+    } catch (err) {
+      const e = /** @type {NodeJS.ErrnoException} */ (err);
+      if (e.code === 'ENOENT') {
+        return undefined;
+      }
+      throw err;
+    }
+  };
+
+  /** @param {string} fpath */
+  const readUnlessMissing = async fpath => {
+    await null; // avoid accidentally catching synchronous exceptions
+    try {
+      return await fs.readFile(fpath, 'utf8');
+    } catch (err) {
+      const e = /** @type {NodeJS.ErrnoException} */ (err);
+      if (e.code === 'ENOENT') {
+        return undefined;
+      }
+      throw err;
+    }
+  };
+
+  /**
+   * @param {string} key
+   * @param {() => Promise<any>} body
+   */
+  const withLock = async (key, body) => {
+    const lockPath = path.join(lockRoot, `${encodeURIComponent(key)}.lock`);
+    const ownerPath = path.join(lockPath, 'owner.json');
+    await fs.mkdir(lockRoot, { recursive: true });
+    const started = now();
+
+    const maybeBreakStaleLock = async () => {
+      const ownerText = await readUnlessMissing(ownerPath);
+      if (ownerText) {
+        try {
+          const ownerInfo = JSON.parse(ownerText);
+          if (
+            ownerInfo &&
+            typeof ownerInfo === 'object' &&
+            Number.isInteger(ownerInfo.pid) &&
+            !isPidAlive(ownerInfo.pid)
+          ) {
+            await fs.rm(lockPath, { recursive: true, force: true });
+            safeEmit({
+              type: 'lock-broken',
+              key,
+              lockPath,
+              reason: 'dead-owner',
+              ownerPid: ownerInfo.pid,
+            });
+            return true;
+          }
+        } catch {
+          // rely on age-based lock breaking for malformed owner files
+        }
+      }
+
+      const lockStats = await statUnlessMissing(lockPath);
+      if (!lockStats) {
+        return true;
+      }
+      const ageMs = now() - lockStats.mtimeMs;
+      if (ageMs >= staleLockMs) {
+        await fs.rm(lockPath, { recursive: true, force: true });
+        safeEmit({
+          type: 'lock-broken',
+          key,
+          lockPath,
+          reason: 'stale-age',
+          ageMs,
+          staleLockMs,
+        });
+        return true;
+      }
+
+      return false;
+    };
+
+    for (;;) {
+      if (await mkdirUnlessExists(lockPath)) {
+        await fs.writeFile(
+          ownerPath,
+          JSON.stringify({ pid, createdAt: now() }),
+          'utf8',
+        );
+        safeEmit({ type: 'lock-acquired', key, lockPath });
+        break;
+      }
+      const recovered = await maybeBreakStaleLock();
+      if (recovered) {
+        continue;
+      }
+      const waitedMs = now() - started;
+      safeEmit({ type: 'lock-waiting', key, lockPath, waitedMs });
+      if (waitedMs >= acquireTimeoutMs) {
+        throw Error(`Timed out waiting for cache lock ${lockPath}`);
+      }
+      await delayMs(20);
+    }
+
+    try {
+      return await body();
+    } finally {
+      await fs.rm(lockPath, { recursive: true, force: true });
+      safeEmit({ type: 'lock-released', key, lockPath });
+    }
+  };
+
+  return harden({ withLock });
+};
+harden(makeDirectoryLock);
+
+/**
+ * @param {{
+ *   fs: Pick<import('node:fs/promises'), 'rename' | 'writeFile'>;
+ *   filePath: string;
+ *   data: string;
+ *   now: () => number;
+ *   pid: number;
+ * }} options
+ * @throws {NodeJS.ErrnoException} when a unique temp file cannot be created
+ *   or the atomic rename fails.
+ */
+export const writeFileAtomic = async ({ fs, filePath, data, now, pid }) => {
+  const tempPath = `${filePath}.${pid}.${now()}.tmp`;
+  await fs.writeFile(tempPath, data, { flag: 'wx' });
+  await fs.rename(tempPath, filePath);
+};
+harden(writeFileAtomic);

--- a/packages/internal/src/build-cache.js
+++ b/packages/internal/src/build-cache.js
@@ -162,6 +162,8 @@ export const makeDirectoryLock = powers => {
 };
 harden(makeDirectoryLock);
 
+let atomicWriteSequence = 0;
+
 /**
  * @param {{
  *   fs: Pick<import('node:fs/promises'), 'rename' | 'writeFile'>;
@@ -174,7 +176,8 @@ harden(makeDirectoryLock);
  *   or the atomic rename fails.
  */
 export const writeFileAtomic = async ({ fs, filePath, data, now, pid }) => {
-  const tempPath = `${filePath}.${pid}.${now()}.tmp`;
+  atomicWriteSequence += 1;
+  const tempPath = `${filePath}.${pid}.${now()}.${atomicWriteSequence}.tmp`;
   await fs.writeFile(tempPath, data, { flag: 'wx' });
   await fs.rename(tempPath, filePath);
 };

--- a/packages/internal/src/types-index.d.ts
+++ b/packages/internal/src/types-index.d.ts
@@ -1,1 +1,2 @@
 export type * from './types.js';
+export type * from './build-cache-types.js';

--- a/packages/internal/test/build-cache.test.js
+++ b/packages/internal/test/build-cache.test.js
@@ -1,0 +1,131 @@
+// @ts-check
+import test from 'ava';
+
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, mkdir, readFile, rm, utimes } from 'node:fs/promises';
+import * as fsPromises from 'node:fs/promises';
+
+import { makeDirectoryLock, writeFileAtomic } from '../src/build-cache.js';
+
+const makeFixture = async t => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'internal-build-cache-'));
+  t.teardown(async () => rm(root, { recursive: true, force: true }));
+  return harden({
+    root,
+    lockRoot: path.join(root, '.locks'),
+    cacheFile: path.join(root, 'artifact.json'),
+  });
+};
+
+test('writeFileAtomic writes content atomically', async t => {
+  const { cacheFile } = await makeFixture(t);
+
+  await writeFileAtomic({
+    fs: fsPromises,
+    filePath: cacheFile,
+    data: '{"hello":"world"}\n',
+    now: Date.now,
+    pid: process.pid,
+  });
+
+  const written = await readFile(cacheFile, 'utf8');
+  t.is(written, '{"hello":"world"}\n');
+});
+
+test('makeDirectoryLock recovers dead-owner lock', async t => {
+  const { lockRoot } = await makeFixture(t);
+  const key = 'dead-owner';
+  const lockPath = path.join(lockRoot, `${encodeURIComponent(key)}.lock`);
+  await mkdir(lockPath, { recursive: true });
+  await fsPromises.writeFile(
+    path.join(lockPath, 'owner.json'),
+    JSON.stringify({ pid: 999_999_999, createdAt: Date.now() }),
+    'utf8',
+  );
+
+  /** @type {Array<{type: string, reason?: string}>} */
+  const events = [];
+  const { withLock } = makeDirectoryLock({
+    fs: fsPromises,
+    delayMs: ms => new Promise(resolve => setTimeout(resolve, ms)),
+    now: Date.now,
+    pid: process.pid,
+    isPidAlive: pid => pid === process.pid,
+    lockRoot,
+    staleLockMs: 60_000,
+    acquireTimeoutMs: 1_000,
+    onEvent: event => events.push(event),
+  });
+
+  const value = await withLock(key, async () => 'ok');
+  t.is(value, 'ok');
+  t.true(events.some(event => event.type === 'lock-broken'));
+  t.true(
+    events.some(
+      event => event.type === 'lock-broken' && event.reason === 'dead-owner',
+    ),
+  );
+});
+
+test('makeDirectoryLock recovers stale lock by age', async t => {
+  const { lockRoot } = await makeFixture(t);
+  const key = 'stale-age';
+  const lockPath = path.join(lockRoot, `${encodeURIComponent(key)}.lock`);
+  await mkdir(lockPath, { recursive: true });
+  await fsPromises.writeFile(path.join(lockPath, 'owner.json'), '{', 'utf8');
+  const staleTime = Date.now() - 120_000;
+  await utimes(lockPath, staleTime / 1000, staleTime / 1000);
+
+  /** @type {Array<{type: string, reason?: string}>} */
+  const events = [];
+  const { withLock } = makeDirectoryLock({
+    fs: fsPromises,
+    delayMs: ms => new Promise(resolve => setTimeout(resolve, ms)),
+    now: Date.now,
+    pid: process.pid,
+    isPidAlive: () => true,
+    lockRoot,
+    staleLockMs: 100,
+    acquireTimeoutMs: 1_000,
+    onEvent: event => events.push(event),
+  });
+
+  await withLock(key, async () => undefined);
+  t.true(
+    events.some(
+      event => event.type === 'lock-broken' && event.reason === 'stale-age',
+    ),
+  );
+});
+
+test('makeDirectoryLock times out waiting for active lock', async t => {
+  const { lockRoot } = await makeFixture(t);
+  const key = 'timeout';
+  const lockPath = path.join(lockRoot, `${encodeURIComponent(key)}.lock`);
+  await mkdir(lockPath, { recursive: true });
+  await fsPromises.writeFile(
+    path.join(lockPath, 'owner.json'),
+    JSON.stringify({ pid: process.pid, createdAt: Date.now() }),
+    'utf8',
+  );
+
+  let tick = 0;
+  const { withLock } = makeDirectoryLock({
+    fs: fsPromises,
+    delayMs: () => Promise.resolve(),
+    now: () => {
+      tick += 25;
+      return tick;
+    },
+    pid: process.pid,
+    isPidAlive: () => true,
+    lockRoot,
+    staleLockMs: 60_000,
+    acquireTimeoutMs: 100,
+  });
+
+  await t.throwsAsync(() => withLock(key, async () => undefined), {
+    message: /Timed out waiting for cache lock/,
+  });
+});


### PR DESCRIPTION
refs: #12381 

## Description

This saves several seconds per `buildAndExtract` in boot/RunUtils tests. It does this through refactoring the code behind `agoric run` to run in-process and to broaden the caching capabilities. It also refactors build caching to consolidate some of the logic. It also adds instrumentation and cleans up some of the earlier time logging.

It should be reviewable by commit.

### Security Considerations
Bundles under test come from cache. Some filesystem and access as the source code.

### Scaling Considerations
n/a

### Documentation Considerations
Should be transparent

### Testing Considerations
CI. Also run locally and have confirmed no rebuilding on subsequent runs.

### Upgrade Considerations
n/a