### PR TITLE
format in pre-commit hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,10 @@ per https://agents.md/
 - `yarn run -T tsc --noEmit --incremental`: Fast typecheck within a package; do this after changes.
     - Watch mode for type errors in active workspaces: run `yarn run -T tsc --noEmit --incremental --watch --preserveWatchOutput` in the workspace(s) being edited, and keep the terminal output visible so Codex can monitor errors.
 - `yarn typecheck-quick` to do a fast typecheck over the whole repo (4-7 seconds)
-- `yarn format`: Format code via Prettier; `yarn lint:format` to check only.
+- `yarn format`: Format code via dprint; `yarn lint:format` to check only.
+- Git hooks: installed by `scripts/install-git-hooks.sh`.
+  - Install or refresh hooks with `yarn hooks:install`.
+  - Pre-commit runs `scripts/git-hooks/pre-commit-dprint.sh`, which formats only staged JS/TS files with the pinned local binary `./node_modules/.bin/dprint` and re-stages them.
 - `./scripts/env-doctor.sh`: Verify toolchain (Node, Go, compiler) versions.
 - Example, single package: `cd packages/eventual-send && yarn test`.
 - Packing/debugging workflow:
@@ -27,7 +30,7 @@ per https://agents.md/
 
 ## Coding Style & Naming Conventions
 - ESM by default; JS and TypeScript both used. Target Node ^20.9 or ^22.11.
-- Prettier enforced with single quotes; 2-space indentation.
+- dprint enforced (Prettier-compatible options include single quotes and trailing commas).
 - ESLint configured via `eslint.config.mjs` (includes AVA, TypeScript, JSDoc, and repository-specific rules).
 - Package names: publishable packages use `@agoric/*`; private/local packages use `@aglocal/*` (verify with `yarn lint:package-names`).
 - `@aglocal` packages are private and never published; `@agoric` packages are published and may only depend on published packages, so `@agoric` packages must never import `@aglocal` packages.

--- a/docs/commit-hygiene.md
+++ b/docs/commit-hygiene.md
@@ -47,6 +47,14 @@ Or format specific files:
 yarn run -T prettier --write path/to/file.js
 ```
 
+### 3b. Install Git Hooks (recommended once per clone)
+
+Install repository hooks so staged JS/TS files are auto-formatted on commit:
+
+```bash
+yarn hooks:install
+```
+
 ### 4. Run Linting
 
 Ensure your changes pass linting:

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "docs:markdown-build": "typedoc --plugin typedoc-plugin-markdown --tsconfig tsconfig.build.json",
     "docs:update-functions-path": "node ./scripts/update-typedoc-functions-path.cjs",
     "doctor": "./scripts/env-doctor.sh",
+    "hooks:install": "./scripts/install-git-hooks.sh",
     "lerna": "lerna",
     "link-cli": "yarn run create-agoric-cli",
     "create-agoric-cli": "node ./scripts/create-agoric-cli.cjs",

--- a/scripts/git-hooks/pre-commit-dprint.sh
+++ b/scripts/git-hooks/pre-commit-dprint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+staged_files=()
+while IFS= read -r -d '' file; do
+  staged_files+=("$file")
+done < <(
+  git diff --cached --name-only --diff-filter=ACMR -z -- \
+    '*.js' '*.jsx' '*.cjs' '*.mjs' '*.ts' '*.tsx' '*.cts' '*.mts'
+)
+
+if [[ ${#staged_files[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+dprint_bin='./node_modules/.bin/dprint'
+if [[ ! -x "$dprint_bin" ]]; then
+  echo "pre-commit: missing local dprint binary at $dprint_bin" >&2
+  echo "Run 'yarn install' to provision dev dependencies." >&2
+  exit 1
+fi
+
+echo "pre-commit: formatting ${#staged_files[@]} staged file(s) with local dprint"
+"$dprint_bin" fmt -- "${staged_files[@]}"
+git add -- "${staged_files[@]}"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# We intentionally install hooks directly instead of using a hook manager.
+# Managers add dependency/runtime overhead, and most rely on package-manager
+# lifecycle hooks (for example `prepare`) to auto-install. This repo sets
+# `enableScripts: false` in `.yarnrc.yml` for security, so lifecycle-based
+# installation is not reliable here.
+
+repo_root=$(git rev-parse --show-toplevel)
+hook_dir="$repo_root/.git/hooks"
+hook_file="$hook_dir/pre-commit"
+
+mkdir -p "$hook_dir"
+cat >"$hook_file" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+exec "$repo_root/scripts/git-hooks/pre-commit-dprint.sh"
+EOF
+
+chmod +x "$hook_file"
+echo "Installed pre-commit hook at .git/hooks/pre-commit"


### PR DESCRIPTION
refs: #12381 

## Description

Agents don't always produce code in the repo's preferred format, even with the instructions in AGENTS.md.

This makes it automatic by putting it in a pre-commit hook. I hate slow commit hooks and this set up is quite fast:
```
❯ time gca -m "feat: format in pre-commit hook"
[ta/autoformat 7e538942ed] feat: format in pre-commit hook
 3 files changed, 40 insertions(+)
 create mode 100755 scripts/git-hooks/pre-commit-dprint.sh
git commit --verbose --all -m "feat: format in pre-commit hook"  0.03s user 0.05s system 134% cpu 0.059 total
````

### Security Considerations
none

### Scaling Considerations
n/a

### Documentation Considerations
Documented in AGENTS.md

### Testing Considerations
Perf tested locally

### Upgrade Considerations
n/a