### PR TITLE
chore(ymax-resolver): remove observing tx reverts for arb and aval in lookback

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -94,7 +94,6 @@ import type { ReadStorageMetaOptions } from './vstorage-utils.ts';
 
 const { values } = Object;
 
-// eslint-disable-next-line no-nested-ternary
 const compareBigints = (a: bigint, b: bigint) => (a > b ? 1 : a < b ? -1 : 0);
 
 const stdoutIsTty = process.stdout.isTTY;

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -340,7 +340,6 @@ const computeWeightedTargets = (
     remainder -= v;
   }
   if (remainder !== 0n) {
-    // eslint-disable-next-line no-nested-ternary
     weights.sort(([_k1, a], [_k2, b]) => (a < b ? 1 : a > b ? -1 : 0));
     for (const [key, _w] of weights) {
       const a = currentValues[key] || 0n;

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -305,13 +305,12 @@ export const createEVMContext = async ({
   clusterName,
   alchemyApiKey,
 }: CreateContextParams): Promise<
-  Pick<EvmContext, 'evmProviders' | 'usdcAddresses' | 'rpcUrls'>
+  Pick<EvmContext, 'evmProviders' | 'usdcAddresses'>
 > => {
   if (clusterName === 'local') clusterName = 'testnet';
   if (!alchemyApiKey) throw Error('missing alchemyApiKey');
 
   const wssUrls = getEvmRpcMap(clusterName, alchemyApiKey, 'wss');
-  const httpsUrls = getEvmRpcMap(clusterName, alchemyApiKey, 'https');
   const evmProviders = Object.fromEntries(
     Object.entries(wssUrls).map(([caip, wsUrl]) => [
       caip,
@@ -324,7 +323,6 @@ export const createEVMContext = async ({
     // XXX Remove now that @agoric/portfolio-api/src/constants.js
     // defines UsdcTokenIds.
     usdcAddresses: usdcAddresses[clusterName],
-    rpcUrls: httpsUrls,
   };
 };
 

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -5,7 +5,6 @@ import type { TxId } from '@aglocal/portfolio-contract/src/resolver/types.js';
 import type { CaipChainId } from '@agoric/orchestration';
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import { tryJsonParse } from '@agoric/internal';
-import type { JSONRPCClient } from 'json-rpc-2.0';
 import { PendingTxCode } from '../pending-tx-manager.ts';
 import {
   getBlockNumberBeforeRealTime,
@@ -279,12 +278,10 @@ type WatchGmpLookback = {
   chainId: CaipChainId;
   setTimeout: typeof globalThis.setTimeout;
   signal?: AbortSignal;
-  rpcClient: JSONRPCClient;
 };
 
 export const lookBackGmp = async ({
   provider,
-  rpcClient,
   contractAddress,
   txId,
   expectedSourceAddress,
@@ -365,7 +362,7 @@ export const lookBackGmp = async ({
       };
     }
 
-    // Failure path second (expensive on Arb/Ava: uses eth_getBlockReceipts).
+    // Failure path second: uses trace_filter (only on supported chains).
     // Only reached when the success scan found nothing in the block range.
     const failedTx = await scanFailedTxsInChunks({
       ...sharedOpts,
@@ -378,7 +375,6 @@ export const lookBackGmp = async ({
         );
       },
       onRejectedChunk: updateFailedTxLowerBound,
-      rpcClient,
     });
 
     if (failedTx) {

--- a/services/ymax-planner/test/abort-signal.test.ts
+++ b/services/ymax-planner/test/abort-signal.test.ts
@@ -289,19 +289,7 @@ test('handlePendingTx aborts GMP watcher in lookback mode when signal is aborted
 
   const ctxWithFetch = harden({
     ...opts,
-    fetch: async (url: string, init?: RequestInit) => {
-      if (Object.values(opts.rpcUrls).includes(url)) {
-        const batch = JSON.parse(init?.body as string);
-        return {
-          ok: true,
-          json: async () =>
-            batch.map((req: any) => ({
-              jsonrpc: '2.0',
-              id: req.id,
-              result: [],
-            })),
-        } as Response;
-      }
+    fetch: async () => {
       return {
         ok: true,
         json: async () => ({

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -390,17 +390,9 @@ const createMockEvmProviders = (
   'eip155:11155111': createMockProvider(latestBlock, events),
 });
 
-const createMockRpcUrls = (): Record<CaipChainId, string> => ({
-  'eip155:1': 'https://mock-ethereum-rpc.example',
-  'eip155:42161': 'https://mock-arbitrum-rpc.example',
-  'eip155:8453': 'https://mock-base-rpc.example',
-  'eip155:11155111': 'https://mock-sepolia-rpc.example',
-});
-
 export const mockEvmCtx = {
   usdcAddresses: {},
   evmProviders: createMockEvmProviders(),
-  rpcUrls: createMockRpcUrls(),
   kvStore: makeKVStoreFromMap(new Map()),
   setTimeout: globalThis.setTimeout,
   makeAbortController,
@@ -508,17 +500,6 @@ export const createMockCosmosRestClient = (
   } as any;
 };
 
-const mockGlobalFetch = (url: string, init?: RequestInit) => {
-  if (Object.values(createMockRpcUrls()).includes(url)) {
-    const batch = JSON.parse(init?.body as string);
-    return {
-      ok: true,
-      json: async () =>
-        batch.map((req: any) => ({ jsonrpc: '2.0', id: req.id, result: [] })),
-    } as Response;
-  }
-  throw new Error(`mockGlobalFetch: unrecognized URL: ${url}`);
-};
 export const createMockPendingTxOpts = (
   latestBlock = 1000,
   events?: Pick<Log, 'blockNumber' | 'data' | 'topics' | 'transactionHash'>[],
@@ -526,10 +507,7 @@ export const createMockPendingTxOpts = (
   cosmosRest: {} as unknown as CosmosRestClient,
   cosmosRpc: {} as unknown as CosmosRPCClient,
   evmProviders: createMockEvmProviders(latestBlock, events),
-  rpcUrls: createMockRpcUrls(),
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore some resolutions don't expect this on global
-  fetch: mockGlobalFetch,
+  fetch: async () => ({ ok: true, json: async () => ({}) }) as Response,
   setTimeout: globalThis.setTimeout,
   marshaller: boardSlottingMarshaller(),
   signingSmartWalletKit: createMockSigningSmartWalletKit(),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Removes support for observing transaction reverts in lookback mode for `GMP` and `MAKE_ACCOUNT` transactions, specifically on Avalanche and Arbitrum. The approach used on these chains can be disruptive and may negatively impact other resolver transactions at scale.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
- Unit tests are passing.
- `ymax0` testing is pending.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment on `ymax0` and `ymax1`.