### PR TITLE
unify SwingSet bundle cache

### DIFF
--- a/packages/SwingSet/test/bundleTool.test.ts
+++ b/packages/SwingSet/test/bundleTool.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import {
   makeNodeBundleCache,
   provideBundleCache,
+  sharedBundleCachePath,
 } from '../tools/bundleTool.js';
 
 // Use a directory ignored by AVA watch mode (via ignore-by-default).
@@ -98,6 +99,11 @@ test('provideBundleCache returns shared cache for same key', async t => {
     bundleB,
     'cache.load fulfills to deeply equal value for same key',
   );
+});
+
+test('sharedBundleCachePath resolves from the repo root', t => {
+  const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
+  t.is(sharedBundleCachePath, path.join(repoRoot, 'bundles'));
 });
 
 test('concurrent load() calls for same key settle without hanging', async t => {

--- a/packages/SwingSet/tools/bundleTool.js
+++ b/packages/SwingSet/tools/bundleTool.js
@@ -321,10 +321,30 @@ harden(provideBundleCache);
 export const unsafeMakeBundleCache = dest =>
   makeNodeBundleCache(dest, {}, s => import(s));
 
-const sharedBundleCachePath = fileURLToPath(
+/**
+ * This is a hack to share bundles across multiple SwingSet instances. It is
+ * not safe to use in general, as it does not coordinate access to the shared
+ * cache. It is only safe if all users are cooperative and use the same locking
+ * mechanism, which is currently only this module's `withBundleLock`. Even then,
+ * there is a risk of lock contention and timeouts if multiple users are trying
+ * to build the same bundle at the same time. Use with caution.
+ *
+ * Also note that assumes bundles are stored in a `bundles` directory at the
+ * root of the project, which is not guaranteed to be the case in all
+ * environments.
+ */
+export const sharedBundleCachePath = fileURLToPath(
   new URL('../../../bundles', import.meta.url),
 );
 
+/**
+ * "Unsafe" because it entails ambient authority.
+ *
+ * Also note that it uses the shared bundle cache path, which is exported
+ * separately for use in other contexts that need to know where the shared
+ * bundles are located, but that also makes it more likely to cause conflicts if
+ * used in multiple places at once.
+ */
 export const unsafeSharedBundleCache = unsafeMakeBundleCache(
   sharedBundleCachePath,
 );

--- a/packages/SwingSet/tools/test-swingset.js
+++ b/packages/SwingSet/tools/test-swingset.js
@@ -1,13 +1,11 @@
 /* eslint-env node */
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
 import { makeReadJsonFile } from '@agoric/internal/src/node/read-json.js';
-import { provideBundleCache } from './bundleTool.js';
+import fs from 'fs';
 import {
   buildSwingsetKernelConfig,
   initializeSwingsetKernel,
 } from '../src/controller/initializeSwingset.js';
+import { unsafeSharedBundleCache } from './bundleTool.js';
 
 /**
  * @import {SwingSetConfig} from '../src/types-external.js';
@@ -18,14 +16,10 @@ import {
 
 const readBundleSpecFile = makeReadJsonFile(fs.promises);
 
-const sharedBundleCachePath = fileURLToPath(
-  new URL('../../../bundles', import.meta.url),
-);
-
 /**
  * Test-only wrapper that supplies ambient-powered bundleSpec loading.
  *
- * @param {SwingSetConfig} config
+ * @param {Omit<SwingSetConfig, 'bundleCachePath' | 'bundleFormat' | 'includeDevDependencies'>} config
  * @param {unknown} bootstrapArgs
  * @param {SwingStoreKernelStorage} kernelStorage
  * @param {InitializationOptions} initializationOptions
@@ -38,20 +32,7 @@ export const initializeTestSwingset = async (
   initializationOptions = {},
   runtimeOptions = {},
 ) => {
-  const {
-    bundleCachePath = sharedBundleCachePath,
-    includeDevDependencies,
-    bundleFormat,
-  } = config;
-  const cache = await provideBundleCache(
-    path.resolve(bundleCachePath),
-    {
-      dev: includeDevDependencies,
-      format: bundleFormat,
-      byteLimit: Infinity,
-    },
-    spec => import(spec),
-  );
+  const cache = await unsafeSharedBundleCache;
 
   const kernelConfig = await buildSwingsetKernelConfig(
     config,

--- a/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
+++ b/packages/boot/test/bootstrapTests/net-ibc-upgrade.test.ts
@@ -9,6 +9,7 @@ import {
   testInterruptedSteps,
   type TestStep,
 } from '@agoric/internal/src/testing-utils.js';
+import { sharedBundleCachePath } from '@agoric/swingset-vat/tools/bundleTool.js';
 import type { EVProxy } from '@agoric/swingset-vat/tools/run-utils.js';
 import type { Installation, ZoeService } from '@agoric/zoe';
 import { makeNodeBundleCache } from '@endo/bundle-source/cache.js';
@@ -27,7 +28,7 @@ const asset = {
 export const makeTestContext = async t => {
   console.time('DefaultTestContext');
 
-  const bundleDir = 'bundles';
+  const bundleDir = sharedBundleCachePath;
   const bundleCache = await makeNodeBundleCache(
     bundleDir,
     { cacheSourceMaps: false },

--- a/packages/boot/test/configs.test.js
+++ b/packages/boot/test/configs.test.js
@@ -10,7 +10,7 @@ import path from 'path';
 import { extractCoreProposalBundles } from '@agoric/deploy-script-support/src/extract-proposal.js';
 import { mustMatch } from '@agoric/store';
 import { loadSwingsetConfigFile, shape as ssShape } from '@agoric/swingset-vat';
-import { provideBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
+import { unsafeSharedBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 
 /**
  * @import {TestFn} from 'ava';
@@ -67,15 +67,13 @@ const makeTestContext = async () => {
   const dirname = path.dirname(pathname);
   const pathResolve = (...ps) => path.join(dirname, ...ps);
 
-  const cacheDir = pathResolve('..', 'bundles');
-  const bundleCache = await provideBundleCache(cacheDir, {}, s => import(s));
+  const bundleCache = await unsafeSharedBundleCache;
 
   const vizTool = pathResolve('..', 'tools', 'authorityViz.js');
   const runViz = pspawn(vizTool, { spawn: ambientSpawn });
 
   return {
     bundleCache,
-    cacheDir,
     pathResolve,
     basename: path.basename,
     runViz,

--- a/packages/boot/test/upgrading/upgrade-vats.test.ts
+++ b/packages/boot/test/upgrading/upgrade-vats.test.ts
@@ -2,6 +2,7 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { BridgeId, deepCopyJsonable } from '@agoric/internal';
 import { buildVatController, type SwingSetConfig } from '@agoric/swingset-vat';
+import { sharedBundleCachePath } from '@agoric/swingset-vat/tools/bundleTool.js';
 import { makeRunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
 import { Fail } from '@endo/errors';
 import { makeTagged } from '@endo/marshal';
@@ -38,7 +39,7 @@ const makeScenario = async (
         ),
       },
     },
-    bundleCachePath: 'bundles',
+    bundleCachePath: sharedBundleCachePath,
     ...kernelConfigOverrides,
   };
 

--- a/packages/boot/tools/supports.ts
+++ b/packages/boot/tools/supports.ts
@@ -32,6 +32,7 @@ import { initSwingStore } from '@agoric/swing-store';
 import { loadSwingsetConfigFile } from '@agoric/swingset-vat';
 import { makeSlogSender } from '@agoric/telemetry';
 import { TimeMath, type Timestamp } from '@agoric/time';
+import { sharedBundleCachePath } from '@agoric/swingset-vat/tools/bundleTool.js';
 import {
   fakeLocalChainBridgeQueryHandler,
   fakeLocalChainBridgeTxMsgHandler,
@@ -446,7 +447,7 @@ export const makeSwingsetTestKit = async <
     EconomyBootstrapPowers['consume'],
 >(
   log: (..._: any[]) => void,
-  bundleDir = 'bundles',
+  bundleDir = sharedBundleCachePath,
   {
     configSpecifier = '@agoric/vm-config/decentral-itest-vaults-config.json',
     label = undefined as string | undefined,

--- a/packages/builders/scripts/lib/build-bundle.js
+++ b/packages/builders/scripts/lib/build-bundle.js
@@ -2,7 +2,10 @@
 import { dirname, resolve as pathResolve } from 'path';
 import { fileURLToPath } from 'url';
 
-import { unsafeMakeBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
+import {
+  sharedBundleCachePath,
+  unsafeMakeBundleCache,
+} from '@agoric/swingset-vat/tools/bundleTool.js';
 
 /** @type {Map<string, Promise<Awaited<ReturnType<typeof unsafeMakeBundleCache>>>>} */
 const bundleCaches = new Map();
@@ -31,7 +34,7 @@ export const buildBundlePath = async (
   bundleName = undefined,
   options = {},
 ) => {
-  const { bundleDirRel = '../bundles' } = options;
+  const { bundleDirRel } = options;
   const fromDir = dirname(fileURLToPath(fromMetaUrl));
   /** @type {string | undefined} */
   let sourceSpec;
@@ -61,7 +64,9 @@ export const buildBundlePath = async (
     );
   }
 
-  const bundleDir = pathResolve(fromDir, bundleDirRel);
+  const bundleDir = bundleDirRel
+    ? pathResolve(fromDir, bundleDirRel)
+    : sharedBundleCachePath;
   // Use '\0' to avoid ambiguity between key components.
   const cacheKey = [bundleDir, sourceSpec, resolvedBundleName].join('\0');
   const cached = bundlePathCache.get(cacheKey);

--- a/packages/cosmic-swingset/test/inquisitor.test.ts
+++ b/packages/cosmic-swingset/test/inquisitor.test.ts
@@ -3,7 +3,6 @@ import anyTest from 'ava';
 
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
-import pathlib from 'node:path';
 
 import tmp from 'tmp';
 
@@ -17,7 +16,7 @@ import {
 } from '@agoric/internal';
 import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import type { SwingSetConfigDescriptor } from '@agoric/swingset-vat';
-import { provideBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
+import { unsafeSharedBundleCache } from '@agoric/swingset-vat/tools/bundleTool.js';
 
 import type { SwingStore } from '@agoric/swing-store';
 import { makeHelpers, makeSwingStoreOverlay } from '../tools/inquisitor.mjs';
@@ -172,8 +171,7 @@ test('vat lifecycle', async t => {
   } = tmp.fileSync({ detachDescriptor: true });
   t.teardown(() => removeCallback());
   fs.writeSync(fd, swingStore.debug.serialize());
-  const bundleDir = pathlib.resolve('bundles');
-  const bundleCache = await provideBundleCache(bundleDir, {}, s => import(s));
+  const bundleCache = await unsafeSharedBundleCache;
   const bundle = await bundleCache.load(
     resolveToPath('@agoric/swingset-vat/tools/vat-puppet-v2.js'),
   );

--- a/packages/deploy-script-support/src/cachedBundleSpec.js
+++ b/packages/deploy-script-support/src/cachedBundleSpec.js
@@ -8,10 +8,10 @@ import { Fail } from '@endo/errors';
 
 /**
  * @param {string} cacheDir
- * @param {{ now: typeof Date.now, fs: promises, pathResolve: typeof resolve }} param1
+ * @param {{ now: typeof Date.now, fs: promises, pathResolve: typeof resolve, pid?: number }} param1
  */
 export const makeCacheAndGetBundleSpec =
-  (cacheDir, { now, fs, pathResolve }) =>
+  (cacheDir, { now, fs, pathResolve, pid = process.pid }) =>
   /**
    * @param {Promise<BundleSourceResult<'endoZipBase64'>>} bundleP
    */
@@ -30,8 +30,7 @@ export const makeCacheAndGetBundleSpec =
       if (e.code !== 'ENOENT') {
         throw e;
       }
-      // FIXME: We could take a hard dependency on `tmp` here, but is it worth it?
-      const tmpFile = `${cacheFile}.${now()}`;
+      const tmpFile = `${cacheFile}.${pid}.${now()}.${Math.random().toString(16).slice(2)}.tmp`;
       await fs.writeFile(tmpFile, JSON.stringify(bundle, null, 2), {
         flag: 'wx',
       });


### PR DESCRIPTION
refs: #12381 

## Description

This PR replaces `provideBundleCache` with `unsafeSharedBundleCache` in test files and improves the temporary file naming strategy in the bundle caching mechanism.

The changes include:
- Replacing `provideBundleCache` calls with `unsafeSharedBundleCache` in `packages/boot/test/configs.test.js` and `packages/cosmic-swingset/test/inquisitor.test.ts`
- Removing the need to specify cache directories and related path resolution in tests
- Enhancing temporary file naming in `cachedBundleSpec.js` to include process ID and random suffix for better uniqueness
- Adding an optional `pid` parameter to `makeCacheAndGetBundleSpec` function

### Security Considerations

The use of `unsafeSharedBundleCache` in tests may introduce shared state between test runs, which could potentially lead to test isolation issues. The improved temporary file naming reduces the risk of file collisions in concurrent environments.

### Scaling Considerations

The shared bundle cache approach may improve performance by reusing cached bundles across tests, reducing redundant bundling operations.

### Documentation Considerations

The change from `provideBundleCache` to `unsafeSharedBundleCache` represents a shift in the testing approach that should be documented for future test writers.

### Testing Considerations

These changes affect test infrastructure and should be verified to ensure test isolation is maintained despite the use of shared caching.

### Upgrade Considerations

This change is primarily internal to testing infrastructure and should not affect production deployments.