### PR TITLE
fix(ymax-resolver): retry resolver settlements on broadcast failure

### DIFF
--- a/services/ymax-planner/scripts/process-tx-lib.ts
+++ b/services/ymax-planner/scripts/process-tx-lib.ts
@@ -184,6 +184,7 @@ export const processTx = async (
         retryProviders,
         fetch,
         setTimeout,
+        now: Date.now,
         kvStore,
         makeAbortController,
         log: (...args) => console.log('[TX]', ...args),

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -291,6 +291,7 @@ export const main = async (
       kvStore,
       makeAbortController,
       setTimeout,
+      now,
       axelarApiUrl: config.axelar.apiUrl,
       ydsNotifier,
       retryProviders,

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -18,6 +18,7 @@ import type { KVStore } from '@agoric/internal/src/kv-store.js';
 
 import type { WebSocketProvider } from 'ethers';
 import { resolvePendingTx } from './resolver.ts';
+import { submitWithRetry } from './retry-settlement.ts';
 import { waitForBlock, type EvmRpc } from './evm-scanner.ts';
 import type { MakeAbortController, UsdcAddresses } from './support.ts';
 import { lookBackCctp, watchCctpTransfer } from './watchers/cctp-watcher.ts';
@@ -53,6 +54,7 @@ export type EvmContext = {
   signingSmartWalletKit: SigningSmartWalletKit;
   fetch: typeof fetch;
   setTimeout: typeof globalThis.setTimeout;
+  now: () => number;
   kvStore: KVStore;
   makeAbortController: MakeAbortController;
   axelarApiUrl: string;
@@ -195,13 +197,27 @@ const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
       return;
     }
 
-    transferResult.settled &&
-      (await resolvePendingTx({
-        signingSmartWalletKit: ctx.signingSmartWalletKit,
-        txId,
-        status:
-          transferResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED,
-      }));
+    if (transferResult.settled) {
+      await submitWithRetry(
+        `${logPrefix} CCTP settlement`,
+        () =>
+          resolvePendingTx({
+            signingSmartWalletKit: ctx.signingSmartWalletKit,
+            txId,
+            status:
+              transferResult.success !== false
+                ? TxStatus.SUCCESS
+                : TxStatus.FAILED,
+          }),
+        {
+          log,
+          setTimeout: ctx.setTimeout,
+          now: ctx.now,
+          errorCode: PendingTxCode.RESOLVER_SETTLEMENT_FAILED,
+          signal: opts.signal,
+        },
+      );
+    }
 
     if (transferResult?.txHash) {
       await ctx.ydsNotifier?.notifySettlement(txId, transferResult.txHash);
@@ -321,13 +337,27 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
       return;
     }
 
-    transferResult.settled &&
-      (await resolvePendingTx({
-        signingSmartWalletKit: ctx.signingSmartWalletKit,
-        txId,
-        status:
-          transferResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED,
-      }));
+    if (transferResult.settled) {
+      await submitWithRetry(
+        `${logPrefix} GMP settlement`,
+        () =>
+          resolvePendingTx({
+            signingSmartWalletKit: ctx.signingSmartWalletKit,
+            txId,
+            status:
+              transferResult.success !== false
+                ? TxStatus.SUCCESS
+                : TxStatus.FAILED,
+          }),
+        {
+          log,
+          setTimeout: ctx.setTimeout,
+          now: ctx.now,
+          errorCode: PendingTxCode.RESOLVER_SETTLEMENT_FAILED,
+          signal: opts.signal,
+        },
+      );
+    }
 
     if (transferResult?.txHash) {
       await ctx.ydsNotifier?.notifySettlement(txId, transferResult.txHash);
@@ -452,13 +482,27 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
       return;
     }
 
-    walletResult.settled &&
-      (await resolvePendingTx({
-        signingSmartWalletKit: ctx.signingSmartWalletKit,
-        txId,
-        status:
-          walletResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED,
-      }));
+    if (walletResult.settled) {
+      await submitWithRetry(
+        `${logPrefix} MAKE_ACCOUNT settlement`,
+        () =>
+          resolvePendingTx({
+            signingSmartWalletKit: ctx.signingSmartWalletKit,
+            txId,
+            status:
+              walletResult.success !== false
+                ? TxStatus.SUCCESS
+                : TxStatus.FAILED,
+          }),
+        {
+          log,
+          setTimeout: ctx.setTimeout,
+          now: ctx.now,
+          errorCode: PendingTxCode.RESOLVER_SETTLEMENT_FAILED,
+          signal: opts.signal,
+        },
+      );
+    }
 
     if (walletResult?.txHash) {
       await ctx.ydsNotifier?.notifySettlement(txId, walletResult.txHash);
@@ -569,13 +613,27 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
       return;
     }
 
-    transferResult.settled &&
-      (await resolvePendingTx({
-        signingSmartWalletKit: ctx.signingSmartWalletKit,
-        txId,
-        status:
-          transferResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED,
-      }));
+    if (transferResult.settled) {
+      await submitWithRetry(
+        `${logPrefix} ROUTED_GMP settlement`,
+        () =>
+          resolvePendingTx({
+            signingSmartWalletKit: ctx.signingSmartWalletKit,
+            txId,
+            status:
+              transferResult.success !== false
+                ? TxStatus.SUCCESS
+                : TxStatus.FAILED,
+          }),
+        {
+          log,
+          setTimeout: ctx.setTimeout,
+          now: ctx.now,
+          errorCode: PendingTxCode.RESOLVER_SETTLEMENT_FAILED,
+          signal: opts.signal,
+        },
+      );
+    }
 
     if (transferResult?.txHash) {
       await ctx.ydsNotifier?.notifySettlement(txId, transferResult.txHash);
@@ -627,6 +685,7 @@ export const PendingTxCode = {
   ROUTED_GMP_TX_NOT_FOUND: 'ROUTED_GMP_TX_NOT_FOUND',
   WALLET_TX_NOT_FOUND: 'WALLET_TX_NOT_FOUND',
   CCTP_TX_NOT_FOUND: 'CCTP_TX_NOT_FOUND',
+  RESOLVER_SETTLEMENT_FAILED: 'RESOLVER_SETTLEMENT_FAILED',
 } as const;
 
 export const TX_TIMEOUT_MS = 30 * 60 * 1000; // 30 min

--- a/services/ymax-planner/src/retry-settlement.ts
+++ b/services/ymax-planner/src/retry-settlement.ts
@@ -1,0 +1,110 @@
+/**
+ * Retry helper for chain submissions (resolver settlements, plan submissions).
+ *
+ * Unbounded retries with exponential backoff. Every failed attempt is logged,
+ * but only the first failure and then one every `alertIntervalMs` carry the
+ * caller-supplied `errorCode` prefix — the ops alerting filter matches on that
+ * code, so this in-code throttling keeps pages to one per interval while the
+ * submission stays stuck.
+ *
+ * Each retry is a fresh call through the sequencing wallet's queue, so other
+ * in-flight submissions interleave normally between attempts.
+ */
+
+export const DEFAULT_INITIAL_DELAY_MS = 5 * 1000;
+export const DEFAULT_MAX_DELAY_MS = 1 * 60 * 1000;
+export const DEFAULT_ALERT_INTERVAL_MS = 5 * 60 * 1000;
+
+export type RetryPolicy = {
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  alertIntervalMs?: number;
+};
+
+export type SubmitWithRetryOpts = {
+  log: (...args: unknown[]) => void;
+  setTimeout: typeof globalThis.setTimeout;
+  now: () => number;
+  /**
+   * Stable code prefixed to a log line on the first failure and then at most
+   * once per `alertIntervalMs` while the submission is stuck. Ops alerting
+   * filters match on this code.
+   */
+  errorCode: string;
+  signal?: AbortSignal;
+  policy?: RetryPolicy;
+};
+
+const sleepOrAbort = (
+  ms: number,
+  setTimeout: typeof globalThis.setTimeout,
+  signal?: AbortSignal,
+): Promise<void> =>
+  new Promise(resolve => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      resolve();
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+
+export const submitWithRetry = async <T>(
+  label: string,
+  thunk: () => Promise<T>,
+  {
+    log,
+    setTimeout,
+    now,
+    errorCode,
+    signal,
+    policy: {
+      initialDelayMs = DEFAULT_INITIAL_DELAY_MS,
+      maxDelayMs = DEFAULT_MAX_DELAY_MS,
+      alertIntervalMs = DEFAULT_ALERT_INTERVAL_MS,
+    } = {},
+  }: SubmitWithRetryOpts,
+): Promise<T | undefined> => {
+  const start = now();
+  // Initialize in the past so the first failure triggers an alert.
+  let lastAlertAt = start - alertIntervalMs;
+  let delay = initialDelayMs;
+  let attempt = 0;
+
+  await null;
+  while (true) {
+    if (signal?.aborted) {
+      log(`${label} aborted before attempt ${attempt + 1}`);
+      return undefined;
+    }
+
+    attempt += 1;
+    try {
+      const result = await thunk();
+      if (attempt > 1) {
+        log(`${label} succeeded after ${attempt} attempts`);
+      }
+      return result;
+    } catch (err) {
+      const elapsedMs = now() - start;
+      const shouldAlert = now() - lastAlertAt >= alertIntervalMs;
+      const prefix = shouldAlert ? `[${errorCode}] ` : '';
+      log(
+        `${prefix}${label} attempt ${attempt} failed after ${elapsedMs}ms, retrying in ${delay}ms`,
+        err,
+      );
+      if (shouldAlert) lastAlertAt = now();
+
+      await sleepOrAbort(delay, setTimeout, signal);
+      delay = Math.min(delay * 2, maxDelayMs);
+    }
+  }
+};
+harden(submitWithRetry);

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -404,6 +404,7 @@ export const mockEvmCtx = {
   retryProviders: defaultMockProviders.retryProviders,
   kvStore: makeKVStoreFromMap(new Map()),
   setTimeout: globalThis.setTimeout,
+  now: Date.now,
   makeAbortController,
   axelarApiUrl: mockAxelarApiAddress,
   ydsNotifier: {
@@ -547,6 +548,7 @@ export const createMockPendingTxOpts = (
     retryProviders,
     fetch: async () => ({ ok: true, json: async () => ({}) }) as Response,
     setTimeout: globalThis.setTimeout,
+    now: Date.now,
     marshaller: boardSlottingMarshaller(),
     signingSmartWalletKit: createMockSigningSmartWalletKit(),
     ydsNotifier: {

--- a/services/ymax-planner/test/retry-settlement.test.ts
+++ b/services/ymax-planner/test/retry-settlement.test.ts
@@ -1,0 +1,164 @@
+import test from 'ava';
+
+import { submitWithRetry } from '../src/retry-settlement.ts';
+
+const TEST_ERROR_CODE = 'TEST_ERROR';
+
+const makeHarness = () => {
+  const logs: unknown[][] = [];
+  const sleeps: number[] = [];
+  let nowMs = 1_000_000;
+  const log = (...args: unknown[]) => logs.push(args);
+  const setTimeout = ((fn: () => void, ms: number) => {
+    sleeps.push(ms);
+    nowMs += ms;
+    queueMicrotask(fn);
+    return 0 as unknown as NodeJS.Timeout;
+  }) as typeof globalThis.setTimeout;
+  const now = () => nowMs;
+  return { logs, sleeps, log, setTimeout, now };
+};
+
+const baseOpts = (h: ReturnType<typeof makeHarness>) => ({
+  log: h.log,
+  setTimeout: h.setTimeout,
+  now: h.now,
+  errorCode: TEST_ERROR_CODE,
+});
+
+test('returns immediately on first-try success', async t => {
+  const h = makeHarness();
+  const result = await submitWithRetry(
+    '[tx1] settlement',
+    async () => 'ok',
+    baseOpts(h),
+  );
+  t.is(result, 'ok');
+  t.deepEqual(h.sleeps, []);
+  t.deepEqual(h.logs, []);
+});
+
+test('retries with exponential backoff until success', async t => {
+  const h = makeHarness();
+  let calls = 0;
+  const result = await submitWithRetry(
+    '[tx2] settlement',
+    async () => {
+      calls += 1;
+      if (calls < 4) throw Error(`boom ${calls}`);
+      return 'settled';
+    },
+    baseOpts(h),
+  );
+  t.is(result, 'settled');
+  t.is(calls, 4);
+  t.deepEqual(h.sleeps, [5_000, 10_000, 20_000]);
+  t.true(h.logs.some(args => String(args[0]).includes('succeeded after 4')));
+});
+
+test('first failure logs with errorCode; subsequent failures log unprefixed until alert interval', async t => {
+  const h = makeHarness();
+  let calls = 0;
+  await submitWithRetry(
+    '[tx3] settlement',
+    async () => {
+      calls += 1;
+      if (calls < 4) throw Error('fail');
+      return 'ok';
+    },
+    {
+      ...baseOpts(h),
+      policy: { initialDelayMs: 100, maxDelayMs: 100, alertIntervalMs: 10_000 },
+    },
+  );
+  const taggedLogs = h.logs.filter(args =>
+    String(args[0]).includes(`[${TEST_ERROR_CODE}]`),
+  );
+  // Only the first failure alerts (subsequent attempts are within the 10s
+  // interval with 100ms between each).
+  t.is(taggedLogs.length, 1);
+});
+
+test('alerts re-fire once alert interval elapses', async t => {
+  const h = makeHarness();
+  let calls = 0;
+  await submitWithRetry(
+    '[tx3b] settlement',
+    async () => {
+      calls += 1;
+      if (calls <= 20) throw Error('fail');
+      return 'ok';
+    },
+    {
+      ...baseOpts(h),
+      policy: { initialDelayMs: 100, maxDelayMs: 100, alertIntervalMs: 250 },
+    },
+  );
+  const taggedLogs = h.logs.filter(args =>
+    String(args[0]).includes(`[${TEST_ERROR_CODE}]`),
+  );
+  t.true(taggedLogs.length >= 5);
+});
+
+test('caps backoff at maxDelayMs', async t => {
+  const h = makeHarness();
+  let calls = 0;
+  await submitWithRetry(
+    '[tx4] settlement',
+    async () => {
+      calls += 1;
+      if (calls < 8) throw Error('stuck');
+      return 'done';
+    },
+    baseOpts(h),
+  );
+  t.deepEqual(
+    h.sleeps,
+    [5_000, 10_000, 20_000, 40_000, 60_000, 60_000, 60_000],
+  );
+});
+
+test('aborts before first attempt when signal already aborted', async t => {
+  const h = makeHarness();
+  const ctrl = new AbortController();
+  ctrl.abort();
+  let calls = 0;
+  const result = await submitWithRetry(
+    '[tx5] settlement',
+    async () => {
+      calls += 1;
+      return 'ok';
+    },
+    { ...baseOpts(h), signal: ctrl.signal },
+  );
+  t.is(result, undefined);
+  t.is(calls, 0);
+  t.true(h.logs.some(args => String(args[0]).includes('aborted')));
+});
+
+test('aborts during retry sleep', async t => {
+  const ctrl = new AbortController();
+  const h = makeHarness();
+  const sleeps: number[] = [];
+  const setTimeoutAbortOnFirst = ((_fn: () => void, ms: number) => {
+    sleeps.push(ms);
+    queueMicrotask(() => ctrl.abort());
+    return 0 as unknown as NodeJS.Timeout;
+  }) as typeof globalThis.setTimeout;
+  let calls = 0;
+  const result = await submitWithRetry(
+    '[tx6] settlement',
+    async () => {
+      calls += 1;
+      throw Error('fail');
+    },
+    {
+      ...baseOpts(h),
+      setTimeout: setTimeoutAbortOnFirst,
+      signal: ctrl.signal,
+    },
+  );
+  t.is(result, undefined);
+  t.is(calls, 1);
+  t.deepEqual(sleeps, [5_000]);
+});


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

ref: https://linear.app/agoric/issue/AGO-476/investigate-unresolved-tx4746-tx4751-tx4758-and-tx4769

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
In [AGO-476](https://linear.app/agoric/issue/AGO-476/investigate-unresolved-tx4746-tx4751-tx4758-and-tx4769), four resolver transactions stayed after settlement submissions failed. The resolver's watcher had already figured out each transaction's outcome, but a submission error left no way to retry before the next planner restart, so the transactions sat stuck until they were resolved manually.

This PR makes the resolver keep retrying settlement submissions with a backoff instead of giving up after one attempt. If the underlying cause clears up on its own (e.g. a lagging RPC catches up), the next retry succeeds automatically. An error code (`RESOLVER_SETTLEMENT_FAILED`) is emitted on the first failure and then at most every 5 minutes while stuck, so ops gets paged once per incident rather than not at all.


### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
- New unit tests for the retry helper.
- Existing tests continue to pass.


### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment for `ymax0` and `ymax1`.
- Configuring resolver alerts to handle/alert `RESOLVER_SETTLEMENT_FAILED`.