### PR TITLE
spike(portfolio-contract): vault flow design + creatorFacet createVault

### DIFF
--- a/multichain-testing/scripts/ymax-admin.ts
+++ b/multichain-testing/scripts/ymax-admin.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env -S node --import ts-blank-space/register
+/**
+ * @file tools for smart wallet stores, e.g. ymaxControl
+ */
+import '@endo/init';
+
+import type { RunTools } from '@aglocal/portfolio-deploy/src/wallet-admin-types.ts';
+import {
+  fetchEnvNetworkConfig,
+  makeSigningSmartWalletKit,
+  makeSmartWalletKit,
+  reflectWalletStore,
+} from '@agoric/client-utils';
+import { makeTracer } from '@agoric/internal';
+import { makeFileRW } from '@agoric/pola-io/src/file.js';
+import { SigningStargateClient, type StdFee } from '@cosmjs/stargate';
+import { Fail } from '@endo/errors';
+import { E } from '@endo/far';
+import fsp from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const Usage = `tool.ts MODULE ...args`;
+
+const trace = makeTracer('ymax-admin');
+
+const makeFee = ({
+  gas = 20_000, // cosmjs default
+  adjustment = 1.0,
+  price = 0.03,
+  denom = 'ubld',
+} = {}): StdFee => ({
+  gas: `${Math.round(gas * adjustment)}`,
+  amount: [{ denom, amount: `${Math.round(gas * adjustment * price)}` }],
+});
+
+export const main = async (
+  argv = process.argv,
+  env = process.env,
+  {
+    fetch = globalThis.fetch,
+    setTimeout = globalThis.setTimeout,
+    connectWithSigner = SigningStargateClient.connectWithSigner,
+    now = Date.now,
+    cwd = process.cwd,
+  } = {},
+) => {
+  const fresh = () => new Date(now()).toISOString();
+  const delay = (ms: number) =>
+    new Promise(resolve => setTimeout(resolve, ms)).then(_ => {});
+
+  const networkConfig = await fetchEnvNetworkConfig({ env, fetch });
+  const walletKit = await makeSmartWalletKit({ fetch, delay }, networkConfig);
+
+  const storeOpts: Partial<TxOpts> = {
+    setTimeout,
+    log: trace,
+    makeNonce: fresh,
+    // use generous gas limit for portfolio-contract,
+    // and a gas price as observed on the RPC node we use on this network.
+    fee: makeFee({ gas: 2_500_000 }),
+    maxRetries: 30,
+  };
+
+  const makeAccount = async (name: string) => {
+    trace('makeAccount', name);
+    const mnemonic = env[name] || Fail`${name} not set`;
+    const ssk = await makeSigningSmartWalletKit(
+      { connectWithSigner, walletUtils: walletKit },
+      mnemonic,
+    );
+    return harden({
+      ...ssk,
+      get store() {
+        return reflectWalletStore(ssk, storeOpts);
+      },
+    });
+  };
+
+  const [_node, _script, specifier, ...scriptArgs] = argv;
+
+  if (!specifier) throw Usage;
+  const cwdPath = `${cwd()}/`;
+  const nodeRequire = createRequire(cwdPath);
+  const modPath = nodeRequire.resolve(specifier);
+  const mod = await import(modPath);
+  const fn: (tools: Partial<RunTools>) => Promise<void> = mod.default;
+  if (!fn) {
+    throw Error(`no default export from ${specifier}`);
+  }
+
+  const cwdIO = makeFileRW(cwdPath, { fsp, path });
+  const tools = {
+    E,
+    harden,
+    scriptArgs,
+    walletKit,
+    makeAccount,
+    cwd: cwdIO,
+  };
+  await fn(tools);
+};
+
+// TODO: use endo-exec so we can unit test the above
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/portfolio-contract/.context-vaults/nifty-vaults.story.md
+++ b/packages/portfolio-contract/.context-vaults/nifty-vaults.story.md
@@ -1,0 +1,43 @@
+# NiftyVaults \- a story
+
+Story
+
+* Chris wants to build a vault that others can invest in made of up 4 different instruments available within Ymax  
+* Chris wants to ensure that on an hourly basis the vault moves all invested funds to the instruments with the highest APY over the past 24 hours  
+* Chris can choose to configure receiving a portion of yield generated as a fee  
+* End-users need to be able to come in and deposit USDC into the vault and get LP tokens out  
+* End-users need to be able to redeem LP tokens to get their USDC back (including any yield) 
+
+Requirements:
+
+* Imagine only 1 deposit asset (USDC)  
+* Imagine only instruments that are already available through Ymax  
+* Imagine only networks that are already available through Ymax
+
+Clarified assumptions for this spike:
+
+* The story models one vault; product direction can support one vault per creator/strategy.
+* Rebalancing is best-effort hourly.
+* LP token/share behavior for this spike follows ERC-4626.
+* Chris picks instruments from the existing Ymax instrument table; for this spike, Chris's instrument choices can be fixed.
+* The creator fee is a cut of yield (performance fee).
+* End-user UI is in scope; creator UI is a stretch goal.
+
+Look at:
+
+* [ERC-4626](https://ethereum.org/developers/docs/standards/tokens/erc-4626)  
+* Veda BoringVault  
+* Can consider looking at [Somm](https://app.somm.finance/)
+
+Some questions
+
+* Currently we use an off-chain service to get APYs  
+  * Could we integrate with on-chain oracles like Chainlink?
+
+Background
+
+* [Veda Blog — What Is DeFi Yield? A Beginner’s Guide](https://veda.tech/blog/what-is-defi-yield-how-does-it-work-beginners-guide) February 11, 2026
+
+Project Management stuff:
+
+* [Spike: Vaults › Overview](https://linear.app/agoric/project/spike-vaults-7ffbdd922a3e/overview)

--- a/packages/portfolio-contract/.context-vaults/ymax-vaults-spike.plan.md
+++ b/packages/portfolio-contract/.context-vaults/ymax-vaults-spike.plan.md
@@ -137,6 +137,18 @@ We'd like a quick spike / prototype to begin to estimate the cost and risks of a
    - [x] prototype directly in `agoric-labs/ymax0-ui0` to leverage fast PR deploy previews
    - [ ] EVM contract spike: implement/fork contract changes with unit tests up front before any deploy/integration steps
      - [ ] planned next (not now): encode privileged extension and accounting invariants as Solidity unit tests first
-   - [ ] stretch goal 🚀: add periodic timer-driven rebalance in code path (orthogonal to core demo)
+   - [x] out of scope: periodic timer-driven rebalance in code path (orthogonal to core demo)
    - [ ] deferred design-to-code task (not now): derive a minimal simulation scaffold from sequence diagrams (e.g., `makeUI(0xVAU1)`, `makeVault()`, `deposit(amount)`, `rebalance()`, `redeem(shares)`)
    - [ ] brand new prototype UI?
+
+## T-Shirt Estimates
+
+- [ ] `agoric-to-axelar-local` EVM vault/factory contract changes (deposit-triggered excess transfer, managed-assets accounting, factory-mediated reporting): `L`
+  - [ ] `agoric-to-axelar-local` EVM vault changes: deposit-triggered excess transfer to `ownerPortfolioAccount` + `managedAssets` accounting updates: `M`
+  - [ ] `agoric-to-axelar-local` EVM factory/reporting changes: `assetReporter` constructor arg and `reportManagedAssets` forwarder (`reporter -> factory -> vault` guards): `M`
+  - [ ] `agoric-to-axelar-local` EVM contract config/plumbing: constructor params, role wiring, and event surface updates for demo integration: `M`
+- [ ] `agoric-to-axelar-local` Solidity/Jest unit tests for invariants and authority guards: `M`
+- [ ] `agoric-sdk/packages/portfolio-contract` APY seam + planner/contract integration updates (plan-only boundary): `M`
+- [ ] `agoric-sdk/packages/portfolio-contract` wiring for creator-facet `createVault(...)` via `ymaxControl`: `M`
+- [ ] `ymax0-ui0` end-user demo flow updates (deposit/withdraw state, vault URL pathing, basic status): `M`
+- [ ] Deployment/config wiring across testnets (factory address, reporter address, env/config propagation): `M`

--- a/packages/portfolio-contract/.context-vaults/ymax-vaults-spike.plan.md
+++ b/packages/portfolio-contract/.context-vaults/ymax-vaults-spike.plan.md
@@ -166,3 +166,13 @@ We'd like a quick spike / prototype to begin to estimate the cost and risks of a
 - [ ] Agoric-side seam: planner->contract boundary carries executable plan only (no APY payload), with policy/version context
 - [x] Agoric-side creator flow: creator-facet `createVault(...)` via `ymaxControl` starts a vault-backed portfolio with fixed target allocation and returns `{ portfolioId, storagePath }` for follow-on wiring
 - [ ] Integration smoke (non-UI): end-to-end happy path reaches “funds moved to `@Avalanche` with accounting updated”
+
+
+## notes
+
+ - split portfolio owner capability between
+   - hot: setAllocation, rebalance
+   - cold: withdraw
+     - withdraw only goes to the vault1 account
+
+"help! I need funds" can be a GMP message

--- a/packages/portfolio-contract/.context-vaults/ymax-vaults-spike.plan.md
+++ b/packages/portfolio-contract/.context-vaults/ymax-vaults-spike.plan.md
@@ -133,22 +133,33 @@ We'd like a quick spike / prototype to begin to estimate the cost and risks of a
      - [x] yes: add focused tests for sync redeem, timer overlap/coalescing behavior, and policy/version guardrails
 
  - [ ] write code
-   - [ ] define APY seam API for spike (planner submits allocation plan under policyVersion)
+   - [x] define APY seam API for spike (planner submits allocation plan under policyVersion)
    - [x] prototype directly in `agoric-labs/ymax0-ui0` to leverage fast PR deploy previews
-   - [ ] EVM contract spike: implement/fork contract changes with unit tests up front before any deploy/integration steps
-     - [ ] planned next (not now): encode privileged extension and accounting invariants as Solidity unit tests first
+   - [x] EVM contract spike: implement/fork contract changes with unit tests up front before any deploy/integration steps
+     - [x] encode privileged extension and accounting invariants as Solidity unit tests first
    - [x] out of scope: periodic timer-driven rebalance in code path (orthogonal to core demo)
    - [ ] deferred design-to-code task (not now): derive a minimal simulation scaffold from sequence diagrams (e.g., `makeUI(0xVAU1)`, `makeVault()`, `deposit(amount)`, `rebalance()`, `redeem(shares)`)
-   - [ ] brand new prototype UI?
+   - [x] creator/admin prototype UI wiring for spike (`creatorFacet.createVault(...)` trigger with fixed allocation)
 
 ## T-Shirt Estimates
 
-- [ ] `agoric-to-axelar-local` EVM vault/factory contract changes (deposit-triggered excess transfer, managed-assets accounting, factory-mediated reporting): `L`
-  - [ ] `agoric-to-axelar-local` EVM vault changes: deposit-triggered excess transfer to `ownerPortfolioAccount` + `managedAssets` accounting updates: `M`
-  - [ ] `agoric-to-axelar-local` EVM factory/reporting changes: `assetReporter` constructor arg and `reportManagedAssets` forwarder (`reporter -> factory -> vault` guards): `M`
-  - [ ] `agoric-to-axelar-local` EVM contract config/plumbing: constructor params, role wiring, and event surface updates for demo integration: `M`
-- [ ] `agoric-to-axelar-local` Solidity/Jest unit tests for invariants and authority guards: `M`
+- [x] `agoric-to-axelar-local` EVM vault/factory contract changes (deposit-triggered excess transfer, managed-assets accounting, factory-mediated reporting): `L`
+  - [x] `agoric-to-axelar-local` EVM vault changes: deposit-triggered excess transfer to `ownerPortfolioAccount` + `managedAssets` accounting updates: `M`
+  - [x] `agoric-to-axelar-local` EVM factory/reporting changes: `assetReporter` constructor arg and `reportManagedAssets` forwarder (`reporter -> factory -> vault` guards): `M`
+  - [x] `agoric-to-axelar-local` EVM contract config/plumbing: constructor params, role wiring, and event surface updates for demo integration: `M`
+- [x] `agoric-to-axelar-local` Solidity/Jest unit tests for invariants and authority guards: `M`
 - [ ] `agoric-sdk/packages/portfolio-contract` APY seam + planner/contract integration updates (plan-only boundary): `M`
-- [ ] `agoric-sdk/packages/portfolio-contract` wiring for creator-facet `createVault(...)` via `ymaxControl`: `M`
+- [x] `agoric-sdk/packages/portfolio-contract` wiring for creator-facet `createVault(...)` via `ymaxControl`: `M`
 - [ ] `ymax0-ui0` end-user demo flow updates (deposit/withdraw state, vault URL pathing, basic status): `M`
 - [ ] Deployment/config wiring across testnets (factory address, reporter address, env/config propagation): `M`
+
+## Test Obligations (Code First)
+
+- [x] EVM vault: `deposit(...)` mints shares and keeps `totalAssets = localBalance + managedAssets` invariant when excess is transferred to `ownerPortfolioAccount`
+- [x] EVM vault: excess-transfer logic follows tiered liquidity policy and `5%` hysteresis for Chris spike defaults
+- [x] EVM factory/vault reporting path: only `0xASSET_REPORTER` can call factory reporting; vault accepts reports only from factory
+- [x] EVM vault reporting semantics: `reportManagedAssets(newManagedAssets, asOf, reportId)` uses absolute values and rejects stale/replayed report identifiers
+- [x] EVM redeem gating: sync redeem succeeds only when local liquidity is sufficient and `maxReportAge = 8h` freshness gate passes
+- [ ] Agoric-side seam: planner->contract boundary carries executable plan only (no APY payload), with policy/version context
+- [x] Agoric-side creator flow: creator-facet `createVault(...)` via `ymaxControl` starts a vault-backed portfolio with fixed target allocation and returns `{ portfolioId, storagePath }` for follow-on wiring
+- [ ] Integration smoke (non-UI): end-to-end happy path reaches “funds moved to `@Avalanche` with accounting updated”

--- a/packages/portfolio-contract/.context-vaults/ymax-vaults-spike.plan.md
+++ b/packages/portfolio-contract/.context-vaults/ymax-vaults-spike.plan.md
@@ -35,6 +35,7 @@ We'd like a quick spike / prototype to begin to estimate the cost and risks of a
        - [x] managed-assets update path is explicit/trusted (resolver-gated reporting path)
        - [x] sync redeem is allowed only when local liquidity is sufficient and accounting state is fresh
        - [ ] product TODO 🏭: harden/reporting trust model for managed-assets/NAV updates
+       - [ ] product TODO 🏭: add ERC-4626 slippage protections (`deposit` min-shares-out / `redeem` min-assets-out) to reduce value extraction from report manipulation windows
      - [x] define local-liquidity management approach for spike
        - [x] question: what policy controls local vault liquidity vs deployed funds?
          - [x] choose tiered policy: `max(localLiquidityFloorAssets, localLiquidityPct * totalAssets)` with hysteresis
@@ -79,6 +80,7 @@ We'd like a quick spike / prototype to begin to estimate the cost and risks of a
    - [x] define authority/ownership approach for vault control surfaces
      - [x] question: who owns `VaultFactory` and who is allowed to create vaults?
        - [x] answer: `createVault(...)` is exposed via creator facet; invoked through `ymaxControl` (creator + Agoric partner operational model)
+       - [ ] product TODO 🏭: decide and enforce production permissioning for `createVault(...)` / factory creation rights (not permissionless by default)
      - [x] question: what is the reporting authority path for managed-assets updates?
        - [x] answer: planner controls `0xASSET_REPORTER`; factory constructor stores reporter; `factory.reportManagedAssets(...)` requires `msg.sender == reporter`; factory forwards to vault; vault requires `msg.sender == factory`
      - [x] question: should managed-assets reports be delta or absolute?
@@ -92,6 +94,7 @@ We'd like a quick spike / prototype to begin to estimate the cost and risks of a
        - [ ] production guardrail candidate: tighter `maxReportAge` (e.g. `15m` or `60m`)
        - [ ] production guardrail candidate: hybrid gate (`maxReportAge` plus monotonic `reportId`/nonce check)
        - [ ] production guardrail candidate: conservative redeem caps when reports are stale-but-allowed
+     - [ ] product TODO 🏭: add liquidity-DoS mitigations for sync redeem (buffer sizing policy, pullback SLOs, and degraded-mode redemption path)
 
  - [x] Define spike success criteria (feasibility, estimate quality, demo expectations)
    - [x] feasibility criterion: either reach working end-to-end flow or identify concrete infeasibility point(s) with reasons

--- a/packages/portfolio-contract/docs-design/vault-accounting-extension.md
+++ b/packages/portfolio-contract/docs-design/vault-accounting-extension.md
@@ -1,0 +1,94 @@
+# Vault Accounting Extension (Spike)
+
+## Purpose
+
+Capture the chosen spike approach for cross-chain yield while keeping canonical shares on one EVM vault contract.
+
+This document is a design artifact for the spike. It defines behavior and invariants. Solidity tests are planned next, but are intentionally not included in this change.
+
+## Chosen Model
+
+- Vault is ERC-4626-compatible for user-facing deposit/redeem semantics.
+- Vault includes a privileged extension for Ymax orchestration on the vault chain.
+- Vault constructor stores `ownerPortfolioAccount` (the smart-wallet address corresponding to `p75` on that chain, e.g. `@Avalanche`).
+- Privileged extension can move local USDC out of vault custody to `ownerPortfolioAccount` for cross-chain strategy execution.
+- Share accounting includes out-of-vault managed assets.
+
+## Core State
+
+- `asset` = USDC ERC-20 address.
+- `ownerPortfolioAccount` = privileged caller for orchestration methods.
+- `managedAssets` = amount of USDC-equivalent value deployed outside the vault contract balance, but still owned economically by vault shareholders.
+- `localLiquidityFloorAssets` = minimum local USDC buffer.
+- `localLiquidityPct` = percent-based local USDC target.
+- `rebalanceIfOffByPct` = hysteresis band for local-liquidity adjustments (`5%` for Chris spike).
+
+## Core Invariant
+
+- `totalAssets() = usdc.balanceOf(vault) + managedAssets`
+
+Implication:
+- Moving funds from vault balance to `ownerPortfolioAccount` must not reduce shareholder value mechanically.
+- The transfer out reduces local balance and increases `managedAssets` by the same amount.
+
+## Methods (Spike Shape)
+
+User-facing (standard):
+- `deposit(uint256 assets, address receiver)`
+- `redeem(uint256 shares, address receiver, address owner)`
+
+Privileged extension (spike):
+- `deployToPortfolio(uint256 assets)`
+  - `require(msg.sender == ownerPortfolioAccount)`
+  - transfer `assets` USDC from vault to `ownerPortfolioAccount`
+  - increment `managedAssets` by `assets`
+  - emit `PortfolioDeploy(ownerPortfolioAccount, assets)`
+
+- `reportManagedAssets(uint256 newManagedAssets, uint256 asOf, bytes32 reportId)`
+  - restricted to trusted reporting authority (resolver-gated path for spike)
+  - sets or updates `managedAssets` from orchestration outcomes
+  - emits `ManagedAssetsReported(newManagedAssets, asOf, reportId)`
+
+Notes:
+- Exact authority wiring for `reportManagedAssets` is part of spike seam work; trust minimization is product follow-up.
+- Naming is provisional; behavior and invariants matter more than exact method names for the spike.
+
+## Local Liquidity Policy (Chosen for Chris Spike)
+
+- Target local liquidity uses a tiered formula:
+  - `targetLocalLiquidity = max(localLiquidityFloorAssets, localLiquidityPct * totalAssets())`
+- Use hysteresis to avoid churn:
+  - only adjust when deviation exceeds `rebalanceIfOffByPct` (`5%` in spike config)
+- On `deposit(...)` and periodic rebalance:
+  - if local liquidity is above target band, deploy only the excess via `deployToPortfolio(...)`
+  - update `managedAssets` consistently with deploy operations
+
+## Redemption/Liquidity Policy
+
+For sync redeem:
+- allowed only when local vault USDC liquidity is sufficient for `assetsOut`
+- and accounting state freshness requirements are met
+
+Otherwise:
+- sync redeem fails in spike path
+- async redemption (`requestRedeem`) remains stretch-goal path
+
+## Relationship To Existing Ymax Pieces
+
+- Agoric contract controls policy and orchestration intent.
+- Cross-chain execution outcomes are observed via resolver success/failure and reporting seams.
+- Planner can assume portfolio liquidity at `@Avalanche` after deploy operations; it does not need direct vault custody to plan subsequent steps.
+
+## Out Of Scope For This Spike
+
+- Full decentralization hardening of managed-assets/NAV source.
+- Final production authority model for reporting updates.
+- Permit2 integration in vault deposit UX (tracked separately as product TODO).
+
+## Planned Next Step
+
+- Encode this design as Solidity unit tests first:
+  - privileged caller checks
+  - deploy accounting invariants
+  - `totalAssets` consistency
+  - redeem gating on local liquidity/freshness

--- a/packages/portfolio-contract/docs-design/vault-creation-flow.mmd
+++ b/packages/portfolio-contract/docs-design/vault-creation-flow.mmd
@@ -1,0 +1,38 @@
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#f3f4f6', 'primaryColor': '#eef2f7', 'secondaryColor': '#e9eef5', 'tertiaryColor': '#f6f8fb', 'lineColor': '#5f6b7a', 'textColor': '#1f2937'}, 'themeCSS': '.sequenceNumber { font-size: 14px !important; font-weight: 600; }'}}%%
+sequenceDiagram
+    title Ymax Vault - Creator Vault Creation Flow
+    autonumber
+
+    actor creator as Chris<br/>EOA: 0xCHR1
+    participant ui as vault-ui-1<br/>URL: /vaults/1
+
+    box Agoric
+    participant yc as Ymax contract<br/>instance: 0xYMAX
+    participant vstorage as vstorage<br/>node: 0xVST1
+    end
+    participant planner as Planner service<br/>svc: 0xPLN1
+
+    box EVM Chain
+    participant factory as VaultFactory<br/>addr: 0xFAC1
+    participant vault as vault-contract-1<br/>ERC-4626: 0xVAU1
+    end
+
+    %% Conventions: solid(->>) = spontaneous trigger; dotted(-->>) = consequence/follow-on
+
+    creator->>ui: createVault({ allocations: [Aave_Base: 60%, Morpho_Base: 40%],<br/>fee: 0.5bps, cadence: P1H })
+    ui-->>yc: createVault(...)
+    yc-->>yc: p75 = openPortfolio()
+    yc-->>yc: vaults.add(p75)
+    yc-->>yc: 0xVAU1 = computeCreate2Address(factory=0xFAC1, salt=p75)
+    yc-->>vstorage: setValue(p75.policy, { vault: 0xVAU1,<br/>allocations: [Aave_Base: 60%, Morpho_Base: 40%],<br/>fee: 0.5bps, cadence: P1H })
+    yc-->>ui: vaultSpecAccepted(p75)
+    yc-->>factory: createVault(0xUSDC, Chris Vault Share, CVSH, p75)
+    Note right of yc: via Axelar GMP
+    factory-->>vault: initialize(0xUSDC, Chris Vault Share, CVSH)
+    Note left of factory: emit VaultCreated(0xVAU1, 0xCHR1, p75)<br/>resolver reports success
+    factory-->>yc: ack
+
+    yc-->>vstorage: setValue(p75.status, ready)
+    vstorage-->>planner: observeValue(p75.policy, p75.status)
+    yc-->>ui: vaultReady(0xVAU1, p75, /vaults/1)
+    ui-->>creator: showVault(0xVAU1, /vaults/1)

--- a/packages/portfolio-contract/docs-design/vault-deposit-flow.mmd
+++ b/packages/portfolio-contract/docs-design/vault-deposit-flow.mmd
@@ -1,0 +1,42 @@
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#f3f4f6', 'primaryColor': '#eef2f7', 'secondaryColor': '#e9eef5', 'tertiaryColor': '#f6f8fb', 'lineColor': '#5f6b7a', 'textColor': '#1f2937'}, 'themeCSS': '.sequenceNumber { font-size: 14px !important; font-weight: 600; }'}}%%
+sequenceDiagram
+    title Ymax Vault - Deposit Flow (USDC -> ERC-4626 Shares)
+    autonumber
+
+    %% Conventions: solid(->>) = spontaneous trigger; dotted(-->>) = consequence/follow-on
+    %% Share token glossary: name = Chris Vault Share, symbol = CVSH
+    %% Product TODO: switch to Permit2 flow (one-time high approval + per-action permit signature) after spike.
+
+    actor user as Trader Tim<br/>EOA: 0xTIM
+    participant wallet as MetaMask<br/>signer: 0xTIM
+    participant ui as vault-ui-1<br/>URL: /vaults/1
+
+    box Avalanche C-Chain
+    participant vault as vault-contract-1<br/>ERC-4626: 0xVAU1
+    participant usdc as USDC Token<br/>ERC-20: 0xUSDC
+    participant p75 as p75 @Avalanche<br/>smart wallet: 0xP751
+    end
+
+    user->>ui: deposit(250USDC)
+    ui-->>ui: approveTx = { to: 0xUSDC,<br/>spender: 0xVAU1, amount: 250USDC,<br/>data, chainId, nonce }
+    ui-->>wallet: requestSignatureAndBroadcast(approveTx)
+    wallet-->>user: promptApproval(approveTx)
+    user->>wallet: approve(approveTx)
+    wallet-->>usdc: approve(0xVAU1, 250USDC)
+    ui-->>ui: depositTx = { to: 0xVAU1,<br/>assets: 250USDC, receiver: 0xTIM,<br/>data, chainId, nonce }
+    ui-->>wallet: requestSignatureAndBroadcast(depositTx)
+    wallet-->>user: promptApproval(depositTx)
+    user->>wallet: approve(depositTx)
+    wallet-->>vault: deposit(250USDC, 0xTIM)
+    vault-->>usdc: transferFrom(0xTIM, 0xVAU1, 250USDC)
+    vault-->>vault: computeExcess(tieredLiquidityPolicy, 5% hysteresis)
+    vault-->>usdc: transfer(0xP751, excessUSDC)
+    Note over usdc,p75: emit Transfer(0xVAU1,<br/>0xP751, excessUSDC)
+    vault-->>vault: managedAssets += excessUSDC
+    vault-->>ui: emit Deposit(0xTIM, 0xTIM, 250USDC, 250CVSH)
+    loop polling interval
+        ui->>ui: pollTick()
+        ui-->>vault: balanceOf(0xTIM)
+        vault-->>ui: balance=250CVSH
+    end
+    ui-->>user: balance=250CVSH

--- a/packages/portfolio-contract/docs-design/vault-evm-prereq-deployment.mmd
+++ b/packages/portfolio-contract/docs-design/vault-evm-prereq-deployment.mmd
@@ -1,0 +1,20 @@
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#f3f4f6', 'primaryColor': '#eef2f7', 'secondaryColor': '#e9eef5', 'tertiaryColor': '#f6f8fb', 'lineColor': '#5f6b7a', 'textColor': '#1f2937'}, 'themeCSS': '.sequenceNumber { font-size: 14px !important; font-weight: 600; }'}}%%
+sequenceDiagram
+    title EVM Prerequisite Flow - VaultFactory Deployment
+    autonumber
+
+    %% Conventions: solid(->>) = spontaneous trigger; dotted(-->>) = consequence/follow-on
+
+    actor ops as Deployer
+    participant wallet as EVM Wallet<br/>EOA: 0xOPS1
+    participant chain as Avalanche C-Chain
+    participant factory as VaultFactory<br/>addr: 0xFAC1
+    participant ymax as Ymax config
+
+    Note right of ops: Use deterministic deployment pattern from `agoric-to-axelar-local`<br/>for consistent addresses across chains.
+    ops->>wallet: deployVaultFactory(0xUSDC, implConfig)
+    wallet-->>chain: create(VaultFactory bytecode, constructorArgs)
+    chain-->>factory: constructor(0xUSDC, implConfig)
+    chain-->>wallet: receipt(contractAddress=0xFAC1)
+    wallet-->>ops: deploymentConfirmed(0xFAC1)
+    ops->>ymax: setFactoryAddress(0xFAC1)

--- a/packages/portfolio-contract/docs-design/vault-evm-prereq-deployment.mmd
+++ b/packages/portfolio-contract/docs-design/vault-evm-prereq-deployment.mmd
@@ -12,9 +12,10 @@ sequenceDiagram
     participant ymax as Ymax config
 
     Note right of ops: Use deterministic deployment pattern from `agoric-to-axelar-local`<br/>for consistent addresses across chains.
-    ops->>wallet: deployVaultFactory(0xUSDC, implConfig)
+    Note right of wallet: Spike key posture (testnet): do not commit private keys.
+    ops->>wallet: deployVaultFactory(0xUSDC, 0xASSET_REPORTER)
     wallet-->>chain: create(VaultFactory bytecode, constructorArgs)
-    chain-->>factory: constructor(0xUSDC, implConfig)
+    chain-->>factory: constructor(0xUSDC, 0xASSET_REPORTER)
     chain-->>wallet: receipt(contractAddress=0xFAC1)
     wallet-->>ops: deploymentConfirmed(0xFAC1)
     ops->>ymax: setFactoryAddress(0xFAC1)

--- a/packages/portfolio-contract/docs-design/vault-rebalance-flow.mmd
+++ b/packages/portfolio-contract/docs-design/vault-rebalance-flow.mmd
@@ -1,0 +1,34 @@
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#f3f4f6', 'primaryColor': '#eef2f7', 'secondaryColor': '#e9eef5', 'tertiaryColor': '#f6f8fb', 'lineColor': '#5f6b7a', 'textColor': '#1f2937'}, 'themeCSS': '.sequenceNumber { font-size: 14px !important; font-weight: 600; }'}}%%
+sequenceDiagram
+    title Ymax Vault - Hourly Best-Effort Rebalance Flow
+    autonumber
+
+    %% Conventions: solid(->>) = spontaneous trigger; dotted(-->>) = consequence/follow-on
+
+    box Agoric
+    participant yc as Ymax contract<br/>instance: 0xYMAX
+    participant timer as chainTimerService<br/>clock: 0xTMR1
+    end
+
+    participant planner as Planner service<br/>svc: 0xPLN1
+
+    box EVM Chain
+    participant aave as Aave_Base<br/>pool: 0xAAV1
+    participant morpho as Morpho_Base<br/>market: 0xMOR1
+    end
+
+    timer->>yc: repeatAfter tick (1h cadence)
+    yc-->>yc: single-flight guard
+    alt no rebalance in flight
+        yc-->>planner: request latest allocation plan(policyVersion)
+        planner-->>planner: queryBalancesAndApyInputs(p75, policyVersion)
+        planner-->>yc: plan
+        yc-->>yc: executeRebalancePlan(p75, plan)
+        rect rgba(226, 232, 240, 0.6)
+        Note over yc,aave: orchestration magic happens here<br/>multi-step execution across Aave_Base / Morpho_Base<br/>resolver reports success/failure only
+        end
+        yc-->>yc: rebalanceComplete(status)
+        yc-->>yc: clear in-flight + pending flags
+    else rebalance already in flight
+        yc-->>yc: coalesce tick (keep at most one pending rerun)
+    end

--- a/packages/portfolio-contract/docs-design/vault-spike-presentation.md
+++ b/packages/portfolio-contract/docs-design/vault-spike-presentation.md
@@ -1,0 +1,320 @@
+---
+marp: true
+paginate: true
+title: Ymax Vaults Spike
+---
+
+# Ymax Vaults Spike
+
+Audience: Product + Engineering + Peers  
+Scope: story clarity, approach decisions, prototype implementation, smoke evidence
+
+---
+
+# What's The Problem?
+
+- We need to estimate cost/risk of adding creator vaults to Ymax.
+- Product expectation: market-norm [ERC-4626](https://eips.ethereum.org/EIPS/eip-4626) UX for deposit/redeem.
+- Core challenge: Ymax yield engine is cross-chain, but user vault UX is EVM-local.
+- We need enough implementation to prove feasibility, not a full production launch.
+
+---
+
+# Tada! What We Did
+
+- We got a real **vault deposit flow running end-to-end on a local chain**.
+- Captured hard evidence for that run:
+  - [Vault Smoke Evidence Gist](https://gist.github.com/dckc/94b7ff46a126e81b1786a84971c4a6f6)
+  - tx hashes
+  - block heights/timestamps
+  - event details
+  - accounting assertions
+- Implemented EVM vault + factory contracts with tests.
+- Designed concrete flows (create, deposit, rebalance, withdraw, prereq deploy).
+- Clarified story + assumptions + explicit TODO/risk plan.
+
+---
+
+# Story + Scope Decisions
+
+- Single-vault story for spike; product can support one per creator/strategy.
+- LP/share model explicitly [ERC-4626](https://eips.ethereum.org/EIPS/eip-4626).
+- End-user UI in scope; creator UI stretch.
+- Rebalance is best-effort hourly.
+- Creator fee modeled as yield cut (performance fee).
+
+---
+
+# Challenge: APY Source + Decentralization 🏭
+
+- APY source has decentralization concerns, but mostly orthogonal to spike feasibility.
+- Decision for spike:
+  - planner consumes YDS HTTP APY per instrument
+  - contract boundary remains plan-only (no APY payload on-chain)
+- Outcome:
+  - kept spike focused on vault mechanics
+  - left production TODO 🏭 for APY/decentralization trust hardening
+  - on-chain oracle-backed APY source ❌ rejected for this spike
+
+---
+
+# Challenge: Cross-Chain Accounting
+
+- Vault token/share accounting is on one EVM chain.
+- Yield opportunities are cross-chain in Ymax.
+- Required a bridge between local vault liquidity and deployed cross-chain funds.
+
+Decision:
+- use privileged extension + managed-assets reporting path:
+  - `reporter -> factory -> vault`
+  - `totalAssets = localVaultBalance + managedAssets`
+
+---
+
+# Challenge: Rebalance Cadence vs Latency
+
+- Typical plan execution can be long (often much longer than an hour).
+- Hourly tick can overlap in-flight execution.
+
+Decision:
+- single-flight lock
+- coalesce pending ticks (at most one rerun)
+- stale-plan/runtime guardrails
+
+---
+
+# Challenge: Redemption Semantics
+
+- Need market-norm UX, but cross-chain liquidity may not be locally available.
+
+Decision:
+- spike default: sync redeem
+- enforce liquidity + freshness checks
+- `requestRedeem` kept as stretch goal 🚀, not implemented in spike
+
+---
+
+# Flow: EVM Prereq Deployment
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#f3f4f6', 'primaryColor': '#eef2f7', 'secondaryColor': '#e9eef5', 'tertiaryColor': '#f6f8fb', 'lineColor': '#5f6b7a', 'textColor': '#1f2937'}, 'themeCSS': '.sequenceNumber { font-size: 14px !important; font-weight: 600; }'}}%%
+sequenceDiagram
+    title EVM Prerequisite Flow - VaultFactory Deployment
+    autonumber
+
+    actor ops as Deployer
+    participant wallet as EVM Wallet<br/>EOA: 0xOPS1
+    participant chain as Avalanche C-Chain
+    participant factory as VaultFactory<br/>addr: 0xFAC1
+    participant ymax as Ymax config
+
+    Note right of ops: Use deterministic deployment pattern from `agoric-to-axelar-local`<br/>for consistent addresses across chains.
+    Note right of wallet: Spike key posture (testnet): do not commit private keys.
+    ops->>wallet: deployVaultFactory(0xUSDC, 0xASSET_REPORTER)
+    wallet-->>chain: create(VaultFactory bytecode, constructorArgs)
+    chain-->>factory: constructor(0xUSDC, 0xASSET_REPORTER)
+    chain-->>wallet: receipt(contractAddress=0xFAC1)
+    wallet-->>ops: deploymentConfirmed(0xFAC1)
+    ops->>ymax: setFactoryAddress(0xFAC1)
+```
+
+---
+
+# Flow: Creator Vault Creation
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#f3f4f6', 'primaryColor': '#eef2f7', 'secondaryColor': '#e9eef5', 'tertiaryColor': '#f6f8fb', 'lineColor': '#5f6b7a', 'textColor': '#1f2937'}, 'themeCSS': '.sequenceNumber { font-size: 14px !important; font-weight: 600; }'}}%%
+sequenceDiagram
+    title Ymax Vault - Creator Vault Creation Flow
+    autonumber
+
+    actor creator as Chris<br/>EOA: 0xCHR1
+    participant ui as vault-ui-1<br/>URL: /vaults/1
+
+    box Agoric
+    participant yc as Ymax contract<br/>instance: 0xYMAX
+    participant vstorage as vstorage<br/>node: 0xVST1
+    end
+    participant planner as Planner service<br/>svc: 0xPLN1
+
+    box EVM Chain
+    participant factory as VaultFactory<br/>addr: 0xFAC1
+    participant vault as vault-contract-1<br/>ERC-4626: 0xVAU1
+    end
+
+    creator->>ui: createVault({ allocations: [Aave_Base: 60%, Morpho_Base: 40%],<br/>fee: 0.5bps, cadence: P1H })
+    ui-->>yc: createVault(...)
+    yc-->>yc: p75 = openPortfolio()
+    yc-->>yc: vaults.add(p75)
+    yc-->>yc: 0xVAU1 = computeCreate2Address(factory=0xFAC1, salt=p75)
+    yc-->>vstorage: setValue(p75.policy, { vault: 0xVAU1,<br/>allocations: [Aave_Base: 60%, Morpho_Base: 40%],<br/>fee: 0.5bps, cadence: P1H })
+    yc-->>ui: vaultSpecAccepted(p75)
+    yc-->>factory: createVault(0xUSDC, Chris Vault Share, CVSH, p75)
+    Note right of yc: via Axelar GMP
+    factory-->>vault: initialize(0xUSDC, Chris Vault Share, CVSH)
+    Note left of factory: emit VaultCreated(0xVAU1, 0xCHR1, p75)<br/>resolver reports success
+    factory-->>yc: ack
+
+    yc-->>vstorage: setValue(p75.status, ready)
+    vstorage-->>planner: observeValue(p75.policy, p75.status)
+    yc-->>ui: vaultReady(0xVAU1, p75, /vaults/1)
+    ui-->>creator: showVault(0xVAU1, /vaults/1)
+```
+
+---
+
+# Flow: Deposit
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#f3f4f6', 'primaryColor': '#eef2f7', 'secondaryColor': '#e9eef5', 'tertiaryColor': '#f6f8fb', 'lineColor': '#5f6b7a', 'textColor': '#1f2937'}, 'themeCSS': '.sequenceNumber { font-size: 14px !important; font-weight: 600; }'}}%%
+sequenceDiagram
+    title Ymax Vault - Deposit Flow (USDC -> ERC-4626 Shares)
+    autonumber
+
+    actor user as Trader Tim<br/>EOA: 0xTIM
+    participant wallet as MetaMask<br/>signer: 0xTIM
+    participant ui as vault-ui-1<br/>URL: /vaults/1
+
+    box Avalanche C-Chain
+    participant vault as vault-contract-1<br/>ERC-4626: 0xVAU1
+    participant usdc as USDC Token<br/>ERC-20: 0xUSDC
+    participant p75 as p75 @Avalanche<br/>smart wallet: 0xP751
+    end
+
+    user->>ui: deposit(250USDC)
+    ui-->>ui: approveTx = { to: 0xUSDC,<br/>spender: 0xVAU1, amount: 250USDC,<br/>data, chainId, nonce }
+    ui-->>wallet: requestSignatureAndBroadcast(approveTx)
+    wallet-->>user: promptApproval(approveTx)
+    user->>wallet: approve(approveTx)
+    wallet-->>usdc: approve(0xVAU1, 250USDC)
+    ui-->>ui: depositTx = { to: 0xVAU1,<br/>assets: 250USDC, receiver: 0xTIM,<br/>data, chainId, nonce }
+    ui-->>wallet: requestSignatureAndBroadcast(depositTx)
+    wallet-->>user: promptApproval(depositTx)
+    user->>wallet: approve(depositTx)
+    wallet-->>vault: deposit(250USDC, 0xTIM)
+    vault-->>usdc: transferFrom(0xTIM, 0xVAU1, 250USDC)
+    vault-->>vault: computeExcess(tieredLiquidityPolicy, 5% hysteresis)
+    vault-->>usdc: transfer(0xP751, excessUSDC)
+    Note over usdc,p75: emit Transfer(0xVAU1,<br/>0xP751, excessUSDC)
+    vault-->>vault: managedAssets += excessUSDC
+    vault-->>ui: emit Deposit(0xTIM, 0xTIM, 250USDC, 250CVSH)
+    loop polling interval
+        ui->>ui: pollTick()
+        ui-->>vault: balanceOf(0xTIM)
+        vault-->>ui: balance=250CVSH
+    end
+    ui-->>user: balance=250CVSH
+```
+
+---
+
+# Flow: Rebalance
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#f3f4f6', 'primaryColor': '#eef2f7', 'secondaryColor': '#e9eef5', 'tertiaryColor': '#f6f8fb', 'lineColor': '#5f6b7a', 'textColor': '#1f2937'}, 'themeCSS': '.sequenceNumber { font-size: 14px !important; font-weight: 600; }'}}%%
+sequenceDiagram
+    title Ymax Vault - Hourly Best-Effort Rebalance Flow
+    autonumber
+
+    box Agoric
+    participant yc as Ymax contract<br/>instance: 0xYMAX
+    participant timer as chainTimerService<br/>clock: 0xTMR1
+    end
+
+    participant planner as Planner service<br/>svc: 0xPLN1
+
+    box EVM Chain
+    participant aave as Aave_Base<br/>pool: 0xAAV1
+    participant morpho as Morpho_Base<br/>market: 0xMOR1
+    end
+
+    timer->>yc: repeatAfter tick (1h cadence)
+    yc-->>yc: single-flight guard
+    alt no rebalance in flight
+        yc-->>planner: request latest allocation plan(policyVersion)
+        planner-->>planner: queryBalancesAndApyInputs(p75, policyVersion)
+        planner-->>yc: plan
+        yc-->>yc: executeRebalancePlan(p75, plan)
+        rect rgba(226, 232, 240, 0.6)
+        Note over yc,aave: orchestration magic happens here<br/>multi-step execution across Aave_Base / Morpho_Base<br/>resolver reports success/failure only
+        end
+        yc-->>yc: rebalanceComplete(status)
+        yc-->>yc: clear in-flight + pending flags
+    else rebalance already in flight
+        yc-->>yc: coalesce tick (keep at most one pending rerun)
+    end
+```
+
+---
+
+# Flow: Withdraw
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#f3f4f6', 'primaryColor': '#eef2f7', 'secondaryColor': '#e9eef5', 'tertiaryColor': '#f6f8fb', 'lineColor': '#5f6b7a', 'textColor': '#1f2937'}, 'themeCSS': '.sequenceNumber { font-size: 14px !important; font-weight: 600; }'}}%%
+sequenceDiagram
+    title Ymax Vault - Withdraw Flow (ERC-4626 Shares -> USDC)
+    autonumber
+
+    actor user as Trader Tim<br/>EOA: 0xTIM
+    participant ui as vault-ui-1<br/>URL: /vaults/1
+
+    box EVM Chain
+    participant vault as vault-contract-1<br/>ERC-4626: 0xVAU1
+    participant usdc as USDC Token<br/>ERC-20: 0xUSDC
+    end
+
+    Note over user,ui: Signing wallet (MetaMask) omitted in this diagram.
+    user->>ui: redeem(250CVSH)
+    ui-->>vault: redeem(250CVSH, 0xTIM, 0xTIM)
+    vault-->>vault: realizeUSDCForRedeem(250CVSH, currentAllocation)
+    vault-->>usdc: transfer(0xTIM, 250USDC)
+    vault-->>ui: emit Withdraw(0xTIM, 0xTIM, 0xTIM, 250USDC, 250CVSH)
+    usdc-->>ui: emit Transfer(0xVAU1, 0xTIM, 250USDC)
+    ui-->>vault: balanceOf(0xTIM)
+    vault-->>ui: balance=0CVSH
+    ui-->>user: balances(usdc=+250USDC, cvsh=0CVSH)
+```
+
+---
+
+# Implementation Artifacts
+
+- `agoric-sdk` PR:  
+  [spike(portfolio-contract): vault flow design + creatorFacet createVault (PR #12513)](https://github.com/Agoric/agoric-sdk/pull/12513)
+- `agoric-to-axelar-local` PR:  
+  [spike: add Ymax vault/factory contracts and local deposit smoke evidence (PR #71)](https://github.com/agoric-labs/agoric-to-axelar-local/pull/71)
+- `ymax0-ui0` PR:  
+  [spike(ui): add creatorFacet createVault action in admin UI (PR #27)](https://github.com/agoric-labs/ymax0-ui0/pull/27)
+
+---
+
+# Evidence: User Intent
+
+- Aliases: `TIM=0x7099…79C8` `VAU1=0xCafa…052c` `P75A=0x90F7…b906`
+- Tim signed:
+  - `approve(spender=VAU1, amount=1000000)`
+  - `deposit(assets=1000000, receiver=TIM)`
+- Vault emitted:
+  - `Deposit(caller=TIM, owner=TIM, assets=1000000, shares=1000000)`
+
+---
+
+# Evidence: Funds Movement
+
+- USDC `Transfer` events in same deposit receipt:
+  - `Transfer(from=TIM, to=VAU1, value=1000000)` (Tim -> vault1)
+  - `Transfer(from=VAU1, to=P75A, value=800000)` (vault1 -> `@Avalanche`)
+- Evidence bundle:
+  - [Vault Smoke Evidence Gist](https://gist.github.com/dckc/94b7ff46a126e81b1786a84971c4a6f6)
+
+---
+
+# Open Risks / Product TODOs 🏭
+
+- Reporter trust hardening and key custody model.
+- Slippage protections (`minSharesOut` / `minAssetsOut`).
+- Final permission model for `createVault`.
+- Liquidity shortfall / redeem DoS mitigation.
+- Production permit2 migration and replenishment logic.
+
+---

--- a/packages/portfolio-contract/docs-design/vault-spike-presentation.md
+++ b/packages/portfolio-contract/docs-design/vault-spike-presentation.md
@@ -4,6 +4,12 @@ paginate: true
 title: Ymax Vaults Spike
 ---
 
+<style>
+section {
+  font-size: 20pt;
+}
+</style>
+
 # Ymax Vaults Spike
 
 Audience: Product + Engineering + Peers  
@@ -20,35 +26,32 @@ Scope: story clarity, approach decisions, prototype implementation, smoke eviden
 
 ---
 
-# Tada! What We Did
+# Tada! Vault Deposit On-Chain Smoke Test
 
 - We got a real **vault deposit flow running end-to-end on a local chain**.
-- Captured hard evidence for that run:
-  - [Vault Smoke Evidence Gist](https://gist.github.com/dckc/94b7ff46a126e81b1786a84971c4a6f6)
-  - tx hashes
-  - block heights/timestamps
-  - event details
-  - accounting assertions
+- Evidence: [Vault Smoke Evidence Gist](https://gist.github.com/dckc/94b7ff46a126e81b1786a84971c4a6f6) with signed calls, event tuples, and one-line accounting assertions.
 - Implemented EVM vault + factory contracts with tests.
 - Designed concrete flows (create, deposit, rebalance, withdraw, prereq deploy).
 - Clarified story + assumptions + explicit TODO/risk plan.
+- Key: `🧪` tested, `🧭` plan-only, `🚀` stretch, `🏭` product TODO
 
 ---
 
 # Story + Scope Decisions
 
-- Single-vault story for spike; product can support one per creator/strategy.
+- Single-vault story for spike
+  - 🏭 product can support one per creator/strategy.
 - LP/share model explicitly [ERC-4626](https://eips.ethereum.org/EIPS/eip-4626).
-- End-user UI in scope; creator UI stretch.
-- Rebalance is best-effort hourly.
-- Creator fee modeled as yield cut (performance fee).
+- 🧭 End-user UI in scope ; creator UI stretch. 🚀
+- 🧭 Rebalance is best-effort hourly.
+- 🧭 Creator fee modeled as yield cut (performance fee).
 
 ---
 
 # Challenge: APY Source + Decentralization 🏭
 
 - APY source has decentralization concerns, but mostly orthogonal to spike feasibility.
-- Decision for spike:
+- Decision for spike 🧭:
   - planner consumes YDS HTTP APY per instrument
   - contract boundary remains plan-only (no APY payload on-chain)
 - Outcome:
@@ -58,36 +61,36 @@ Scope: story clarity, approach decisions, prototype implementation, smoke eviden
 
 ---
 
-# Challenge: Cross-Chain Accounting
+# Challenge: Cross-Chain Accounting 🏭
 
-- Vault token/share accounting is on one EVM chain.
-- Yield opportunities are cross-chain in Ymax.
-- Required a bridge between local vault liquidity and deployed cross-chain funds.
+- 🧪 Vault token/share accounting is on one EVM chain.
+- 🧭 Yield opportunities are cross-chain in Ymax.
+- 🧪 Required a bridge between local vault liquidity and deployed cross-chain funds.
 
-Decision:
+Working model 🧪:
 - use privileged extension + managed-assets reporting path:
   - `reporter -> factory -> vault`
   - `totalAssets = localVaultBalance + managedAssets`
 
 ---
 
-# Challenge: Rebalance Cadence vs Latency
+# Challenge: Rebalance Cadence vs Latency 🏭
 
-- Typical plan execution can be long (often much longer than an hour).
+- Plan execution, while normally 5-20min, can be longer than an hour.
 - Hourly tick can overlap in-flight execution.
 
-Decision:
+Spike Decision 🧭:
 - single-flight lock
 - coalesce pending ticks (at most one rerun)
 - stale-plan/runtime guardrails
 
 ---
 
-# Challenge: Redemption Semantics
+# Challenge: Redemption Semantics 🏭
 
 - Need market-norm UX, but cross-chain liquidity may not be locally available.
 
-Decision:
+Decision 🧪:
 - spike default: sync redeem
 - enforce liquidity + freshness checks
 - `requestRedeem` kept as stretch goal 🚀, not implemented in spike
@@ -279,16 +282,16 @@ sequenceDiagram
 
 # Implementation Artifacts
 
-- `agoric-sdk` PR:  
-  [spike(portfolio-contract): vault flow design + creatorFacet createVault (PR #12513)](https://github.com/Agoric/agoric-sdk/pull/12513)
-- `agoric-to-axelar-local` PR:  
+- 🧪 `agoric-to-axelar-local` PR:  
   [spike: add Ymax vault/factory contracts and local deposit smoke evidence (PR #71)](https://github.com/agoric-labs/agoric-to-axelar-local/pull/71)
-- `ymax0-ui0` PR:  
+- 🧭 `agoric-sdk` PR:  
+  [spike(portfolio-contract): vault flow design + creatorFacet createVault (PR #12513)](https://github.com/Agoric/agoric-sdk/pull/12513)
+- 🧭 `ymax0-ui0` PR:  
   [spike(ui): add creatorFacet createVault action in admin UI (PR #27)](https://github.com/agoric-labs/ymax0-ui0/pull/27)
 
 ---
 
-# Evidence: User Intent
+# Evidence: User Intent 🧪
 
 - Aliases: `TIM=0x7099…79C8` `VAU1=0xCafa…052c` `P75A=0x90F7…b906`
 - Tim signed:
@@ -299,7 +302,7 @@ sequenceDiagram
 
 ---
 
-# Evidence: Funds Movement
+# Evidence: Funds Movement 🧪
 
 - USDC `Transfer` events in same deposit receipt:
   - `Transfer(from=TIM, to=VAU1, value=1000000)` (Tim -> vault1)

--- a/packages/portfolio-contract/docs-design/vault-withdraw-flow.mmd
+++ b/packages/portfolio-contract/docs-design/vault-withdraw-flow.mmd
@@ -1,0 +1,25 @@
+%%{init: {'theme': 'base', 'themeVariables': {'background': '#f3f4f6', 'primaryColor': '#eef2f7', 'secondaryColor': '#e9eef5', 'tertiaryColor': '#f6f8fb', 'lineColor': '#5f6b7a', 'textColor': '#1f2937'}, 'themeCSS': '.sequenceNumber { font-size: 14px !important; font-weight: 600; }'}}%%
+sequenceDiagram
+    title Ymax Vault - Withdraw Flow (ERC-4626 Shares -> USDC)
+    autonumber
+
+    %% Conventions: solid(->>) = spontaneous trigger; dotted(-->>) = consequence/follow-on
+
+    actor user as Trader Tim<br/>EOA: 0xTIM
+    participant ui as vault-ui-1<br/>URL: /vaults/1
+
+    box EVM Chain
+    participant vault as vault-contract-1<br/>ERC-4626: 0xVAU1
+    participant usdc as USDC Token<br/>ERC-20: 0xUSDC
+    end
+
+    Note over user,ui: Signing wallet (MetaMask) omitted in this diagram.
+    user->>ui: redeem(250CVSH)
+    ui-->>vault: redeem(250CVSH, 0xTIM, 0xTIM)
+    vault-->>vault: realizeUSDCForRedeem(250CVSH, currentAllocation)
+    vault-->>usdc: transfer(0xTIM, 250USDC)
+    vault-->>ui: emit Withdraw(0xTIM, 0xTIM, 0xTIM, 250USDC, 250CVSH)
+    usdc-->>ui: emit Transfer(0xVAU1, 0xTIM, 250USDC)
+    ui-->>vault: balanceOf(0xTIM)
+    vault-->>ui: balance=0CVSH
+    ui-->>user: balances(usdc=+250USDC, cvsh=0CVSH)

--- a/packages/portfolio-contract/docs-design/ymax-vaults-feature-design.md
+++ b/packages/portfolio-contract/docs-design/ymax-vaults-feature-design.md
@@ -91,9 +91,30 @@ Diagram notation in this doc:
 
 ## Withdraw (Sync Redeem Path)
 
-### Withdraw Diagram
+Continuing the same example, Tim now holds `CVSH` shares in `0xVAU1` and wants to redeem.
+Tim uses `/vault-1` and submits a standard ERC-4626 `redeem(shares, receiver, owner)` request.
+
+See diagram: [docs-design/vault-withdraw-flow.mmd](./vault-withdraw-flow.mmd)
 
 ### Freshness and Liquidity Gates
+
+In this spike design, withdraw uses a synchronous redeem path _(`requestRedeem` async fallback is deferred; see [A.2](#a2-redemption-semantics-sync-redeem-vs-requestredeem))_:
+
+Share value at redeem depends on `totalAssets`, which includes managed assets reported from cross-chain positions _(valuation source/trust model in [A.1](#a1-cross-chain-valuation-source-off-chain-reporting-vs-on-chain-oracle))_.
+
+1. Tim requests redeem in the UI; MetaMask signing is implied (omitted from this diagram for brevity).
+2. The UI calls `redeem(250CVSH, 0xTIM, 0xTIM)` on `0xVAU1`.
+3. `0xVAU1` checks two gates before releasing USDC:
+   - local-liquidity sufficiency
+   - managed-assets report freshness
+4. If both gates pass, `0xVAU1` transfers USDC to Tim and emits `Withdraw(...)`.
+5. The UI refreshes balances (`CVSH` down, USDC up) and shows completion.
+
+### Key Mechanics In This Flow
+
+- User-facing behavior stays market-norm ERC-4626 (`redeem`) when local conditions allow.
+- Freshness gate bounds risk from stale managed-assets reporting.
+- Liquidity gate prevents over-promising local redemption when funds are deployed elsewhere.
 
 ## Vault Setup Prerequisite (How `0xVAU1` and `/vault-1` Exist)
 
@@ -113,12 +134,89 @@ Diagram notation in this doc:
 
 ## Appendix A: Alternatives Not Taken
 
-### A.1 APY Source: Off-Chain YDS vs On-Chain Oracle
+### A.1 Cross-Chain Valuation Source: Off-Chain Reporting vs On-Chain Oracle
+
+Chosen for spike:
+- `0xVAU1` learns cross-chain deployed value via managed-assets reporting (`assetReporter -> factory -> vault`).
+- This reported value is used in `totalAssets` accounting and therefore affects share-value outcomes during redeem.
+
+Why this was chosen now:
+- Keeps the spike focused on deposit/redeem mechanics and cross-chain liquidity/accounting seams.
+- Reuses existing Ymax planner/resolver reporting operations.
+
+Why on-chain valuation oracles are still relevant:
+- Better decentralization and trust minimization for cross-chain value reporting.
+- Better resilience against single operator/service failure modes.
+
+What would be required to switch later:
+- Select oracle source(s) and normalization for position value inputs.
+- Define aggregation/confidence/freshness policy for reported valuation.
+- Define redeem behavior under stale/missing/conflicting valuation data.
 
 ### A.2 Redemption Semantics: Sync Redeem vs `requestRedeem`
 
+Chosen for spike:
+- Sync redeem only: `redeem(...)` succeeds when local liquidity + freshness gates pass.
+
+Why this was chosen now:
+- Market-familiar ERC-4626 behavior for trader Tim when conditions are healthy.
+- Simpler state machine for spike implementation and demo.
+
+What `requestRedeem` would add:
+- Async path when local liquidity is temporarily insufficient.
+- Additional UX/state management (requested, pending, settled, failed).
+- Additional policy/SLO definitions (target completion windows, escalation behavior).
+
+Where this matters:
+- High utilization periods when most assets are deployed and local liquidity is thin.
+
 ### A.3 Rebalance Overlap: Single-Flight vs Overlap
+
+Chosen for spike:
+- Single-flight execution with coalescing (at most one pending rerun).
+
+Why this was chosen now:
+- Reduces correctness risk from overlapping long-running plans.
+- Makes execution state and failure recovery easier to reason about.
+
+Rejected for now:
+- Full overlap: higher throughput in theory, but significantly more conflict/ordering complexity.
+- Queue-all-ticks: can accumulate stale work and amplify lag.
+
+Operational interpretation:
+- "Best-effort hourly" means attempt at most once per hour when idle; while busy, coalesce to one follow-up attempt.
 
 ### A.4 Liquidity Policy: Tiered vs Fixed vs Percent-Only
 
+Chosen for spike:
+- Tiered local-liquidity target with hysteresis:
+  - `targetLocalLiquidity = max(localLiquidityFloorAssets, localLiquidityPct * totalAssets)`
+  - Rebalance/deploy when deviation exceeds hysteresis threshold (`5%` in spike config).
+
+Why this was chosen now:
+- Better behavior across small and large vault sizes than fixed-only or percent-only alone.
+- Limits churn from small oscillations.
+
+Alternatives not chosen:
+- Fixed-only target: simple, but can become too small or too large as vault size changes.
+- Percent-only target: adapts to vault size, but may under-buffer smaller vaults.
+
+Productization question:
+- Tune floor, percent, and hysteresis from observed redemption/latency telemetry.
+
 ## Appendix B: Product TODOs
+
+- Permit2 migration:
+  - Replace approve-per-deposit with one-time Permit2 approval plus per-action permit signatures.
+- Managed-assets reporting hardening:
+  - Production key custody/rotation/separation-of-duties for `assetReporter`.
+  - Explicit freshness/replay protections and operator runbooks.
+- Redeem-path hardening:
+  - Define/implement `requestRedeem` async fallback UX and contract flow.
+  - Define low-liquidity degraded-mode behavior and user messaging.
+- Liquidity policy tuning:
+  - Set production defaults for floor/percent/hysteresis from telemetry.
+  - Add replenishment policy/SLO when local liquidity falls below thresholds.
+- Cross-chain valuation-source hardening:
+  - Evaluate and, if justified, integrate decentralized oracle-backed valuation inputs.
+  - Define behavior for stale or conflicting valuation data.

--- a/packages/portfolio-contract/docs-design/ymax-vaults-feature-design.md
+++ b/packages/portfolio-contract/docs-design/ymax-vaults-feature-design.md
@@ -1,0 +1,251 @@
+# Ymax Creator Vaults Design
+
+Current Ymax target users are sophisticated cross-chain portfolio operators.
+There's an existing market of vaults of various strategies with common vault UX patterns:
+
+- Morpho: reported growth from `67,000` to `1.4M+` users during 2025 ([Morpho 2026](https://morpho.org/blog/morpho-2026/), January 16, 2026).
+- Veda (BoringVault infrastructure): reported deposits from `100,000+` users and `$3.7B+` TVL ([CoinDesk](https://www.coindesk.com/business/2025/06/23/veda-raises-usd18m-to-expand-defi-vault-infrastructure-powering-over-usd3-7b-in-assets), June 23, 2025).
+- Beefy: community-reported `131,887` active users and `485,827` unique accounts ([Outposts](https://outposts.io/explore/beefy), accessed February 27, 2026).
+- Yearn v3: launch examples reached `$10M+ TVL` per new Base vault in under 24h ([Yearn post via Outposts](https://outposts.io/article/yearn-v3-launches-new-seamless-vaults-on-base-ff98a05c-8d40-478e-a074-fa8f307d2978), February 2025).
+
+ERC-4626 is the EVM tokenized-vault standard that normalizes deposit/redeem/share behavior and makes vault UX/tooling more interoperable.
+
+Opportunity:
+- connect Ymax to this larger audience by packaging Ymax portfolio execution as the strategy back-end for ERC-4626 vaults.
+
+## Purpose
+
+Creator vaults should expose ERC-4626 vault UX on an EVM chain while earning yield from Ymax cross-chain strategy execution.
+
+This document describes the target feature architecture first, then records the current spike cut and deferred items.
+
+A creator vault is a vault instance configured by a creator strategy/policy and exposed at a dedicated UI route.
+For a concrete running example, this doc uses `vault-ui-1` (the route/UI surface) paired with `vault-contract-1` (the EVM ERC-4626 vault contract).
+
+## Feature Scope
+
+In scope:
+- One concrete creator vault flow (`vault-ui-1` + `vault-contract-1`) for end-user deposit/redeem.
+- ERC-4626-style share accounting on an EVM vault contract.
+- Cross-chain deploy path from vault local liquidity to portfolio smart wallet (`p75 @Avalanche`).
+- Managed-assets reporting path (`assetReporter -> VaultFactory -> VaultContract`).
+
+Deferred or alternative feature concerns:
+- Production APY decentralization hardening (see [Appendix A.1](#appendix-a-alternatives-not-taken-brief)).
+- Async redemption UX (`requestRedeem`) beyond stretch discussion (see [Appendix A.2](#appendix-a-alternatives-not-taken-brief)).
+- Strategy adapter contract layer (see [Appendix A.3](#appendix-a-alternatives-not-taken-brief)).
+- Overlapping rebalance execution policy alternatives (see [Appendix A.4](#appendix-a-alternatives-not-taken-brief)).
+- Alternative local-liquidity policy variants (see [Appendix A.5](#appendix-a-alternatives-not-taken-brief)).
+
+## Design Goals
+
+- Preserve market-norm user semantics: EVM wallet signs `approve` + `deposit`/`redeem`.
+- Keep vault share accounting coherent with cross-chain deployment of assets.
+- Keep trust boundaries explicit and auditable.
+- Produce implementation-level evidence for feasibility estimation.
+
+## Architecture
+
+Core components:
+- End-user UI (`vault-ui-1`): builds tx payloads and reads balances/events.
+- EVM vault (`vault-contract-1`): ERC-4626 surface + managed-assets accounting extension.
+- EVM vault factory: creates vaults and gates managed-assets reporting authority.
+- Ymax contract (Agoric): policy/state publication, create-vault orchestration hooks.
+- Planner + resolver (off-chain): planning/execution/reporting pipeline.
+- Portfolio smart wallet on vault chain (`p75 @Avalanche`): receives deployed excess liquidity. This is the owner portfolio account for the vault on Avalanche.
+
+Key boundary:
+- APY is consumed off-chain by planner from YDS HTTP (Ymax Data Service); APY values are not on-chain inputs for this spike (alternative in [Appendix A.1](#appendix-a-alternatives-not-taken-brief)).
+
+### System Context (High Level)
+
+```mermaid
+flowchart LR
+  user[End User]
+  creator[Creator]
+  ui[vault-ui-1]
+  vault[vault-contract-1<br/>ERC-4626]
+  usdc[USDC ERC-20]
+  p75[p75 @Avalanche]
+  yc[Ymax Contract]
+  planner[Planner + Resolver]
+  yds[YDS HTTP]
+  vstorage[vstorage]
+  factory[VaultFactory]
+
+  user --> ui
+  creator --> ui
+  ui --> vault
+  vault --> usdc
+  vault --> p75
+
+  ui --> yc
+  yc --> vstorage
+  planner --> vstorage
+  planner --> yds
+  yc --> factory
+  factory --> vault
+```
+
+## Data and Invariants
+
+Vault state includes:
+- `asset` (USDC ERC-20)
+- `ownerPortfolioAccount` (for example, `p75 @Avalanche`, the vault's portfolio smart-wallet account on Avalanche)
+- `managedAssets`
+- local-liquidity policy params (`floor`, `%`, hysteresis)
+
+Core invariant:
+- `totalAssets = localVaultUsdc + managedAssets`
+
+Implication:
+- Transfers from vault local balance to `ownerPortfolioAccount` must be mirrored by managed-assets accounting.
+
+## Core Flows
+
+Source diagrams:
+- [EVM prereq deployment](./vault-evm-prereq-deployment.mmd)
+- [Creator vault creation](./vault-creation-flow.mmd)
+- [Deposit](./vault-deposit-flow.mmd)
+- [Rebalance](./vault-rebalance-flow.mmd)
+- [Withdraw](./vault-withdraw-flow.mmd)
+
+### 1) Prereq deployment
+
+- Deploy `VaultFactory` with constructor args: `usdc`, `assetReporter`.
+- Use deterministic deployment pattern for consistent addresses across chains.
+
+### 2) Creator vault creation
+
+- Creator initiates `createVault(...)` through UI/control path.
+- Ymax opens portfolio (`p75`), computes deterministic vault address, and publishes policy.
+- Ymax triggers EVM `factory.createVault(...)` (via Axelar General Message Passing (GMP) path in full architecture).
+- Factory initializes vault with concrete share name/symbol (`Chris Vault Share`, `CVSH`) and owner portfolio account.
+
+### 3) Deposit
+
+- User signs `approve(USDC -> vault)` then `deposit(assets, receiver)`.
+- Vault receives USDC, mints shares, computes excess local liquidity, and transfers excess to `ownerPortfolioAccount`.
+- Vault updates managed-assets accounting consistent with transfer out.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor user as Trader Tim
+    participant wallet as MetaMask
+    participant vault as vault-contract-1
+    participant usdc as USDC
+    participant p75 as p75 @Avalanche
+
+    user->>wallet: approve(USDC->vault-contract-1, amount)
+    wallet-->>usdc: approve(vault-contract-1, amount)
+    user->>wallet: deposit(assets, receiver)
+    wallet-->>vault: deposit(assets, receiver)
+    vault-->>usdc: transferFrom(Trader Tim, vault-contract-1, assets)
+    vault-->>vault: computeExcess(tiered policy + hysteresis)
+    vault-->>usdc: transfer(p75 @Avalanche, excess)
+    vault-->>vault: managedAssets += excess
+    vault-->>wallet: emit Deposit(caller, owner, assets, shares)
+```
+
+Notation for sequence diagrams in this document:
+- `->>` denotes a spontaneous trigger action.
+- `-->>` denotes a consequence/follow-on action.
+
+### 4) Rebalance
+
+- Agoric timer triggers best-effort cadence.
+- Single-flight guard prevents overlap.
+- Busy ticks are coalesced (at most one pending rerun).
+- Planner computes plan from balances + APY inputs and returns executable plan.
+
+Alternative overlap policies are discussed in [Appendix A.4](#appendix-a-alternatives-not-taken-brief).
+
+### 5) Withdraw (sync redeem)
+
+- User signs `redeem(shares, receiver, owner)`.
+- Vault succeeds only if local liquidity and report freshness gates pass.
+- Async fallback (`requestRedeem`) is deferred to product follow-up (see [Appendix A.2](#appendix-a-alternatives-not-taken-brief)).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor user as Trader Tim
+    participant ui as vault-ui-1
+    participant vault as vault-contract-1
+    participant usdc as USDC
+
+    user->>ui: redeem(shares)
+    ui-->>vault: redeem(shares, receiver, owner)
+    vault-->>vault: enforce(liquidity + freshness)
+    vault-->>usdc: transfer(receiver, assets)
+    vault-->>ui: emit Withdraw(...)
+```
+
+## Authority and Trust Model
+
+Create-vault authority:
+- Exposed via the Agoric creator facet (control path used by `ymaxControl`).
+
+Managed-assets reporting authority:
+- Planner controls the asset reporter key (`assetReporter`).
+- `factory.reportManagedAssets(...)` requires `msg.sender == assetReporter`.
+- Vault accepts managed-assets reports only from the factory (`assetReporter -> factory -> vault`).
+
+## Current Spike Status
+
+Implemented in spike:
+- Testnet/local-chain-focused implementation posture.
+- Avoid committing private keys.
+- Local smoke validation for deposit path and accounting evidence.
+
+Not implemented in spike:
+- Production custody/rotation/separation-of-duties for reporter authority.
+- Timer-driven periodic rebalance code path.
+- Async redeem path (`requestRedeem`).
+
+## Current Spike Parameterization
+
+- Rebalance cadence target: `P1H` (best effort).
+- Managed-assets freshness gate for sync redeem: `8h`.
+- Local-liquidity control: tiered target + `5%` hysteresis.
+
+Alternative local-liquidity policies are summarized in [Appendix A.5](#appendix-a-alternatives-not-taken-brief).
+
+## Validation Strategy
+
+- Solidity unit tests first for invariant and authority behavior.
+- Local on-chain smoke run to prove concrete deposit path and event/accounting evidence.
+- UI prototype quality bar: functional for demo, not production-polish.
+
+## Open Product TODOs
+
+- APY source decentralization/hardening.
+- Permissioning finalization for `createVault`.
+- Slippage protections for deposit/redeem.
+- Liquidity shortfall / redeem DoS mitigation.
+- Permit2 migration from approve-per-deposit flow.
+- Replenishment strategy when local liquidity is low.
+
+## Appendix A: Alternatives Not Taken (Brief)
+
+A.1 APY from on-chain oracle aggregation (not chosen for spike)
+- Why not now: orthogonal to main feasibility path; would add significant integration/ops work.
+- Why later: improves decentralization/trust of APY inputs.
+
+A.2 Async `requestRedeem` as primary redemption path (not chosen for spike)
+- Why not now: higher UX and state-machine complexity for end users.
+- Why later: needed when local liquidity constraints make sync redeem unreliable.
+
+A.3 Strategy adapters per protocol (not chosen for spike)
+- Why not now: single-contract approach is faster for proving core accounting and authority seams.
+- Why later: better modularity/upgrade boundaries at product scale.
+
+A.4 Allow overlapping rebalance executions (not chosen for spike)
+- Why not now: overlap complicates correctness and conflict handling under long-running plans.
+- Chosen instead: single-flight + coalesced pending tick.
+
+A.5 Other local-liquidity policies (not chosen for spike default)
+- Fixed absolute liquidity target only: simple, but less adaptive to TVL changes.
+- Percent-only target: adaptive, but can under-buffer small vaults.
+- Chosen instead: tiered (`max(floor, pct*assets)`) + hysteresis.

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -263,6 +263,22 @@ export const TargetAllocationShape: TypedPattern<TargetAllocation> = M.recordOf(
 export const TargetAllocationShapeExt: TypedPattern<Record<string, NatValue>> =
   M.recordOf(PoolKeyShapeExt, M.nat());
 
+export type VaultConfig = {
+  allocation: TargetAllocation;
+  fee: unknown;
+  cadence: unknown;
+};
+
+export const VaultConfigShape: TypedPattern<VaultConfig> = M.splitRecord(
+  {
+    allocation: TargetAllocationShape,
+    fee: M.any(),
+    cadence: M.any(),
+  },
+  {},
+  {},
+);
+
 // #endregion
 
 // #region ymax0 vstorage keys and values

--- a/packages/portfolio-contract/test/target-allocation.test.ts
+++ b/packages/portfolio-contract/test/target-allocation.test.ts
@@ -131,9 +131,16 @@ test('multiple portfolios have independent allocations', async t => {
 
 test('creatorFacet.createVault publishes target allocation', async t => {
   const { common, started } = await setupTrader(t);
-  const targetAllocation = harden({ Aave_Base: 6000n, Compound_Base: 4000n });
+  const createVaultArgs = harden({
+    allocation: {
+      Aave_Base: 6000n,
+      Compound_Base: 4000n,
+    },
+    fee: '0.5bps',
+    cadence: 'P1H',
+  });
 
-  const result = await E(started.creatorFacet).createVault(targetAllocation);
+  const result = await E(started.creatorFacet).createVault(createVaultArgs);
   t.like(result, {
     portfolioId: 0,
     storagePath: `${ROOT_STORAGE_PATH}.portfolios.portfolio0`,
@@ -145,18 +152,25 @@ test('creatorFacet.createVault publishes target allocation', async t => {
   const portfolioStatus = common.bootstrap.storage
     .getDeserialized(result.storagePath)
     .at(-1) as { targetAllocation?: Record<string, bigint> };
-  t.deepEqual(portfolioStatus.targetAllocation, targetAllocation);
+  t.deepEqual(portfolioStatus.targetAllocation, {
+    Aave_Base: 6000n,
+    Compound_Base: 4000n,
+  });
 });
 
 test('creatorFacet.createVault rejects invalid pool keys', async t => {
   const { started } = await setupTrader(t);
-  const badTargetAllocation = harden({
-    Aave_Base: 5000n,
-    Nope_Not_A_Protocol: 5000n,
+  const badCreateVaultArgs = harden({
+    allocation: {
+      Aave_Base: 5000n,
+      Nope_Not_A_Protocol: 5000n,
+    },
+    fee: '0.5bps',
+    cadence: 'P1H',
   });
 
   await t.throwsAsync(
-    () => E(started.creatorFacet).createVault(badTargetAllocation),
+    () => E(started.creatorFacet).createVault(badCreateVaultArgs),
     { message: /Nope_Not_A_Protocol/ },
   );
 });

--- a/packages/portfolio-deploy/src/wallet-admin-types.ts
+++ b/packages/portfolio-deploy/src/wallet-admin-types.ts
@@ -1,0 +1,29 @@
+/**
+ * @file
+ *
+ * @see ymaxAdmin
+ */
+import type {
+  SigningSmartWalletKit,
+  SmartWalletKit,
+  reflectWalletStore,
+} from '@agoric/client-utils';
+import type { FileRW } from '@agoric/pola-io/src/file.js';
+import type { E } from '@endo/far';
+import type { main as ymaxAdmin } from '../../../multichain-testing/scripts/ymax-admin.ts';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const keepDocsTypesImported: undefined | typeof ymaxAdmin = undefined;
+
+export type SigningSmartWalletKitWithStore = SigningSmartWalletKit & {
+  store: ReturnType<typeof reflectWalletStore>;
+};
+
+export interface RunTools {
+  scriptArgs: string[];
+  walletKit: SmartWalletKit;
+  makeAccount(name: string): Promise<SigningSmartWalletKitWithStore>;
+  E: typeof E;
+  harden: typeof harden;
+  cwd: FileRW;
+}

--- a/packages/portfolio-deploy/src/ymax-create-vault.ts
+++ b/packages/portfolio-deploy/src/ymax-create-vault.ts
@@ -1,0 +1,85 @@
+/** @file create vault via ymaxControl.creatorFacet */
+import type { start as YMaxStart } from '@aglocal/portfolio-contract/src/portfolio.contract.ts';
+import {
+  TargetAllocationShape,
+  type VaultConfig,
+} from '@aglocal/portfolio-contract/src/type-guards.js';
+import { makeTracer, mustMatch, type TypedPattern } from '@agoric/internal';
+import { PORTFOLIO_CONTRACT_NAMES } from '@agoric/portfolio-api/src/portfolio-constants.js';
+import { parseArgs } from 'node:util';
+import type { RunTools } from './wallet-admin-types.ts';
+
+const parseArgValues = (args: string[]) =>
+  parseArgs({
+    args,
+    options: {
+      contract: { type: 'string', default: 'ymax0' },
+      allocation: { type: 'string' },
+      fee: { type: 'string', default: '0.5bps' },
+      cadence: { type: 'string', default: 'P1H' },
+    },
+  });
+
+const trace = makeTracer('ymax-create-vault');
+
+const parseTypedJSON = <T>(
+  json: string,
+  shape: TypedPattern<T>,
+  reviver?: (k, v) => unknown,
+  makeError?: (err) => unknown,
+): T => {
+  try {
+    const result = harden(JSON.parse(json, reviver));
+    mustMatch(result, shape);
+    return result;
+  } catch (err) {
+    throw makeError ? makeError(err) : err;
+  }
+};
+
+const parseVaultConfig = (
+  values: ReturnType<typeof parseArgValues>['values'],
+): VaultConfig => {
+  const { fee, cadence, ...rest } = values;
+
+  if (!rest.allocation) throw Error('--allocation missing');
+  if (!fee) throw Error('--fee missing');
+  if (!cadence) throw Error('--cadence missing');
+
+  const allocation = parseTypedJSON(
+    rest.allocation,
+    TargetAllocationShape,
+    (_k, v) => (typeof v === 'number' ? BigInt(v) : v),
+    err => Error(`Invalid target allocation JSON: ${err.message}`),
+  );
+
+  return harden({ fee, cadence, allocation });
+};
+
+const createVault = async ({ scriptArgs, makeAccount }: RunTools) => {
+  const { values } = parseArgValues(scriptArgs);
+  const { contract } = values;
+
+  if (!(PORTFOLIO_CONTRACT_NAMES as readonly string[]).includes(contract)) {
+    throw Error(`contract? ${contract}`);
+  }
+  const traceC = trace.sub(contract);
+  const accountKey = `${contract.toUpperCase()}_CTRL`;
+  const ctrlAcct = await makeAccount(accountKey);
+  traceC.sub('ymaxControl')(ctrlAcct.address);
+
+  const vaultConfig = parseVaultConfig(values);
+  trace('vaultConfig', vaultConfig);
+
+  // ASSUME creatorFacet is already in the store.
+  // const ymaxControl =
+  //   ctrlAcct.store.get<ContractControl<typeof YMaxStart>>(WALLET_KEY);
+  // await ctrlAcct.saveAs('creatorFacet').getCreatorFacet();
+
+  type CreatorFacet = Awaited<ReturnType<typeof YMaxStart>>['creatorFacet'];
+  const creatorFacet = ctrlAcct.store.get<CreatorFacet>('creatorFacet');
+  const result = await creatorFacet.createVault(vaultConfig);
+  console.log(JSON.stringify(result));
+};
+
+export default createVault;


### PR DESCRIPTION
**WARNING: unreviewed LLM output**

## Goal
Reduce uncertainty for a Ymax vault spike by:
- specifying a concrete story + approach
- producing sequence/design artifacts
- implementing minimal contract-side Agoric wiring for creator-driven vault setup

## Included
- Story + evolving spike plan in `packages/portfolio-contract/.context-vaults/`
- Sequence/design docs in `packages/portfolio-contract/docs-design/`
- `creatorFacet.createVault(targetAllocation)` in portfolio contract
- target-allocation tests for creator-facet vault creation path

## Why this is a spike
This PR intentionally mixes design and minimal implementation to validate feasibility and identify risks quickly.

## Evidence / Outputs
- New creator-facet method returns `{ portfolioId, storagePath }` and starts portfolio open flow with fixed target allocation.
- Added tests in `packages/portfolio-contract/test/target-allocation.test.ts` for:
  - successful `creatorFacet.createVault(...)` publication path
  - invalid pool-key rejection

## Out of Scope
- production authority hardening and key custody
- full end-user vault UI
- full cross-chain integration smoke
- timer-driven periodic rebalance productionization

## Follow-up
Companion implementation/smoke PR in `agoric-labs/agoric-to-axelar-local` references this PR for EVM vault/factory + local smoke evidence.
