### PR TITLE
feat(ymax-planner): Fallback RPC endpoint support

### DIFF
--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -15,13 +15,14 @@ import {
   fetchEnvNetworkConfig,
   getInvocationUpdate,
   makeTxSequencer,
-  makeSigningSmartWalletKit,
-  makeSmartWalletKit,
   makeSequencingSmartWallet,
   reflectWalletStore,
 } from '@agoric/client-utils';
 import type { BaseAccountSDKType } from '@agoric/cosmic-proto/cosmos/auth/v1beta1/auth.js';
-import type { SigningSmartWalletKit } from '@agoric/client-utils';
+import type {
+  MinimalNetworkConfig,
+  SigningSmartWalletKit,
+} from '@agoric/client-utils';
 import type { CaipChainId } from '@agoric/orchestration';
 import {
   deeplyFulfilledObject,
@@ -44,6 +45,8 @@ import { CosmosRPCClient } from './cosmos-rpc.ts';
 import { makeGraphqlMultiClient } from './graphql-client.ts';
 import { getSdk as getSpectrumBlockchainSdk } from './graphql/api-spectrum-blockchain/__generated/sdk.ts';
 import { startEngine } from './engine.ts';
+import makeSmartWalletKit from './wrappers/smart-wallet.ts';
+import makeSigningSmartWalletKit from './wrappers/signing-smart-wallet.ts';
 import {
   createEVMContext,
   prepareAbortController,
@@ -69,6 +72,25 @@ const assertChainId = async (
   actualChainId || Fail`Chain ID not found in RPC status: ${status}`;
   actualChainId === chainId ||
     Fail`Expected chain ID ${q(actualChainId)} to be ${q(chainId)}`;
+};
+
+/**
+ * Parts of the network config fetched from the chain
+ * can be overriden using env vars starting from
+ * `OVERRIDE_`
+ */
+const overrideNetworkConfigFromEnvironmentVariables = (
+  { chainName, rpcAddrs }: MinimalNetworkConfig,
+  { env }: { env: NodeJS.ProcessEnv },
+) => {
+  if (env.OVERRIDE_RPC_ADDRESS) rpcAddrs[0] = env.OVERRIDE_RPC_ADDRESS;
+  if (env.FALLBACK_RPC_ADDRESS) rpcAddrs.push(env.FALLBACK_RPC_ADDRESS);
+
+  return {
+    chainName,
+    rpcAddrs,
+    websocketUrl: env.OVERRIDE_WEBSOCKET_URL || rpcAddrs.find(Boolean)!,
+  };
 };
 
 export type SimplePowers = {
@@ -125,11 +147,12 @@ export const main = async (
   const networkConfig = await fetchEnvNetworkConfig({
     env: { AGORIC_NET: config.cosmosRest.agoricNetworkSpec },
     fetch,
-  });
-  const agoricRpcAddr = networkConfig.rpcAddrs[0];
+  }).then(_networkConfig =>
+    overrideNetworkConfigFromEnvironmentVariables(_networkConfig, { env }),
+  );
   console.warn('Initializing planner:', networkConfig);
 
-  const rpc = new CosmosRPCClient(agoricRpcAddr, {
+  const rpc = new CosmosRPCClient(networkConfig.websocketUrl, {
     WebSocket,
     heartbeats: generateInterval(6000),
   });
@@ -326,4 +349,5 @@ export const main = async (
     });
   });
 };
+
 harden(main);

--- a/services/ymax-planner/src/wrappers/signing-smart-wallet.ts
+++ b/services/ymax-planner/src/wrappers/signing-smart-wallet.ts
@@ -1,0 +1,33 @@
+import type { SigningStargateClient } from '@cosmjs/stargate';
+import {
+  makeSigningSmartWalletKitFromClient,
+  type SmartWalletKit,
+} from '@agoric/client-utils';
+import makeStargateClientKit from './stargate-client.ts';
+
+const makeSigningSmartWalletKit = async (
+  {
+    connectWithSigner,
+    walletUtils,
+  }: {
+    connectWithSigner: typeof SigningStargateClient.connectWithSigner;
+    walletUtils: SmartWalletKit;
+  },
+  MNEMONIC: string,
+) => {
+  const { address, client } = await makeStargateClientKit(MNEMONIC, {
+    connectWithSigner,
+    now: Date.now,
+    rpcAddresses: walletUtils.networkConfig.rpcAddrs,
+  });
+
+  return makeSigningSmartWalletKitFromClient({
+    address,
+    client,
+    smartWalletKit: walletUtils,
+  });
+};
+
+harden(makeSigningSmartWalletKit);
+
+export default makeSigningSmartWalletKit;

