### PR TITLE
refactor: decouple client-utils published path typing from domain packages

### DIFF
--- a/multichain-testing/scripts/ymax-tool.ts
+++ b/multichain-testing/scripts/ymax-tool.ts
@@ -16,6 +16,7 @@ import type { MovementDesc } from '@aglocal/portfolio-contract/src/type-guards-s
 import {
   TargetAllocationShape,
   type OfferArgsFor,
+  type PortfolioPublishedPathTypes,
   type ProposalType,
   type TargetAllocation,
 } from '@aglocal/portfolio-contract/src/type-guards.ts';
@@ -36,6 +37,7 @@ import {
   makeVstorageKit,
   type makeSmartWalletKit,
   type SigningSmartWalletKit,
+  type TypedPublishedFor,
   type VstorageKit,
 } from '@agoric/client-utils';
 import type { ContractControl } from '@agoric/deploy-script-support/src/control/contract-control.contract.js';
@@ -205,6 +207,9 @@ const parseTypedJSON = <T>(
 };
 
 type SmartWalletKit = Awaited<ReturnType<typeof makeSmartWalletKit>>;
+type PortfolioReadPublished = <P extends string>(
+  subpath: P,
+) => Promise<TypedPublishedFor<P, PortfolioPublishedPathTypes>>;
 
 const noPoll = (wk: SmartWalletKit): SmartWalletKit => ({
   ...wk,
@@ -830,7 +835,10 @@ const main = async (
       const { path } = opened;
       // XXX would be nice if readPublished allowed ^published.
       const subPath = path.replace(/^published./, '') as typeof path;
-      const pq = makePortfolioQuery(walletKit.readPublished, subPath);
+      const pq = makePortfolioQuery(
+        walletKit.readPublished as PortfolioReadPublished,
+        subPath,
+      );
       const status = await pq.getPortfolioStatus();
       trace('status', status);
       if (status.depositAddress && env.AGORIC_NET === 'devnet') {

--- a/multichain-testing/test/fast-usdc/fast-usdc.test.ts
+++ b/multichain-testing/test/fast-usdc/fast-usdc.test.ts
@@ -7,6 +7,7 @@ import { AmountMath, type Brand } from '@agoric/ertp';
 import { divideBy, multiplyBy } from '@agoric/ertp/src/ratio.js';
 import type { USDCProposalShapes } from '@agoric/fast-usdc/src/pool-share-math.js';
 import type { CctpTxEvidence } from '@agoric/fast-usdc/src/types.js';
+import type { TransactionRecord } from '@agoric/fast-usdc/src/types.js';
 import { makeTracer } from '@agoric/internal';
 import type { AccountId, Denom, DenomDetail } from '@agoric/orchestration';
 import type { ExecutionContext, TestFn } from 'ava';
@@ -199,9 +200,9 @@ const makeTestContext = async (t: ExecutionContext) => {
   );
 
   const queryTxRecord = async (txHash: string) => {
-    const record = await common.smartWalletKit.readPublished(
+    const record = (await common.smartWalletKit.readPublished(
       `fastUsdc.txns.${txHash}`,
-    );
+    )) as TransactionRecord;
     if (!record) {
       throw new Error(`no record for ${txHash}`);
     }

--- a/packages/agoric-cli/src/commands/gov.js
+++ b/packages/agoric-cli/src/commands/gov.js
@@ -21,6 +21,7 @@ import {
  * @import {OfferSpec} from '@agoric/smart-wallet/src/offers.js';
  * @import {AgoricNamesRemotes} from '@agoric/vats/tools/board-utils.js';
  * @import {CurrentWalletRecord} from '@agoric/smart-wallet/src/smartWallet.js';
+ * @import {GovernancePublishedPathTypes} from '@agoric/governance/src/types.js';
  * @import {VstorageKit} from '@agoric/client-utils';
  * @import {Logger} from '@agoric/internal/vendor/anylogger.js';
  * @import {Writable} from 'stream';
@@ -346,6 +347,7 @@ export const makeGovCommand = (_logger, io = {}) => {
       normalizeAddress,
     )
     .action(async function (opts, options) {
+      /** @type {VstorageKit<GovernancePublishedPathTypes>} */
       const vsk = makeVstorageKit({ fetch }, networkConfig);
       const { readPublished } = vsk;
 

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -8,7 +8,7 @@ import { basename, join } from 'node:path';
 import { inspect } from 'node:util';
 import tmp from 'tmp';
 
-import type { TypedPublished } from '@agoric/client-utils';
+import type { TypedPublishedFor } from '@agoric/client-utils';
 import { buildSwingset } from '@agoric/cosmic-swingset/src/launch-chain.js';
 import { makeHelpers } from '@agoric/cosmic-swingset/tools/inquisitor.mjs';
 import {
@@ -56,6 +56,8 @@ import type { FastUSDCCorePowers } from '@aglocal/fast-usdc-deploy/src/start-fas
 import type { CoreEvalSDKType } from '@agoric/cosmic-proto/swingset/swingset.js';
 import { computronCounter } from '@agoric/cosmic-swingset/src/computron-counter.js';
 import { defaultBeansPerVatCreation } from '@agoric/cosmic-swingset/src/sim-params.js';
+import type { FastUsdcPublishedPathTypes } from '@agoric/fast-usdc';
+import type { GovernancePublishedPathTypes } from '@agoric/governance/src/types.js';
 import type { EconomyBootstrapPowers } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
 import { base64ToBytes } from '@agoric/network';
 import type { SwingsetController } from '@agoric/swingset-vat/src/controller/controller.js';
@@ -85,6 +87,9 @@ type ConsumeBootrapItem = <N extends string>(
   : N extends keyof EconomyBootstrapPowers['consume']
     ? EconomyBootstrapPowers['consume'][N]
     : unknown;
+
+type BootstrapPublishedPathTypes = FastUsdcPublishedPathTypes &
+  GovernancePublishedPathTypes;
 
 // XXX should satisfy EVProxy from run-utils.js but that's failing to import
 /**
@@ -470,7 +475,10 @@ export const makeSwingsetTestKit = async (
   };
 
   const readPublished = <T extends string>(subpath: T) =>
-    readLatest(`published.${subpath}`) as TypedPublished<T>;
+    readLatest(`published.${subpath}`) as TypedPublishedFor<
+      T,
+      BootstrapPublishedPathTypes
+    >;
 
   let lastBankNonce = 0n;
   let ibcSequenceNonce = 0;

--- a/packages/client-utils/src/signing-smart-wallet-kit.ts
+++ b/packages/client-utils/src/signing-smart-wallet-kit.ts
@@ -44,6 +44,12 @@ export const makeSigningSmartWalletKitFromClient = async ({
   address: string;
   client: SigningStargateClient;
 }) => {
+  type PollOfferWithoutAddressArgs = [
+    id: Parameters<SmartWalletKit['pollOffer']>[1],
+    minHeight?: Parameters<SmartWalletKit['pollOffer']>[2],
+    untilNumWantsSatisfied?: Parameters<SmartWalletKit['pollOffer']>[3],
+  ];
+
   // Omit deprecated utilities
   const { storedWalletState: _, ...swk } = walletUtils;
 
@@ -52,14 +58,8 @@ export const makeSigningSmartWalletKitFromClient = async ({
     vstorage: swk.vstorage,
     getLastUpdate: () => swk.getLastUpdate(address),
     getCurrentWalletRecord: () => swk.getCurrentWalletRecord(address),
-    pollOffer: (
-      ...args: Parameters<SmartWalletKit['pollOffer']> extends [
-        any,
-        ...infer Rest,
-      ]
-        ? Rest
-        : never
-    ) => swk.pollOffer(address, ...args),
+    pollOffer: (...args: PollOfferWithoutAddressArgs) =>
+      swk.pollOffer(address, ...args),
   };
 
   const sendBridgeAction = async (

--- a/packages/client-utils/src/smart-wallet-kit.js
+++ b/packages/client-utils/src/smart-wallet-kit.js
@@ -13,7 +13,7 @@ import {
  * @import {CurrentWalletRecord, UpdateRecord} from '@agoric/smart-wallet/src/smartWallet.js';
  * @import {MinimalNetworkConfig} from './network-config.js';
  * @import {RetryOptionsAndPowers} from './sync-tools.js';
- * @import {VstorageKit} from './vstorage-kit.js';
+ * @import {VstorageKit} from './types.js';
  * @import {AgoricNamesRemotes} from '@agoric/vats/tools/board-utils.js';
  * @import {Instance, InvitationDetails} from '@agoric/zoe';
  */

--- a/packages/client-utils/src/sync-tools.js
+++ b/packages/client-utils/src/sync-tools.js
@@ -15,7 +15,7 @@
 
 /**
  * @import {RemotableObject} from '@endo/marshal';
- * @import {VstorageKit} from './vstorage-kit.js';
+ * @import {VstorageKit} from './types.js';
  */
 
 /**

--- a/packages/client-utils/src/vstorage-kit.js
+++ b/packages/client-utils/src/vstorage-kit.js
@@ -10,7 +10,7 @@ export { boardSlottingMarshaller };
 /**
  * @import {Marshal} from '@endo/marshal';
  * @import {MinimalNetworkConfig} from './network-config.js';
- * @import {TypedPublished} from './types.js';
+ * @import {PublishedPathTypes, TypedPublishedFor, VstorageKit} from './types.js';
  * @import {VStorage} from './vstorage.js';
  * @import {AgoricNamesRemotes} from '@agoric/vats/tools/board-utils.js';
  * @import {BoardRemote} from '@agoric/vats/tools/board-utils.js';
@@ -97,10 +97,12 @@ export const makeAgoricNames = async (ctx, vstorage) => {
 };
 
 /**
+ * @template {PublishedPathTypes} [Ext={}]
  * @param {object} config
  * @param {VStorage} config.vstorage
  * @param {MinimalNetworkConfig} config.networkConfig
  * @param {Pick<Marshal<string>, 'fromCapData' | 'toCapData'>} [config.marshaller]
+ * @returns {VstorageKit<Ext>}
  * @alpha
  */
 export const makeVstorageKitFromVstorage = ({
@@ -150,10 +152,10 @@ export const makeVstorageKitFromVstorage = ({
    * vstorage, which is validated in testing of the chain code that is run
    * in consensus.
    *
-   * @type {<T extends string>(subpath: T) => Promise<TypedPublished<T>>}
+   * @type {<T extends string>(subpath: T) => Promise<TypedPublishedFor<T, Ext>>}
    */
   const readPublished = subpath =>
-    /** @type {Promise<TypedPublished<any>>} */ (
+    /** @type {Promise<TypedPublishedFor<any, Ext>>} */ (
       readLatestHead(`published.${subpath}`)
     );
 
@@ -170,8 +172,10 @@ export const makeVstorageKitFromVstorage = ({
 harden(makeVstorageKitFromVstorage);
 
 /**
+ * @template {PublishedPathTypes} [Ext={}]
  * @param {{ fetch: typeof window.fetch }} io
  * @param {MinimalNetworkConfig} networkConfig
+ * @returns {VstorageKit<Ext>}
  */
 export const makeVstorageKit = ({ fetch }, networkConfig) => {
   const vstorage = tryNow(
@@ -183,5 +187,3 @@ export const makeVstorageKit = ({ fetch }, networkConfig) => {
   return makeVstorageKitFromVstorage({ vstorage, networkConfig });
 };
 harden(makeVstorageKit);
-
-/** @typedef {ReturnType<typeof makeVstorageKit>} VstorageKit */

--- a/packages/fast-usdc/src/cli/lp-commands.js
+++ b/packages/fast-usdc/src/cli/lp-commands.js
@@ -5,6 +5,7 @@
  * @import {OfferSpec} from '@agoric/smart-wallet/src/offers.js';
  * @import {ExecuteOfferAction} from '@agoric/smart-wallet/src/smartWallet.js';
  * @import {USDCProposalShapes} from '../pool-share-math.js';
+ * @import {PoolMetrics} from '../types.js';
  * @import {SmartWalletKit} from '@agoric/client-utils';
  */
 
@@ -98,7 +99,9 @@ export const addLPCommands = (
 
       const usdcAmount = parseUSDCAmount(opts.amount, usdc);
 
-      const metrics = await swk.readPublished('fastUsdc.poolMetrics');
+      const metrics = /** @type {PoolMetrics} */ (
+        await swk.readPublished('fastUsdc.poolMetrics')
+      );
       const fastLPAmount = floorDivideBy(usdcAmount, metrics.shareWorth);
 
       const offer = Offers.fastUsdc.Deposit(swk.agoricNames, {
@@ -141,7 +144,9 @@ export const addLPCommands = (
 
       const usdcAmount = parseUSDCAmount(opts.amount, usdc);
 
-      const metrics = await swk.readPublished('fastUsdc.poolMetrics');
+      const metrics = /** @type {PoolMetrics} */ (
+        await swk.readPublished('fastUsdc.poolMetrics')
+      );
       const fastLPAmount = ceilDivideBy(usdcAmount, metrics.shareWorth);
 
       const offer = Offers.fastUsdc.Withdraw(swk.agoricNames, {

--- a/packages/fast-usdc/src/types.ts
+++ b/packages/fast-usdc/src/types.ts
@@ -130,6 +130,17 @@ export interface PoolMetrics extends PoolStats {
   shareWorth: Ratio;
 }
 
+/**
+ * Published vstorage values under the `fastUsdc.` hierarchy.
+ */
+export type FastUsdcPublishedPathTypes = {
+  fastUsdc: ContractRecord;
+  'fastUsdc.feeConfig': FeeConfig;
+  'fastUsdc.poolMetrics': PoolMetrics;
+} & {
+  [K in `fastUsdc.txns.${string}`]: TransactionRecord;
+};
+
 export interface ChainPolicy {
   /** `msg.sender` of DepositAndBurn to TokenMessenger must be an attenuated wrapper contract that does not contain `replaceDepositForBurn` */
   attenuatedCttpBridgeAddresses: EvmHash[];

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -161,6 +161,16 @@ export {};
  */
 
 /**
+ * Published vstorage values under the `committees.` hierarchy.
+ *
+ * @typedef {{
+ *   [K in `committees.${string}.latestQuestion`]: QuestionDetails;
+ * } & {
+ *   [K in `committees.${string}.latestOutcome`]: OutcomeRecord;
+ * }} GovernancePublishedPathTypes
+ */
+
+/**
  * @typedef {object} GovernancePair
  * @property {Instance} governor
  * @property {Instance} governed

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -269,6 +269,30 @@ export const TargetAllocationShapeExt: TypedPattern<Record<string, NatValue>> =
 // XXX the vstorage path API is kinda awkward to use; see ymax-deploy.test.ts
 
 /**
+ * Published vstorage values produced by the portfolio contract.
+ */
+export type PortfolioPublishedPathTypes = {
+  ymax0: StatusFor['contract'];
+  ymax1: StatusFor['contract'];
+  'ymax0.portfolios': StatusFor['portfolios'];
+  'ymax1.portfolios': StatusFor['portfolios'];
+} & {
+  [K in `ymax${'0' | '1'}.portfolios.portfolio${number}`]: StatusFor['portfolio'];
+} & {
+  [K in `ymax${'0' | '1'}.portfolios.portfolio${number}.positions.${string}`]: StatusFor['position'];
+} & {
+  [K in `ymax${'0' | '1'}.portfolios.portfolio${number}.pendingTx.tx${number}`]: StatusFor['pendingTx'];
+} & {
+  [K in `ymax${'0' | '1'}.portfolios.portfolio${number}.flows.flow${number}`]: StatusFor['flow'];
+} & {
+  [K in `ymax${'0' | '1'}.portfolios.portfolio${number}.flows.flow${number}.steps`]: StatusFor['flowSteps'];
+} & {
+  [K in `ymax${'0' | '1'}.evmWallets.0x${string}.portfolio`]: StatusFor['evmWalletPortfolios'];
+} & {
+  [K in `ymax${'0' | '1'}.evmWallets.0x${string}`]: StatusFor['evmWallet'];
+};
+
+/**
  * Creates vstorage path for portfolio status under published.ymax0.
  *
  * Portfolio status includes position counts, account mappings, and flow history.

--- a/packages/portfolio-contract/test/contract-setup.ts
+++ b/packages/portfolio-contract/test/contract-setup.ts
@@ -15,6 +15,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 import type { PortfolioPrivateArgs } from '../src/portfolio.contract.ts';
 import * as contractExports from '../src/portfolio.contract.ts';
 import type { PublishedTx, TxId, TxStatus } from '../src/resolver/types.ts';
+import type { PortfolioPublishedPathTypes } from '../src/type-guards.ts';
 import { makeEvmTrader, makeTrader } from '../tools/portfolio-actors.ts';
 import { makeWallet } from '../tools/wallet-offer-tools.ts';
 import {
@@ -43,7 +44,7 @@ const makeReadPublished = (
       .getDeserialized(`${ROOT_STORAGE_PATH}.${subpath}`)
       .at(-1);
     return val;
-  }) as unknown as VstorageKit['readPublished'];
+  }) as unknown as VstorageKit<PortfolioPublishedPathTypes>['readPublished'];
 
 const makeEvmWalletHandler = async (
   zoe: ZoeService,

--- a/packages/portfolio-contract/test/supports.ts
+++ b/packages/portfolio-contract/test/supports.ts
@@ -30,7 +30,10 @@ import type { AssetInfo } from '@agoric/vats/src/vat-bank.js';
 import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
 import { E } from '@endo/far';
 import type { ExecutionContext } from 'ava';
-import type { StatusFor } from '../src/type-guards.ts';
+import type {
+  PortfolioPublishedPathTypes,
+  StatusFor,
+} from '../src/type-guards.ts';
 import type { MovementDesc } from '../src/type-guards-steps.js';
 
 // Use realistic flow values (e.g., millions of uUSDC) but format for
@@ -116,7 +119,7 @@ export const makeStorageTools = (storage: FakeStorageKit) => {
         storage.getValues(`${ROOT_STORAGE_PATH}.${path}`).at(-1) || '',
       ),
     );
-  }) as VstorageKit['readPublished'];
+  }) as VstorageKit<PortfolioPublishedPathTypes>['readPublished'];
 
   const readLegible = async (path: string) => {
     await vstoragePendingWrites();

--- a/packages/portfolio-contract/test/target-allocation.test.ts
+++ b/packages/portfolio-contract/test/target-allocation.test.ts
@@ -7,6 +7,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import { E } from '@endo/far';
 import { makeTrader } from '../tools/portfolio-actors.js';
 import { makeWallet } from '../tools/wallet-offer-tools.js';
+import type { PortfolioPublishedPathTypes } from '../src/type-guards.ts';
 import { setupTrader } from './contract-setup.js';
 
 const ackNFA = (utils, ix = 0) =>
@@ -65,7 +66,7 @@ test('multiple portfolios have independent allocations', async t => {
     await eventLoopIteration();
     const val = storage.getDeserialized(`orchtest.${subpath}`).at(-1);
     return val;
-  }) as unknown as VstorageKit['readPublished'];
+  }) as unknown as VstorageKit<PortfolioPublishedPathTypes>['readPublished'];
 
   // Create two separate wallets and traders
   const { mint: _, ...poc26SansMint } = poc26;

--- a/packages/portfolio-contract/tools/portfolio-actors.ts
+++ b/packages/portfolio-contract/tools/portfolio-actors.ts
@@ -28,6 +28,7 @@ import {
   portfolioIdOfPath,
   type OfferArgsFor,
   type ProposalType,
+  type PortfolioPublishedPathTypes,
   type StatusFor,
   type PoolKey,
   type EVMContractAddressesMap,
@@ -56,7 +57,7 @@ assert.equal(ROOT_STORAGE_PATH, 'orchtest');
 const stripRoot = (path: string) => path.replace(/^orchtest\./, '');
 
 export const makePortfolioQuery = (
-  readPublished: VstorageKit['readPublished'],
+  readPublished: VstorageKit<PortfolioPublishedPathTypes>['readPublished'],
   portfolioKey: `${string}.portfolios.portfolio${number}`,
 ) => {
   const self = harden({
@@ -100,7 +101,7 @@ export const makePortfolioQuery = (
 export const makeTrader = (
   wallet: WalletTool,
   instance: Instance<typeof start>,
-  readPublished: VstorageKit['readPublished'] = () =>
+  readPublished: VstorageKit<PortfolioPublishedPathTypes>['readPublished'] = () =>
     assert.fail('no vstorage access'),
 ) => {
   let nonce = 0;
@@ -277,7 +278,7 @@ type EvmTraderConfig = {
   contractsByChain: EVMContractAddressesMap;
   chainInfoByName: Record<AxelarChain, ChainInfo<'eip155'>>;
   timerService: ERemote<TimerService>;
-  readPublished: VstorageKit['readPublished'];
+  readPublished: VstorageKit<PortfolioPublishedPathTypes>['readPublished'];
   when: VowTools['when'];
 };
 
@@ -308,11 +309,15 @@ export const makeEvmTrader = ({
     await when(vow);
   };
 
+  // FIXME: bare `evmWallets.*` paths are inconsistent with the `ymax0|ymax1`
+  // published root contract; switch to rooted paths.
   const getWalletPortfolios = async () =>
     readPublished(`evmWallets.${account.address}.portfolio`) as Promise<
       StatusFor['evmWalletPortfolios']
     >;
 
+  // FIXME: bare `evmWallets.*` paths are inconsistent with the `ymax0|ymax1`
+  // published root contract; switch to rooted paths.
   const getWalletStatus = async () =>
     readPublished(`evmWallets.${account.address}`) as Promise<
       StatusFor['evmWallet']

--- a/packages/portfolio-deploy/test/portfolio.test.ts
+++ b/packages/portfolio-deploy/test/portfolio.test.ts
@@ -481,7 +481,9 @@ test.serial('restart contract', async t => {
   // XXX There is got to be a cleaner way to do this
   const getPortfolioCount = () => {
     try {
-      const portfolioData = t.context.readPublished('ymax0.portfolios');
+      const portfolioData = t.context.readPublished('ymax0.portfolios') as {
+        addPortfolio: string;
+      };
       const match = portfolioData.addPortfolio.match(/^portfolio(\d+)$/);
       return parseInt(match![1], 10) + 1;
     } catch (e) {
@@ -789,7 +791,7 @@ test.serial('invite evm handler; test open portfolio', async t => {
 
   const portfolios = t.context.readPublished(
     `ymax0.evmWallets.${userAccount.address}.portfolio`,
-  );
+  ) as string[];
 
   t.true(portfolios.some(p => p.endsWith(portfolio)));
 });
@@ -946,7 +948,9 @@ test.serial(
 
     const getPortfolioCount = () => {
       try {
-        const portfolioData = t.context.readPublished('ymax0.portfolios');
+        const portfolioData = t.context.readPublished('ymax0.portfolios') as {
+          addPortfolio: string;
+        };
         const match = portfolioData.addPortfolio.match(/^portfolio(\d+)$/);
         return parseInt(match![1], 10) + 1;
       } catch {

--- a/packages/smart-wallet/src/types.ts
+++ b/packages/smart-wallet/src/types.ts
@@ -12,6 +12,7 @@ import type { AgoricNamesRemotes } from '@agoric/vats/tools/board-utils.js';
 import type { InvitationDetails } from '@agoric/zoe';
 import type { PublicTopic } from '@agoric/zoe/src/contractSupport/topics.js';
 import type { OfferSpec } from './offers.js';
+import type { CurrentWalletRecord, UpdateRecord } from './smartWallet.js';
 
 // Match the type in Zoe, which can't be imported because it's ambient.
 // This omits the parameters that aren't used in this module.
@@ -88,3 +89,13 @@ export type OfferMaker = (
   agoricNames: AgoricNamesRemotes,
   ...rest: any[]
 ) => OfferSpec;
+
+/**
+ * Published vstorage values under the `wallet.` hierarchy.
+ */
+export type SmartWalletPublishedPathValue<P extends string> =
+  P extends `wallet.${string}.current`
+    ? CurrentWalletRecord
+    : P extends `wallet.${string}`
+      ? UpdateRecord
+      : never;

--- a/packages/vats/src/types.ts
+++ b/packages/vats/src/types.ts
@@ -1,13 +1,30 @@
 /* eslint-disable @typescript-eslint/no-unused-vars -- fails to notice the @see uses */
 import type { JsonSafe } from '@agoric/cosmic-proto';
+import type { Brand, Issuer } from '@agoric/ertp';
 import type { FungibleTokenPacketData } from '@agoric/cosmic-proto/ibc/applications/transfer/v2/packet.js';
 import type { PacketSDKType } from '@agoric/cosmic-proto/ibc/core/channel/v1/channel.js';
 import type { BridgeId, Remote } from '@agoric/internal';
 import type { Bytes } from '@agoric/network';
 import type { Guarded } from '@endo/exo';
 import type { CaipChainId } from '@agoric/orchestration';
+import type {
+  Installation,
+  Instance,
+} from '@agoric/zoe/src/zoeService/types.js';
 import type { TargetApp } from './bridge-target.js';
 import type { LocalChainAccount } from './localchain.js';
+import type { AssetInfo } from './vat-bank.js';
+
+/**
+ * Published vstorage values under the `agoricNames.` hierarchy.
+ */
+export type AgoricNamesPublishedPathTypes = {
+  'agoricNames.installation': Array<[string, Installation]>;
+  'agoricNames.instance': Array<[string, Instance]>;
+  'agoricNames.brand': Array<[string, Brand]>;
+  'agoricNames.issuer': Array<[string, Issuer]>;
+  'agoricNames.vbankAsset': Array<[string, AssetInfo]>;
+};
 
 export type Board = ReturnType<
   ReturnType<typeof import('./lib-board.js').prepareBoardKit>

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -19,6 +19,7 @@ import type {
 } from '@aglocal/portfolio-contract/tools/network/network-spec.js';
 import type { GasEstimator } from '@aglocal/portfolio-contract/tools/plan-solve.ts';
 import { makePortfolioQuery } from '@aglocal/portfolio-contract/tools/portfolio-actors.js';
+import type { PortfolioPublishedPathTypes } from '@aglocal/portfolio-contract/src/type-guards.ts';
 import type { VstorageKit } from '@agoric/client-utils';
 import { AmountMath } from '@agoric/ertp';
 import type { Brand, NatAmount } from '@agoric/ertp/src/types.js';
@@ -74,7 +75,7 @@ const handleDeposit = async (
   amount: NatAmount,
   feeBrand: Brand<'nat'>,
   powers: {
-    readPublished: VstorageKit['readPublished'];
+    readPublished: VstorageKit<PortfolioPublishedPathTypes>['readPublished'];
     cosmosRest?: CosmosRestClient;
     gasEstimator: GasEstimator;
     spectrumBlockchain?: SpectrumBlockchainSdk;
@@ -226,9 +227,9 @@ test('handleDeposit works with mocked dependencies', async t => {
   };
 
   // Mock VstorageKit
-  const mockVstorageKit: VstorageKit = {
+  const mockVstorageKit: VstorageKit<PortfolioPublishedPathTypes> = {
     readPublished: mockReadPublished,
-  } as VstorageKit;
+  } as VstorageKit<PortfolioPublishedPathTypes>;
 
   const result = await handleDeposit(portfolioKey, deposit, feeBrand, {
     readPublished: mockVstorageKit.readPublished,
@@ -300,9 +301,9 @@ test('handleDeposit handles missing targetAllocation gracefully', async t => {
   };
 
   // Mock VstorageKit
-  const mockVstorageKit: VstorageKit = {
+  const mockVstorageKit: VstorageKit<PortfolioPublishedPathTypes> = {
     readPublished: mockReadPublished,
-  } as VstorageKit;
+  } as VstorageKit<PortfolioPublishedPathTypes>;
 
   const result = await handleDeposit(portfolioKey, deposit, feeBrand, {
     readPublished: mockVstorageKit.readPublished,
@@ -346,9 +347,9 @@ test('handleDeposit handles different position types correctly', async t => {
   };
 
   // Mock VstorageKit
-  const mockVstorageKit: VstorageKit = {
+  const mockVstorageKit: VstorageKit<PortfolioPublishedPathTypes> = {
     readPublished: mockReadPublished,
-  } as VstorageKit;
+  } as VstorageKit<PortfolioPublishedPathTypes>;
 
   const result = await handleDeposit(
     portfolioKey,


### PR DESCRIPTION
## Summary
- refactor `@agoric/client-utils` published path typing to be generic via `VstorageKit<PublishedPathTypes>` with core defaults only (`agoricNames.*` + `wallet.*`)
- move domain-specific published path mappings to owning packages:
  - `GovernancePublishedPathTypes` in `@agoric/governance`
  - `FastUsdcPublishedPathTypes` in `@agoric/fast-usdc`
  - `PortfolioPublishedPathTypes` in `@aglocal/portfolio-contract`
- update callsites/tests to provide explicit path-map typing where non-core paths are read
- add FIXME for bare `evmWallets.*` reads in portfolio actors to switch to rooted `ymax0|ymax1` paths

## Validation
- `yarn build`
- `yarn typecheck-quick`

Makes progress on https://github.com/Agoric/agoric-sdk/issues/11601.
