### PR TITLE
chore: filter lookback pending txs by resolver-supported types

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -812,7 +812,7 @@ export const startEngine = async (
       data = marshaller.fromCapData(marshalledData);
       if (
         data?.status !== TxStatus.PENDING ||
-        data.type === TxType.CCTP_TO_AGORIC
+        !RESOLVER_SUPPORTED_TRANSACTIONS.includes(data.type)
       )
         return;
       mustMatch(harden(data), PublishedTxShape, path);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->


## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
The startup lookback path was only excluding `CCTP_TO_AGORIC` instead of filtering to the supported set, allowing unsupported tx types through. It is now aligned with the other processing paths by using `RESOLVER_SUPPORTED_TRANSACTIONS`.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment for `ymax0` and `ymax1`