### PR TITLE
chore: support AGORIC_REST_URL to override REST endpoint

### DIFF
--- a/services/ymax-planner/README.md
+++ b/services/ymax-planner/README.md
@@ -174,6 +174,7 @@ Environment variables:
 - `REQUEST_RETRIES`: Retry count for external requests (default "3")
 - `COSMOS_REST_TIMEOUT`: Overrides `REQUEST_TIMEOUT` for Agoric/Noble/etc. Cosmos REST APIs (optional)
 - `COSMOS_REST_RETRIES`: Overrides `REQUEST_RETRIES` for Agoric/Noble/etc. Cosmos REST APIs (optional)
+- `AGORIC_REST_URL`: Overrides the default Agoric REST endpoint (sourced from `chain-registry`) used for account-state queries (optional)
 - `GRAPHQL_ENDPOINTS`: JSON text for a Record\<dirname, url[]> object describing endpoints associated with each api-\* GraphQL API directory under [graphql](./src/graphql) (optional)
 - `SQLITE_DB_PATH`: The path where the SQLiteDB used by the resolver should be created. While a relative path can be provided (relative to the cwd),
 an absolute path is recommended

--- a/services/ymax-planner/src/config.ts
+++ b/services/ymax-planner/src/config.ts
@@ -36,6 +36,7 @@ export interface YmaxPlannerConfig {
     readonly agoricNetworkSpec: string;
     readonly timeout: number;
     readonly retries: number;
+    readonly agoricRestUrl?: string;
   };
   readonly axelar: {
     readonly apiUrl: string;
@@ -173,6 +174,8 @@ export const loadConfig = async (
   const ydsApiKey = env.YDS_API_KEY?.trim();
   !ydsUrl || ydsApiKey || Fail`YDS_API_KEY is required with YDS_URL`;
 
+  const agoricRestUrl = validateUrl(env, 'AGORIC_REST_URL', undefined);
+
   const config: YmaxPlannerConfig = harden({
     clusterName,
     contractInstance,
@@ -184,6 +187,7 @@ export const loadConfig = async (
       agoricNetworkSpec,
       timeout: parsePositiveInteger(env, 'COSMOS_REST_TIMEOUT', timeout),
       retries: parsePositiveInteger(env, 'COSMOS_REST_RETRIES', maxRetries),
+      ...(agoricRestUrl ? { agoricRestUrl } : {}),
     },
     axelar: {
       apiUrl: axelarApiAddress,

--- a/services/ymax-planner/src/cosmos-rest-client.ts
+++ b/services/ymax-planner/src/cosmos-rest-client.ts
@@ -20,6 +20,11 @@ interface CosmosRestClientConfig {
   clusterName: ClusterName;
   timeout?: number;
   retries?: number;
+  /**
+   * Optional override for the Agoric REST endpoint. When set, takes precedence
+   * over the `chain-registry` default.
+   */
+  agoricRestUrl?: string;
 }
 
 interface CosmosRestClientPowers {
@@ -109,6 +114,16 @@ export class CosmosRestClient {
 
     // Initialize with predefined chains
     this.chainConfigs = new Map(Object.entries(chainConfig));
+
+    if (config.agoricRestUrl) {
+      const agoric = this.chainConfigs.get('agoric');
+      if (agoric) {
+        this.chainConfigs.set('agoric', {
+          ...agoric,
+          restEndpoint: config.agoricRestUrl,
+        });
+      }
+    }
 
     // Create ky instance using provided fetch, retry, and timeout settings.
     this.http = ky.create({

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -142,6 +142,7 @@ export const main = async (
     clusterName,
     timeout: config.cosmosRest.timeout,
     retries: config.cosmosRest.retries,
+    agoricRestUrl: config.cosmosRest.agoricRestUrl,
   });
   const agoricChainInfo = await cosmosRest.getChainInfo('agoric');
   const agoricVersions = (agoricChainInfo as any)?.application_version;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->


refs: https://linear.app/agoric/issue/AGO-476/investigate-unresolved-tx4746-tx4751-tx4758-and-tx4769

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

The planner fetches the signer's account state over REST to get its sequence number. The default REST URL comes from `chain-registry` and currently points to `main.api.agoric.net`, which seems unhealthy today, serving stale data ~30–60% of the time(See this [thread](https://linear.app/agoric/issue/AGO-476/investigate-unresolved-tx4746-tx4751-tx4758-and-tx4769#comment-db44c86d)). That stale sequence is what's been causing the account sequence mismatch errors behind [AGO-476](https://linear.app/agoric/issue/AGO-476/investigate-unresolved-tx4746-tx4751-tx4758-and-tx4769) and today's alerts.

This PR adds an `AGORIC_REST_URL` env var to override the default. When unset, behavior is unchanged.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment for `ymax0` and `ymax`.