### PR TITLE
chore(ymax-resolver): poll for confirmations instead of newHeads subscription

### DIFF
--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -602,7 +602,7 @@ export const waitForConfirmations = async ({
         `Waiting for more confirmations: txHash=${txHash} observed=${confirmationCount} of ${minConfirmations} currentBlock=${currentBlock} receiptBlock=${receipt.blockNumber}`,
       );
     } else if (everSeenReceipt) {
-      log(`Transaction ${txHash} receipt disappeared - likely reorged out`);
+      log(`Transaction ${txHash} receipt disappeared - likely lost in a reorg`);
       return null;
     }
 

--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -551,6 +551,11 @@ export type WaitForConfirmationsOpts = {
   provider: EvmRpc;
   txHash: string;
   minConfirmations: number;
+  /**
+   * If set, the wait between polls is extended to the estimated time until the
+   * remaining confirmations have accrued, avoiding pointless RPC round-trips.
+   */
+  meanBlockTimeMs?: number;
   pollIntervalMs?: number;
   signal?: AbortSignal;
   setTimeout?: typeof globalThis.setTimeout;
@@ -561,6 +566,7 @@ export const waitForConfirmations = async ({
   provider,
   txHash,
   minConfirmations,
+  meanBlockTimeMs,
   pollIntervalMs = DEFAULT_CONFIRMATION_POLL_INTERVAL_MS,
   signal,
   setTimeout = globalThis.setTimeout,
@@ -573,6 +579,7 @@ export const waitForConfirmations = async ({
   while (true) {
     if (signal?.aborted) return null;
 
+    let sleepMs = pollIntervalMs;
     const receipt = await provider.getTransactionReceipt(txHash);
     if (receipt) {
       everSeenReceipt = true;
@@ -582,16 +589,20 @@ export const waitForConfirmations = async ({
       log(
         `Waiting for more confirmations: txHash=${txHash} observed=${confirmationCount} of ${minConfirmations} currentBlock=${currentBlock} receiptBlock=${receipt.blockNumber}`,
       );
+      if (meanBlockTimeMs) {
+        const confirmationsStillNeeded = minConfirmations - confirmationCount;
+        sleepMs = Math.max(
+          pollIntervalMs,
+          (confirmationsStillNeeded + 1) * meanBlockTimeMs,
+        );
+      }
     } else if (everSeenReceipt) {
       log(`Transaction ${txHash} receipt disappeared - likely lost in a reorg`);
       return null;
     }
 
     await new Promise(resolve => {
-      const timeoutSignal = makeAbortController(
-        pollIntervalMs,
-        racingSignals,
-      ).signal;
+      const timeoutSignal = makeAbortController(sleepMs, racingSignals).signal;
       if (timeoutSignal.aborted) return resolve(undefined);
       timeoutSignal.addEventListener('abort', () => resolve(undefined));
     });

--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -1,5 +1,5 @@
 import { WebSocketProvider, Log, toQuantity, isError } from 'ethers';
-import type { Filter, TransactionResponse } from 'ethers';
+import type { Filter, TransactionReceipt, TransactionResponse } from 'ethers';
 import type { Address as EvmAddress } from 'viem';
 import type { CaipChainId } from '@agoric/orchestration';
 import { getBlockTimeMs } from './support.ts';
@@ -73,10 +73,6 @@ export const makeEvmRpc = (
       () => provider.getTransactionReceipt(txHash),
       setTimeout,
     ),
-  waitForTransaction: (
-    ...args: Parameters<WebSocketProvider['waitForTransaction']>
-  ) =>
-    withRateLimitRetry(() => provider.waitForTransaction(...args), setTimeout),
   send: (...args: Parameters<WebSocketProvider['send']>) =>
     withRateLimitRetry(() => provider.send(...args), setTimeout),
   // Subscription pass-throughs (no retry needed)
@@ -547,4 +543,69 @@ export const waitForBlock = async (provider: EvmRpc, targetBlock: number) => {
     };
     void provider.on('block', listener);
   });
+};
+
+export const DEFAULT_CONFIRMATION_POLL_INTERVAL_MS = 5_000;
+
+export type WaitForConfirmationsOpts = {
+  provider: EvmRpc;
+  txHash: string;
+  confirmations: number;
+  pollIntervalMs?: number;
+  signal?: AbortSignal;
+  setTimeout?: typeof globalThis.setTimeout;
+  log?: (...args: unknown[]) => void;
+};
+
+const sleepRespectingAbort = (
+  ms: number,
+  setTimeout: typeof globalThis.setTimeout,
+  signal?: AbortSignal,
+): Promise<void> =>
+  new Promise(resolve => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      resolve();
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+
+export const waitForConfirmations = async ({
+  provider,
+  txHash,
+  confirmations,
+  pollIntervalMs = DEFAULT_CONFIRMATION_POLL_INTERVAL_MS,
+  signal,
+  setTimeout = globalThis.setTimeout,
+  log = () => {},
+}: WaitForConfirmationsOpts): Promise<TransactionReceipt | null> => {
+  await null;
+  let everSeenReceipt = false;
+  while (true) {
+    if (signal?.aborted) return null;
+
+    const receipt = await provider.getTransactionReceipt(txHash);
+    if (receipt) {
+      everSeenReceipt = true;
+      const currentBlock = await provider.getBlockNumber();
+      const observed = currentBlock - receipt.blockNumber + 1;
+      if (observed >= confirmations) return receipt;
+      log(
+        `Waiting for confirmations: txHash=${txHash} observed=${observed}/${confirmations} currentBlock=${currentBlock} receiptBlock=${receipt.blockNumber}`,
+      );
+    } else if (everSeenReceipt) {
+      log(`Transaction ${txHash} receipt disappeared - likely reorged out`);
+      return null;
+    }
+
+    await sleepRespectingAbort(pollIntervalMs, setTimeout, signal);
+  }
 };

--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -550,7 +550,7 @@ export const DEFAULT_CONFIRMATION_POLL_INTERVAL_MS = 5_000;
 export type WaitForConfirmationsOpts = {
   provider: EvmRpc;
   txHash: string;
-  confirmations: number;
+  minConfirmations: number;
   pollIntervalMs?: number;
   signal?: AbortSignal;
   setTimeout?: typeof globalThis.setTimeout;
@@ -581,7 +581,7 @@ const sleepRespectingAbort = (
 export const waitForConfirmations = async ({
   provider,
   txHash,
-  confirmations,
+  minConfirmations,
   pollIntervalMs = DEFAULT_CONFIRMATION_POLL_INTERVAL_MS,
   signal,
   setTimeout = globalThis.setTimeout,
@@ -596,10 +596,10 @@ export const waitForConfirmations = async ({
     if (receipt) {
       everSeenReceipt = true;
       const currentBlock = await provider.getBlockNumber();
-      const observed = currentBlock - receipt.blockNumber + 1;
-      if (observed >= confirmations) return receipt;
+      const confirmationCount = currentBlock - receipt.blockNumber + 1;
+      if (confirmationCount >= minConfirmations) return receipt;
       log(
-        `Waiting for confirmations: txHash=${txHash} observed=${observed}/${confirmations} currentBlock=${currentBlock} receiptBlock=${receipt.blockNumber}`,
+        `Waiting for more confirmations: txHash=${txHash} observed=${confirmationCount} of ${minConfirmations} currentBlock=${currentBlock} receiptBlock=${receipt.blockNumber}`,
       );
     } else if (everSeenReceipt) {
       log(`Transaction ${txHash} receipt disappeared - likely reorged out`);

--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -2,7 +2,7 @@ import { WebSocketProvider, Log, toQuantity, isError } from 'ethers';
 import type { Filter, TransactionReceipt, TransactionResponse } from 'ethers';
 import type { Address as EvmAddress } from 'viem';
 import type { CaipChainId } from '@agoric/orchestration';
-import { getBlockTimeMs } from './support.ts';
+import { getBlockTimeMs, prepareAbortController } from './support.ts';
 
 export type WatcherTimeoutOptions = {
   timeoutMs?: number;
@@ -557,27 +557,6 @@ export type WaitForConfirmationsOpts = {
   log?: (...args: unknown[]) => void;
 };
 
-const sleepRespectingAbort = (
-  ms: number,
-  setTimeout: typeof globalThis.setTimeout,
-  signal?: AbortSignal,
-): Promise<void> =>
-  new Promise(resolve => {
-    if (signal?.aborted) {
-      resolve();
-      return;
-    }
-    const timeoutId = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
-    const onAbort = () => {
-      clearTimeout(timeoutId);
-      resolve();
-    };
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
-
 export const waitForConfirmations = async ({
   provider,
   txHash,
@@ -587,6 +566,8 @@ export const waitForConfirmations = async ({
   setTimeout = globalThis.setTimeout,
   log = () => {},
 }: WaitForConfirmationsOpts): Promise<TransactionReceipt | null> => {
+  const makeAbortController = prepareAbortController({ setTimeout });
+  const racingSignals = signal ? [signal] : undefined;
   await null;
   let everSeenReceipt = false;
   while (true) {
@@ -606,6 +587,13 @@ export const waitForConfirmations = async ({
       return null;
     }
 
-    await sleepRespectingAbort(pollIntervalMs, setTimeout, signal);
+    await new Promise(resolve => {
+      const timeoutSignal = makeAbortController(
+        pollIntervalMs,
+        racingSignals,
+      ).signal;
+      if (timeoutSignal.aborted) return resolve(undefined);
+      timeoutSignal.addEventListener('abort', () => resolve(undefined));
+    });
   }
 };

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -234,16 +234,14 @@ export const watchGmp = ({
          * from our own wallet. Spurious executions from unauthorized parties are already
          * filtered out by the sourceAddress check above.
          */
-        const result = await handleTxRevert(
+        const result = await handleTxRevert({
           receipt,
           txHash,
-          `txId=${txId}`,
+          identifier: `txId=${txId}`,
           chainId,
-          provider,
-          log,
-          setTimeout,
           signal,
-        );
+          powers: { provider, log, setTimeout },
+        });
         if (result) {
           return finish(result);
         }
@@ -403,16 +401,14 @@ export const lookBackGmp = async ({
       log(`Found matching failed transaction`);
       const receipt = await provider.getTransactionReceipt(failedTx.hash);
       if (receipt) {
-        const result = await handleTxRevert(
+        const result = await handleTxRevert({
           receipt,
-          failedTx.hash,
-          `txId=${txId}`,
+          txHash: failedTx.hash,
+          identifier: `txId=${txId}`,
           chainId,
-          provider,
-          log,
-          setTimeout,
-          sharedSignal,
-        );
+          signal: sharedSignal,
+          powers: { provider, log, setTimeout },
+        });
         if (result) {
           deleteTxBlockLowerBound(kvStore, txId, MULTICALL_STATUS_EVENT);
           deleteTxBlockLowerBound(kvStore, txId, FAILED_TX_SCOPE);

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -241,6 +241,8 @@ export const watchGmp = ({
           chainId,
           provider,
           log,
+          setTimeout,
+          signal,
         );
         if (result) {
           return finish(result);
@@ -408,6 +410,8 @@ export const lookBackGmp = async ({
           chainId,
           provider,
           log,
+          setTimeout,
+          sharedSignal,
         );
         if (result) {
           deleteTxBlockLowerBound(kvStore, txId, MULTICALL_STATUS_EVENT);

--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -318,21 +318,19 @@ export const watchOperationResult = ({
           }
 
           // Event-level failure: wait for confirmations before declaring failure
-          const filter: Filter = {
+          const logFilter: Filter = {
             address: routerAddress,
             topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
           };
-          const result = await handleOperationFailure(
-            operationResultLog,
-            filter,
-            parseOperationResultLog,
-            `expectedId=${txId}`,
+          const result = await handleOperationFailure({
+            eventLog: operationResultLog,
+            logFilter,
+            parseEvent: parseOperationResultLog,
+            identifier: `expectedId=${txId}`,
             chainId,
-            provider,
-            log,
-            setTimeout,
             signal,
-          );
+            powers: { provider, log, setTimeout },
+          });
 
           if (result) {
             return finish(result);
@@ -489,17 +487,15 @@ export const lookBackOperationResult = async ({
       }
 
       // Failure case: wait for confirmations before declaring failure
-      const result = await handleOperationFailure(
-        matchingEvent,
-        baseFilter,
-        parseOperationResultLog,
-        `txId=${txId}`,
+      const result = await handleOperationFailure({
+        eventLog: matchingEvent,
+        logFilter: baseFilter,
+        parseEvent: parseOperationResultLog,
+        identifier: `txId=${txId}`,
         chainId,
-        provider,
-        log,
-        setTimeout,
-        sharedSignal,
-      );
+        signal: sharedSignal,
+        powers: { provider, log, setTimeout },
+      });
       deleteTxBlockLowerBound(kvStore, txId);
       deleteTxBlockLowerBound(kvStore, txId, FAILED_TX_SCOPE);
 

--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -341,16 +341,14 @@ export const watchOperationResult = ({
         }
 
         // No OperationResult event — check for transaction revert
-        const result = await handleTxRevert(
+        const result = await handleTxRevert({
           receipt,
           txHash,
-          `txId=${txId}`,
+          identifier: `txId=${txId}`,
           chainId,
-          provider,
-          log,
-          setTimeout,
           signal,
-        );
+          powers: { provider, log, setTimeout },
+        });
         if (result) {
           return finish(result);
         }
@@ -528,16 +526,14 @@ export const lookBackOperationResult = async ({
       log(`Found matching failed transaction`);
       const receipt = await provider.getTransactionReceipt(failedTx.hash);
       if (receipt) {
-        const result = await handleTxRevert(
+        const result = await handleTxRevert({
           receipt,
-          failedTx.hash,
-          `txId=${txId}`,
+          txHash: failedTx.hash,
+          identifier: `txId=${txId}`,
           chainId,
-          provider,
-          log,
-          setTimeout,
-          sharedSignal,
-        );
+          signal: sharedSignal,
+          powers: { provider, log, setTimeout },
+        });
         if (result) {
           deleteTxBlockLowerBound(kvStore, txId);
           deleteTxBlockLowerBound(kvStore, txId, FAILED_TX_SCOPE);

--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -330,6 +330,8 @@ export const watchOperationResult = ({
             chainId,
             provider,
             log,
+            setTimeout,
+            signal,
           );
 
           if (result) {
@@ -346,6 +348,8 @@ export const watchOperationResult = ({
           chainId,
           provider,
           log,
+          setTimeout,
+          signal,
         );
         if (result) {
           return finish(result);
@@ -495,6 +499,8 @@ export const lookBackOperationResult = async ({
         chainId,
         provider,
         log,
+        setTimeout,
+        sharedSignal,
       );
       deleteTxBlockLowerBound(kvStore, txId);
       deleteTxBlockLowerBound(kvStore, txId, FAILED_TX_SCOPE);
@@ -529,6 +535,8 @@ export const lookBackOperationResult = async ({
           chainId,
           provider,
           log,
+          setTimeout,
+          sharedSignal,
         );
         if (result) {
           deleteTxBlockLowerBound(kvStore, txId);

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -303,6 +303,8 @@ export const watchSmartWalletTx = ({
           chainId,
           provider,
           log,
+          setTimeout,
+          signal,
         );
         if (result) {
           return finish(result);
@@ -490,6 +492,8 @@ export const lookBackSmartWalletTx = async ({
           chainId,
           provider,
           log,
+          setTimeout,
+          sharedSignal,
         );
         if (result) {
           deleteTxBlockLowerBound(kvStore, txId);

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -296,16 +296,14 @@ export const watchSmartWalletTx = ({
           return finish({ settled: true, txHash, success: true });
         }
 
-        const result = await handleTxRevert(
+        const result = await handleTxRevert({
           receipt,
           txHash,
-          `expectedAddr=${expectedAddr}`,
+          identifier: `expectedAddr=${expectedAddr}`,
           chainId,
-          provider,
-          log,
-          setTimeout,
           signal,
-        );
+          powers: { provider, log, setTimeout },
+        });
         if (result) {
           return finish(result);
         }
@@ -485,16 +483,14 @@ export const lookBackSmartWalletTx = async ({
       log(`Found matching failed transaction`);
       const receipt = await provider.getTransactionReceipt(failedTx.hash);
       if (receipt) {
-        const result = await handleTxRevert(
+        const result = await handleTxRevert({
           receipt,
-          failedTx.hash,
-          `expectedAddr=${expectedAddr}`,
+          txHash: failedTx.hash,
+          identifier: `expectedAddr=${expectedAddr}`,
           chainId,
-          provider,
-          log,
-          setTimeout,
-          sharedSignal,
-        );
+          signal: sharedSignal,
+          powers: { provider, log, setTimeout },
+        });
         if (result) {
           deleteTxBlockLowerBound(kvStore, txId);
           deleteTxBlockLowerBound(kvStore, txId, FAILED_TX_SCOPE);

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -276,7 +276,7 @@ const waitForFinalConfirmations = async (
   const receipt = await waitForConfirmations({
     provider,
     txHash,
-    confirmations,
+    minConfirmations: confirmations,
     setTimeout,
     signal,
     log,

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -6,6 +6,7 @@ import { decodeAbiParameters } from 'viem';
 import type { EvmRpc } from '../evm-scanner.ts';
 import { waitForConfirmations } from '../evm-scanner.ts';
 import {
+  getBlockTimeMs,
   getConfirmationsRequired,
   getRevertConfirmationsRequired,
 } from '../support.ts';
@@ -268,6 +269,7 @@ export const fetchReceiptWithRetry = async (
 const waitForFinalConfirmations = async (
   txHash: string,
   confirmations: number,
+  chainId: CaipChainId,
   provider: EvmRpc,
   log: (...args: unknown[]) => void,
   setTimeout: typeof globalThis.setTimeout = globalThis.setTimeout,
@@ -277,6 +279,7 @@ const waitForFinalConfirmations = async (
     provider,
     txHash,
     minConfirmations: confirmations,
+    meanBlockTimeMs: getBlockTimeMs(chainId),
     setTimeout,
     signal,
     log,
@@ -332,6 +335,7 @@ export const handleTxRevert = async ({
   const confirmedReceipt = await waitForFinalConfirmations(
     txHash,
     confirmations,
+    chainId,
     provider,
     log,
     setTimeout,
@@ -397,6 +401,7 @@ export const handleOperationFailure = async <T extends { success: boolean }>({
   const confirmedReceipt = await waitForFinalConfirmations(
     txHash,
     confirmations,
+    chainId,
     provider,
     log,
     setTimeout,

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -4,6 +4,7 @@ import type { CaipChainId } from '@agoric/orchestration';
 import { depositFactoryCreateAndDepositInputs } from '@aglocal/portfolio-contract/src/utils/evm-orch-factory.ts';
 import { decodeAbiParameters } from 'viem';
 import type { EvmRpc } from '../evm-scanner.ts';
+import { waitForConfirmations } from '../evm-scanner.ts';
 import {
   getConfirmationsRequired,
   getRevertConfirmationsRequired,
@@ -269,8 +270,17 @@ const waitForFinalConfirmations = async (
   confirmations: number,
   provider: EvmRpc,
   log: (...args: unknown[]) => void,
+  setTimeout: typeof globalThis.setTimeout = globalThis.setTimeout,
+  signal?: AbortSignal,
 ): Promise<TransactionReceipt | null> => {
-  const receipt = await provider.waitForTransaction(txHash, confirmations);
+  const receipt = await waitForConfirmations({
+    provider,
+    txHash,
+    confirmations,
+    setTimeout,
+    signal,
+    log,
+  });
   if (!receipt) {
     log(
       `Transaction ${txHash} not confirmed after waiting for ${confirmations} confirmations (possibly reorged out)`,
@@ -302,6 +312,8 @@ export const handleTxRevert = async (
   chainId: `${string}:${string}`,
   provider: EvmRpc,
   log: (...args: unknown[]) => void,
+  setTimeout: typeof globalThis.setTimeout = globalThis.setTimeout,
+  signal?: AbortSignal,
 ): Promise<{ settled: true; txHash: string; success: boolean } | null> => {
   await null;
   // TODO(https://github.com/Agoric/agoric-private/issues/783): also wait for confirmations on success cases — a reorg can flip
@@ -314,6 +326,8 @@ export const handleTxRevert = async (
     confirmations,
     provider,
     log,
+    setTimeout,
+    signal,
   );
   if (!confirmedReceipt) return null;
 
@@ -357,6 +371,8 @@ export const handleOperationFailure = async <T extends { success: boolean }>(
   chainId: CaipChainId,
   provider: EvmRpc,
   log: (...args: unknown[]) => void,
+  setTimeout: typeof globalThis.setTimeout = globalThis.setTimeout,
+  signal?: AbortSignal,
 ): Promise<{ settled: true; txHash: string; success: boolean } | null> => {
   const txHash = eventLog.transactionHash;
 
@@ -366,6 +382,8 @@ export const handleOperationFailure = async <T extends { success: boolean }>(
     confirmations,
     provider,
     log,
+    setTimeout,
+    signal,
   );
   if (!confirmedReceipt) return null;
 

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -354,6 +354,22 @@ export const handleTxRevert = async ({
   }
 };
 
+export type HandleOperationFailureOpts<T extends { success: boolean }> = {
+  eventLog: Log;
+  /** Filter to re-fetch the event after confirmations. */
+  logFilter: Filter;
+  parseEvent: (log: Log) => T;
+  /** A string identifier for logging. */
+  identifier: string;
+  chainId: CaipChainId;
+  signal?: AbortSignal;
+  powers: {
+    provider: EvmRpc;
+    log: (...args: unknown[]) => void;
+    setTimeout?: typeof globalThis.setTimeout;
+  };
+};
+
 /**
  * Handle event-level failure with finality protection.
  *
@@ -361,27 +377,20 @@ export const handleTxRevert = async ({
  * business logic failed (e.g., OperationResult event with success=false).
  * We wait for confirmations and re-verify the event to ensure the failure
  * is permanent before reporting it.
- *
- * @param eventLog - The event log containing the failure
- * @param filter - Filter to re-fetch the event after confirmations
- * @param parseEvent - Function to parse the event and return its success status
- * @param identifier - A string identifier for logging
- * @param chainId - Chain ID to determine confirmation requirements
- * @param provider - WebSocket provider for waiting for confirmations
- * @param log - Logging function
- * @returns Object with settled flag, success status, and transaction hash, or null if reorged
  */
-export const handleOperationFailure = async <T extends { success: boolean }>(
-  eventLog: Log,
-  filter: Filter,
-  parseEvent: (log: Log) => T,
-  identifier: string,
-  chainId: CaipChainId,
-  provider: EvmRpc,
-  log: (...args: unknown[]) => void,
-  setTimeout: typeof globalThis.setTimeout = globalThis.setTimeout,
-  signal?: AbortSignal,
-): Promise<{ settled: true; txHash: string; success: boolean } | null> => {
+export const handleOperationFailure = async <T extends { success: boolean }>({
+  eventLog,
+  logFilter,
+  parseEvent,
+  identifier,
+  chainId,
+  signal,
+  powers: { provider, log, setTimeout = globalThis.setTimeout },
+}: HandleOperationFailureOpts<T>): Promise<{
+  settled: true;
+  txHash: string;
+  success: boolean;
+} | null> => {
   const txHash = eventLog.transactionHash;
 
   const confirmations = getConfirmationsRequired(chainId);
@@ -399,7 +408,7 @@ export const handleOperationFailure = async <T extends { success: boolean }>(
 
   // Fetch logs to verify the failure is still present
   const logsInBlock = await provider.getLogs({
-    ...filter,
+    ...logFilter,
     fromBlock: finalBlock,
     toBlock: finalBlock,
   });

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -289,6 +289,20 @@ const waitForFinalConfirmations = async (
   return receipt;
 };
 
+export type HandleTxRevertOpts = {
+  receipt: TransactionReceipt;
+  txHash: string;
+  /** A string identifier for logging (e.g., "txId=tx1" or "expectedAddr=0x123"). */
+  identifier: string;
+  chainId: `${string}:${string}`;
+  signal?: AbortSignal;
+  powers: {
+    provider: EvmRpc;
+    log: (...args: unknown[]) => void;
+    setTimeout?: typeof globalThis.setTimeout;
+  };
+};
+
 /**
  * Handle receipt status for a transaction that has been validated as matching
  * the watcher's criteria. Returns the result to report to the caller.
@@ -296,25 +310,19 @@ const waitForFinalConfirmations = async (
  * This implements the finality protection pattern:
  * - Success (status 1): Return immediately without confirmations
  * - Failure (status 0): Wait for confirmations to ensure failure is permanent
- *
- * @param receipt - The transaction receipt to handle
- * @param txHash - Transaction hash for logging
- * @param identifier - A string identifier for logging (e.g., "txId=tx1" or "expectedAddr=0x123")
- * @param chainId - Chain ID to determine confirmation requirements
- * @param provider - EVM RPC provider for waiting for confirmations
- * @param log - Logging function
- * @returns Object with settled flag, success status, and transaction hash
  */
-export const handleTxRevert = async (
-  receipt: TransactionReceipt,
-  txHash: string,
-  identifier: string,
-  chainId: `${string}:${string}`,
-  provider: EvmRpc,
-  log: (...args: unknown[]) => void,
-  setTimeout: typeof globalThis.setTimeout = globalThis.setTimeout,
-  signal?: AbortSignal,
-): Promise<{ settled: true; txHash: string; success: boolean } | null> => {
+export const handleTxRevert = async ({
+  receipt,
+  txHash,
+  identifier,
+  chainId,
+  signal,
+  powers: { provider, log, setTimeout = globalThis.setTimeout },
+}: HandleTxRevertOpts): Promise<{
+  settled: true;
+  txHash: string;
+  success: boolean;
+} | null> => {
   await null;
   // TODO(https://github.com/Agoric/agoric-private/issues/783): also wait for confirmations on success cases — a reorg can flip
   // success → failure just as it can flip failure → success.

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -186,6 +186,10 @@ test('handlePendingTx detects legitimate failure from ContractCallFailed revert'
       return null;
     };
 
+    // waitForConfirmations polls getBlockNumber; return a block ≥ receipt +
+    // revert confirmations (up to ~2000 on Arbitrum; 5000 is a safe buffer).
+    provider.getBlockNumber = async () => 18500000 + 5000;
+
     // Set up provider.call to throw ContractCallFailed error
     provider.call = async () => {
       const error: any = new Error('execution reverted');

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -335,27 +335,6 @@ export const createMockProvider = (
 
       throw Error(`Unrecognized function selector in mock call: ${selector}`);
     },
-    async waitForTransaction(
-      this: any,
-      txHash: string,
-      confirmations?: number,
-      _timeout?: number,
-    ) {
-      // Get receipt - use getTransactionReceipt to respect test overrides
-      const receipt = await this.getTransactionReceipt(txHash);
-
-      if (!receipt) return null;
-
-      // Simulate waiting for confirmations by advancing blocks
-      if (confirmations && confirmations > 1) {
-        for (let i = 1; i < confirmations; i++) {
-          await new Promise(resolve => setTimeout(resolve, 1));
-          currentBlock += 1;
-        }
-      }
-
-      return receipt;
-    },
   };
 
   return mockProvider as unknown as WebSocketProvider;

--- a/services/ymax-planner/test/operation-watcher.test.ts
+++ b/services/ymax-planner/test/operation-watcher.test.ts
@@ -254,13 +254,9 @@ test('watchOperationResult detects failed OperationResult event with finality pr
   // Re-fetch logs for finality check (handleOperationFailure)
   (provider as any).getLogs = async () => [mockLog];
 
-  // Override waitForTransaction for finality check
-  (provider as any).waitForTransaction = async () => ({
-    status: 1,
-    blockNumber,
-    blockHash: '0xblockhash',
-    transactionHash: txHash,
-  });
+  // waitForConfirmations polls getBlockNumber; return a block ≥ receipt +
+  // revert confirmations (up to ~2000 on Arbitrum).
+  (provider as any).getBlockNumber = async () => blockNumber + 5000;
 
   // Emit Alchemy mined-tx message after a short delay
   setTimeout(() => {
@@ -375,22 +371,20 @@ test('lookBackOperationResult finds failed OperationResult event with finality p
   );
 
   const provider = createMockProvider(latestBlock, [mockLog]);
-  (provider as any).getLogs = async (args: any) => {
-    if (
-      args.fromBlock <= blockNumber &&
-      (args.toBlock === undefined || args.toBlock >= blockNumber)
-    ) {
-      return [mockLog];
-    }
-    return [];
-  };
+  (provider as any).getLogs = async () => [mockLog];
 
-  (provider as any).waitForTransaction = async () => ({
-    status: 1,
-    blockNumber,
-    blockHash: '0xblockhash',
-    transactionHash: txHash,
-  });
+  // waitForConfirmations polls getTransactionReceipt + getBlockNumber;
+  // provide both with the failed-receipt data.
+  (provider as any).getTransactionReceipt = async (hash: string) => {
+    if (hash !== txHash) return null;
+    return {
+      status: 1,
+      blockNumber,
+      blockHash: '0xblockhash',
+      transactionHash: txHash,
+    };
+  };
+  (provider as any).getBlockNumber = async () => blockNumber + 5000;
 
   const logMessages: string[] = [];
   const logger = (...args: any[]) => logMessages.push(args.join(' '));
@@ -475,13 +469,7 @@ test('lookBackOperationResult phase 2 detects reverted tx via padded txId', asyn
     return null;
   };
 
-  // waitForTransaction for finality check
-  (provider as any).waitForTransaction = async () => ({
-    status: 0,
-    blockNumber: latestBlock,
-    blockHash: '0xblockhash',
-    transactionHash: revertTxHash,
-  });
+  (provider as any).getBlockNumber = async () => latestBlock + 5000;
 
   const logMessages: string[] = [];
   const logger = (...args: any[]) => logMessages.push(args.join(' '));
@@ -536,13 +524,7 @@ test('watchOperationResult detects revert via Alchemy subscription (live mode)',
     return null;
   };
 
-  // waitForTransaction for finality check
-  (provider as any).waitForTransaction = async () => ({
-    status: 0,
-    blockNumber,
-    blockHash: '0xblockhash',
-    transactionHash: revertTxHash,
-  });
+  (provider as any).getBlockNumber = async () => blockNumber + 5000;
 
   const logMessages: string[] = [];
   const logger = (...args: any[]) => logMessages.push(args.join(' '));

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -795,6 +795,7 @@ const FAILED_TX_SOURCE =
   'cosmos:agoric-3:agoric18d47rcfj0g4r7j7yvypm44kqczl4jrft6up233p9zv95p8ut49mqufghzh';
 const FAILED_TX_TIME_MS = 1700000000; // 2023-11-14T22:13:20Z
 const FAILED_TX_LATEST_BLOCK = 1_450_031;
+const BLOCK_NUMBER_BUFFER = 5000;
 
 /** Hex-encode an ASCII string (e.g. 'tx553' → '7478353533'). */
 const asciiToHex = (s: string) =>
@@ -855,7 +856,11 @@ const makeFailedTxTestContext = ({
   const opts = createMockPendingTxOpts();
   const mockProvider = opts.evmProviders[chainId] as any;
 
-  mockProvider.getBlockNumber = async () => FAILED_TX_LATEST_BLOCK;
+  // Bumped above receipt.blockNumber so the polling waitForConfirmations
+  // helper observes enough confirmations on any chain (Arbitrum needs ~2000;
+  // 5000 is a safe buffer).
+  mockProvider.getBlockNumber = async () =>
+    FAILED_TX_LATEST_BLOCK + BLOCK_NUMBER_BUFFER;
   mockProvider.getBlock = async (blockNumber: number) => {
     const blocksAgo = FAILED_TX_LATEST_BLOCK - blockNumber;
     const ts = FAILED_TX_TIME_MS - blocksAgo * avgBlockTimeMs;
@@ -872,7 +877,9 @@ const makeFailedTxTestContext = ({
         // Emit the correct block number so waitForBlock resolves deterministically
         on: (evt: any, listener: Function) => {
           if (evt === 'block') {
-            queueMicrotask(() => listener(FAILED_TX_LATEST_BLOCK + 1));
+            queueMicrotask(() =>
+              listener(FAILED_TX_LATEST_BLOCK + BLOCK_NUMBER_BUFFER + 1),
+            );
           }
         },
         getTransactionReceipt: async () => ({

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -301,7 +301,8 @@ test('find a failed tx in MAKE_ACCOUNT lookback mode via trace_filter', async t 
   const avgBlockTimeMs = 2500;
 
   const latestBlock = 1_450_031;
-  mockProvider.getBlockNumber = async () => latestBlock;
+  const blockNumberBuffer = 5000;
+  mockProvider.getBlockNumber = async () => latestBlock + blockNumberBuffer;
 
   mockProvider.getBlock = async (blockNumber: number) => {
     const blocksAgo = latestBlock - blockNumber;
@@ -320,7 +321,9 @@ test('find a failed tx in MAKE_ACCOUNT lookback mode via trace_filter', async t 
         // Emit the correct block number so waitForBlock resolves deterministically
         on: (event: any, listener: Function) => {
           if (event === 'block') {
-            queueMicrotask(() => listener(latestBlock + 1));
+            queueMicrotask(() =>
+              listener(latestBlock + blockNumberBuffer + 1),
+            );
           }
         },
         // trace_filter uses provider.send()

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -321,9 +321,7 @@ test('find a failed tx in MAKE_ACCOUNT lookback mode via trace_filter', async t 
         // Emit the correct block number so waitForBlock resolves deterministically
         on: (event: any, listener: Function) => {
           if (event === 'block') {
-            queueMicrotask(() =>
-              listener(latestBlock + blockNumberBuffer + 1),
-            );
+            queueMicrotask(() => listener(latestBlock + blockNumberBuffer + 1));
           }
         },
         // trace_filter uses provider.send()


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://linear.app/agoric/issue/AGO-500/ymax-resolver-investigate-alchemy-websocket-spike-on-april-19th

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Replace `provider.waitForTransaction(txHash, confirmations)` in the revert finality path with a new `waitForConfirmations` helper that polls `eth_getTransactionReceipt` + `eth_blockNumber`. `ethers` implements `waitForTransaction` over a `newHeads` subscription held open for the full wait (~40 CU per block event delivered); on Arbitrum (~300 ms blocks) a 10-minute revert wait receives ~2000 events ≈ 120K CU per revert. Polling is chain-independent at ~3.6K CU for the same wait.


### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment on ymax0 and ymax1.