--- a/services/ymax-planner/src/wrappers/smart-wallet.ts
+++ b/services/ymax-planner/src/wrappers/smart-wallet.ts
@@ -1,0 +1,25 @@
+import {
+  makeSmartWalletKitFromVstorageKit,
+  type MinimalNetworkConfig,
+} from '@agoric/client-utils';
+import makeVstorageKit from './vstorage-kit.ts';
+
+const makeSmartWalletKit = async (
+  {
+    fetch,
+    delay: _delay,
+    names = true,
+  }: {
+    delay: (ms: number) => Promise<void>;
+    fetch: typeof globalThis.fetch;
+    names?: boolean;
+  },
+  networkConfig: MinimalNetworkConfig,
+) =>
+  makeSmartWalletKitFromVstorageKit(makeVstorageKit({ fetch }, networkConfig), {
+    names,
+  });
+
+harden(makeSmartWalletKit);
+
+export default makeSmartWalletKit;

--- a/services/ymax-planner/src/wrappers/stargate-client.ts
+++ b/services/ymax-planner/src/wrappers/stargate-client.ts
@@ -1,0 +1,188 @@
+import { MsgWalletSpendAction } from '@agoric/cosmic-proto/agoric/swingset/msgs.js';
+import {
+  DirectSecp256k1HdWallet,
+  Registry,
+  type GeneratedType,
+} from '@cosmjs/proto-signing';
+import { stringToPath } from '@cosmjs/crypto';
+import { SigningStargateClient } from '@cosmjs/stargate';
+import { Fail } from '@endo/errors';
+import { verifyStatus } from './utils.ts';
+
+const AgoricMsgs = {
+  MsgWalletSpendAction: {
+    aminoType: 'swingset/WalletSpendAction',
+    typeUrl: '/agoric.swingset.MsgWalletSpendAction',
+  },
+};
+
+const agoricRegistryTypes: Array<[string, GeneratedType]> = [
+  [
+    AgoricMsgs.MsgWalletSpendAction.typeUrl,
+    MsgWalletSpendAction as GeneratedType,
+  ],
+];
+
+const makeStargateClientKit = async (
+  mnemonic: string,
+  {
+    connectWithSigner,
+    hdPath = `m/44'/564'/0'/0/0`,
+    now,
+    prefix = 'agoric',
+    rpcAddresses,
+  }: {
+    connectWithSigner: typeof SigningStargateClient.connectWithSigner;
+    hdPath?: string;
+    now: () => number;
+    prefix?: string;
+    rpcAddresses: Array<string>;
+  },
+) => {
+  const [priorityRpcAddress, fallbackRpcAddress] = rpcAddresses;
+
+  let fallbackClient: SigningStargateClient;
+
+  const signer = await DirectSecp256k1HdWallet.fromMnemonic(mnemonic, {
+    prefix,
+    hdPaths: [stringToPath(hdPath)],
+  });
+
+  const accounts = await signer.getAccounts();
+  accounts.length === 1 || Fail`expected exactly one account`;
+
+  const [{ address }] = accounts;
+
+  const client = await connectWithSigner(priorityRpcAddress, signer, {
+    registry: new Registry(agoricRegistryTypes),
+  });
+
+  if (fallbackRpcAddress)
+    fallbackClient = await connectWithSigner(fallbackRpcAddress, signer, {
+      registry: new Registry(agoricRegistryTypes),
+    });
+
+  const broadcastTx: typeof client.broadcastTx = async (
+    tx,
+    timeoutMs,
+    pollIntervalMs,
+  ) => {
+    let response: Awaited<ReturnType<typeof client.broadcastTx>>;
+
+    await null;
+
+    try {
+      if (fallbackClient) await verifyStatus({ now }, priorityRpcAddress);
+
+      response = await client.broadcastTx(tx, timeoutMs, pollIntervalMs);
+    } catch (err) {
+      if (fallbackClient) {
+        console.error(
+          `Error while executing "broadcastTx" on ${priorityRpcAddress}, falling back to ${fallbackRpcAddress}`,
+          err,
+        );
+
+        response = await fallbackClient.broadcastTx(
+          tx,
+          timeoutMs,
+          pollIntervalMs,
+        );
+      } else throw err;
+    }
+
+    return response;
+  };
+
+  const sign: typeof client.sign = async (
+    signerAddress,
+    messages,
+    fee,
+    memo,
+    explicitSignerData,
+    timeoutHeight,
+  ) => {
+    let response: Awaited<ReturnType<typeof client.sign>>;
+
+    await null;
+
+    try {
+      if (fallbackClient) await verifyStatus({ now }, priorityRpcAddress);
+
+      response = await client.sign(
+        signerAddress,
+        messages,
+        fee,
+        memo,
+        explicitSignerData,
+        timeoutHeight,
+      );
+    } catch (err) {
+      if (fallbackClient) {
+        console.error(
+          `Error while executing "sign" on ${priorityRpcAddress}, falling back to ${fallbackRpcAddress}`,
+          err,
+        );
+
+        response = await fallbackClient.sign(
+          signerAddress,
+          messages,
+          fee,
+          memo,
+          explicitSignerData,
+          timeoutHeight,
+        );
+      } else throw err;
+    }
+
+    return response;
+  };
+
+  const signAndBroadcast: typeof client.signAndBroadcast = async (
+    signerAddress,
+    messages,
+    fee,
+    memo,
+    timeoutHeight,
+  ) => {
+    let response: Awaited<ReturnType<typeof client.signAndBroadcast>>;
+
+    await null;
+
+    try {
+      if (fallbackClient) await verifyStatus({ now }, priorityRpcAddress);
+
+      response = await client.signAndBroadcast(
+        signerAddress,
+        messages,
+        fee,
+        memo,
+        timeoutHeight,
+      );
+    } catch (err) {
+      if (fallbackClient) {
+        console.error(
+          `Error while executing "signAndBroadcast" on ${priorityRpcAddress}, falling back to ${fallbackRpcAddress}`,
+          err,
+        );
+
+        response = await fallbackClient.signAndBroadcast(
+          signerAddress,
+          messages,
+          fee,
+          memo,
+          timeoutHeight,
+        );
+      } else throw err;
+    }
+
+    return response;
+  };
+
+  client.broadcastTx = broadcastTx;
+  client.sign = sign;
+  client.signAndBroadcast = signAndBroadcast;
+
+  return Object.freeze({ address, client });
+};
+
+export default makeStargateClientKit;

