### PR TITLE
fix(internal): `onceWithError` subscribes once per stream+eventName

### DIFF
--- a/packages/internal/src/node/fs-stream.js
+++ b/packages/internal/src/node/fs-stream.js
@@ -48,14 +48,15 @@ export const fsStreamReady = stream =>
   });
 
 /**
- * Wait for a stream event and reject on stream error first.
+ * Subscribe fresh listeners for a single stream event and reject on stream
+ * error first.
  *
  * @param {StreamLike} stream
  * @param {EventName} eventName
  * @param {() => void} [onCleanup] called when the event is emitted or an error occurs, after listeners are removed
  * @returns {Promise<void>}
  */
-const naiveOnceWithError = (stream, eventName, onCleanup = () => {}) =>
+const subscribeOnceWithError = (stream, eventName, onCleanup = () => {}) =>
   new Promise((resolve, reject) => {
     const onEvent = () => {
       cleanup();
@@ -129,7 +130,7 @@ const makeMemoizedOnceWithError = doOnceWithError => {
  * @param {EventName} eventName
  * @returns {Promise<void>}
  */
-const onceWithError = makeMemoizedOnceWithError(naiveOnceWithError);
+const onceWithError = makeMemoizedOnceWithError(subscribeOnceWithError);
 
 /**
  * @param {WriteStream | Socket} stream

--- a/packages/internal/src/node/fs-stream.js
+++ b/packages/internal/src/node/fs-stream.js
@@ -49,9 +49,10 @@ export const fsStreamReady = stream =>
  *
  * @param {ReadStream | WriteStream | Socket} stream
  * @param {'drain' | 'ready'} eventName
+ * @param {() => void} [onCleanup] called when the event is emitted or an error occurs, after listeners are removed
  * @returns {Promise<void>}
  */
-const onceWithError = (stream, eventName) =>
+const naiveOnceWithError = (stream, eventName, onCleanup = () => {}) =>
   new Promise((resolve, reject) => {
     const onEvent = () => {
       cleanup();
@@ -65,10 +66,68 @@ const onceWithError = (stream, eventName) =>
     const cleanup = () => {
       stream.off(eventName, onEvent);
       stream.off('error', onError);
+      onCleanup();
     };
     stream.on(eventName, onEvent);
     stream.on('error', onError);
   });
+
+/**
+ * Memoize promises to prevent multiple subscriptions to the same event on the
+ * same stream.  This is necessary to prevent:
+ *
+ * (node:1224) MaxListenersExceededWarning: Possible EventEmitter memory leak
+ * detected. 11 drain listeners added to [WriteStream]. MaxListeners is 10. Use
+ * emitter.setMaxListeners() to increase limit
+ *
+ * @param {(stream: ReadStream | WriteStream | Socket,
+ *   eventName: 'drain' | 'ready', onDone?: () => void) => Promise<void>} doOnceWithError
+ * @returns {(stream: ReadStream | WriteStream | Socket,
+ *   eventName: 'drain' | 'ready') => Promise<void>}
+ */
+const makeMemoizedOnceWithError = doOnceWithError => {
+  /**
+   * @type {Map<string, WeakMap<ReadStream | WriteStream | Socket,
+   *   Promise<void>>>}
+   */
+  const promiseFromEventAndStream = new Map();
+
+  /**
+   * Wait for a stream event and reject on stream error first.
+   *
+   * @param {ReadStream | WriteStream | Socket} stream
+   * @param {'drain' | 'ready'} eventName
+   * @returns {Promise<void>}
+   */
+  const memoizedOnceWithError = (stream, eventName) => {
+    let promiseFromStream = promiseFromEventAndStream.get(eventName);
+    if (!promiseFromStream) {
+      promiseFromStream = new WeakMap();
+      promiseFromEventAndStream.set(eventName, promiseFromStream);
+    }
+    /** @type {Promise<void> | undefined} */
+    let promise = promiseFromStream.get(stream);
+    if (promise) {
+      return promise;
+    }
+    promise = doOnceWithError(stream, eventName, () =>
+      promiseFromStream.delete(stream),
+    );
+    promiseFromStream.set(stream, promise);
+    return promise;
+  };
+
+  return memoizedOnceWithError;
+};
+
+/**
+ * Wait for a stream event and reject on stream error first.
+ *
+ * @param {ReadStream | WriteStream | Socket} stream
+ * @param {'drain' | 'ready'} eventName
+ * @returns {Promise<void>}
+ */
+const onceWithError = makeMemoizedOnceWithError(naiveOnceWithError);
 
 /**
  * @param {WriteStream | Socket} stream

--- a/packages/internal/src/node/fs-stream.js
+++ b/packages/internal/src/node/fs-stream.js
@@ -9,6 +9,7 @@ import { promisify } from 'node:util';
  */
 
 /** @typedef {ReadStream | WriteStream | Socket} StreamLike */
+/** @typedef {'drain' | 'ready'} EventName */
 
 /**
  * @param {StreamLike} stream
@@ -50,7 +51,7 @@ export const fsStreamReady = stream =>
  * Wait for a stream event and reject on stream error first.
  *
  * @param {StreamLike} stream
- * @param {'drain' | 'ready'} eventName
+ * @param {EventName} eventName
  * @param {() => void} [onCleanup] called when the event is emitted or an error occurs, after listeners are removed
  * @returns {Promise<void>}
  */
@@ -83,9 +84,9 @@ const naiveOnceWithError = (stream, eventName, onCleanup = () => {}) =>
  * emitter.setMaxListeners() to increase limit
  *
  * @param {(stream: StreamLike,
- *   eventName: 'drain' | 'ready', onDone?: () => void) => Promise<void>} doOnceWithError
+ *   eventName: EventName, onDone?: () => void) => Promise<void>} doOnceWithError
  * @returns {(stream: StreamLike,
- *   eventName: 'drain' | 'ready') => Promise<void>}
+ *   eventName: EventName) => Promise<void>}
  */
 const makeMemoizedOnceWithError = doOnceWithError => {
   /**
@@ -97,7 +98,7 @@ const makeMemoizedOnceWithError = doOnceWithError => {
    * Wait for a stream event and reject on stream error first.
    *
    * @param {StreamLike} stream
-   * @param {'drain' | 'ready'} eventName
+   * @param {EventName} eventName
    * @returns {Promise<void>}
    */
   const memoizedOnceWithError = (stream, eventName) => {
@@ -125,7 +126,7 @@ const makeMemoizedOnceWithError = doOnceWithError => {
  * Wait for a stream event and reject on stream error first.
  *
  * @param {StreamLike} stream
- * @param {'drain' | 'ready'} eventName
+ * @param {EventName} eventName
  * @returns {Promise<void>}
  */
 const onceWithError = makeMemoizedOnceWithError(naiveOnceWithError);

--- a/packages/internal/src/node/fs-stream.js
+++ b/packages/internal/src/node/fs-stream.js
@@ -8,8 +8,10 @@ import { promisify } from 'node:util';
  * @import {Socket} from 'net';
  */
 
+/** @typedef {ReadStream | WriteStream | Socket} StreamLike */
+
 /**
- * @param {ReadStream | WriteStream | Socket} stream
+ * @param {StreamLike} stream
  * @returns {Promise<void>}
  */
 export const fsStreamReady = stream =>
@@ -47,7 +49,7 @@ export const fsStreamReady = stream =>
 /**
  * Wait for a stream event and reject on stream error first.
  *
- * @param {ReadStream | WriteStream | Socket} stream
+ * @param {StreamLike} stream
  * @param {'drain' | 'ready'} eventName
  * @param {() => void} [onCleanup] called when the event is emitted or an error occurs, after listeners are removed
  * @returns {Promise<void>}
@@ -80,22 +82,21 @@ const naiveOnceWithError = (stream, eventName, onCleanup = () => {}) =>
  * detected. 11 drain listeners added to [WriteStream]. MaxListeners is 10. Use
  * emitter.setMaxListeners() to increase limit
  *
- * @param {(stream: ReadStream | WriteStream | Socket,
+ * @param {(stream: StreamLike,
  *   eventName: 'drain' | 'ready', onDone?: () => void) => Promise<void>} doOnceWithError
- * @returns {(stream: ReadStream | WriteStream | Socket,
+ * @returns {(stream: StreamLike,
  *   eventName: 'drain' | 'ready') => Promise<void>}
  */
 const makeMemoizedOnceWithError = doOnceWithError => {
   /**
-   * @type {Map<string, WeakMap<ReadStream | WriteStream | Socket,
-   *   Promise<void>>>}
+   * @type {Map<string, WeakMap<StreamLike, Promise<void>>>}
    */
   const promiseFromEventAndStream = new Map();
 
   /**
    * Wait for a stream event and reject on stream error first.
    *
-   * @param {ReadStream | WriteStream | Socket} stream
+   * @param {StreamLike} stream
    * @param {'drain' | 'ready'} eventName
    * @returns {Promise<void>}
    */
@@ -123,7 +124,7 @@ const makeMemoizedOnceWithError = doOnceWithError => {
 /**
  * Wait for a stream event and reject on stream error first.
  *
- * @param {ReadStream | WriteStream | Socket} stream
+ * @param {StreamLike} stream
  * @param {'drain' | 'ready'} eventName
  * @returns {Promise<void>}
  */

--- a/packages/internal/test/fs-stream.test.js
+++ b/packages/internal/test/fs-stream.test.js
@@ -1,0 +1,154 @@
+// @ts-check
+import test from 'ava';
+import { EventEmitter } from 'node:events';
+import { open, rm, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { waitUntilQuiescent } from '../src/lib-nodejs/waitUntilQuiescent.js';
+import { makeFsStreamWriter } from '../src/node/fs-stream.js';
+
+/** @import {FileHandle} from 'node:fs/promises' */
+
+class FakeWriteStream extends EventEmitter {
+  #destroyed = false;
+
+  pending = false;
+
+  get destroyed() {
+    return this.#destroyed;
+  }
+
+  /**
+   * @param {string | Uint8Array} _data
+   * @param {(err?: Error | null) => void} cb
+   * @returns {false}
+   */
+  write(_data, cb) {
+    if (this.#destroyed) {
+      cb(Error('Stream closed'));
+      return false;
+    }
+    void Promise.resolve().then(() => cb(null));
+    return false;
+  }
+
+  /** @param {(err?: Error | null) => void} [cb] */
+  close(cb) {
+    this.#destroyed = true;
+    cb?.(null);
+  }
+}
+
+const makeTestWriter = async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'fs-stream-test-'));
+  const filePath = join(tempDir, 'output.log');
+
+  const probeHandle = await open(filePath, 'a');
+  const fileHandleProto = Object.getPrototypeOf(probeHandle);
+  await probeHandle.close();
+
+  /** @type {FakeWriteStream | undefined} */
+  let stream;
+  /** @type {FileHandle[]} */
+  const openedHandles = [];
+  const originalCreateWriteStream = fileHandleProto.createWriteStream;
+  const cleanup = async () => {
+    fileHandleProto.createWriteStream = originalCreateWriteStream;
+    await Promise.allSettled(openedHandles.map(handle => handle.close()));
+    await rm(tempDir, { recursive: true, force: true });
+  };
+
+  fileHandleProto.createWriteStream = function createWriteStream() {
+    openedHandles.push(this);
+    stream = new FakeWriteStream();
+    return stream;
+  };
+
+  try {
+    const writer = await makeFsStreamWriter(filePath);
+    if (!writer || !stream) {
+      throw Error('Expected makeFsStreamWriter to return a writer and stream');
+    }
+    return {
+      stream,
+      writer,
+      cleanup,
+    };
+  } catch (err) {
+    await cleanup();
+    throw err;
+  }
+};
+
+test.serial(
+  'makeFsStreamWriter reuses one drain waiter across concurrent writes',
+  async t => {
+    const { writer, stream, cleanup } = await makeTestWriter();
+    const baselineErrorListeners = stream.listenerCount('error');
+
+    try {
+      const writes = Array.from({ length: 25 }, (_, i) =>
+        writer.write(`chunk-${i}`),
+      );
+
+      await waitUntilQuiescent();
+
+      t.is(stream.listenerCount('drain'), 1);
+      t.is(stream.listenerCount('error'), baselineErrorListeners + 1);
+
+      stream.emit('drain');
+      await Promise.all(writes);
+
+      t.is(stream.listenerCount('drain'), 0);
+      t.is(stream.listenerCount('error'), baselineErrorListeners);
+
+      const nextWrites = Array.from({ length: 12 }, (_, i) =>
+        writer.write(`next-${i}`),
+      );
+
+      await waitUntilQuiescent();
+
+      t.is(stream.listenerCount('drain'), 1);
+      t.is(stream.listenerCount('error'), baselineErrorListeners + 1);
+
+      stream.emit('drain');
+      await Promise.all(nextWrites);
+      await writer.close();
+    } finally {
+      await cleanup();
+    }
+  },
+);
+
+test.serial(
+  'makeFsStreamWriter shares drain rejection across concurrent writes',
+  async t => {
+    const { writer, stream, cleanup } = await makeTestWriter();
+    const baselineErrorListeners = stream.listenerCount('error');
+
+    try {
+      const writes = Array.from({ length: 12 }, () => writer.write('chunk'));
+
+      await waitUntilQuiescent();
+
+      t.is(stream.listenerCount('drain'), 1);
+      t.is(stream.listenerCount('error'), baselineErrorListeners + 1);
+
+      const boom = Error('boom');
+      stream.emit('error', boom);
+
+      const results = await Promise.allSettled(writes);
+      t.true(
+        results.every(
+          result => result.status === 'rejected' && result.reason === boom,
+        ),
+      );
+
+      t.is(stream.listenerCount('drain'), 0);
+      t.is(stream.listenerCount('error'), baselineErrorListeners);
+    } finally {
+      await cleanup();
+    }
+  },
+);

--- a/packages/internal/test/fs-stream.test.js
+++ b/packages/internal/test/fs-stream.test.js
@@ -81,6 +81,8 @@ const makeTestWriter = async () => {
   }
 };
 
+// These tests monkey-patch FileHandle.prototype.createWriteStream, so they must
+// run serially even though makeFsStreamWriter itself does not require it.
 test.serial(
   'makeFsStreamWriter reuses one drain waiter across concurrent writes',
   async t => {


### PR DESCRIPTION
## Summary
- memoize `onceWithError` promises by `stream` and `eventName` in `packages/internal/src/node/fs-stream.js`
- reuse an in-flight `drain` or `ready` waiter instead of registering duplicate listeners on the same stream
- clear the memoized waiter after it settles so later waits can subscribe again
- add AVA coverage for concurrent backpressured writes and shared error rejection

## Problem
Repeated writes could stack `drain` listeners on the same `WriteStream`, triggering `MaxListenersExceededWarning` warnings from Node.

## Testing
- yarn ava packages/internal/test/fs-stream.test.js
- yarn run -T eslint packages/internal/test/fs-stream.test.js

Refs: AGO-454

Co-authored-by: Codex <codex@openai.com>