### PR TITLE
feat(ymax-planner): Suppress too-small balance changes

### DIFF
--- a/packages/internal/tools/ava-assertions.js
+++ b/packages/internal/tools/ava-assertions.js
@@ -21,7 +21,12 @@ export const arrayIsLike = (t, array, expected, message) => {
     actualExcess > 0
       ? [...expected, ...Array.from({ length: actualExcess })]
       : expected;
-  t.like(array, comparable, message);
+  if (comparable.length === 0) {
+    // Ava `like` rejects an empty array selector, so use `deepEqual` instead.
+    t.deepEqual(array, comparable, message);
+  } else {
+    t.like(array, comparable, message);
+  }
 
   if (actualLength === expectedLength) return;
 

--- a/packages/portfolio-contract/tools/network/buildGraph.ts
+++ b/packages/portfolio-contract/tools/network/buildGraph.ts
@@ -4,7 +4,10 @@ import { zeroPad } from '@endo/marshal';
 
 import type { NatAmount } from '@agoric/ertp/src/types.js';
 import { partialMap, typedEntries } from '@agoric/internal/src/js-utils.js';
-import { AxelarChain } from '@agoric/portfolio-api/src/constants.js';
+import {
+  AxelarChain,
+  SupportedChain,
+} from '@agoric/portfolio-api/src/constants.js';
 import {
   isDepositFromChainRef,
   isInstrumentId,
@@ -42,15 +45,17 @@ export interface FlowGraph {
 }
 
 // XXX Possible to consolidate with {@link getChainNameOfPlaceRef}?
-export const chainOf = (id: AssetPlaceRef): string => {
+export const chainOf = (id: AssetPlaceRef): SupportedChain => {
   if (id.startsWith('<')) return 'agoric';
   // {@link AssetPlaceRef} explains why this `.slice(1)` returns a chain name.
+  // @ts-expect-error promotion of string to SupportedChain
   if (!isInstrumentId(id)) return id.slice(1);
   if (Object.hasOwn(PoolPlaces, id)) return PoolPlaces[id as PoolKey].chainName;
 
-  // Fallback: syntactic pool id like "Protocol_Chain" => chain
+  // Fallback: syntactic pool id like `${Protocol}_${Chain}` => `${Chain}`
   // This enables base graph edges for pools even if not listed in PoolPlaces
   const m = /^([A-Za-z0-9]+)_([A-Za-z0-9-]+)$/.exec(id);
+  // @ts-expect-error promotion of string to SupportedChain
   if (m) return m[2];
 
   throw Fail`Cannot determine chain for ${id}`;

--- a/packages/portfolio-contract/tools/network/network-spec.ts
+++ b/packages/portfolio-contract/tools/network/network-spec.ts
@@ -44,15 +44,19 @@ export type FeeMode =
 // Chains (hubs)
 export interface ChainSpec {
   name: SupportedChain;
-  control: ControlProtocol; // how agoric reaches this chain: 'ibc' (noble) or 'axelar' (EVM) or 'local' (agoric)
-  deltaSoftMin?: NatValue; // minimum delta amount for planned moves involving this chain
+  /** how agoric reaches this chain: 'ibc' (noble) or 'axelar' (EVM) or 'local' (agoric) */
+  control: ControlProtocol;
+  /** minimum delta amount for planned moves involving this chain */
+  deltaSoftMin?: NatValue;
 }
 
 // Pools (leaves)
 export interface PoolSpec {
-  pool: PoolKey; // e.g., 'Aave_Arbitrum', 'USDNVault'
-  chain: SupportedChain; // host chain of the pool
-  protocol: YieldProtocol; // reuse existing YieldProtocol keys
+  pool: PoolKey;
+  /** host chain of the corresponding instrument */
+  chain: SupportedChain;
+  /** protocol of the corresponding instrument */
+  protocol: YieldProtocol;
 }
 
 /**
@@ -71,18 +75,25 @@ export interface LinkSpec {
   src: AssetPlaceRef;
   dest: AssetPlaceRef;
 
-  // Fees
-  variableFeeBps: number; // basis points of amount
-  flatFee?: NatValue; // minor units in src fee token
+  /**
+   * variable transfer fee in basis points to be applied against the transferred
+   * amount of major units (e.g., USDC)
+   */
+  variableFeeBps: number;
+  /** flat-rate transfer fee in minor units (e.g., uusdc) */
+  flatFee?: NatValue;
 
-  // Performance & limits
-  timeSec: number; // latency
-  capacity?: NatValue; // optional throughput limit
-  min?: NatValue; // optional min transfer size
+  /** expected transfer settlement time in seconds */
+  timeSec: number;
+  /** inclusive maximum transfer amount in minor units (e.g., uusdc) */
+  capacity?: NatValue;
+  /** inclusive minimum transfer amount in minor units (e.g., uusdc) */
+  min?: NatValue;
 
-  // Protocols
-  transfer: TransferProtocol; // asset transfer mechanism
-  feeMode?: FeeMode; // how fees apply to transation using this link. See plan-solve.ts
+  /** mechanism by which the transfer occurs */
+  transfer: TransferProtocol;
+  /** designator for how fees apply to transactions over this link */
+  feeMode?: FeeMode;
 }
 
 /** Details of how chains/pools/etc. and how they connect. */

--- a/packages/portfolio-contract/tools/network/network-spec.ts
+++ b/packages/portfolio-contract/tools/network/network-spec.ts
@@ -43,28 +43,28 @@ export type FeeMode =
 
 // Chains (hubs)
 export interface ChainSpec {
-  name: SupportedChain;
+  readonly name: SupportedChain;
   /** how agoric reaches this chain: 'ibc' (noble) or 'axelar' (EVM) or 'local' (agoric) */
-  control: ControlProtocol;
+  readonly control: ControlProtocol;
   /** minimum delta amount for planned moves involving this chain */
-  deltaSoftMin?: NatValue;
+  readonly deltaSoftMin?: NatValue;
 }
 
 // Pools (leaves)
 export interface PoolSpec {
-  pool: PoolKey;
+  readonly pool: PoolKey;
   /** host chain of the corresponding instrument */
-  chain: SupportedChain;
+  readonly chain: SupportedChain;
   /** protocol of the corresponding instrument */
-  protocol: YieldProtocol;
+  readonly protocol: YieldProtocol;
 }
 
 /**
  * A +agoric local account or <Deposit>/<Cash> Agoric blockchain contract seat.
  */
 export interface LocalPlaceSpec {
-  id: '<Deposit>' | '<Cash>' | '+agoric';
-  chain: 'agoric';
+  readonly id: '<Deposit>' | '<Cash>' | '+agoric';
+  readonly chain: 'agoric';
 }
 
 /**
@@ -72,38 +72,38 @@ export interface LocalPlaceSpec {
  * endpoint.
  */
 export interface LinkSpec {
-  src: AssetPlaceRef;
-  dest: AssetPlaceRef;
+  readonly src: AssetPlaceRef;
+  readonly dest: AssetPlaceRef;
 
   /**
    * variable transfer fee in basis points to be applied against the transferred
    * amount of major units (e.g., USDC)
    */
-  variableFeeBps: number;
+  readonly variableFeeBps: number;
   /** flat-rate transfer fee in minor units (e.g., uusdc) */
-  flatFee?: NatValue;
+  readonly flatFee?: NatValue;
 
   /** expected transfer settlement time in seconds */
-  timeSec: number;
+  readonly timeSec: number;
   /** inclusive maximum transfer amount in minor units (e.g., uusdc) */
-  capacity?: NatValue;
+  readonly capacity?: NatValue;
   /** inclusive minimum transfer amount in minor units (e.g., uusdc) */
-  min?: NatValue;
+  readonly min?: NatValue;
 
   /** mechanism by which the transfer occurs */
-  transfer: TransferProtocol;
+  readonly transfer: TransferProtocol;
   /** designator for how fees apply to transactions over this link */
-  feeMode?: FeeMode;
+  readonly feeMode?: FeeMode;
 }
 
 /** Details of how chains/pools/etc. and how they connect. */
 export interface NetworkSpec {
-  debug?: boolean;
-  environment?: 'dev' | 'test' | 'prod';
+  readonly debug?: boolean;
+  readonly environment?: 'dev' | 'test' | 'prod';
 
-  chains: ChainSpec[];
-  pools: PoolSpec[];
-  localPlaces?: LocalPlaceSpec[];
-  links: LinkSpec[];
+  readonly chains: ChainSpec[];
+  readonly pools: PoolSpec[];
+  readonly localPlaces?: LocalPlaceSpec[];
+  readonly links: LinkSpec[];
 }
 export type { PoolKey };

--- a/packages/portfolio-contract/tools/network/network-spec.ts
+++ b/packages/portfolio-contract/tools/network/network-spec.ts
@@ -1,6 +1,5 @@
 import type { NatValue } from '@agoric/ertp';
 import type {
-  AxelarChain,
   YieldProtocol,
   SupportedChain,
 } from '@agoric/portfolio-api/src/constants.js';
@@ -45,12 +44,6 @@ export type FeeMode =
 // Chains (hubs)
 export interface ChainSpec {
   name: SupportedChain;
-  chainId?: string; // cosmos chain-id or network id
-  evmChainId?: number; // EVM numeric chain id if applicable
-  bech32Prefix?: string; // for Cosmos
-  axelarKey?: AxelarChain; // Axelar registry key if differs from name
-  feeDenom?: string; // e.g., 'ubld', 'uusdc'
-  gasDenom?: string; // if distinct from feeDenom
   control: ControlProtocol; // how agoric reaches this chain: 'ibc' (noble) or 'axelar' (EVM) or 'local' (agoric)
   deltaSoftMin?: NatValue; // minimum delta amount for planned moves involving this chain
 }
@@ -68,12 +61,6 @@ export interface PoolSpec {
 export interface LocalPlaceSpec {
   id: AssetPlaceRef; // '<Deposit>' | '<Cash>' | '+agoric' | PoolKey (treated as local to its hub)
   chain: SupportedChain; // typically 'agoric'
-  // Local edge fee/policy when connecting to the hub on the same chain
-  variableFeeBps?: number;
-  flatFee?: NatValue;
-  timeSec?: number;
-  capacity?: NatValue;
-  enabled?: boolean;
 }
 
 /**
@@ -96,10 +83,6 @@ export interface LinkSpec {
   // Protocols
   transfer: TransferProtocol; // asset transfer mechanism
   feeMode?: FeeMode; // how fees apply to transation using this link. See plan-solve.ts
-
-  // Policy / guardrails (optional)
-  // priority?: number; // tie-break hint
-  // enabled?: boolean; // admin toggle
 }
 
 /** Details of how chains/pools/etc. and how they connect. */

--- a/packages/portfolio-contract/tools/network/network-spec.ts
+++ b/packages/portfolio-contract/tools/network/network-spec.ts
@@ -52,6 +52,7 @@ export interface ChainSpec {
   feeDenom?: string; // e.g., 'ubld', 'uusdc'
   gasDenom?: string; // if distinct from feeDenom
   control: ControlProtocol; // how agoric reaches this chain: 'ibc' (noble) or 'axelar' (EVM) or 'local' (agoric)
+  deltaSoftMin?: NatValue; // minimum delta amount for planned moves involving this chain
 }
 
 // Pools (leaves)

--- a/packages/portfolio-contract/tools/network/network-spec.ts
+++ b/packages/portfolio-contract/tools/network/network-spec.ts
@@ -62,7 +62,9 @@ export interface PoolSpec {
   protocol: YieldProtocol; // reuse existing YieldProtocol keys
 }
 
-// Local places: seats (<Deposit>, <Cash>) and local accounts (+agoric), with local edge fees
+/**
+ * A +agoric local account or <Deposit>/<Cash> Agoric blockchain contract seat.
+ */
 export interface LocalPlaceSpec {
   id: AssetPlaceRef; // '<Deposit>' | '<Cash>' | '+agoric' | PoolKey (treated as local to its hub)
   chain: SupportedChain; // typically 'agoric'
@@ -74,7 +76,10 @@ export interface LocalPlaceSpec {
   enabled?: boolean;
 }
 
-// Directed inter-hub link
+/**
+ * A directed edge from one place to another, usually having at least one hub
+ * endpoint.
+ */
 export interface LinkSpec {
   src: AssetPlaceRef;
   dest: AssetPlaceRef;
@@ -97,7 +102,7 @@ export interface LinkSpec {
   // enabled?: boolean; // admin toggle
 }
 
-// Overall network definition
+/** Details of how chains/pools/etc. and how they connect. */
 export interface NetworkSpec {
   debug?: boolean;
   environment?: 'dev' | 'test' | 'prod';

--- a/packages/portfolio-contract/tools/network/network-spec.ts
+++ b/packages/portfolio-contract/tools/network/network-spec.ts
@@ -59,8 +59,8 @@ export interface PoolSpec {
  * A +agoric local account or <Deposit>/<Cash> Agoric blockchain contract seat.
  */
 export interface LocalPlaceSpec {
-  id: AssetPlaceRef; // '<Deposit>' | '<Cash>' | '+agoric' | PoolKey (treated as local to its hub)
-  chain: SupportedChain; // typically 'agoric'
+  id: '<Deposit>' | '<Cash>' | '+agoric';
+  chain: 'agoric';
 }
 
 /**

--- a/packages/portfolio-contract/tools/network/prod-network.ts
+++ b/packages/portfolio-contract/tools/network/prod-network.ts
@@ -1,7 +1,7 @@
 import type { NetworkSpec } from './network-spec.js';
 
 // Initial production network in NetworkSpec format
-export const PROD_NETWORK: NetworkSpec = {
+export const PROD_NETWORK: NetworkSpec = harden({
   // Enable debug diagnostics to aid troubleshooting in tests
   debug: true,
   environment: 'prod',
@@ -373,6 +373,6 @@ export const PROD_NETWORK: NetworkSpec = {
 
     */
   ],
-};
+});
 
 export default PROD_NETWORK;

--- a/packages/portfolio-contract/tools/network/test-network.ts
+++ b/packages/portfolio-contract/tools/network/test-network.ts
@@ -11,7 +11,7 @@ const Polygon: SupportedChain = 'Polygon';
 // @ts-expect-error TS2322: Type '"Compound_Polygon"' is not assignable to type 'PoolKey'.
 const Compound_Polygon: PoolKey = 'Compound_Polygon';
 
-export const TEST_NETWORK: NetworkSpec = {
+export const TEST_NETWORK: NetworkSpec = harden({
   debug: true,
   environment: 'test',
   chains: [
@@ -194,6 +194,6 @@ export const TEST_NETWORK: NetworkSpec = {
       feeMode: 'evmToEvm',
     },
   ],
-};
+});
 
 export default TEST_NETWORK;

--- a/services/ymax-planner/package.json
+++ b/services/ymax-planner/package.json
@@ -61,6 +61,7 @@
     "@cosmjs/encoding": "^0.36.0",
     "@cosmjs/proto-signing": "^0.36.0",
     "@cosmjs/stargate": "^0.36.0",
+    "@endo/common": "^1.2.13",
     "@endo/errors": "^1.2.13",
     "@endo/init": "^1.1.12",
     "@endo/lockdown": "^1.0.18",

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -1,3 +1,4 @@
+import { fromUniqueEntries } from '@endo/common/from-unique-entries.js';
 import { assert, Fail, q, X } from '@endo/errors';
 
 import type { AssetPlaceRef } from '@aglocal/portfolio-contract/src/type-guards-steps.js';
@@ -21,6 +22,7 @@ import {
   fromTypedEntries,
   objectMap,
   objectMetaMap,
+  provideLazyMap,
   typedEntries,
 } from '@agoric/internal';
 import type { Caip10Record, CaipChainId } from '@agoric/orchestration';
@@ -60,16 +62,31 @@ const rejectUserInput = (details: ReturnType<typeof X> | string): never =>
 const isDust = (value: bigint): boolean =>
   -ACCOUNT_DUST_EPSILON < value && value < ACCOUNT_DUST_EPSILON;
 
+const chainRecordsByNetwork = new WeakMap<
+  NetworkSpec,
+  Map<AssetPlaceRef, ChainSpec>
+>();
+
 const getChainData = (
   place: AssetPlaceRef,
   network: NetworkSpec,
 ): ChainSpec => {
-  // TODO: memoize place->chainName and network->chains
-  const chainName = chainOf(place);
-  return (
-    network.chains.find(chain => chain.name === chainName) ||
-    Fail`No chain found for asset place ${q(place)}`
-  );
+  // Memoization of immutable NetworkSpec data: get a
+  // Map<AssetPlaceRef, ChainSpec> for `network`, initialized to the
+  // hubs for its `chains` and then lazily populated for each observed non-hub
+  // `place` by mapping to those hubs via chain name.
+  const chainRecordsMap = provideLazyMap(chainRecordsByNetwork, network, () => {
+    const mapEntries = network.chains.map(
+      chainRecord =>
+        [`@${chainRecord.name}`, chainRecord] as [AssetPlaceRef, ChainSpec],
+    );
+    return new Map(typedEntries(fromUniqueEntries(mapEntries)));
+  });
+  const chainData = provideLazyMap(chainRecordsMap, place, () => {
+    const chainName = chainOf(place);
+    return chainRecordsMap.get(`@${chainName}`);
+  });
+  return chainData || Fail`No chain found for asset place ${q(place)}`;
 };
 
 const isNonemptyPositionEntry = (entry: [AssetPlaceRef, NatValue]): boolean => {

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -394,9 +394,22 @@ const computeWeightedTargets = <
     };
   }
 
-  // All changes were suppressed.
-  // TODO: Let a withdraw succeed anyway.
-  return {};
+  // All deltas were suppressed, and if this is for a deposit or rebalance then
+  // we're done.
+  if (balanceDelta >= 0n) return {};
+
+  // A withdraw should succeed regardless, but minimize the count of deltas
+  // rather than the divergence from target allocation.
+  // @ts-expect-error Record confused by null prototype
+  const draft: Partial<Record<C | T, NatAmount>> = { __proto__: null };
+  remainder = -balanceDelta;
+  for (const [place, value] of natEntriesDesc(typedEntries(currentValues))) {
+    const take = value < remainder ? value : remainder;
+    draft[place] = AmountMath.make(brand, value - take);
+    remainder -= take;
+    if (remainder === 0n) break;
+  }
+  return { ...draft };
 };
 
 export type PlannerContext<

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -13,7 +13,12 @@ import { planRebalanceFlow } from '@aglocal/portfolio-contract/tools/plan-solve.
 import type { GasEstimator } from '@aglocal/portfolio-contract/tools/plan-solve.ts';
 import { AmountMath } from '@agoric/ertp/src/amountMath.js';
 import type { Brand, NatAmount, NatValue } from '@agoric/ertp/src/types.js';
-import { objectMap, objectMetaMap, typedEntries } from '@agoric/internal';
+import {
+  fromTypedEntries,
+  objectMap,
+  objectMetaMap,
+  typedEntries,
+} from '@agoric/internal';
 import type { Caip10Record, CaipChainId } from '@agoric/orchestration';
 import { parseAccountId } from '@agoric/orchestration/src/utils/address.js';
 import type {
@@ -35,6 +40,11 @@ import type { EvmChain } from './pending-tx-manager.ts';
 import { UserInputError } from './support.ts';
 import { getOwn, lookupValueForKey } from './utils.js';
 
+// TODO: const DEFAULT_DELTA_SOFT_MIN = 1_000_000n; // 1 USDC
+const DEFAULT_DELTA_SOFT_MIN = ACCOUNT_DUST_EPSILON;
+
+const bigintAbs = (x: bigint) => (x < 0n ? -x : x);
+
 const scale6 = (x: number) => {
   assert.typeof(x, 'number');
   return BigInt(Math.round(x * 1e6));
@@ -51,6 +61,9 @@ const isNonemptyPositionEntry = (entry: [AssetPlaceRef, NatValue]): boolean => {
   const [place, value] = entry;
   return isInstrumentId(place) && value > 0n;
 };
+
+const natEntriesDesc = <T extends [string, NatValue]>(entries: T[]): T[] =>
+  entries.sort(([_k1, a], [_k2, b]) => (a < b ? 1 : a > b ? -1 : 0));
 
 const amountFromSpectrumAccountBalance = (
   brand: Brand<'nat'>,
@@ -181,8 +194,8 @@ export const getCurrentBalances = async (
       : { balances: [] },
     spectrumAccountQueries.length
       ? spectrumBlockchain.getBalances({
-          accounts: spectrumAccountQueries.map(q =>
-            makeSpectrumGetAddressBalanceInput(q, powers),
+          accounts: spectrumAccountQueries.map(queryDesc =>
+            makeSpectrumGetAddressBalanceInput(queryDesc, powers),
           ),
         })
       : { balances: [] },
@@ -281,7 +294,7 @@ const computeWeightedTargets = <
   total >= 0n || rejectUserInput('Insufficient funds for withdrawal.');
 
   type PW = [C | T, NatValue];
-  const weights: PW[] = Object.keys(allocation).length
+  const allWeights: PW[] = Object.keys(allocation).length
     ? typedEntries({
         // Any current balance with no target has an effective weight of 0.
         ...objectMap(currentValues, () => 0n),
@@ -294,56 +307,81 @@ const computeWeightedTargets = <
           ? valueEntries.map(([p, v]) => [p, isInstrumentId(p) ? v : 0n] as PW)
           : valueEntries;
       })(typedEntries(currentValues));
-  const sumW = weights.reduce((acc, entry) => {
-    const w = entry[1];
-    (typeof w === 'bigint' && w >= 0n) ||
-      rejectUserInput(
-        X`Target allocation weight in ${entry} must be a natural number.`,
-      );
-    return acc + w;
-  }, 0n);
+  let sumW = allWeights.reduce((acc, entry) => acc + entry[1], 0n);
   sumW > 0n ||
     rejectUserInput('Total target allocation weights must be positive.');
 
-  // Try to satisfy the weights, leaving any amount otherwise subject to
-  // rounding loss or representing a too-small delta at the highest-weight
-  // place that can accept it.
-  const draft: Partial<Record<C | T, NatValue>> = {};
+  let prunedTotal = total;
   let remainder = total;
-  for (const [key, w] of weights) {
-    const a = getOwn(currentValues, key) ?? 0n;
-    const b = (total * w) / sumW;
-    const v = isDust(b - a) ? a : b;
-    draft[key] = v;
-    remainder -= v;
-  }
-  if (remainder !== 0n) {
-    weights.sort(([_k1, a], [_k2, b]) => (a < b ? 1 : a > b ? -1 : 0));
-    for (const [key, _w] of weights) {
-      const a = getOwn(currentValues, key) ?? 0n;
-      const v = (draft[key] ?? 0n) + remainder;
-      if (v === a || !isDust(v - a)) {
-        draft[key] = v;
-        remainder = 0n;
-        break;
+  for (const prunedWeights = fromTypedEntries(allWeights); sumW > 0n; ) {
+    // Try to satisfy the weights, suppressing deltas that are too small and
+    // tracking the geometric magnitude by which they miss.
+    const draft: Partial<Record<C | T, NatValue>> = {};
+    const suppressions: [C | T, number][] = [];
+    for (const [place, weight] of typedEntries(prunedWeights) as PW[]) {
+      const current = getOwn(currentValues, place) ?? 0n;
+      const target = (prunedTotal * weight) / sumW;
+      const absDelta = bigintAbs(target - current);
+      // TODO: const chainData = getChainData(place, network);
+      // TODO: const { deltaSoftMin = DEFAULT_DELTA_SOFT_MIN } = getChainData(place, network);
+      const deltaSoftMin = DEFAULT_DELTA_SOFT_MIN;
+      const suppressed = absDelta !== 0n && absDelta < deltaSoftMin;
+      if (suppressed) {
+        suppressions.push([place, Number(deltaSoftMin) / Number(absDelta)]);
       }
+      const resolved = suppressed ? current : target;
+      draft[place] = resolved;
+      remainder -= resolved;
     }
-    remainder === 0n ||
-      rejectUserInput(
-        X`Nowhere to place ${remainder} in update of ${currentValues} to ${draft}`,
-      );
+
+    // If any deltas were suppressed, filter out weights for the biggest misses
+    // and try again with the pruned subset.
+    if (suppressions.length > 0) {
+      suppressions.sort(([_k1, a], [_k2, b]) => (a < b ? 1 : a > b ? -1 : 0));
+      for (let i = 0; i < suppressions.length; i += 1) {
+        const [place, softLimitGap] = suppressions[i];
+        if (i > 0 && softLimitGap !== suppressions[i - 1][1]) break;
+        sumW -= prunedWeights[place] as NatValue;
+        prunedTotal -= getOwn(currentValues, place) ?? 0n;
+        delete prunedWeights[place];
+      }
+      remainder = prunedTotal;
+      continue;
+    }
+
+    // We have our targets. Distribute any rounding loss to the highest-weight
+    // place that can accept it.
+    // XXX We should instead redistribute to minimize error.
+    if (remainder !== 0n) {
+      const weightsDesc = natEntriesDesc(typedEntries(prunedWeights) as PW[]);
+      for (const [key, _w] of weightsDesc) {
+        const a = getOwn(currentValues, key) ?? 0n;
+        const v = (draft[key] ?? 0n) + remainder;
+        if (v === a || !isDust(v - a)) {
+          draft[key] = v;
+          remainder = 0n;
+          break;
+        }
+      }
+      remainder === 0n ||
+        rejectUserInput(
+          X`Nowhere to place ${remainder} in update of ${currentValues} to ${draft}`,
+        );
+    }
+
+    // Return a mutable Record that omits no-change entries.
+    return {
+      ...objectMetaMap(draft, (desc, place) => {
+        const targetValue = desc.value as NatValue;
+        if (targetValue === getOwn(currentValues, place)) return undefined;
+        return { ...desc, value: AmountMath.make(brand, targetValue) };
+      }),
+    };
   }
 
-  // Delete entries reflecting no change.
-  for (const [key, amount] of typedEntries(draft)) {
-    if (amount === getOwn(currentValues, key)) {
-      delete draft[key];
-    }
-  }
-
-  return {
-    ...objectMap(draft, (value: NatValue) => AmountMath.make(brand, value)),
-  };
+  // All changes were suppressed.
+  // TODO: Let a withdraw succeed anyway.
+  return {};
 };
 
 export type PlannerContext<

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -1,4 +1,4 @@
-import { assert, Fail, X } from '@endo/errors';
+import { assert, Fail, q, X } from '@endo/errors';
 
 import type { AssetPlaceRef } from '@aglocal/portfolio-contract/src/type-guards-steps.js';
 import type {
@@ -8,7 +8,11 @@ import type {
   TargetAllocation,
 } from '@aglocal/portfolio-contract/src/type-guards.js';
 import { PoolPlaces } from '@aglocal/portfolio-contract/src/type-guards.js';
-import type { NetworkSpec } from '@aglocal/portfolio-contract/tools/network/network-spec.js';
+import { chainOf } from '@aglocal/portfolio-contract/tools/network/buildGraph.js';
+import type {
+  ChainSpec,
+  NetworkSpec,
+} from '@aglocal/portfolio-contract/tools/network/network-spec.js';
 import { planRebalanceFlow } from '@aglocal/portfolio-contract/tools/plan-solve.js';
 import type { GasEstimator } from '@aglocal/portfolio-contract/tools/plan-solve.ts';
 import { AmountMath } from '@agoric/ertp/src/amountMath.js';
@@ -40,8 +44,7 @@ import type { EvmChain } from './pending-tx-manager.ts';
 import { UserInputError } from './support.ts';
 import { getOwn, lookupValueForKey } from './utils.js';
 
-// TODO: const DEFAULT_DELTA_SOFT_MIN = 1_000_000n; // 1 USDC
-const DEFAULT_DELTA_SOFT_MIN = ACCOUNT_DUST_EPSILON;
+const DEFAULT_DELTA_SOFT_MIN = 1_000_000n; // 1 USDC
 
 const bigintAbs = (x: bigint) => (x < 0n ? -x : x);
 
@@ -56,6 +59,18 @@ const rejectUserInput = (details: ReturnType<typeof X> | string): never =>
 
 const isDust = (value: bigint): boolean =>
   -ACCOUNT_DUST_EPSILON < value && value < ACCOUNT_DUST_EPSILON;
+
+const getChainData = (
+  place: AssetPlaceRef,
+  network: NetworkSpec,
+): ChainSpec => {
+  // TODO: memoize place->chainName and network->chains
+  const chainName = chainOf(place);
+  return (
+    network.chains.find(chain => chain.name === chainName) ||
+    Fail`No chain found for asset place ${q(place)}`
+  );
+};
 
 const isNonemptyPositionEntry = (entry: [AssetPlaceRef, NatValue]): boolean => {
   const [place, value] = entry;
@@ -284,6 +299,7 @@ const computeWeightedTargets = <
   currentAmounts: Record<C, NatAmount>,
   balanceDelta: NatValue,
   allocation: Partial<Pick<TargetAllocation, T>> = {},
+  network: NetworkSpec,
 ): Partial<Record<C | T, NatAmount>> => {
   const currentValues = objectMap(currentAmounts, amount => amount.value);
   const currentTotal = Object.values<NatValue>(currentValues).reduce(
@@ -322,9 +338,8 @@ const computeWeightedTargets = <
       const current = getOwn(currentValues, place) ?? 0n;
       const target = (prunedTotal * weight) / sumW;
       const absDelta = bigintAbs(target - current);
-      // TODO: const chainData = getChainData(place, network);
-      // TODO: const { deltaSoftMin = DEFAULT_DELTA_SOFT_MIN } = getChainData(place, network);
-      const deltaSoftMin = DEFAULT_DELTA_SOFT_MIN;
+      const chainData = getChainData(place, network);
+      const { deltaSoftMin = DEFAULT_DELTA_SOFT_MIN } = chainData;
       const suppressed = absDelta !== 0n && absDelta < deltaSoftMin;
       if (suppressed) {
         suppressions.push([place, Number(deltaSoftMin) / Number(absDelta)]);
@@ -409,7 +424,7 @@ export const planDepositToAllocations = async <
     fromChain?: SupportedChain;
   },
 ): Promise<FundsFlowPlan> => {
-  const { amount, brand, currentBalances, targetAllocation } = details;
+  const { amount, brand, currentBalances, network, targetAllocation } = details;
   const { fromChain = 'agoric' } = details;
   if (!targetAllocation) return { flow: [] };
   const target = computeWeightedTargets(
@@ -417,6 +432,7 @@ export const planDepositToAllocations = async <
     currentBalances,
     amount.value,
     targetAllocation,
+    network,
   );
 
   // The deposit should be distributed.
@@ -427,7 +443,7 @@ export const planDepositToAllocations = async <
   const resolvedCurrent = { ...currentBalances, [depositFrom]: amount };
   const resolvedTarget = { ...target, [depositFrom]: zeroAmount };
 
-  const { network, feeBrand, gasEstimator } = details;
+  const { feeBrand, gasEstimator } = details;
   const flowDetail = await planRebalanceFlow({
     network,
     current: resolvedCurrent,
@@ -449,16 +465,17 @@ export const planRebalanceToAllocations = async <
 >(
   details: PlannerContext<C, T>,
 ): Promise<FundsFlowPlan> => {
-  const { brand, currentBalances, targetAllocation } = details;
+  const { brand, currentBalances, network, targetAllocation } = details;
   if (!targetAllocation) return { flow: [] };
   const target = computeWeightedTargets(
     brand,
     currentBalances,
     0n,
     targetAllocation,
+    network,
   );
 
-  const { network, feeBrand, gasEstimator } = details;
+  const { feeBrand, gasEstimator } = details;
   const flowDetail = await planRebalanceFlow({
     network,
     current: currentBalances,
@@ -483,13 +500,14 @@ export const planWithdrawFromAllocations = async <
     toChain?: SupportedChain;
   },
 ): Promise<FundsFlowPlan> => {
-  const { amount, brand, currentBalances, targetAllocation } = details;
+  const { amount, brand, currentBalances, network, targetAllocation } = details;
   const { toChain = 'agoric' } = details;
   const target = computeWeightedTargets(
     brand,
     currentBalances,
     -amount.value,
     targetAllocation,
+    network,
   );
 
   const withdrawTo =
@@ -499,7 +517,7 @@ export const planWithdrawFromAllocations = async <
   const resolvedCurrent = { ...currentBalances, [withdrawTo]: zeroAmount };
   const resolvedTarget = { ...target, [withdrawTo]: amount };
 
-  const { network, feeBrand, gasEstimator } = details;
+  const { feeBrand, gasEstimator } = details;
   const flowDetail = await planRebalanceFlow({
     network,
     current: resolvedCurrent,

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -424,22 +424,20 @@ export type PlannerContext<
   gasEstimator: GasEstimator;
 };
 
-/**
- * Plan deposit driven by target allocation weights.
- * Computes absolute targets, then plans the corresponding flow.
- */
-export const planDepositToAllocations = async <
+type PlanMaker<D = unknown> = <
   C extends AssetPlaceRef,
   T extends keyof TargetAllocation,
 >(
-  details: PlannerContext<C, T> & {
-    amount: NatAmount;
-    fromChain?: SupportedChain;
-  },
-): Promise<FundsFlowPlan> => {
+  details: PlannerContext<C, T> & D,
+) => Promise<FundsFlowPlan>;
+
+/** Plan absorption of a deposit into current balances and target weights. */
+export const planDepositToAllocations: PlanMaker<{
+  amount: NatAmount;
+  fromChain?: SupportedChain;
+}> = async details => {
   const { amount, brand, currentBalances, network, targetAllocation } = details;
-  const { fromChain = 'agoric' } = details;
-  if (!targetAllocation) return { flow: [] };
+  if (!targetAllocation) return { flow: [], order: undefined };
   const target = computeWeightedTargets(
     brand,
     currentBalances,
@@ -447,16 +445,15 @@ export const planDepositToAllocations = async <
     targetAllocation,
     network,
   );
+  if (Object.keys(target).length === 0) return { flow: [], order: undefined };
 
-  // The deposit should be distributed.
+  const { feeBrand, gasEstimator, fromChain = 'agoric' } = details;
   const depositFrom =
     // TODO(#12309): Remove the `<Deposit>` special case in favor of `+agoric`.
     (fromChain === 'agoric' ? '<Deposit>' : `+${fromChain}`) as AssetPlaceRef;
   const zeroAmount = AmountMath.make(brand, 0n);
   const resolvedCurrent = { ...currentBalances, [depositFrom]: amount };
   const resolvedTarget = { ...target, [depositFrom]: zeroAmount };
-
-  const { feeBrand, gasEstimator } = details;
   const flowDetail = await planRebalanceFlow({
     network,
     current: resolvedCurrent,
@@ -468,18 +465,10 @@ export const planDepositToAllocations = async <
   return flowDetail.plan;
 };
 
-/**
- * Plan rebalance driven by target allocation weights.
- * Computes absolute targets, then plans the corresponding flow.
- */
-export const planRebalanceToAllocations = async <
-  C extends AssetPlaceRef,
-  T extends keyof TargetAllocation,
->(
-  details: PlannerContext<C, T>,
-): Promise<FundsFlowPlan> => {
+/** Plan rebalancing of current balances against target weights. */
+export const planRebalanceToAllocations: PlanMaker = async details => {
   const { brand, currentBalances, network, targetAllocation } = details;
-  if (!targetAllocation) return { flow: [] };
+  if (!targetAllocation) return { flow: [], order: undefined };
   const target = computeWeightedTargets(
     brand,
     currentBalances,
@@ -487,6 +476,7 @@ export const planRebalanceToAllocations = async <
     targetAllocation,
     network,
   );
+  if (Object.keys(target).length === 0) return { flow: [], order: undefined };
 
   const { feeBrand, gasEstimator } = details;
   const flowDetail = await planRebalanceFlow({
@@ -500,21 +490,12 @@ export const planRebalanceToAllocations = async <
   return flowDetail.plan;
 };
 
-/**
- * Plan withdrawal driven by target allocation weights.
- * Computes absolute targets, then plans the corresponding flow.
- */
-export const planWithdrawFromAllocations = async <
-  C extends AssetPlaceRef,
-  T extends keyof TargetAllocation,
->(
-  details: PlannerContext<C, T> & {
-    amount: NatAmount;
-    toChain?: SupportedChain;
-  },
-): Promise<FundsFlowPlan> => {
+/** Plan a rebalancing withdrawal from current balances and target weights. */
+export const planWithdrawFromAllocations: PlanMaker<{
+  amount: NatAmount;
+  toChain?: SupportedChain;
+}> = async details => {
   const { amount, brand, currentBalances, network, targetAllocation } = details;
-  const { toChain = 'agoric' } = details;
   const target = computeWeightedTargets(
     brand,
     currentBalances,
@@ -523,14 +504,13 @@ export const planWithdrawFromAllocations = async <
     network,
   );
 
+  const { feeBrand, gasEstimator, toChain = 'agoric' } = details;
   const withdrawTo =
     // TODO(#12309): Remove the `<Cash>` special case in favor of `-agoric`.
     (toChain === 'agoric' ? '<Cash>' : `-${toChain}`) as AssetPlaceRef;
   const zeroAmount = AmountMath.make(brand, 0n);
   const resolvedCurrent = { ...currentBalances, [withdrawTo]: zeroAmount };
   const resolvedTarget = { ...target, [withdrawTo]: amount };
-
-  const { feeBrand, gasEstimator } = details;
   const flowDetail = await planRebalanceFlow({
     network,
     current: resolvedCurrent,

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -246,11 +246,11 @@ export const getCurrentBalances = async (
   return Object.fromEntries(balances);
 };
 
-export const getNonDustBalances = async (
+export const getNonDustBalances = async <C extends AssetPlaceRef>(
   status: StatusFor['portfolio'],
   brand: Brand<'nat'>,
   powers: BalanceQueryPowers,
-): Promise<Partial<Record<AssetPlaceRef, NatAmount>>> => {
+): Promise<Record<C, NatAmount>> => {
   const currentBalances = await getCurrentBalances(status, brand, powers);
   const nonDustBalances = objectMetaMap(currentBalances, desc =>
     desc.value && desc.value.value > ACCOUNT_DUST_EPSILON ? desc : undefined,
@@ -263,24 +263,25 @@ export const getNonDustBalances = async (
  * (chains; keys starting with '@') that have non-zero current amounts. Returns only entries
  * whose values change by at least ACCOUNT_DUST_EPSILON compared to current.
  */
-const computeWeightedTargets = (
+const computeWeightedTargets = <
+  C extends AssetPlaceRef,
+  T extends keyof TargetAllocation,
+>(
   brand: Brand<'nat'>,
-  currentAmounts: Partial<Record<AssetPlaceRef, NatAmount>>,
-  balanceDelta: bigint,
-  allocation: TargetAllocation = {},
-): Partial<Record<AssetPlaceRef, NatAmount>> => {
-  const currentValues = objectMap(
-    currentAmounts as Required<typeof currentAmounts>,
-    amount => amount.value,
-  );
-  const currentTotal = Object.values(currentValues).reduce(
+  currentAmounts: Record<C, NatAmount>,
+  balanceDelta: NatValue,
+  allocation: Partial<Pick<TargetAllocation, T>> = {},
+): Partial<Record<C | T, NatAmount>> => {
+  const currentValues = objectMap(currentAmounts, amount => amount.value);
+  const currentTotal = Object.values<NatValue>(currentValues).reduce(
     (acc, value) => acc + value,
     0n,
   );
   const total = currentTotal + balanceDelta;
   total >= 0n || rejectUserInput('Insufficient funds for withdrawal.');
 
-  const weights: [AssetPlaceRef, NatValue][] = Object.keys(allocation).length
+  type PW = [C | T, NatValue];
+  const weights: PW[] = Object.keys(allocation).length
     ? typedEntries({
         // Any current balance with no target has an effective weight of 0.
         ...objectMap(currentValues, () => 0n),
@@ -290,10 +291,10 @@ const computeWeightedTargets = (
       // zero out hubs (chains) if there is anywhere else to deploy their funds.
       (valueEntries => {
         return valueEntries.some(isNonemptyPositionEntry)
-          ? valueEntries.map(([p, v]) => [p, isInstrumentId(p) ? v : 0n])
+          ? valueEntries.map(([p, v]) => [p, isInstrumentId(p) ? v : 0n] as PW)
           : valueEntries;
       })(typedEntries(currentValues));
-  const sumW = weights.reduce<bigint>((acc, entry) => {
+  const sumW = weights.reduce((acc, entry) => {
     const w = entry[1];
     (typeof w === 'bigint' && w >= 0n) ||
       rejectUserInput(
@@ -307,10 +308,10 @@ const computeWeightedTargets = (
   // Try to satisfy the weights, leaving any amount otherwise subject to
   // rounding loss or representing a too-small delta at the highest-weight
   // place that can accept it.
-  const draft: Partial<Record<AssetPlaceRef, NatValue>> = {};
+  const draft: Partial<Record<C | T, NatValue>> = {};
   let remainder = total;
   for (const [key, w] of weights) {
-    const a = currentValues[key] || 0n;
+    const a = getOwn(currentValues, key) ?? 0n;
     const b = (total * w) / sumW;
     const v = isDust(b - a) ? a : b;
     draft[key] = v;
@@ -319,8 +320,8 @@ const computeWeightedTargets = (
   if (remainder !== 0n) {
     weights.sort(([_k1, a], [_k2, b]) => (a < b ? 1 : a > b ? -1 : 0));
     for (const [key, _w] of weights) {
-      const a = currentValues[key] || 0n;
-      const v = (draft[key] || 0n) + remainder;
+      const a = getOwn(currentValues, key) ?? 0n;
+      const v = (draft[key] ?? 0n) + remainder;
       if (v === a || !isDust(v - a)) {
         draft[key] = v;
         remainder = 0n;
@@ -334,8 +335,8 @@ const computeWeightedTargets = (
   }
 
   // Delete entries reflecting no change.
-  for (const [key, amount] of Object.entries(draft)) {
-    if (amount === currentValues[key]) {
+  for (const [key, amount] of typedEntries(draft)) {
+    if (amount === getOwn(currentValues, key)) {
       delete draft[key];
     }
   }
@@ -345,9 +346,12 @@ const computeWeightedTargets = (
   };
 };
 
-export type PlannerContext = {
-  currentBalances: Partial<Record<AssetPlaceRef, NatAmount>>;
-  targetAllocation?: TargetAllocation;
+export type PlannerContext<
+  C extends AssetPlaceRef,
+  T extends keyof TargetAllocation,
+> = {
+  currentBalances: Record<C, NatAmount>;
+  targetAllocation?: Partial<Pick<TargetAllocation, T>>;
   network: NetworkSpec;
   brand: Brand<'nat'>;
   feeBrand: Brand<'nat'>;
@@ -358,8 +362,14 @@ export type PlannerContext = {
  * Plan deposit driven by target allocation weights.
  * Computes absolute targets, then plans the corresponding flow.
  */
-export const planDepositToAllocations = async (
-  details: PlannerContext & { amount: NatAmount; fromChain?: SupportedChain },
+export const planDepositToAllocations = async <
+  C extends AssetPlaceRef,
+  T extends keyof TargetAllocation,
+>(
+  details: PlannerContext<C, T> & {
+    amount: NatAmount;
+    fromChain?: SupportedChain;
+  },
 ): Promise<FundsFlowPlan> => {
   const { amount, brand, currentBalances, targetAllocation } = details;
   const { fromChain = 'agoric' } = details;
@@ -395,8 +405,11 @@ export const planDepositToAllocations = async (
  * Plan rebalance driven by target allocation weights.
  * Computes absolute targets, then plans the corresponding flow.
  */
-export const planRebalanceToAllocations = async (
-  details: PlannerContext,
+export const planRebalanceToAllocations = async <
+  C extends AssetPlaceRef,
+  T extends keyof TargetAllocation,
+>(
+  details: PlannerContext<C, T>,
 ): Promise<FundsFlowPlan> => {
   const { brand, currentBalances, targetAllocation } = details;
   if (!targetAllocation) return { flow: [] };
@@ -423,8 +436,14 @@ export const planRebalanceToAllocations = async (
  * Plan withdrawal driven by target allocation weights.
  * Computes absolute targets, then plans the corresponding flow.
  */
-export const planWithdrawFromAllocations = async (
-  details: PlannerContext & { amount: NatAmount; toChain?: SupportedChain },
+export const planWithdrawFromAllocations = async <
+  C extends AssetPlaceRef,
+  T extends keyof TargetAllocation,
+>(
+  details: PlannerContext<C, T> & {
+    amount: NatAmount;
+    toChain?: SupportedChain;
+  },
 ): Promise<FundsFlowPlan> => {
   const { amount, brand, currentBalances, targetAllocation } = details;
   const { toChain = 'agoric' } = details;

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -388,7 +388,7 @@ const computeWeightedTargets = <
       const weightsDesc = natEntriesDesc(typedEntries(prunedWeights) as PW[]);
       for (const [key, _w] of weightsDesc) {
         const a = getOwn(currentValues, key) ?? 0n;
-        const v = (draft[key] ?? 0n) + remainder;
+        const v = (getOwn(draft, key) ?? 0n) + remainder;
         if (v === a || !isDust(v - a)) {
           draft[key] = v;
           remainder = 0n;

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -27,7 +27,7 @@ import { makePortfolioQuery } from '@aglocal/portfolio-contract/tools/portfolio-
 import type { VstorageKit } from '@agoric/client-utils';
 import { AmountMath } from '@agoric/ertp';
 import type { Brand, NatAmount } from '@agoric/ertp/src/types.js';
-import { objectMap } from '@agoric/internal';
+import { fromTypedEntries, objectMap } from '@agoric/internal';
 import { arrayIsLike } from '@agoric/internal/tools/ava-assertions.js';
 import { Far } from '@endo/pass-style';
 import PROD_NETWORK from '@aglocal/portfolio-contract/tools/network/prod-network.ts';
@@ -319,6 +319,37 @@ test('handleDeposit handles missing targetAllocation gracefully', async t => {
   t.deepEqual(result, { policyVersion: 4, rebalanceCount: 0, plan: emptyPlan });
 });
 
+test('targetAllocation must have positive total weight', async t => {
+  const badContext = {
+    ...plannerContext,
+    targetAllocation: { Aave_Arbitrum: 0n, Compound_Arbitrum: 0n },
+    currentBalances: {},
+  };
+  const expectation = {
+    message: 'Total target allocation weights must be positive.',
+  };
+  const amount = makeDeposit(scale6(1));
+  await t.throwsAsync(
+    planRebalanceToAllocations(badContext),
+    expectation,
+    'planRebalanceToAllocations',
+  );
+  await t.throwsAsync(
+    planDepositToAllocations({ ...badContext, amount }),
+    expectation,
+    'planDepositToAllocations',
+  );
+  await t.throwsAsync(
+    planWithdrawFromAllocations({
+      ...badContext,
+      currentBalances: { Aave_Arbitrum: amount, Compound_Arbitrum: amount },
+      amount,
+    }),
+    expectation,
+    'planWithdrawFromAllocations',
+  );
+});
+
 test('handleDeposit handles different position types correctly', async t => {
   const deposit = makeDeposit(1_000_000n);
   const portfolioKey = 'test.portfolios.portfolio1' as const;
@@ -459,6 +490,18 @@ test('planWithdrawFromAllocations withdraws and rebalances', async t => {
   t.snapshot(plan && readableSteps(plan.flow, depositBrand), 'steps');
   t.snapshot(plan?.order && readableOrder(plan.order), 'step dependencies');
   t.snapshot(plan, 'raw plan');
+});
+
+test('planWithdrawFromAllocations rejects overdrafts', async t => {
+  await t.throwsAsync(
+    planWithdrawFromAllocations({
+      ...plannerContext,
+      targetAllocation: { USDN: 100n },
+      currentBalances: { USDN: makeDeposit(2000n) },
+      amount: makeDeposit(3000n),
+    }),
+    { message: 'Insufficient funds for withdrawal.' },
+  );
 });
 
 test('planWithdrawFromAllocations can withdraw to an EVM account', async t => {
@@ -872,7 +915,7 @@ test('planRebalanceToAllocations regression - CCTPv2 multi-source rebalance', as
     Aave_Optimism: 5.99,
     Aave_Avalanche: 2.6,
     Beefy_re7_Avalanche: 0.008,
-  };
+  } satisfies Partial<Record<AssetPlaceRef, number>>;
   const makeBalances = (scale: number) =>
     objectMap(balancesTemplate, v => makeDeposit(BigInt(v * 1e6 * scale)));
 
@@ -1057,6 +1100,45 @@ test('planRebalanceToAllocations regression - CCTPv2 multi-source rebalance', as
       { amount, src: 'Aave_Ethereum', dest: '@Ethereum' },
       { amount, src: '@Ethereum', dest: '@agoric' },
       { amount, src: '@agoric', dest: '<Cash>' },
+    ]);
+  });
+
+  test('planWithdrawFromAllocations works despite small deltas (amount > first currentBalances entry)', async t => {
+    const plan = await planWithdrawFromAllocations({
+      ...plannerContext,
+      network: expensiveEthNetwork,
+      targetAllocation,
+      currentBalances: fromTypedEntries(
+        Object.keys(balancesTemplate)
+          .reverse()
+          .map((place: AssetPlaceRef, idx: number) => [
+            place,
+            makeDeposit(scale6(idx * 0.1)),
+          ]),
+      ),
+      amount: makeDeposit(scale6(0.8)),
+    });
+
+    // All deltas are too small, so the $0.80 withdrawal is pulled from
+    // descending balances (Aave_{Ethereum,Base,Optimism} at
+    // [$0.40, $0.30, $0.20], with only $0.10 needed from Aave_Optimism).
+    // t.log(readableSteps(plan.flow, depositBrand));
+    arrayIsLike(t, plan?.flow, [
+      { src: 'Aave_Base', dest: '@Base', amount: makeDeposit(scale6(0.3)) },
+      { src: '@Base', dest: '@agoric', amount: makeDeposit(scale6(0.3)) },
+      {
+        src: 'Aave_Ethereum',
+        dest: '@Ethereum',
+        amount: makeDeposit(scale6(0.4)),
+      },
+      { src: '@Ethereum', dest: '@agoric', amount: makeDeposit(scale6(0.4)) },
+      {
+        src: 'Aave_Optimism',
+        dest: '@Optimism',
+        amount: makeDeposit(scale6(0.1)),
+      },
+      { src: '@Optimism', dest: '@agoric', amount: makeDeposit(scale6(0.1)) },
+      { src: '@agoric', dest: '<Cash>', amount: makeDeposit(scale6(0.8)) },
     ]);
   });
 }

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -13,7 +13,6 @@ import type {
   PortfolioPublishedPathTypes,
   TargetAllocation,
 } from '@aglocal/portfolio-contract/src/type-guards.ts';
-import { planUSDNDeposit } from '@aglocal/portfolio-contract/test/mocks.js';
 import {
   readableSteps,
   readableOrder,
@@ -63,6 +62,11 @@ const plannerContext: Omit<
   feeBrand,
   gasEstimator: mockGasEstimator,
 };
+
+const noMinChainRecords = plannerContext.network.chains.map(chain => ({
+  ...chain,
+  deltaSoftMin: 0n,
+}));
 
 const emptyPlan = harden({ flow: [], order: undefined });
 
@@ -380,7 +384,7 @@ test('handleDeposit handles different position types correctly', async t => {
         [compoundEthereumAddress]: 75_000n,
       },
     },
-    TEST_NETWORK,
+    harden({ ...plannerContext.network, chains: noMinChainRecords }),
   );
   const plan = result?.plan;
   t.snapshot(plan && readableSteps(plan.flow, depositBrand), 'steps');
@@ -425,6 +429,7 @@ test('planRebalanceToAllocations emits an empty plan when almost balanced', asyn
 test('planRebalanceToAllocations moves funds when needed', async t => {
   const plan = await planRebalanceToAllocations({
     ...plannerContext,
+    network: harden({ ...plannerContext.network, chains: noMinChainRecords }),
     targetAllocation: {
       USDN: 40n,
       USDNVault: 0n,
@@ -441,6 +446,7 @@ test('planRebalanceToAllocations moves funds when needed', async t => {
 test('planWithdrawFromAllocations withdraws and rebalances', async t => {
   const plan = await planWithdrawFromAllocations({
     ...plannerContext,
+    network: harden({ ...plannerContext.network, chains: noMinChainRecords }),
     targetAllocation: { USDN: 40n, Aave_Arbitrum: 40n, Compound_Arbitrum: 20n },
     currentBalances: { USDN: makeDeposit(2000n) },
     amount: makeDeposit(1000n),
@@ -453,6 +459,7 @@ test('planWithdrawFromAllocations withdraws and rebalances', async t => {
 test('planWithdrawFromAllocations can withdraw to an EVM account', async t => {
   const plan = await planWithdrawFromAllocations({
     ...plannerContext,
+    network: harden({ ...plannerContext.network, chains: noMinChainRecords }),
     targetAllocation: { USDN: 40n, Aave_Arbitrum: 40n, Compound_Arbitrum: 20n },
     currentBalances: { USDN: makeDeposit(2000n) },
     amount: makeDeposit(1000n),
@@ -466,6 +473,7 @@ test('planWithdrawFromAllocations can withdraw to an EVM account', async t => {
 test('planWithdrawFromAllocations considers former allocation targets', async t => {
   const plan = await planWithdrawFromAllocations({
     ...plannerContext,
+    network: harden({ ...plannerContext.network, chains: noMinChainRecords }),
     targetAllocation: { Compound_Arbitrum: 100n },
     currentBalances: {
       Aave_Avalanche: makeDeposit(1000n),
@@ -481,6 +489,7 @@ test('planWithdrawFromAllocations considers former allocation targets', async t 
 test('planWithdrawFromAllocations with no target preserves relative positions', async t => {
   const plan = await planWithdrawFromAllocations({
     ...plannerContext,
+    network: harden({ ...plannerContext.network, chains: noMinChainRecords }),
     targetAllocation: {},
     currentBalances: {
       '@Arbitrum': makeDeposit(200n),
@@ -498,6 +507,7 @@ test('planWithdrawFromAllocations with no target preserves relative positions', 
 test('planWithdrawFromAllocations with no target and no positions preserves relative amounts', async t => {
   const plan = await planWithdrawFromAllocations({
     ...plannerContext,
+    network: harden({ ...plannerContext.network, chains: noMinChainRecords }),
     targetAllocation: {},
     currentBalances: {
       '@Arbitrum': makeDeposit(1000n),
@@ -511,20 +521,25 @@ test('planWithdrawFromAllocations with no target and no positions preserves rela
 });
 
 test('planDepositToAllocations produces plan expected by contract', async t => {
-  const amount = makeDeposit(1000n);
-  const actual = await planDepositToAllocations({
+  const amount = makeDeposit(1_000_000n);
+  const plan = await planDepositToAllocations({
     ...plannerContext,
     targetAllocation: { USDN: 1n },
     currentBalances: {},
     amount,
   });
 
-  const expected = planUSDNDeposit(amount);
-  t.deepEqual(actual, expected);
+  const expectedFlow = [
+    { amount, src: '<Deposit>', dest: '@agoric' },
+    { amount, src: '@agoric', dest: '@noble' },
+    { amount, src: '@noble', dest: 'USDN', detail: { usdnOut: 999499n } },
+  ];
+  arrayIsLike(t, plan?.flow, expectedFlow);
+  t.deepEqual(plan, { flow: expectedFlow, order: undefined });
 });
 
 test('planDepositToAllocations can deposit from an EVM account', async t => {
-  const amount = makeDeposit(1000n);
+  const amount = makeDeposit(1_000_000n);
   const plan = await planDepositToAllocations({
     ...plannerContext,
     targetAllocation: { USDN: 1n },

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -53,6 +53,11 @@ const makeDeposit = value => AmountMath.make(depositBrand, value);
 
 const feeBrand = Far('fee brand (BLD)') as Brand<'nat'>;
 
+const scale6 = (x: number) => {
+  assert.typeof(x, 'number');
+  return BigInt(Math.round(x * 1e6));
+};
+
 const plannerContext: Omit<
   PlannerContext<AssetPlaceRef, keyof TargetAllocation>,
   'currentBalances' | 'targetAllocation'
@@ -841,3 +846,217 @@ test('planRebalanceToAllocations regression - CCTPv2 multi-source rebalance', as
 
   t.snapshot(plan, 'CCTPv2 multi-source rebalance');
 });
+
+{
+  // Create scenarios where a 10 USDC minimum delta for Ethereum and the default
+  // of 1 USDC elsewhere suppress changes until balances are scaled up.
+  const chainRecords = plannerContext.network.chains.map(chain =>
+    chain.name === 'Ethereum'
+      ? { ...chain, deltaSoftMin: 100_000_000n }
+      : chain,
+  );
+  const expensiveEthNetwork = harden({
+    ...plannerContext.network,
+    chains: chainRecords,
+  });
+  const targetAllocation = {
+    Aave_Ethereum: 880n,
+    Aave_Base: 50n,
+    Aave_Optimism: 50n,
+    Aave_Avalanche: 20n,
+    Beefy_re7_Avalanche: 0n,
+  };
+  const balancesTemplate = {
+    Aave_Ethereum: 12.5,
+    Aave_Base: 4.01,
+    Aave_Optimism: 5.99,
+    Aave_Avalanche: 2.6,
+    Beefy_re7_Avalanche: 0.008,
+  };
+  const makeBalances = (scale: number) =>
+    objectMap(balancesTemplate, v => makeDeposit(BigInt(v * 1e6 * scale)));
+
+  test('planRebalanceToAllocations suppresses small deltas', async t => {
+    const plan = await planRebalanceToAllocations({
+      ...plannerContext,
+      network: expensiveEthNetwork,
+      targetAllocation,
+      currentBalances: makeBalances(1),
+    });
+
+    // All deltas are too small.
+    arrayIsLike(t, plan?.flow, []);
+  });
+
+  test('planDepositToAllocations suppresses small deltas', async t => {
+    const amount = makeDeposit(scale6(0.9));
+    const plan = await planDepositToAllocations({
+      ...plannerContext,
+      network: expensiveEthNetwork,
+      targetAllocation,
+      currentBalances: objectMap(makeBalances(1), (amt, place) =>
+        place === 'Aave_Avalanche' ? AmountMath.subtract(amt, amount) : amt,
+      ),
+      amount,
+    });
+
+    // All deltas are too small.
+    arrayIsLike(t, plan?.flow, []);
+  });
+
+  test('planRebalanceToAllocations suppresses small deltas, 10x', async t => {
+    const plan = await planRebalanceToAllocations({
+      ...plannerContext,
+      network: expensiveEthNetwork,
+      targetAllocation,
+      currentBalances: makeBalances(10),
+    });
+
+    // Deltas for the largest and smallest weights are too small, but relative
+    // adjustment between Aave_{Avalanche,Optimism,Base} can succeed,
+    // distibuting $26 + $59.90 + $40.10 = $126 over respective weights
+    // [20, 50, 50] to [$21, $52.50, $52.50].
+    // t.log(readableSteps(plan.flow, depositBrand));
+    arrayIsLike(t, plan?.flow, [
+      makeMovementDesc('Aave_Avalanche', '@Avalanche', scale6(5)),
+      makeMovementDesc('@Avalanche', '@agoric', scale6(5)),
+      makeMovementDesc('Aave_Optimism', '@Optimism', scale6(7.4)),
+      makeMovementDesc('@Optimism', '@agoric', scale6(7.4)),
+      makeMovementDesc('@agoric', '@noble', scale6(12.4)),
+      makeMovementDesc('@noble', '@Base', scale6(12.4)),
+      makeMovementDesc('@Base', 'Aave_Base', scale6(12.4)),
+    ]);
+  });
+
+  test('planDepositToAllocations suppresses small deltas, 10x', async t => {
+    const amount = makeDeposit(scale6(9));
+    const plan = await planDepositToAllocations({
+      ...plannerContext,
+      network: expensiveEthNetwork,
+      targetAllocation,
+      currentBalances: objectMap(makeBalances(10), (amt, place) =>
+        place === 'Aave_Avalanche' ? AmountMath.subtract(amt, amount) : amt,
+      ),
+      amount,
+    });
+
+    // Deltas for the largest and smallest weights are too small, but relative
+    // adjustment between <Deposit> and Aave_{Avalanche,Optimism,Base} can
+    // succeed, distibuting $9 + $17 + $59.90 + $40.10 = $126 over respective
+    // weights [0, 20, 50, 50] to [$0, $21, $52.50, $52.50].
+    // t.log(readableSteps(plan.flow, depositBrand));
+    arrayIsLike(t, plan?.flow, [
+      makeMovementDesc('Aave_Optimism', '@Optimism', scale6(7.4)),
+      makeMovementDesc('@Optimism', '@agoric', scale6(7.4)),
+      makeMovementDesc('<Deposit>', '@agoric', scale6(9)),
+      makeMovementDesc('@agoric', '@noble', scale6(16.4)),
+      makeMovementDesc('@noble', '@Avalanche', scale6(4)),
+      makeMovementDesc('@noble', '@Base', scale6(12.4)),
+      makeMovementDesc('@Avalanche', 'Aave_Avalanche', scale6(4)),
+      makeMovementDesc('@Base', 'Aave_Base', scale6(12.4)),
+    ]);
+  });
+
+  test('planRebalanceToAllocations suppresses small deltas, 100x', async t => {
+    const plan = await planRebalanceToAllocations({
+      ...plannerContext,
+      network: expensiveEthNetwork,
+      targetAllocation,
+      currentBalances: makeBalances(100),
+    });
+
+    // The lowest-weight delta is too small, but values at
+    // Aave_{Avalanche,Base,Optimism,Ethereum} of $260 + $401 + $599 + $1250 =
+    // $2510 can be distributed over respective weights [20, 50, 50, 880] to
+    // [$50.20, $125.50, $125.50, $2208.80].
+    // t.log(readableSteps(plan.flow, depositBrand));
+    arrayIsLike(t, plan?.flow, [
+      makeMovementDesc('Aave_Avalanche', '@Avalanche', scale6(209.8)),
+      makeMovementDesc('Aave_Base', '@Base', scale6(275.5)),
+      makeMovementDesc('@Base', '@Avalanche', scale6(275.5)),
+      makeMovementDesc('Aave_Optimism', '@Optimism', scale6(473.5)),
+      makeMovementDesc('@Optimism', '@agoric', scale6(473.5)),
+      makeMovementDesc('@Avalanche', '@agoric', scale6(485.3)),
+      makeMovementDesc('@agoric', '@noble', scale6(958.8)),
+      makeMovementDesc('@noble', '@Ethereum', scale6(958.8)),
+      makeMovementDesc('@Ethereum', 'Aave_Ethereum', scale6(958.8)),
+    ]);
+  });
+
+  test('planDepositToAllocations suppresses small deltas, 100x', async t => {
+    const amount = makeDeposit(scale6(90));
+    const plan = await planDepositToAllocations({
+      ...plannerContext,
+      network: expensiveEthNetwork,
+      targetAllocation,
+      currentBalances: objectMap(makeBalances(100), (amt, place) =>
+        place === 'Aave_Avalanche' ? AmountMath.subtract(amt, amount) : amt,
+      ),
+      amount,
+    });
+
+    // Deltas for the largest and smallest weights are too small, but relative
+    // adjustment between <Deposit> and Aave_{Avalanche,Optimism,Base} can
+    // succeed, distibuting $9 + $17 + $59.90 + $40.10 = $126 over respective
+    // weights [0, 20, 50, 50] to [$0, $21, $52.50, $52.50].
+    // t.log(readableSteps(plan.flow, depositBrand));
+    // The lowest-weight delta is too small, but values at
+    // <Deposit> and Aave_{Avalanche,Base,Optimism,Ethereum} of
+    // $90 + $170 + $401 + $599 + $1250 = $2510 can be distributed over
+    // respective weights [0, 20, 50, 50, 880] to
+    // [$0, $50.20, $125.50, $125.50, $2208.80].
+    // t.log(readableSteps(plan.flow, depositBrand));
+    arrayIsLike(t, plan?.flow, [
+      makeMovementDesc('Aave_Avalanche', '@Avalanche', scale6(119.8)),
+      makeMovementDesc('@Avalanche', '@agoric', scale6(119.8)),
+      makeMovementDesc('Aave_Base', '@Base', scale6(275.5)),
+      makeMovementDesc('@Base', '@agoric', scale6(275.5)),
+      makeMovementDesc('Aave_Optimism', '@Optimism', scale6(473.5)),
+      makeMovementDesc('@Optimism', '@agoric', scale6(473.5)),
+      makeMovementDesc('<Deposit>', '@agoric', scale6(90)),
+      makeMovementDesc('@agoric', '@noble', scale6(958.8)),
+      makeMovementDesc('@noble', '@Ethereum', scale6(958.8)),
+      makeMovementDesc('@Ethereum', 'Aave_Ethereum', scale6(958.8)),
+    ]);
+  });
+
+  test('planWithdrawFromAllocations works despite small deltas (amount >= deltaSoftMin)', async t => {
+    const amount = makeDeposit(scale6(1));
+    const plan = await planWithdrawFromAllocations({
+      ...plannerContext,
+      network: expensiveEthNetwork,
+      targetAllocation,
+      currentBalances: objectMap(makeBalances(1), (amt, place) =>
+        place === 'Aave_Ethereum' ? AmountMath.add(amt, amount) : amt,
+      ),
+      amount,
+    });
+
+    // t.log(readableSteps(plan.flow, depositBrand));
+    arrayIsLike(t, plan?.flow, [
+      { amount, src: 'Aave_Optimism', dest: '@Optimism' },
+      { amount, src: '@Optimism', dest: '@agoric' },
+      { amount, src: '@agoric', dest: '<Cash>' },
+    ]);
+  });
+
+  test('planWithdrawFromAllocations works despite small deltas (amount < deltaSoftMin)', async t => {
+    const amount = makeDeposit(scale6(0.9));
+    const plan = await planWithdrawFromAllocations({
+      ...plannerContext,
+      network: expensiveEthNetwork,
+      targetAllocation,
+      currentBalances: objectMap(makeBalances(1), (amt, place) =>
+        place === 'Aave_Ethereum' ? AmountMath.add(amt, amount) : amt,
+      ),
+      amount,
+    });
+
+    // t.log(readableSteps(plan.flow, depositBrand));
+    arrayIsLike(t, plan?.flow, [
+      { amount, src: 'Aave_Ethereum', dest: '@Ethereum' },
+      { amount, src: '@Ethereum', dest: '@agoric' },
+      { amount, src: '@agoric', dest: '<Cash>' },
+    ]);
+  });
+}

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -5,9 +5,14 @@ import {
   ACCOUNT_DUST_EPSILON,
   CaipChainIds,
   SupportedChain,
+  type AssetPlaceRef,
   type InterChainAccountRef,
   type StatusFor,
 } from '@agoric/portfolio-api';
+import type {
+  PortfolioPublishedPathTypes,
+  TargetAllocation,
+} from '@aglocal/portfolio-contract/src/type-guards.ts';
 import { planUSDNDeposit } from '@aglocal/portfolio-contract/test/mocks.js';
 import {
   readableSteps,
@@ -20,7 +25,6 @@ import type {
 } from '@aglocal/portfolio-contract/tools/network/network-spec.js';
 import type { GasEstimator } from '@aglocal/portfolio-contract/tools/plan-solve.ts';
 import { makePortfolioQuery } from '@aglocal/portfolio-contract/tools/portfolio-actors.js';
-import type { PortfolioPublishedPathTypes } from '@aglocal/portfolio-contract/src/type-guards.ts';
 import type { VstorageKit } from '@agoric/client-utils';
 import { AmountMath } from '@agoric/ertp';
 import type { Brand, NatAmount } from '@agoric/ertp/src/types.js';
@@ -31,7 +35,6 @@ import PROD_NETWORK from '@aglocal/portfolio-contract/tools/network/prod-network
 import type { EvmAddress } from '@agoric/fast-usdc';
 import { USDN } from '../src/cosmos-rest-client.ts';
 import {
-  getCurrentBalances,
   getNonDustBalances,
   planDepositToAllocations,
   planRebalanceToAllocations,
@@ -52,7 +55,7 @@ const makeDeposit = value => AmountMath.make(depositBrand, value);
 const feeBrand = Far('fee brand (BLD)') as Brand<'nat'>;
 
 const plannerContext: Omit<
-  PlannerContext,
+  PlannerContext<AssetPlaceRef, keyof TargetAllocation>,
   'currentBalances' | 'targetAllocation'
 > = {
   brand: depositBrand,
@@ -93,7 +96,7 @@ const handleDeposit = async (
   if (!targetAllocation) {
     return { policyVersion, rebalanceCount, plan: emptyPlan };
   }
-  const currentBalances = await getCurrentBalances(status, amount.brand, {
+  const currentBalances = await getNonDustBalances(status, amount.brand, {
     spectrumChainIds: powers.spectrumChainIds || {},
     usdcTokensByChain: powers.usdcTokensByChain || {},
     evmTokenAddresses: powers.evmTokenAddresses || {},

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -903,7 +903,12 @@ test.serial('unsolvable flow is rejected', testRejection, {
     Ethereum: AmountMath.make(depositBrand, 2_000_000n),
   },
   mutatePortfolioKit: kit => {
-    for (const link of kit.powers.network.links) link.min = 10_000_000n;
+    const replacementNetwork = { ...kit.powers.network };
+    replacementNetwork.links = replacementNetwork.links.map(link => ({
+      ...link,
+      min: 10_000_000n,
+    }));
+    kit.powers.network = harden(replacementNetwork);
   },
   flow: {
     type: 'withdraw',

--- a/yarn.lock
+++ b/yarn.lock
@@ -315,6 +315,7 @@ __metadata:
     "@cosmjs/encoding": "npm:^0.36.0"
     "@cosmjs/proto-signing": "npm:^0.36.0"
     "@cosmjs/stargate": "npm:^0.36.0"
+    "@endo/common": "npm:^1.2.13"
     "@endo/errors": "npm:^1.2.13"
     "@endo/init": "npm:^1.1.12"
     "@endo/lockdown": "npm:^1.0.18"


### PR DESCRIPTION
closes: AGO-373

I have tagged a large number of potential reviewers, but only need a review from one.

## Description
When computing target balances from current balances and target allocations and the balance for at least one place needs to change by a delta that is less than some soft minimum (defaulting to 1 USDC but configurable per blockchain), sort the relative magnitudes by which those deltas miss the minimum, filter out weights and current balances associated with the biggest misses (such that balances at those places should instead remain static), and recalculate new target balances from the smaller set of weights and current balances, repeating the process until all deltas are big enough (or everything has been suppressed) and returning the resulting target balances. As a special case, withdrawal is allowed to succeed even if all deltas are suppressed, but pulls from the highest-balance places rather than attempting to align with target allocations (on the presumption that fewer transactions are better).

Includes cleanup that narrows typing and/or removes unused fields to validate the changes and make them more comprehensible.

### Security Considerations
This intentionally introduces failures in flows that previously could have succeeded by using small-value transactions, although it attempts to avoid such failures for withdrawal. But upon encountering them, users have options to mitigate (albeit not all fully documented):
* adjust target allocation to drive bigger deltas
* add enough funds to recover otherwise stranded balances (e.g., deposit _x_ to withdraw _x_ + _ε_)
* bypass the planner by submitting a manual plan

### Scaling Considerations
This makes computation of target balances more computationally expensive, but not in a concerning way given the relatively small count of possible positions for any given portfolio. And memoization is applied to minimize the cost of mapping placeName→chainData.

### Documentation Considerations
Added new JSDoc and behavioral comments.

### Testing Considerations
New test coverage demonstrates the withdrawal special-case, and also scale-sensitive suppression (i.e., that suppression can be overcome by increasing balances).

### Upgrade Considerations
Safe for immediate deployment.