--- a/services/ymax-planner/src/wrappers/utils.ts
+++ b/services/ymax-planner/src/wrappers/utils.ts
@@ -1,0 +1,38 @@
+// Roughly equal to block interval
+const STATUS_CACHE_TTL_MS = 5 * 1000;
+
+let statusCache: { promise: Promise<void>; timestamp: number } | null = null;
+
+export const verifyStatus = (
+  { now }: { now: () => number },
+  rpcAddress: string,
+) => {
+  const currentTimestamp = now();
+  if (
+    statusCache &&
+    currentTimestamp - statusCache.timestamp < STATUS_CACHE_TTL_MS
+  )
+    return statusCache.promise;
+
+  const promise = (async () => {
+    const url = `${rpcAddress}/status`;
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(STATUS_CACHE_TTL_MS / 2),
+    });
+    if (!response.ok) throw Error(`Unable to connect to ${url}`);
+
+    const json = (await response.json()) as {
+      result: {
+        node_info: { id: string };
+        sync_info: { catching_up: boolean; latest_block_height: string };
+      };
+    };
+    if (json.result.sync_info.catching_up)
+      throw Error(
+        `Node ${json.result.node_info.id} falling behind at height ${json.result.sync_info.latest_block_height}`,
+      );
+  })();
+
+  statusCache = { timestamp: currentTimestamp, promise };
+  return promise;
+};

