### PR TITLE
track patches with patchlift

### DIFF
--- a/.agents/skills/maintaining-dependency-patches/SKILL.md
+++ b/.agents/skills/maintaining-dependency-patches/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: maintaining-dependency-patches
+description: Manage a source-code repo's local patches against its installed package-manager dependencies — when a dep has a bug, security fix, or behavior tweak that upstream will not ship in time. Covers tracking each patch's relationship to upstream (is an issue filed? is a PR open? has it merged or been rejected?), detecting drift when upstream changes, forward-porting across version bumps, and upstream etiquette. Use when working with patch-package, yarn patch, pnpm patch, .yarn/patches/, the cweagans/composer-patches plugin in PHP, or Bazel's http_archive patches and Bzlmod single_version_override patches (which handle diff patching for polyglot deps regardless of language). Not for distribution-side patching (Homebrew/nixpkgs/Debian/Gentoo/BSD ports) nor for fork-and-redirect approaches (Cargo [patch], go mod replace, Bundler :git, requirements.txt git URLs, Elixir Mix :git).
+license: MIT
+---
+
+## Scope & when to activate
+
+This skill applies when **a source-code repo carries local patches against its installed package-manager dependencies** — because a dep has a bug, a security fix not yet released, a behavior tweak upstream will not accept, or a compatibility shim for your stack. The patches live in your repo, alongside your application code; they are applied at install time on top of already-built artifacts pulled from the registry.
+
+**Activate for:**
+
+- JavaScript/TypeScript projects using `patch-package`, `yarn patch`, or `pnpm patch`. Patches typically land in `patches/` or `.yarn/patches/`. See [references/ecosystems/js.md](references/ecosystems/js.md).
+- PHP projects using the `cweagans/composer-patches` Composer plugin. Patches are referenced from `extra.patches` in `composer.json`. See [references/ecosystems/php.md](references/ecosystems/php.md).
+- Bazel monorepos patching deps via `http_archive(patches = [...])` (WORKSPACE-era) or `single_version_override(patches = [...])` (Bzlmod). Applies regardless of the dep's language — C/C++, Go, Java, Python, etc. See [references/ecosystems/bazel.md](references/ecosystems/bazel.md).
+
+**Do not activate for:**
+
+- **Distribution-side patching** — Homebrew `patch do`, nixpkgs `patches = [...]` / `fetchpatch`, Debian `debian/patches/` with `quilt`, Gentoo ebuild `PATCHES=()`, BSD ports `files/patch-*`. Different lifecycle; see [the repo README](../README.md#out-of-scope-distribution-side-patching) for rationale.
+- **Fork-and-redirect** — Cargo `[patch]`, `go mod replace`, Bundler `:git`/`:path`, `requirements.txt` git URLs, Elixir Mix `{:pkg, git: …}`, Maven/Gradle artifactory forks. Different mechanics; see [the repo README](../README.md#out-of-scope-fork-and-redirect) for rationale.
+- Claude session edits as a portable `.patch` file → [generating-patches](https://skills.sh/oaustegard/claude-skills/generating-patches).
+- Pulumi Terraform-provider submodule + rebase workflow → [upstream-patches](https://skills.sh/pulumi/agent-skills/upstream-patches).
+
+## Upstream disposition and freshness
+
+Every patch has two orthogonal states worth tracking. Ecosystems differ widely in how formally they record them, but the states themselves are the same.
+
+**Upstream disposition** — the patch's relationship to upstream maintainers:
+
+- *No contact.* Private workaround; no issue, no PR. Fine short-term; risky as long-term posture — no one else knows about the bug.
+- *Issue filed.* Bug visible to upstream; no fix proposed yet.
+- *PR submitted.* Fix proposed, awaiting review. Ideal: patch on disk equals the PR's commits so retirement is a one-line delete on merge.
+- *Accepted upstream.* Merged upstream but not yet in a pinned release. Retire at the next bump past the release.
+- *Rejected.* Upstream declined. The patch is now indefinite; reconsider vendoring or forking.
+- *Will-not-upstream.* Intentionally local (e.g., a deployment-specific default). Never retires; record the reason so future maintainers do not try to upstream it.
+
+**Freshness** — the patch's relationship to the upstream version you have pinned:
+
+- *Applies cleanly.* No conflicts, offset, or fuzz against current pinned source.
+- *Applies with offset or fuzz.* Tool reports surrounding-context shifts. Works today, likely breaks on next bump — refresh now against current source.
+- *Conflicts.* No longer applies. Forward-port against the new source, or retire if no longer needed.
+- *Obsolete.* Target code removed or refactored away. Delete the patch.
+- *Fixed upstream in the pinned release.* Pinned version already contains the fix. Delete the patch; note the retirement in the version-bump commit.
+
+The axes are orthogonal, and the combination tells you what to do. *PR submitted, applies cleanly* is a healthy in-flight patch. *Accepted, conflicts* is an invitation to forward-port once and then drop the patch at the next bump. *Rejected, obsolete* should have been deleted already and is a drift signal worth investigating.
+
+How disposition is recorded varies by tool, but consumer-repo dep patching is a young enough niche that no cross-tool standard has emerged. `patch-package`, Yarn's `patch:` protocol, pnpm's `patchedDependencies`, `composer-patches`, and Bazel's `http_archive(patches = [...])` all work with plain unified-diff files and have no metadata schema; teams record disposition however they like — a README alongside the patches, a sidecar file per patch, a row in a ticket tracker. Freshness is surfaced the same way across all of them: the tool fails at install time with a diff-application error. See the relevant ecosystem reference for per-tool specifics and [references/drift-detection.md](references/drift-detection.md) for active-check techniques that catch drift before the next install fails.
+
+Before editing or renewing an existing patch, read whatever disposition record exists — header, comment, or sidecar — since it determines whether the right move is to amend the patch, open a new PR, or retire it entirely. See [references/drift-detection.md](references/drift-detection.md) for automated freshness checks.
+
+## Drift detection
+
+Drift is the gap between a patch as it sits on disk and what would be correct right now — target code moved, fix released upstream, linked issue/PR state changed. Run it as a loop: detect → forward-port or retire each finding → re-detect until clean. On every dependency bump at minimum; ideally in CI. See [references/drift-detection.md](references/drift-detection.md) for the full drift taxonomy, per-tool passive signals, and active-check techniques.
+
+## Forward-porting on version bumps
+
+Every patch must be re-validated against each new upstream version. The core sequence:
+
+1. **Inventory the patch stack** and read each patch's recorded disposition (header, comment, or sidecar) *before* touching anything. You will want that context when interpreting conflicts.
+2. **Bump the dependency** and attempt to re-apply the stack.
+3. **For each conflict**, forward-port the patch against the new source, or retire it if the patch is obsolete or fixed upstream. Do not use `--force` or high fuzz factors to paper over conflicts — the value of patches is that they are reviewed diffs; a silently-wrong patch is worse than a failing one.
+4. **Update disposition records** to reflect any change in upstream state surfaced during the bump (PR merged, issue closed, rejection rationale).
+5. **Commit the bump, updated patches, and retirements together** so the diff is reviewable as a single unit.
+
+See [references/forward-porting.md](references/forward-porting.md) for conflict-resolution heuristics and the ecosystem-specific refresh commands.
+
+## Upstream etiquette
+
+Any patch that persists beyond a day or two should have a public upstream pathway. The minimum obligation is one of:
+
+- An **issue** filed upstream describing the bug the patch works around, linked from the disposition record.
+- A **PR** proposing the fix, linked from the disposition record. Where feasible, the patch file on disk should be the commits that the PR contains, so retirement is a mechanical delete once the PR merges rather than a re-authoring exercise.
+
+When a linked PR merges, retire the patch at the first bump past the release that contains the fix. When a PR is rejected, update the record with the rationale — a future maintainer needs to know whether to keep trying to upstream the change or accept the patch as permanent. Private workarounds with no upstream contact are acceptable for hotfixes and deployment-specific overrides, but should not be a team's default posture for general-purpose bugs.
+

--- a/.agents/skills/maintaining-dependency-patches/references/drift-detection.md
+++ b/.agents/skills/maintaining-dependency-patches/references/drift-detection.md
@@ -1,0 +1,35 @@
+# Detecting drift in a patch stack
+
+Drift is any gap between a patch as it sits on disk and what would be correct right now (see the `Upstream disposition and freshness` section of `SKILL.md` for the framing). Drift accumulates silently between version bumps; detection is how you keep the stack honest.
+
+## What to check
+
+For each patch in the stack, answer four questions. The first two are about the patch file itself; the second two are about its relationship to upstream.
+
+1. **Does the patch still apply cleanly?** Not "does the install succeed" — does it apply *cleanly*, with no fuzz, no offset, no rejection. Fuzz and offset are pre-drift warnings that most installers do not surface to the user.
+2. **Is the target code still there?** If the function or file being patched was deleted or refactored upstream, the patch may accidentally apply to some replacement construct, or silently apply no effective change.
+3. **Is the linked issue or PR still in the state the record claims?** A merged PR means the patch may be retirable at the next bump past the release. A closed-without-merge PR means the record needs a rejection rationale.
+4. **Has upstream shipped a release that contains the fix?** Cross-check the linked PR's release-tag against your pinned version.
+
+## Passive signals by tool
+
+Each in-scope tool surfaces question 1 automatically, at install time:
+
+- **JS (`patch-package` / `yarn patch` / `pnpm patch`).** `npm install` / `yarn install` / `pnpm install` fails with a diff-application error at the patch step.
+- **PHP (`composer-patches`).** `composer install` fails at the patch step *only if* `composer-exit-on-patch-failure: true` is set. Without it, the failure is a warning easily missed in install output.
+- **Bazel (`http_archive(patches = [...])` / `single_version_override`).** `bazel build` / `bazel fetch` fails in the repository rule, reporting the failing file and hunks. Bazel's aggressive caching means `bazel clean --expunge` (or `bazel fetch --force`) may be needed to re-trigger the apply step after editing a patch.
+
+Passive signals catch outright breakage but miss fuzz/offset warnings and miss the upstream-state questions (3 and 4) entirely.
+
+## Active checks (recommended in CI)
+
+Running these on a schedule — not only at bump time — keeps the stack from becoming a surprise during a release-blocking upgrade.
+
+1. **Re-apply from a clean checkout.** Destroy and re-create the install/build directory, then re-install or re-build. This surfaces fuzz and offset that incremental builds hide.
+2. **Lint patches with `patch --dry-run -F0 --no-backup-if-mismatch`.** Runs apply logic without modifying files and reports any non-zero offset or fuzz explicitly. Useful wherever raw diff files are on disk and the upstream source is unpacked nearby.
+3. **Poll linked issue/PR state.** A small script that reads each patch's disposition record, extracts the issue/PR URL, and queries the forge (GitHub, GitLab, Bitbucket) for the current state. Flag any mismatch between the recorded disposition and the actual state.
+4. **Diff targeted files against upstream.** For each patch, enumerate the files it touches and inspect the upstream git log for those files since the patch was authored. Activity on the targeted lines is the strongest leading indicator that forward-porting will be needed.
+
+## How often
+
+At minimum, on every bump. In CI, monthly is a reasonable cadence — long enough that each run is not pure noise, short enough that no patch goes stale for a full release cycle. Surface drift findings as tickets in the same tracker you use for other dependency hygiene, not as chat messages that scroll away.

--- a/.agents/skills/maintaining-dependency-patches/references/ecosystems/bazel.md
+++ b/.agents/skills/maintaining-dependency-patches/references/ecosystems/bazel.md
@@ -1,0 +1,81 @@
+# Bazel
+
+Bazel is a polyglot build system; it fetches third-party code via repository rules (WORKSPACE-era) or module overrides (Bzlmod) and applies patches to the fetched archive before any build step runs. The patched source is then built like any other dep — regardless of its language — so Bazel's patching surface is the practical mechanism for consumer-side diff patching of C/C++, Go, Java, or Python deps in Bazel monorepos, which otherwise would not have a native diff-patch tool.
+
+## WORKSPACE-era: `http_archive`
+
+From the [Bazel repo rules docs](https://bazel.build/rules/lib/repo/http):
+
+```python
+http_archive(
+    name = "foo",
+    urls = ["https://example.com/foo-1.2.3.tar.gz"],
+    sha256 = "abc...",
+    strip_prefix = "foo-1.2.3",
+    patches = [
+        "//third_party/foo:001-fix-race.patch",
+        "//third_party/foo:002-backport-pr-456.patch",
+    ],
+    patch_args = ["-p1"],
+)
+```
+
+Patch-related attributes:
+
+| Attribute | Type | Purpose |
+|---|---|---|
+| `patches` | list of Labels | Patch files in your repo, applied in list order. |
+| `patch_args` | list of strings | Passed to `patch` (e.g., `["-p1"]`). |
+| `patch_strip` | int | Alternative to `-p` in `patch_args` — sets strip level. |
+| `patch_cmds` | list of strings | Shell commands run after patches on Linux/macOS. |
+| `patch_cmds_win` | list of strings | Same, for Windows. |
+| `patch_tool` | string | Override the default `patch` binary. |
+| `remote_patches` | dict (URL → sha256) | Patches fetched by URL rather than from the local tree. |
+| `remote_patch_strip` | int | Strip level for `remote_patches`. |
+
+**Execution order:** `remote_patches` first, then `patches` from the local tree, then `patch_cmds`. The same attribute set is available on `new_git_repository` and `git_repository`.
+
+## Bzlmod: `single_version_override`
+
+`MODULE.bazel` does not accept patches on `bazel_dep()` directly. To patch a module dep, use `single_version_override` (or `archive_override` / `git_override`, which forward to `http_archive` / `git_repository`):
+
+```python
+# MODULE.bazel
+bazel_dep(name = "foo", version = "1.2.3")
+
+single_version_override(
+    module_name = "foo",
+    patches = ["//patches:foo-001-fix-race.patch"],
+    patch_strip = 1,
+)
+```
+
+`single_version_override` attributes for patching:
+
+- `patches` — list of labels, applied in list order.
+- `patch_strip` — same as `-p` in Unix `patch`.
+- `patch_cmds` — sequence of Bash commands applied after patches (Linux/macOS).
+
+`archive_override` and `git_override` forward to the underlying repository rules, so the full WORKSPACE-era patch attribute set is reachable through them when needed.
+
+## Patch storage
+
+By convention, patches live in a `patches/` directory or a language-keyed `third_party/<dep>/` subtree at the repo root. The label pointing to each patch must reference a package that exports the patch file:
+
+```python
+# third_party/foo/BUILD.bazel
+exports_files([
+    "001-fix-race.patch",
+    "002-backport-pr-456.patch",
+])
+```
+
+Without `exports_files` (or `filegroup`), `patches = [...]` labels will not resolve.
+
+## Disposition recording
+
+No schema. Use the general recording options SKILL.md describes. One Bazel-specific idiom: since patches are declared with human-readable filenames (`001-fix-race.patch`, `backport-pr-456.patch`), the filename can carry a lightweight disposition hint — a sequence number for apply order, an upstream PR reference. Treat this as shorthand only; the full disposition record still belongs in a sidecar or header.
+
+## Freshness
+
+Surfaced at `bazel build` / `bazel fetch` time when the patch step fails; Bazel reports the failing file and the offending hunks. Caveat: Bazel caches repository state aggressively, so after editing a patch file or the archive declaration you may need `bazel clean --expunge` (or a targeted `bazel fetch --force`) to invalidate the cached patched tree and see a fresh apply attempt. Incremental builds can otherwise continue using the previously-patched cache and hide drift.

--- a/.agents/skills/maintaining-dependency-patches/references/ecosystems/js.md
+++ b/.agents/skills/maintaining-dependency-patches/references/ecosystems/js.md
@@ -1,0 +1,68 @@
+# JavaScript and TypeScript
+
+The JS ecosystem has several patch tools, each producing plain unified diff files but with different storage conventions and install-time wiring. None of them carry a native disposition record — which is a gap projects layer their own convention on top of.
+
+## Tools
+
+**`patch-package`** ([on npm](https://www.npmjs.com/package/patch-package)). The original. Works with npm and Yarn Classic.
+
+```
+# after editing node_modules/<pkg>
+npx patch-package <pkg>
+```
+
+Patches land in `patches/<pkg>+<version>.patch`. Applied by a `postinstall` hook:
+
+```json
+"scripts": { "postinstall": "patch-package" }
+```
+
+**`yarn patch`** (Yarn Berry, Yarn 2+). First-party.
+
+```
+yarn patch <pkg>                # prints an isolated working dir path
+# edit files in the working dir
+yarn patch-commit -s <dir>      # writes the patch, wires it up
+```
+
+Patches land in `.yarn/patches/<pkg>-<hash>.patch`. `package.json` gets a `resolutions` entry pointing `<pkg>@<version>` at a `patch:` protocol URL referencing the patch file. Applied automatically at install time by Yarn.
+
+**`pnpm patch`** (pnpm 7+). First-party.
+
+```
+pnpm patch <pkg>                # prints an isolated working dir path
+# edit files
+pnpm patch-commit <dir>
+```
+
+Patches land in `patches/<pkg>@<version>.patch` by default. `package.json` gets a `pnpm.patchedDependencies` entry mapping the exact version to the patch file. Applied automatically at install time by pnpm.
+
+## Disposition recording
+
+None of the three tools records upstream state. A common workaround — a `# Upstream PR: …` comment at the top of the patch file — is fragile: some patch tools strip leading comments, others reject them as malformed diff headers, and a single freeform line cannot capture the multi-axis state from SKILL.md's lifecycle section.
+
+Use the general recording options SKILL.md describes (README, sidecar file, tracker row).
+
+One JS-specific tooling option: [patchlift](https://github.com/turadg/patchlift). It has two decoupled pieces — a producer-agnostic upstream-issue utility and a sidecar-based disposition tracker tied to the `.yarn/patches/` layout. Install as a dev dep for repeated tracker use (`pnpm add -D patchlift`), or run one-shot via `npx`.
+
+**Drafting an upstream issue** (producer-agnostic — works on any plain `.patch` file from `patch-package`, `yarn patch`, `pnpm patch`, or similar):
+
+```
+npx patchlift issue patches/react+18.0.0.patch
+```
+
+Reads the patch, drafts a GitHub issue from the diff, and opens a browser pre-filled to file it. Pure utility; no state is written.
+
+**Tracking disposition via sidecars** (assumes the `.yarn/patches/<name>.patch` layout): patchlift maintains a sidecar at `.patchlift/<name>.yml` per patch, carrying fields like `upstream.issue`, `upstream.pr`, and `status`. The workflow:
+
+- `patchlift triage` — interactive loop over untracked patches; prompts you to set a disposition on each. Run when first adopting patchlift, and after a bump surfaces new patches.
+- `patchlift status <patch> …` — create or update a single patch's sidecar with a new status or metadata. Run as upstream events happen (PR merged, issue closed, rejection rationale). E.g. `patchlift status patches/react+18.0.0.patch --status merged --pr https://github.com/facebook/react/pull/12345`.
+- `patchlift inspect` — read-only view of the current metadata across the patch stack. Useful in CI to catch sidecar/patch drift.
+
+Status values: `untracked`, `proposed`, `merged`, `rejected`, `localonly`, `obsolete`. These flatten SKILL.md's disposition × freshness axes into one label (e.g., `obsolete` collapses "target code gone" with "no longer needed"); map back to the two-axis framing when reasoning about lifecycle decisions.
+
+## Other notes
+
+- **`overrides` / `resolutions` are not patches.** They pin a transitive dependency to a specific version, not a modified version of that version. If you need to change code, you still need one of the patch tools above.
+- **Editing `node_modules` directly is not patching.** The edit is wiped on the next install unless captured via one of the three tools.
+- **Monorepos.** In Yarn workspaces and pnpm workspaces, patches declared at the repo root apply across all workspace installs. Do not maintain per-workspace patch directories — they will not be applied consistently.

--- a/.agents/skills/maintaining-dependency-patches/references/ecosystems/php.md
+++ b/.agents/skills/maintaining-dependency-patches/references/ecosystems/php.md
@@ -1,0 +1,52 @@
+# PHP (Composer)
+
+Consumer-repo dep patching in PHP is handled almost exclusively by the [`cweagans/composer-patches`](https://github.com/cweagans/composer-patches) plugin. It reads patch declarations from `composer.json` and applies them to installed dependencies at install time — the direct analog of `patch-package` for the Composer ecosystem.
+
+## Install
+
+```
+composer require cweagans/composer-patches
+```
+
+## Declare patches in `composer.json`
+
+```json
+{
+  "extra": {
+    "patches": {
+      "vendor/package-name": {
+        "Fix the frobnicator race": "patches/vendor/fix-frobnicator.patch",
+        "Backport PR #234": "https://github.com/vendor/package/pull/234.patch"
+      }
+    }
+  }
+}
+```
+
+Structure: `vendor/package-name` → description → patch source. Both local file paths and remote URLs are supported in the same dependency entry. Local patches conventionally live in `patches/<vendor>/<file>.patch`.
+
+The description string is arbitrary human-readable text; the plugin does not interpret it as metadata. It is surfaced in `composer install` output when the patch is applied, which makes it a natural place to mention the upstream PR — but see the disposition-recording note below for why the description alone is not enough.
+
+## External patch manifest
+
+For large patch sets, set `patches-file` to reference an external JSON file instead of inlining `extra.patches`:
+
+```json
+{
+  "extra": {
+    "patches-file": "patches.json"
+  }
+}
+```
+
+`patches.json` has the same shape as the inline `extra.patches` value.
+
+## Related configuration
+
+- `enable-patching` — controls whether patches declared by *dependencies* (not only by the root package) are applied. Defaults off. Leave it off unless you have a reason to trust every dep to declare patches sensibly — otherwise transitive patches can silently change behavior on a dep bump.
+- `composer-exit-on-patch-failure` — when `true`, `composer install` fails if any patch fails to apply. **Set this in CI.** Otherwise a silent failure leaves a broken dep in place until someone actually exercises the patched code path.
+- `patches-ignore` — a map of `vendor/pkg` → list of patch descriptions to skip. Useful to disable a patch without removing it from the config (e.g., during a migration).
+
+## Disposition recording
+
+composer-patches has no metadata schema. The description string in `extra.patches` is the only structured field, and it is uninterpreted — the plugin just echoes it in install output. Use the general recording options SKILL.md describes (README, sidecar file, tracker row); the description string is complementary but insufficient on its own.

--- a/.agents/skills/maintaining-dependency-patches/references/forward-porting.md
+++ b/.agents/skills/maintaining-dependency-patches/references/forward-porting.md
@@ -1,0 +1,31 @@
+# Forward-porting patches across version bumps
+
+Bumping a patched dependency is a small project in itself. The patch stack is state, and state must be re-validated against each new upstream version. This reference expands on the short playbook in `SKILL.md`.
+
+## The bump
+
+SKILL.md's step 1 is the inventory step — read each patch's disposition record *before* touching the dependency. Skipping it makes conflict resolution much harder: you won't be able to tell whether a conflict is "upstream evolved the code" or "upstream merged my fix and now my patch collides with itself."
+
+1. **Bump the dependency in isolation** — one commit containing only the lockfile/version change, no other changes. This keeps the diff reviewable.
+2. **Attempt to re-apply the stack.** Each tool does this automatically at install time; see [drift-detection.md](drift-detection.md) for the per-tool signal.
+3. **For each failed patch,** decide:
+   - **Forward-port.** Re-author the patch against the new source. If it is a clean re-expression of the same change, keep the disposition record as-is.
+   - **Retire because fixed upstream.** The release you are now pinned to contains the fix. Delete the patch and record the retirement in the bump commit message.
+   - **Retire because obsolete.** The code the patch targeted was removed or refactored so the patch's purpose no longer applies. Delete it; note the reason in the commit.
+4. **Update disposition records** for any patch whose upstream state changed (PR merged, issue closed, rejection rationale added).
+5. **Refresh patches that applied with fuzz or offset.** Even when they "applied," regenerate them against current source. Fuzz today becomes a conflict tomorrow, and the reviewer of your bump commit should see each patch at its correct line numbers.
+
+## Conflict heuristics
+
+When a patch fails to apply, the rejection file (`.rej` in most tools, or similar) shows what could not be placed. Read the `.rej` alongside the upstream git log for the targeted file. The combination almost always tells you which of these happened:
+
+- **The surrounding code moved.** Re-locate the hunk; the change itself still applies.
+- **The surrounding code was rewritten.** The change may need to be re-expressed in the new idiom, or the whole patch may now be obsolete. If the rewrite *was* the fix, retire the patch.
+- **Your change was upstreamed in some form.** Check whether the upstream edit is equivalent to yours. If yes, retire. If not, your patch may still be needed in a modified form.
+- **The surrounding code was deleted.** The patch is almost certainly obsolete.
+
+If you find yourself reaching for `--force` or increasing the fuzz factor to make a patch go, stop. The reviewer of your bump commit cannot tell a correctly-forward-ported patch from a silently-wrong one; the whole value of patches is that they are reviewed diffs.
+
+## Committing
+
+Ship the bump, the patch-file updates, and the disposition-record updates **together** in a single reviewable diff. A bump commit that leaves the patch stack stale breaks the install/build for anyone who pulls before the follow-up lands. Reviewers should see one diff containing: the version change, any patch-file diffs, any retirements (with reasons in the commit message), and any sidecar/header updates.

--- a/.yarn/patches/.patchlift/@agoric-wallet-ui-npm-0.1.3-solo.0-00666f4b09.yml
+++ b/.yarn/patches/.patchlift/@agoric-wallet-ui-npm-0.1.3-solo.0-00666f4b09.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:e3a4cc9a20a73184f9d9b0a05c9756c76ecd57b4e687d17645be4300291e2924
+package:
+  name: "@agoric/wallet-ui"
+  version: 0.1.3-solo.0
+upstream:
+  repo:
+  issue:
+  pr:
+status: localonly
+notes:
+createdAt: 2026-04-16T20:44:35.885Z
+updatedAt: 2026-04-16T20:44:35.885Z

--- a/.yarn/patches/.patchlift/@chain-registry-client-npm-1.47.4-e1f663239f.yml
+++ b/.yarn/patches/.patchlift/@chain-registry-client-npm-1.47.4-e1f663239f.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:78ee61dcb8bd95e43c9c85150e6c23d51e0f667c87cb2f9f37cfdd92ac23888e
+package:
+  name: "@chain-registry/client"
+  version: 1.47.4
+upstream:
+  repo: cosmology-tech/chain-registry
+  issue:
+  pr:
+status: localonly
+notes:
+createdAt: 2026-04-16T17:44:51.590Z
+updatedAt: 2026-04-16T17:44:51.590Z

--- a/.yarn/patches/.patchlift/@cosmology-ast-npm-2.2.0-40b2669a5e.yml
+++ b/.yarn/patches/.patchlift/@cosmology-ast-npm-2.2.0-40b2669a5e.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:1d4b013b895602cdb0193e1e649dff1a5da4917f9930f7129cd17866b08d3a54
+package:
+  name: "@cosmology/ast"
+  version: 2.2.0
+upstream:
+  repo: hyperweb-io/telescope
+  issue:
+  pr:
+status: localonly
+notes:
+createdAt: 2026-04-16T18:00:49.978Z
+updatedAt: 2026-04-16T18:00:49.978Z

--- a/.yarn/patches/.patchlift/@endo-bundle-source-npm-4.1.2-80da9522ea.yml
+++ b/.yarn/patches/.patchlift/@endo-bundle-source-npm-4.1.2-80da9522ea.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:7a5304a83305b4eed807a80b445fb732b17f37ad365c531f12bf1204dfabbde7
+package:
+  name: "@endo/bundle-source"
+  version: 4.1.2
+upstream:
+  repo: endojs/endo
+  issue: null
+  pr: null
+status: localonly
+notes: null
+createdAt: 2026-04-16T05:02:14.698Z
+updatedAt: 2026-04-16T05:02:14.698Z

--- a/.yarn/patches/.patchlift/@endo-pass-style-npm-1.6.3-139d4e4c47.yml
+++ b/.yarn/patches/.patchlift/@endo-pass-style-npm-1.6.3-139d4e4c47.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:d2867299d4138190bc7e1c3f9f57fbd06e805e512699f0ba2ec1c2bd72cf8693
+package:
+  name: "@endo/pass-style"
+  version: 1.6.3
+upstream:
+  repo: endojs/endo
+  issue: null
+  pr: null
+status: merged
+notes: null
+createdAt: 2026-04-16T05:02:28.600Z
+updatedAt: 2026-04-16T05:02:28.600Z

--- a/.yarn/patches/.patchlift/@endo-pass-style-patch-613c0f4a7a.yml
+++ b/.yarn/patches/.patchlift/@endo-pass-style-patch-613c0f4a7a.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:e6a2421ea4a622fcb2c5e865fa10dba33f909f08740534cc826e6e7fd0ed310d
+package:
+  name: "@endo/pass-style"
+  version: 1.6.3
+upstream:
+  repo: endojs/endo
+  issue: null
+  pr: null
+status: merged
+notes: null
+createdAt: 2026-04-16T05:02:45.312Z
+updatedAt: 2026-04-16T05:02:45.312Z

--- a/.yarn/patches/.patchlift/@endo-pass-style-patch-fd208907c7.yml
+++ b/.yarn/patches/.patchlift/@endo-pass-style-patch-fd208907c7.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:5a48b06c2dc8b34e2cf67d284bebfcee7948e9deb8cd6bbf27d525de72daa660
+package:
+  name: "@endo/pass-style"
+  version: 1.6.3
+upstream:
+  repo: endojs/endo
+  issue: null
+  pr: null
+status: merged
+notes: null
+createdAt: 2026-04-16T05:02:36.818Z
+updatedAt: 2026-04-16T05:02:36.818Z

--- a/.yarn/patches/.patchlift/@endo-patterns-npm-1.7.0-70bb963d8a.yml
+++ b/.yarn/patches/.patchlift/@endo-patterns-npm-1.7.0-70bb963d8a.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:9282d22a2e2d2d7115c9c28ffe1cef31ef8e9c0e27d9946ad9780bf133b1aa2a
+package:
+  name: "@endo/patterns"
+  version: 1.7.0
+upstream:
+  repo: endojs/endo
+  issue: null
+  pr: null
+status: merged
+notes: null
+createdAt: 2026-04-16T05:03:02.982Z
+updatedAt: 2026-04-16T05:03:02.982Z

--- a/.yarn/patches/.patchlift/@graphql-codegen-visitor-plugin-common-npm-6.1.0-c6f558d634.yml
+++ b/.yarn/patches/.patchlift/@graphql-codegen-visitor-plugin-common-npm-6.1.0-c6f558d634.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1
+patchHash: sha256:5afa1bbb2657089bf5924d1817e9eb7f43dc88cbe38e18324d2032b7f15ad791
+package:
+  name: "@graphql-codegen/visitor-plugin-common"
+  version: 6.1.0
+upstream:
+  repo: dotansimha/graphql-code-generator
+  pr: https://github.com/dotansimha/graphql-code-generator/pull/10482
+status: proposed
+notes:
+createdAt: 2026-04-16T20:30:07.459Z
+updatedAt: 2026-04-16T20:30:07.459Z

--- a/.yarn/patches/.patchlift/@graphql-codegen-visitor-plugin-common-npm-6.2.2-1dfc1601b5.yml
+++ b/.yarn/patches/.patchlift/@graphql-codegen-visitor-plugin-common-npm-6.2.2-1dfc1601b5.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1
+patchHash: sha256:a137244653301344859ba90ec0ebe3a5b46aab71976805bb011b31e692462974
+package:
+  name: "@graphql-codegen/visitor-plugin-common"
+  version: 6.2.2
+upstream:
+  repo: dotansimha/graphql-code-generator
+  pr: https://github.com/dotansimha/graphql-code-generator/pull/10482
+status: proposed
+notes:
+createdAt: 2026-04-16T20:30:35.481Z
+updatedAt: 2026-04-16T20:30:35.481Z

--- a/.yarn/patches/.patchlift/@graphql-tools-optimize-npm-2.0.0-710bf461f3.yml
+++ b/.yarn/patches/.patchlift/@graphql-tools-optimize-npm-2.0.0-710bf461f3.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:05051d9823e2cd29ef968ad34e8e29e3ecfa222e892f2a57665637f733ab9b2e
+package:
+  name: "@graphql-tools/optimize"
+  version: 2.0.0
+upstream:
+  repo: ardatan/graphql-tools
+  issue: https://github.com/ardatan/graphql-tools/issues/7658
+  pr:
+status: proposed
+notes:
+createdAt: 2026-04-16T20:31:57.563Z
+updatedAt: 2026-04-16T20:31:57.563Z

--- a/.yarn/patches/.patchlift/@hyperweb-telescope-npm-2.2.1-36a0c8cf9a.yml
+++ b/.yarn/patches/.patchlift/@hyperweb-telescope-npm-2.2.1-36a0c8cf9a.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:7566dbbdd65a378489ba1571d3db7d55c3c218f7b694815b238d8b65d18e3124
+package:
+  name: "@hyperweb/telescope"
+  version: 2.2.1
+upstream:
+  repo: hyperweb-io/telescope
+  issue:
+  pr:
+status: localonly
+notes:
+createdAt: 2026-04-16T20:32:02.371Z
+updatedAt: 2026-04-16T20:32:02.371Z

--- a/.yarn/patches/.patchlift/@lerna-lite-version-npm-4.6.1-77cc9b6d7e.yml
+++ b/.yarn/patches/.patchlift/@lerna-lite-version-npm-4.6.1-77cc9b6d7e.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:a6a2e1536c562e230876da26fd23e1c408d879b3e7315a1602f25c68684c012f
+package:
+  name: "@lerna-lite/version"
+  version: 4.6.1
+upstream:
+  repo: lerna-lite/lerna-lite
+  issue: null
+  pr: null
+status: obsolete
+notes: null
+createdAt: 2026-04-16T04:56:02.627Z
+updatedAt: 2026-04-16T04:59:58.952Z

--- a/.yarn/patches/.patchlift/ava-npm-6.4.1-be769b2551.yml
+++ b/.yarn/patches/.patchlift/ava-npm-6.4.1-be769b2551.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:2ddd8eead3473264edeb035f4a5b6264ed2764d5c7c11b609d58cf8c4ed77695
+package:
+  name: ava
+  version: 6.4.1
+upstream:
+  repo: avajs/ava
+  issue:
+  pr:
+status: localonly
+notes:
+createdAt: 2026-04-16T01:56:58.074Z
+updatedAt: 2026-04-16T05:12:10.456Z

--- a/.yarn/patches/.patchlift/concordance-npm-5.0.4-e641405dd9.yml
+++ b/.yarn/patches/.patchlift/concordance-npm-5.0.4-e641405dd9.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:fd76a6f15bc881b934af2ca723e11c540257f34f726a11e203c19f2355672a53
+package:
+  name: concordance
+  version: 5.0.4
+upstream:
+  repo: concordancejs/concordance
+  issue: null
+  pr: https://github.com/concordancejs/concordance/pull/88
+status: proposed
+notes: null
+createdAt: 2026-04-16T05:09:19.601Z
+updatedAt: 2026-04-16T05:09:19.601Z

--- a/.yarn/patches/.patchlift/jessie.js-npm-0.3.4-3fca255cb3.yml
+++ b/.yarn/patches/.patchlift/jessie.js-npm-0.3.4-3fca255cb3.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:00a56a53e862d553e8d86d223a9eac573451f485482721241536250e739f2ad8
+package:
+  name: jessie.js
+  version: 0.3.4
+upstream:
+  repo: endojs/Jessie
+  issue: null
+  pr: null
+status: obsolete
+notes: added for "bundler" mode https://github.com/Agoric/agoric-sdk/pull/9185
+createdAt: 2026-04-16T05:01:18.177Z
+updatedAt: 2026-04-16T05:01:54.479Z

--- a/.yarn/patches/.patchlift/rxjs-npm-7.5.5-d0546b1ccb.yml
+++ b/.yarn/patches/.patchlift/rxjs-npm-7.5.5-d0546b1ccb.yml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+patchHash: sha256:6a2ded14b520a9942ed0de8cb46392f55ed035b1495e44dcb9ff07cd179515d8
+package:
+  name: rxjs
+  version: 7.5.5
+upstream:
+  repo: reactivex/rxjs
+  issue: null
+  pr: https://github.com/ReactiveX/rxjs/pull/6991
+status: rejected
+notes: null
+createdAt: 2026-04-16T05:06:29.861Z
+updatedAt: 2026-04-16T05:06:29.861Z

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-require-extensions": "^0.1.3",
     "execa": "^9.6.0",
     "npm-run-all": "^4.1.5",
+    "patchlift": "^0.3.0",
     "prettier": "^3.8.1",
     "prettier-plugin-jsdoc": "~1.8.0",
     "prettier-plugin-sh": "^0.18.0",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -20,6 +20,11 @@
       "source": "depot/skills",
       "sourceType": "github",
       "computedHash": "6c8de79b1be93caf2249b4a796534620363253761559ca9463a61bc46ead8d45"
+    },
+    "maintaining-dependency-patches": {
+      "source": "turadg/skills",
+      "sourceType": "github",
+      "computedHash": "e0cc047ae42fcefe938a5b248416fc09b0aef6b694d4cfcd79a8804fbee767f6"
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,6 +1033,7 @@ __metadata:
     eslint-plugin-require-extensions: "npm:^0.1.3"
     execa: "npm:^9.6.0"
     npm-run-all: "npm:^4.1.5"
+    patchlift: "npm:^0.3.0"
     prettier: "npm:^3.8.1"
     prettier-plugin-jsdoc: "npm:~1.8.0"
     prettier-plugin-sh: "npm:^0.18.0"
@@ -2026,6 +2027,28 @@ __metadata:
   dependencies:
     "@chain-registry/v2-types": "npm:^0.53.146"
   checksum: 10c0/949068c947a53ef4ab49d47df49a677a338d6ff6cb817fa7987c05e4987152ab35c72e584d615c27201cebd0da57485d5c831193eae83f0d686601558f988c5b
+  languageName: node
+  linkType: hard
+
+"@clack/core@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@clack/core@npm:1.2.0"
+  dependencies:
+    fast-wrap-ansi: "npm:^0.1.3"
+    sisteransi: "npm:^1.0.5"
+  checksum: 10c0/9ffd2d00a514b966ef28d91ef0b5ecd400e0378f78df352a5a98df2a773a91afa02b181322cb5cbd79d8d42e5c14c00874fe5f4e97d93f5f0d97bbddeb1c805a
+  languageName: node
+  linkType: hard
+
+"@clack/prompts@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@clack/prompts@npm:1.2.0"
+  dependencies:
+    "@clack/core": "npm:1.2.0"
+    fast-string-width: "npm:^1.1.0"
+    fast-wrap-ansi: "npm:^0.1.3"
+    sisteransi: "npm:^1.0.5"
+  checksum: 10c0/ad88eb1f4d48671f903a9a7aa2072a82bd8c23d7f2e282e69dd178b4e91497ec864af945c3fa26a2884d468ea494397a131a2d1a9ac4aa8d2be24909e0e9423a
   languageName: node
   linkType: hard
 
@@ -8074,6 +8097,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bundle-name@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "bundle-name@npm:4.1.0"
+  dependencies:
+    run-applescript: "npm:^7.0.0"
+  checksum: 10c0/8e575981e79c2bcf14d8b1c027a3775c095d362d1382312f444a7c861b0e21513c0bd8db5bd2b16e50ba0709fa622d4eab6b53192d222120305e68359daece29
+  languageName: node
+  linkType: hard
+
 "bundle-require@npm:^5.1.0":
   version: 5.1.0
   resolution: "bundle-require@npm:5.1.0"
@@ -8723,6 +8755,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^14.0.3":
+  version: 14.0.3
+  resolution: "commander@npm:14.0.3"
+  checksum: 10c0/755652564bbf56ff2ff083313912b326450d3f8d8c85f4b71416539c9a05c3c67dbd206821ca72635bf6b160e2afdefcb458e86b317827d5cb333b69ce7f1a24
+  languageName: node
+  linkType: hard
+
 "commander@npm:^4.0.0":
   version: 4.1.1
   resolution: "commander@npm:4.1.1"
@@ -9324,6 +9363,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"default-browser-id@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "default-browser-id@npm:5.0.1"
+  checksum: 10c0/5288b3094c740ef3a86df9b999b04ff5ba4dee6b64e7b355c0fff5217752c8c86908d67f32f6cba9bb4f9b7b61a1b640c0a4f9e34c57e0ff3493559a625245ee
+  languageName: node
+  linkType: hard
+
+"default-browser@npm:^5.4.0":
+  version: 5.5.0
+  resolution: "default-browser@npm:5.5.0"
+  dependencies:
+    bundle-name: "npm:^4.1.0"
+    default-browser-id: "npm:^5.0.0"
+  checksum: 10c0/576593b617b17a7223014b4571bfe1c06a2581a4eb8b130985d90d253afa3f40999caec70eb0e5776e80d4af6a41cce91018cd3f86e57ad578bf59e46fb19abe
+  languageName: node
+  linkType: hard
+
 "defaults@npm:^1.0.3":
   version: 1.0.3
   resolution: "defaults@npm:1.0.3"
@@ -9348,6 +9404,13 @@ __metadata:
   version: 2.0.0
   resolution: "define-lazy-prop@npm:2.0.0"
   checksum: 10c0/db6c63864a9d3b7dc9def55d52764968a5af296de87c1b2cc71d8be8142e445208071953649e0386a8cc37cfcf9a2067a47207f1eb9ff250c2a269658fdae422
+  languageName: node
+  linkType: hard
+
+"define-lazy-prop@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "define-lazy-prop@npm:3.0.0"
+  checksum: 10c0/5ab0b2bf3fa58b3a443140bbd4cd3db1f91b985cc8a246d330b9ac3fc0b6a325a6d82bddc0b055123d745b3f9931afeea74a5ec545439a1630b9c8512b0eeb49
   languageName: node
   linkType: hard
 
@@ -10624,6 +10687,31 @@ __metadata:
   dependencies:
     fast-decode-uri-component: "npm:^1.0.1"
   checksum: 10c0/e8223273a9b199722f760f5a047a77ad049a14bd444b821502cb8218f5925e3a5fffb56b64389bca73ab2ac6f1aa7aebbe4e203e5f6e53ff5978de97c0fde4e3
+  languageName: node
+  linkType: hard
+
+"fast-string-truncated-width@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "fast-string-truncated-width@npm:1.2.1"
+  checksum: 10c0/21ee31b5d1f62c48ba875081c726d31e464dfce7591ec13651baa4269316f6e10d70efa08cc511bc2de681c47791065a12b5cab596ea81a4afa5745180f92a20
+  languageName: node
+  linkType: hard
+
+"fast-string-width@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "fast-string-width@npm:1.1.0"
+  dependencies:
+    fast-string-truncated-width: "npm:^1.2.0"
+  checksum: 10c0/7ed29610e8960fce477fde55a35f0687aeb14e844487dde6784409cdfe24aff4015c6eebcd872d00b76279325f9f707fdef9eae9aac9156a72cec1c9b38a2cab
+  languageName: node
+  linkType: hard
+
+"fast-wrap-ansi@npm:^0.1.3":
+  version: 0.1.6
+  resolution: "fast-wrap-ansi@npm:0.1.6"
+  dependencies:
+    fast-string-width: "npm:^1.1.0"
+  checksum: 10c0/509e6b1c9f4eae9de9153d8f8020d3ea622c6be92a190963deafee70a3c83b6d58e41d8fd85c62a03c149b0659f79aaf76d2e042d29ee82ad35aab1cb07a46ef
   languageName: node
   linkType: hard
 
@@ -12279,6 +12367,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-docker@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-docker@npm:3.0.0"
+  bin:
+    is-docker: cli.js
+  checksum: 10c0/d2c4f8e6d3e34df75a5defd44991b6068afad4835bb783b902fa12d13ebdb8f41b2a199dcb0b5ed2cb78bfee9e4c0bbdb69c2d9646f4106464674d3e697a5856
+  languageName: node
+  linkType: hard
+
 "is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
@@ -12340,6 +12437,24 @@ __metadata:
   dependencies:
     is-extglob: "npm:^2.1.1"
   checksum: 10c0/17fb4014e22be3bbecea9b2e3a76e9e34ff645466be702f1693e8f1ee1adac84710d0be0bd9f967d6354036fd51ab7c2741d954d6e91dae6bb69714de92c197a
+  languageName: node
+  linkType: hard
+
+"is-in-ssh@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-in-ssh@npm:1.0.0"
+  checksum: 10c0/fbb4c25d85c543df09997fbe7aeca410ae0c839c5825bba2d4c672df765e9ce0e7558e781b371c0a21d6ef9bbac39b31875617a68eaaea5504438d07db9a2ffa
+  languageName: node
+  linkType: hard
+
+"is-inside-container@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-inside-container@npm:1.0.0"
+  dependencies:
+    is-docker: "npm:^3.0.0"
+  bin:
+    is-inside-container: cli.js
+  checksum: 10c0/a8efb0e84f6197e6ff5c64c52890fa9acb49b7b74fed4da7c95383965da6f0fa592b4dbd5e38a79f87fc108196937acdbcd758fcefc9b140e479b39ce1fcd1cd
   languageName: node
   linkType: hard
 
@@ -12609,6 +12724,15 @@ __metadata:
   dependencies:
     is-docker: "npm:^2.0.0"
   checksum: 10c0/a6fa2d370d21be487c0165c7a440d567274fbba1a817f2f0bfa41cc5e3af25041d84267baa22df66696956038a43973e72fca117918c91431920bdef490fa25e
+  languageName: node
+  linkType: hard
+
+"is-wsl@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "is-wsl@npm:3.1.1"
+  dependencies:
+    is-inside-container: "npm:^1.0.0"
+  checksum: 10c0/7e5023522bfb8f27de4de960b0d82c4a8146c0bddb186529a3616d78b5bbbfc19ef0c5fc60d0b3a3cc0bf95a415fbdedc18454310ea3049587c879b07ace5107
   languageName: node
   linkType: hard
 
@@ -14817,6 +14941,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"open@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "open@npm:11.0.0"
+  dependencies:
+    default-browser: "npm:^5.4.0"
+    define-lazy-prop: "npm:^3.0.0"
+    is-in-ssh: "npm:^1.0.0"
+    is-inside-container: "npm:^1.0.0"
+    powershell-utils: "npm:^0.1.0"
+    wsl-utils: "npm:^0.3.0"
+  checksum: 10c0/7aeeda4131268ed90f90e7728dda5c46bb0c6205b27a4be3e86ea33593e30dd393423e20e31c00802a8e635ef59becaee33ef9749a8ceb027567cd253e9e7b1e
+  languageName: node
+  linkType: hard
+
 "opener@npm:^1.5.2":
   version: 1.5.2
   resolution: "opener@npm:1.5.2"
@@ -15179,6 +15317,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"patchlift@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "patchlift@npm:0.3.0"
+  dependencies:
+    "@clack/prompts": "npm:^1.2.0"
+    commander: "npm:^14.0.3"
+    open: "npm:^11.0.0"
+    yaml: "npm:^2.8.3"
+  bin:
+    patchlift: dist/index.mjs
+  checksum: 10c0/aa975f5c815758f64fa0a8a93021cda0a9524d89aa750561bf231f44315c9134af24c663bf9cbef013208f528bcf0cba102ff4c2253218defe97d83cb70ab79c
+  languageName: node
+  linkType: hard
+
 "path-browserify@npm:^1.0.1":
   version: 1.0.1
   resolution: "path-browserify@npm:1.0.1"
@@ -15446,6 +15598,13 @@ __metadata:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
   checksum: 10c0/0fef257cfd1c0fe93c18a3f8a6e739b4438b527054fd77e9a62730a89b2d0ded1b59314a7e4aaa55bc256204f40830fecd2eb50f20f8cb7ab3a10b52aa06c8aa
+  languageName: node
+  linkType: hard
+
+"powershell-utils@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "powershell-utils@npm:0.1.0"
+  checksum: 10c0/a64713cf3583259c9ed6be211c06b4b19e8608bcb0f7f6287ffac0a95b8c7582b6b662eea0e201fd659492c8e9f9c5fd0bfc4579645c5add9c1a600075621c95
   languageName: node
   linkType: hard
 
@@ -16264,6 +16423,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"run-applescript@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "run-applescript@npm:7.1.0"
+  checksum: 10c0/ab826c57c20f244b2ee807704b1ef4ba7f566aa766481ae5922aac785e2570809e297c69afcccc3593095b538a8a77d26f2b2e9a1d9dffee24e0e039502d1a03
+  languageName: node
+  linkType: hard
+
 "run-async@npm:^2.2.0, run-async@npm:^2.3.0, run-async@npm:^2.4.0":
   version: 2.4.1
   resolution: "run-async@npm:2.4.1"
@@ -16718,6 +16884,13 @@ __metadata:
   dependencies:
     semver: "npm:^7.5.3"
   checksum: 10c0/2a00bd03bfbcbf8a737c47ab230d7920f8bfb92d1159d421bdd194479f6d01ebc995d13fbe13d45dace23066a78a3dc6642999b4e3b38b847e6664191575b20c
+  languageName: node
+  linkType: hard
+
+"sisteransi@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "sisteransi@npm:1.0.5"
+  checksum: 10c0/230ac975cca485b7f6fe2b96a711aa62a6a26ead3e6fb8ba17c5a00d61b8bed0d7adc21f5626b70d7c33c62ff4e63933017a6462942c719d1980bb0b1207ad46
   languageName: node
   linkType: hard
 
@@ -18753,6 +18926,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wsl-utils@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "wsl-utils@npm:0.3.1"
+  dependencies:
+    is-wsl: "npm:^3.1.0"
+    powershell-utils: "npm:^0.1.0"
+  checksum: 10c0/b3ba99cc6b71f66457eef598d529beeb8cb57a72646877fe25993894b808c60b82f6d47df5463f0b6e54632272f62f5eaea105c12784fd09b06f500f3f53aa2e
+  languageName: node
+  linkType: hard
+
 "xstream@npm:^11.14.0":
   version: 11.14.0
   resolution: "xstream@npm:11.14.0"
@@ -18797,6 +18980,15 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10c0/7c587be00d9303d2ae1566e03bc5bc7fe978ba0d9bf39cc418c3139d37929dfcb93a230d9749f2cb578b6aa5d9ebebc322415e4b653cb83acd8bc0bc321707f3
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "yaml@npm:2.8.3"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
_incidental_

## Description

We have a bunch of patches and it's a little hard to keep track of their lifecycle. I made a little tool to help,
- https://www.npmjs.com/package/patchlift

This uses it to help track the patches in the repo.

### Security Considerations
none

### Scaling Considerations
none

### Documentation Considerations
Adds an agent skill for how to use it.

### Testing Considerations
none

### Upgrade Considerations
n/a