### PR TITLE
feat(client-utils): RPC fallback with priority-based node selection for vstorage

### DIFF
--- a/packages/client-utils/src/vstorage.js
+++ b/packages/client-utils/src/vstorage.js
@@ -23,6 +23,12 @@ import {
  *   log?: string;
  *   value?: string;
  * }} AbciQueryResponse
+ *
+ * @typedef {{
+ *  result: {
+ *    response: JsonSafe<AbciQueryResponse>
+ *  }
+ * }} AbciQueryResponseRaw
  */
 
 const kindToRpc = /** @type {const} */ ({
@@ -73,9 +79,21 @@ export const makeAbciQuery = (
 /**
  * @param {object} powers
  * @param {typeof window.fetch} powers.fetch
+ * @param {() => number} [powers.now] clock source for testability, defaults to Date.now
  * @param {MinimalNetworkConfig} config
  */
-export const makeVStorage = ({ fetch }, config) => {
+export const makeVStorage = ({ fetch, now = Date.now }, config) => {
+  /** @type {number} Index of the currently active RPC node */
+  let activeNodeIndex = 0;
+  /** @type {bigint} Highest block height observed across RPC responses */
+  let highWaterMark = 0n;
+  /** @type {number} Timestamp (ms) of the last attempt to try higher-priority nodes */
+  let lastPreferredCheckTime = now();
+
+  /** Interval (ms) before re-trying higher-priority nodes */
+  const PREFERRED_RECHECK_INTERVAL_MS = 30 * 1000;
+  const rpcAddresses = Array.from(new Set(config.rpcAddrs));
+
   /**
    * @template {'data' | 'children'} T
    * @param {string} vstoragePath
@@ -88,10 +106,90 @@ export const makeVStorage = ({ fetch }, config) => {
     vstoragePath,
     { kind = /** @type {T} */ ('children'), height = 0 } = {},
   ) => {
-    const url =
-      config.rpcAddrs[0] + makeAbciQuery(vstoragePath, { kind, height });
-    const res = await fetch(url, { keepalive: true });
-    return res.json();
+    await null;
+
+    const isLatestQuery = !height;
+    const nodeCount = rpcAddresses.length;
+
+    // Periodically reset to index 0 so higher-priority nodes are re-tried
+    let startIndex = activeNodeIndex;
+
+    if (activeNodeIndex) {
+      const currentTime = now();
+      if (
+        currentTime - lastPreferredCheckTime >=
+        PREFERRED_RECHECK_INTERVAL_MS
+      ) {
+        lastPreferredCheckTime = currentTime;
+        startIndex = 0;
+      }
+    }
+
+    /** @type {{ data: AbciQueryResponseRaw, height: bigint, nodeIndex: number } | null} */
+    let bestStaleCandidate = null;
+    /** @type {AbciQueryResponseRaw | null} */
+    let lastErrorResponse = null;
+    /** @type {Error | null} */
+    let lastNetworkError = null;
+
+    for (let i = 0; i < nodeCount; i += 1) {
+      const nodeIndex = (startIndex + i) % nodeCount;
+      const url =
+        rpcAddresses[nodeIndex] + makeAbciQuery(vstoragePath, { kind, height });
+
+      /** @type {AbciQueryResponseRaw} */
+      let data;
+      try {
+        const res = await fetch(url, { keepalive: true });
+        data = await res.json();
+      } catch (err) {
+        lastNetworkError = /** @type {Error} */ (err);
+        continue;
+      }
+
+      const response = data?.result?.response;
+
+      // Non-zero error code — try next node
+      if (response?.code !== 0) {
+        lastErrorResponse = data;
+        continue;
+      }
+
+      // For latest queries, enforce monotonicity via high-water mark
+      if (isLatestQuery && response?.height !== undefined) {
+        const responseHeight = BigInt(response.height);
+
+        if (responseHeight < highWaterMark) {
+          if (!bestStaleCandidate || responseHeight > bestStaleCandidate.height)
+            bestStaleCandidate = { data, height: responseHeight, nodeIndex };
+
+          continue;
+        }
+
+        highWaterMark = responseHeight;
+      }
+
+      // Valid response
+      if (nodeIndex !== activeNodeIndex) lastPreferredCheckTime = now();
+
+      activeNodeIndex = nodeIndex;
+      return data;
+    }
+
+    // All nodes exhausted — return best available
+    if (bestStaleCandidate) {
+      if (bestStaleCandidate.nodeIndex !== activeNodeIndex)
+        lastPreferredCheckTime = now();
+
+      activeNodeIndex = bestStaleCandidate.nodeIndex;
+      return bestStaleCandidate.data;
+    }
+
+    if (lastErrorResponse) return lastErrorResponse;
+
+    throw (
+      lastNetworkError || Error(`no RPC nodes available for ${vstoragePath}`)
+    );
   };
 
   /**
@@ -247,4 +345,5 @@ export const makeVStorage = ({ fetch }, config) => {
   };
   return vstorage;
 };
+
 /** @typedef {ReturnType<typeof makeVStorage>} VStorage */

--- a/packages/client-utils/test/vstorage.test.js
+++ b/packages/client-utils/test/vstorage.test.js
@@ -1,6 +1,8 @@
 /* eslint-env node */
 // @ts-check
 import test from 'ava';
+import { encodeBase64 } from '@endo/base64';
+import { QueryDataResponse } from '@agoric/cosmic-proto/agoric/vstorage/query.js';
 import { makeVStorage } from '../src/vstorage.js';
 
 const testConfig = {
@@ -10,6 +12,72 @@ const testConfig = {
 
 /** @type {any} */
 const fetch = () => Promise.resolve({});
+
+// === Fallback test helpers ===
+
+/** @param {string} value */
+const encodeDataValue = (value = '') =>
+  encodeBase64(QueryDataResponse.toProto({ value }));
+
+/**
+ * @param {object} [opts]
+ * @param {number} [opts.code]
+ * @param {number} [opts.height]
+ * @param {string} [opts.value]
+ * @param {string} [opts.log]
+ * @param {string} [opts.codespace]
+ */
+const makeAbciResponse = ({
+  code = 0,
+  height = 100,
+  value,
+  log = '',
+  codespace = '',
+} = {}) => ({
+  result: {
+    response: {
+      code,
+      height: String(height),
+      ...(code === 0
+        ? { value: value ?? encodeDataValue(`data-h${height}`) }
+        : {}),
+      log,
+      codespace,
+    },
+  },
+});
+
+/**
+ * @param {Record<string, (url: string) => object>} handlers keyed by rpcAddr prefix
+ */
+const makeMockFetch = handlers => {
+  /** @type {string[]} */
+  const calls = [];
+
+  /** @type {any} */
+  const mockFetch = async (/** @type {string} */ url) => {
+    calls.push(url);
+    for (const [prefix, handler] of Object.entries(handlers)) {
+      if (url.startsWith(prefix)) {
+        const result = handler(url);
+        return { json: () => Promise.resolve(result) };
+      }
+    }
+    throw Error(`no mock handler for ${url}`);
+  };
+
+  return { fetch: mockFetch, calls };
+};
+
+/** @param {string} url */
+const nodeOf = url => url.match(/^https?:\/\/[^/]+/)?.[0];
+
+const NODE_A = 'http://node-a:26657';
+const NODE_B = 'http://node-b:26657';
+const NODE_C = 'http://node-c:26657';
+
+/** @param {string[]} addrs */
+const makeConfig = (...addrs) => ({ chainName: 'test', rpcAddrs: addrs });
 
 test('readFully can be used without instance binding', async t => {
   const vstorage = makeVStorage({ fetch }, testConfig);
@@ -77,4 +145,256 @@ test('storage history should be in chronological order', async t => {
   const response = await vstorageKit.readFully(storagePathName, minimumHeight);
 
   t.deepEqual(response, generateDescendingValues(maximumHeight, minimumHeight));
+});
+
+test('fallback - single node succeeds as before', async t => {
+  const mock = makeMockFetch({
+    [NODE_A]: () => makeAbciResponse({ height: 100 }),
+  });
+
+  const vs = makeVStorage({ fetch: mock.fetch }, makeConfig(NODE_A));
+  const meta = await vs.readStorageMeta('published.test', { kind: 'data' });
+
+  t.is(meta.blockHeight, 100n);
+  t.is(meta.result.value, 'data-h100');
+  t.is(mock.calls.length, 1);
+  t.is(nodeOf(mock.calls[0]), NODE_A);
+});
+
+test('fallback - falls back to next node on network error', async t => {
+  const mock = makeMockFetch({
+    [NODE_A]: () => {
+      throw Error('ECONNREFUSED');
+    },
+    [NODE_B]: () => makeAbciResponse({ height: 200 }),
+  });
+
+  const vs = makeVStorage({ fetch: mock.fetch }, makeConfig(NODE_A, NODE_B));
+  const meta = await vs.readStorageMeta('published.test', { kind: 'data' });
+
+  t.is(meta.blockHeight, 200n);
+  t.is(meta.result.value, 'data-h200');
+  t.is(mock.calls.length, 2);
+  t.is(nodeOf(mock.calls[0]), NODE_A);
+  t.is(nodeOf(mock.calls[1]), NODE_B);
+});
+
+test('fallback - falls back to next node on error code', async t => {
+  const mock = makeMockFetch({
+    [NODE_A]: () => makeAbciResponse({ code: 1, log: 'internal error' }),
+    [NODE_B]: () => makeAbciResponse({ height: 150 }),
+  });
+
+  const vs = makeVStorage({ fetch: mock.fetch }, makeConfig(NODE_A, NODE_B));
+  const meta = await vs.readStorageMeta('published.test', { kind: 'data' });
+
+  t.is(meta.blockHeight, 150n);
+  t.is(meta.result.value, 'data-h150');
+  t.is(mock.calls.length, 2);
+});
+
+test('fallback - stale response triggers fallback to fresher node', async t => {
+  let heightA = 100;
+  const mock = makeMockFetch({
+    [NODE_A]: () => makeAbciResponse({ height: heightA }),
+    [NODE_B]: () => makeAbciResponse({ height: 200 }),
+  });
+
+  const vs = makeVStorage({ fetch: mock.fetch }, makeConfig(NODE_A, NODE_B));
+
+  // First call: node A at height 100 sets HWM
+  const r1 = await vs.readStorageMeta('published.test', { kind: 'data' });
+  t.is(r1.blockHeight, 100n);
+  t.is(mock.calls.length, 1);
+
+  // Node A now returns stale height (50 < HWM 100)
+  heightA = 50;
+  const r2 = await vs.readStorageMeta('published.test', { kind: 'data' });
+
+  t.is(r2.blockHeight, 200n);
+  t.is(r2.result.value, 'data-h200');
+  // Tried A first (stale), then fell to B
+  t.is(nodeOf(mock.calls[1]), NODE_A);
+  t.is(nodeOf(mock.calls[2]), NODE_B);
+});
+
+test('fallback - all nodes stale uses best candidate with highest height', async t => {
+  let heightA = 200;
+  let heightB = 200;
+  const mock = makeMockFetch({
+    [NODE_A]: () => makeAbciResponse({ height: heightA }),
+    [NODE_B]: () => makeAbciResponse({ height: heightB }),
+  });
+
+  const vs = makeVStorage({ fetch: mock.fetch }, makeConfig(NODE_A, NODE_B));
+
+  // First call sets HWM to 200
+  await vs.readStorageMeta('published.test', { kind: 'data' });
+
+  // Now both return stale heights
+  heightA = 80;
+  heightB = 90;
+  const meta = await vs.readStorageMeta('published.test', { kind: 'data' });
+
+  // Should pick the higher stale candidate
+  t.is(meta.blockHeight, 90n);
+  t.is(meta.result.value, 'data-h90');
+});
+
+test('fallback - throws when all nodes have network errors', async t => {
+  const mock = makeMockFetch({
+    [NODE_A]: () => {
+      throw Error('ECONNREFUSED');
+    },
+    [NODE_B]: () => {
+      throw Error('ETIMEDOUT');
+    },
+  });
+
+  const vs = makeVStorage({ fetch: mock.fetch }, makeConfig(NODE_A, NODE_B));
+
+  await t.throwsAsync(
+    () => vs.readStorageMeta('published.test', { kind: 'data' }),
+    { message: /cannot read data of published.test/ },
+  );
+});
+
+test('fallback - throws with error code when all nodes return errors', async t => {
+  const mock = makeMockFetch({
+    [NODE_A]: () =>
+      makeAbciResponse({ code: 5, codespace: 'sdk', log: 'not found' }),
+    [NODE_B]: () =>
+      makeAbciResponse({ code: 5, codespace: 'sdk', log: 'not found' }),
+  });
+
+  const vs = makeVStorage({ fetch: mock.fetch }, makeConfig(NODE_A, NODE_B));
+
+  const err = await t.throwsAsync(() =>
+    vs.readStorageMeta('published.test', { kind: 'data' }),
+  );
+  t.truthy(err && err.message.includes('error code 5'));
+});
+
+test('fallback - explicit height skips high-water mark check', async t => {
+  let heightA = 100;
+  const mock = makeMockFetch({
+    [NODE_A]: () => makeAbciResponse({ height: heightA }),
+  });
+
+  const vs = makeVStorage({ fetch: mock.fetch }, makeConfig(NODE_A));
+
+  // Set HWM to 100
+  await vs.readStorageMeta('published.test', { kind: 'data' });
+
+  // Query at explicit height 50 — should NOT be rejected as stale
+  heightA = 50;
+  const meta = await vs.readStorageMeta('published.test', {
+    kind: 'data',
+    height: 50,
+  });
+
+  t.is(meta.blockHeight, 50n);
+  t.is(mock.calls.length, 2);
+  // Only node A was called — no fallback triggered
+  t.is(nodeOf(mock.calls[0]), NODE_A);
+  t.is(nodeOf(mock.calls[1]), NODE_A);
+});
+
+test('fallback - retries higher-priority nodes after recheck interval', async t => {
+  let currentTime = 1_000_000;
+  const now = () => currentTime;
+
+  let nodeAFails = true;
+  const mock = makeMockFetch({
+    [NODE_A]: () => {
+      if (nodeAFails) throw Error('ECONNREFUSED');
+      return makeAbciResponse({ height: 300 });
+    },
+    [NODE_B]: () => makeAbciResponse({ height: 200 }),
+  });
+
+  const vs = makeVStorage(
+    { fetch: mock.fetch, now },
+    makeConfig(NODE_A, NODE_B),
+  );
+
+  // 1) Node A fails, falls to B
+  const r1 = await vs.readStorageMeta('published.test', { kind: 'data' });
+  t.is(r1.blockHeight, 200n);
+  t.is(nodeOf(mock.calls[0]), NODE_A);
+  t.is(nodeOf(mock.calls[1]), NODE_B);
+
+  // 2) Within 30s — stays on B, does NOT try A
+  currentTime += 10_000;
+  mock.calls.length = 0;
+  const r2 = await vs.readStorageMeta('published.test', { kind: 'data' });
+  t.is(r2.blockHeight, 200n);
+  t.is(mock.calls.length, 1);
+  t.is(nodeOf(mock.calls[0]), NODE_B);
+
+  // 3) After 30s — retries from A (which is now back)
+  currentTime += 25_000; // total 35s since switch
+  mock.calls.length = 0;
+  nodeAFails = false;
+  const r3 = await vs.readStorageMeta('published.test', { kind: 'data' });
+  t.is(r3.blockHeight, 300n);
+  t.is(nodeOf(mock.calls[0]), NODE_A);
+});
+
+test('fallback - recovery walks priorities: tries 0, 1, ... until success', async t => {
+  let currentTime = 1_000_000;
+  const now = () => currentTime;
+
+  const mock = makeMockFetch({
+    [NODE_A]: () => {
+      throw Error('ECONNREFUSED');
+    },
+    [NODE_B]: () => {
+      throw Error('ECONNREFUSED');
+    },
+    [NODE_C]: () => makeAbciResponse({ height: 100 }),
+  });
+
+  const vs = makeVStorage(
+    { fetch: mock.fetch, now },
+    makeConfig(NODE_A, NODE_B, NODE_C),
+  );
+
+  // Falls through A → B → C
+  await vs.readStorageMeta('published.test', { kind: 'data' });
+  t.is(mock.calls.length, 3);
+  t.is(nodeOf(mock.calls[2]), NODE_C);
+
+  // After 30s: re-check tries A, B (both still down), settles on C
+  currentTime += 35_000;
+  mock.calls.length = 0;
+  await vs.readStorageMeta('published.test', { kind: 'data' });
+
+  t.is(mock.calls.length, 3);
+  t.is(nodeOf(mock.calls[0]), NODE_A);
+  t.is(nodeOf(mock.calls[1]), NODE_B);
+  t.is(nodeOf(mock.calls[2]), NODE_C);
+});
+
+test('fallback - multi-hop: network error then error code then success', async t => {
+  const mock = makeMockFetch({
+    [NODE_A]: () => {
+      throw Error('ECONNREFUSED');
+    },
+    [NODE_B]: () => makeAbciResponse({ code: 2, log: 'unavailable' }),
+    [NODE_C]: () => makeAbciResponse({ height: 500 }),
+  });
+
+  const vs = makeVStorage(
+    { fetch: mock.fetch },
+    makeConfig(NODE_A, NODE_B, NODE_C),
+  );
+  const meta = await vs.readStorageMeta('published.test', { kind: 'data' });
+
+  t.is(meta.blockHeight, 500n);
+  t.is(meta.result.value, 'data-h500');
+  t.is(mock.calls.length, 3);
+  t.is(nodeOf(mock.calls[0]), NODE_A);
+  t.is(nodeOf(mock.calls[1]), NODE_B);
+  t.is(nodeOf(mock.calls[2]), NODE_C);
 });


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description
- Add multi-node RPC fallback to `makeVStorage` so queries automatically try the next node on network errors, ABCI error codes, or stale responses
- Enforce block-height monotonicity via a high-water mark to prevent returning data from a node that has fallen behind
- Periodically (every 30s) re-try higher-priority nodes so traffic returns to preferred endpoints once they recover

### Motivation

The vstorage client was hardcoded to use the first rpc address provided in the array, meaning a single unresponsive or stale RPC node would break all reads with no recovery path. Services using this kit might also need to point at a dedicated node while falling back to a constantly active node. Rather than building retry logic in every consumer, the vstorage layer now handles this natively using the existing `rpcAddrs` array — nodes are tried in list order, so callers control priority simply by ordering the array.

### How it works

1. Fallback loop — `getVstorageJson` iterates through deduplicated rpc addresses array. A node is skipped on network error (fetch throws), non-zero ABCI code, or a block height below the high-water mark
2. High-water mark (HWM) — Tracks the highest block height seen. "Latest" queries (height = 0) reject responses below the HWM as stale. Explicit-height queries (used by `readAt` or `readFully`) bypass this check since they intentionally read historical data
3. Best stale candidate — If every node is below the HWM, the response with the highest height is returned rather than failing
4. Priority recovery — Every 30 seconds the loop resets to index 0, walking 0 → 1 → 2 → … until a healthy node is found. The active node is updated and the recheck timer resets on each switch
5. Injectable clock — `makeVStorage` accepts an optional now parameter (defaults to `Date.now`) so the 30-second recheck interval can be tested deterministically under SES lockdown

### Test plan

11 new test cases added to `packages/client-utils/test/vstorage.test.js`:
- Single node succeeds (baseline)
- Falls back on network error (ECONNREFUSED)
- Falls back on non-zero ABCI error code
- Stale response triggers fallback to a fresher node
- All nodes stale — picks the highest-height candidate 
- All nodes have network errors — throws with descriptive message
- All nodes return error codes — throws with error code details
- Explicit height bypasses high-water mark check
- After 30s, retries higher-priority nodes
- Recovery walks priorities: tries 0 → 1 → … until success across 3 nodes
- Multi-hop: network error → error code → success across 3 nodes

### Security Considerations
None

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
Tests added in the PR
If existing tests, that should prove nothing existing breaks

### Upgrade Considerations
None