--- a/services/ymax-planner/src/wrappers/vstorage-kit.ts
+++ b/services/ymax-planner/src/wrappers/vstorage-kit.ts
@@ -1,0 +1,185 @@
+import {
+  makeVStorage,
+  makeVstorageKitFromVstorage,
+  type MinimalNetworkConfig,
+} from '@agoric/client-utils';
+import { mustMatch, tryNow } from '@agoric/internal';
+import { StreamCellShape } from '@agoric/internal/src/lib-chainStorage.js';
+import {
+  QueryChildrenResponse,
+  QueryDataResponse,
+} from '@agoric/cosmic-proto/agoric/vstorage/query.js';
+import { verifyStatus } from './utils.ts';
+
+type QueryChildrenMetaResponse = QueryMetaResponseBase & {
+  result: QueryChildrenResponse;
+};
+
+type QueryMetaResponseBase = { blockHeight?: bigint; log?: string };
+
+type QueryDataMetaResponse = QueryMetaResponseBase & {
+  result: QueryDataResponse;
+};
+
+const makeVstorageKitWrapper = (
+  { fetch }: { fetch: typeof globalThis.fetch },
+  networkConfig: MinimalNetworkConfig,
+) => {
+  const vstorage = tryNow(
+    () => makeVstoragetWrapper({ fetch }, networkConfig),
+    err => {
+      throw Error(`RPC failure (${networkConfig.rpcAddrs}): ${err.message}`);
+    },
+  );
+  return makeVstorageKitFromVstorage({ vstorage, networkConfig });
+};
+
+const makeVstoragetWrapper = (
+  {
+    fetch,
+    now = Date.now,
+  }: {
+    fetch: typeof globalThis.fetch;
+    now?: () => number;
+  },
+  networkConfig: MinimalNetworkConfig,
+) => {
+  const [priorityRpcAddress, fallbackRpcAddress] = networkConfig.rpcAddrs;
+
+  let fallbackVstorage: ReturnType<typeof makeVStorage>;
+
+  const vstorage = makeVStorage(
+    { fetch },
+    {
+      chainName: networkConfig.chainName,
+      rpcAddrs: [priorityRpcAddress],
+    },
+  );
+
+  if (fallbackRpcAddress)
+    fallbackVstorage = makeVStorage(
+      { fetch },
+      {
+        chainName: networkConfig.chainName,
+        rpcAddrs: [fallbackRpcAddress],
+      },
+    );
+
+  const readStorage = async <T extends 'children' | 'data'>(
+    path?: string,
+    config?: { height?: bigint | number; kind?: T },
+  ) => {
+    let curr: T extends 'children' ? QueryChildrenResponse : QueryDataResponse;
+
+    await null;
+
+    try {
+      if (fallbackVstorage) await verifyStatus({ now }, priorityRpcAddress);
+
+      curr = await vstorage.readStorage(path, {
+        height: config?.height,
+        kind: config?.kind,
+      });
+    } catch (err) {
+      if (fallbackVstorage) {
+        console.error(
+          `Error while fetching ${path} from storage, possibly falling back`,
+          err,
+        );
+
+        curr = await fallbackVstorage.readStorage(path, {
+          height: config?.height,
+          kind: config?.kind,
+        });
+      } else throw err;
+    }
+
+    return curr;
+  };
+
+  const readStorageMeta = async <T extends 'children' | 'data'>(
+    path?: string,
+    config?: { height?: bigint | number; kind?: T },
+  ) => {
+    let curr: T extends 'children'
+      ? QueryChildrenMetaResponse
+      : QueryDataMetaResponse;
+
+    await null;
+
+    try {
+      if (fallbackVstorage) await verifyStatus({ now }, priorityRpcAddress);
+
+      curr = await vstorage.readStorageMeta(path, {
+        height: config?.height,
+        kind: config?.kind,
+      });
+    } catch (err) {
+      if (fallbackVstorage) {
+        console.error(
+          `Error while fetching ${path} metadata from storage, possibly falling back`,
+          err,
+        );
+
+        curr = await fallbackVstorage.readStorageMeta(path, {
+          height: config?.height,
+          kind: config?.kind,
+        });
+      } else throw err;
+    }
+
+    return curr;
+  };
+
+  const vstorageWrapper = {
+    keys: async (path = 'published') =>
+      readStorage(path, { kind: 'children' }).then(({ children }) => children),
+    readAt: async (path: string, height?: number) => {
+      const response = await readStorage(path, { kind: 'data', height });
+      const cell = harden(JSON.parse(response.value));
+      mustMatch(cell, StreamCellShape);
+      return cell;
+    },
+    readFully: async (path: string, minHeight?: number) => {
+      // undefined the first iteration, to query at the highest
+      let blockHeight: string | undefined;
+      const parts: Array<unknown> = [];
+
+      await null;
+
+      do {
+        let values: Array<unknown>;
+        try {
+          ({ blockHeight, values } = await vstorageWrapper.readAt(
+            path,
+            blockHeight === undefined ? undefined : Number(blockHeight) - 1,
+          ));
+        } catch (err) {
+          if (
+            err.codespace === 'sdk' &&
+            err.code === 18 &&
+            err.message.match(/pruned/)
+          )
+            break;
+
+          throw err;
+        }
+
+        parts.push(values.reverse());
+
+        if (minHeight && Number(blockHeight) <= Number(minHeight)) break;
+      } while (Number(blockHeight));
+
+      return parts.flat() as Array<string>;
+    },
+    readLatest: (path = 'published') => readStorage(path, { kind: 'data' }),
+    readStorage,
+    readStorageMeta,
+  };
+
+  return vstorageWrapper;
+};
+
+harden(makeVstorageKitWrapper);
+
+export default makeVstorageKitWrapper;


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description 
Adds fallback RPC support to the ymax planner service. When a primary RPC node is unavailable or falling behind, requests automatically fail over to a configured fallback node

#### Key changes:
- `src/main.ts`: Adds `overrideNetworkConfigFromEnvironmentVariables` to support `OVERRIDE_RPC_ADDRESS`, `FALLBACK_RPC_ADDRESS`, and `OVERRIDE_WEBSOCKET_URL` env vars. Switches `makeSmartWalletKit` and `makeSigningSmartWalletKit` imports from `@agoric/client-utils` to local wrappers that are fallback-aware
- `src/wrappers/stargate-client.ts` (new): Wraps `SigningStargateClient` so that `broadcastTx`, `sign`, and `signAndBroadcast` each verify the primary node's health before calling it, falling back to the secondary node on failure
- `src/wrappers/vstorage-kit.ts` (new): Wraps vstorage's `readStorage` and `readStorageMeta` with the same primary/fallback pattern
- `src/wrappers/smart-wallet.ts` (new): Thin adapter that constructs a `SmartWalletKit` using the fallback-aware vstorage kit
- `src/wrappers/signing-smart-wallet.ts` (new): Thin adapter that constructs a `SigningSmartWalletKit` using the fallback-aware stargate client
- `src/wrappers/utils.ts` (new): `verifyStatus` helper that hits the RPC /status endpoint with a 5-second cache TTL, rejecting if the node is catching up

### Security Considerations 
No new authorities are introduced. The fallback RPC address is configured via a server-side environment variable `FALLBACK_RPC_ADDRESS`, not user input. The status check uses `AbortSignal.timeout` to prevent hanging requests. Trust boundaries remain the same — both primary and fallback nodes are expected to be trusted RPC endpoints configured by the operator

### Scaling Considerations
Each RPC call now incurs an additional `/status` health check against the primary node, cached for 5 seconds (roughly one block interval). This adds one lightweight HTTP request per ~5 seconds under load. When a fallback client is configured, an additional `SigningStargateClient` and `VStorage` connection are maintained, doubling the connection footprint to RPC nodes

### Documentation Considerations
N/A 

### Testing Considerations
N/A

### Upgrade Considerations
This is an additive change to the ymax planner service. Existing deployments without the new environment variables will behave identically to before — no fallback client is created unless `FALLBACK_RPC_ADDRESS` is set. To adopt, operators set the env vars and redeploy; no data migration or on-chain changes required