### PR TITLE
chore(ymax-planner): Replace use of the ambient `Date.now`

### DIFF
--- a/services/ymax-planner/scripts/process-tx-lib.ts
+++ b/services/ymax-planner/scripts/process-tx-lib.ts
@@ -52,7 +52,7 @@ export const processTx = async (
     env = process.env,
     fetch = globalThis.fetch,
     generateInterval = timersPromises.setInterval,
-    _now = Date.now,
+    now = globalThis.performance.now.bind(globalThis.performance),
     setTimeout = globalThis.setTimeout,
     connectWithSigner = SigningStargateClient.connectWithSigner,
     AbortController = globalThis.AbortController,
@@ -60,7 +60,6 @@ export const processTx = async (
     WebSocket = ws.WebSocket,
   } = {},
 ) => {
-  void _now;
   console.log(`\n🔍 Resolving transaction: ${txId}\n`);
 
   const maybeOpts = cliArgs;
@@ -184,7 +183,7 @@ export const processTx = async (
         retryProviders,
         fetch,
         setTimeout,
-        now: Date.now,
+        now,
         kvStore,
         makeAbortController,
         log: (...args) => console.log('[TX]', ...args),

--- a/services/ymax-planner/scripts/process-tx-lib.ts
+++ b/services/ymax-planner/scripts/process-tx-lib.ts
@@ -33,6 +33,7 @@ import type { SimplePowers } from '../src/main.ts';
 import { makeSQLiteKeyValueStore } from '../src/kv-store.ts';
 import type { HandlePendingTxOpts } from '../src/pending-tx-manager.ts';
 import { handlePendingTx } from '../src/pending-tx-manager.ts';
+import { makeNowISO } from '../src/utils.ts';
 import {
   parseStreamCell,
   parseStreamCellValue,
@@ -55,6 +56,8 @@ export const processTx = async (
     now = globalThis.performance.now.bind(globalThis.performance),
     setTimeout = globalThis.setTimeout,
     connectWithSigner = SigningStargateClient.connectWithSigner,
+    // Default to the wall clock for debugging sent transactions.
+    makeNonce = makeNowISO(Date.now),
     AbortController = globalThis.AbortController,
     AbortSignal = globalThis.AbortSignal,
     WebSocket = ws.WebSocket,
@@ -190,6 +193,7 @@ export const processTx = async (
         error: (...args) => console.error('[ERROR]', ...args),
         marshaller,
         signingSmartWalletKit,
+        makeNonce,
         vstoragePathPrefixes,
         axelarApiUrl: config.axelar.apiUrl,
         pendingTxAbortControllers: new Map(),

--- a/services/ymax-planner/scripts/resolve-tx-lib.ts
+++ b/services/ymax-planner/scripts/resolve-tx-lib.ts
@@ -17,6 +17,7 @@ import { loadConfig } from '../src/config.ts';
 import { prepareAbortController } from '../src/support.ts';
 import type { SimplePowers } from '../src/main.ts';
 import { resolvePendingTx } from '../src/resolver.ts';
+import { makeNowISO } from '../src/utils.ts';
 
 const parseStatus = (statusArg: string): Omit<TxStatus, 'pending'> => {
   const normalized = statusArg.toLowerCase();
@@ -39,6 +40,8 @@ export const resolveTx = async (
     fetch = globalThis.fetch,
     setTimeout = globalThis.setTimeout,
     connectWithSigner = SigningStargateClient.connectWithSigner,
+    // Default to the wall clock for debugging sent transactions.
+    makeNonce = makeNowISO(Date.now),
     AbortController = globalThis.AbortController,
     AbortSignal = globalThis.AbortSignal,
   } = {},
@@ -85,6 +88,7 @@ export const resolveTx = async (
 
   await resolvePendingTx({
     signingSmartWalletKit,
+    makeNonce,
     txId,
     status,
     ...(status === TxStatus.FAILED ? { rejectionReason: reason } : {}),

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -172,7 +172,8 @@ export const makeVstorageEvent = (
 
 export type Powers = {
   console?: Pick<Console, 'debug' | 'info' | 'log' | 'warn' | 'error'>;
-  evmCtx: Omit<EvmContext, 'signingSmartWalletKit' | 'fetch'>;
+  // TODO(AGO-512): Derive EvmContext from Powers rather than embedding it.
+  evmCtx: Omit<EvmContext, 'signingSmartWalletKit' | 'makeNonce' | 'fetch'>;
   rpc: CosmosRPCClient;
   setTimeout: typeof globalThis.setTimeout;
   spectrumBlockchain: SpectrumBlockchainSdk;
@@ -180,6 +181,8 @@ export type Powers = {
   evmTokenAddresses: Partial<Record<InstrumentId, EvmAddress>>;
   network: NetworkSpec;
   signingSmartWalletKit: SigningSmartWalletKit;
+  /** Used to generate unique suffixes in agoric Smart Wallet OfferSpec ids. */
+  makeNonce: () => string;
   walletStore: ReturnType<typeof reflectWalletStore>;
   getWalletInvocationUpdate: (
     messageId: string | number,
@@ -687,6 +690,7 @@ export const startEngine = async (
     evmCtx,
     rpc,
     signingSmartWalletKit,
+    makeNonce,
   } = powers;
   const vstoragePathPrefixes = makeVstoragePathPrefixes(contractInstance);
   const { portfoliosPathPrefix, pendingTxPathPrefix } = vstoragePathPrefixes;
@@ -798,6 +802,7 @@ export const startEngine = async (
     error: console.error.bind(console),
     marshaller,
     signingSmartWalletKit,
+    makeNonce,
     vstoragePathPrefixes,
     pendingTxAbortControllers,
   });

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -185,7 +185,8 @@ export type Powers = {
     messageId: string | number,
     retryOpts?: RetryOptionsAndPowers,
   ) => ReturnType<typeof getInvocationUpdate>;
-  now: typeof Date.now;
+  /** Prefer monotonicity (e.g., `performance.now` rather than `Date.now`). */
+  now: () => number;
   gasEstimator: GasEstimator;
   usdcTokensByChain: Partial<Record<SupportedChain, string>>;
   chainNameToChainIdMap: Partial<Record<EvmChain, CaipChainId>>;

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -51,8 +51,8 @@ import { makeGasEstimator } from './gas-estimation.ts';
 import { makeSQLiteKeyValueStore } from './kv-store.ts';
 import { YdsNotifier } from './yds-notifier.ts';
 import { getPoolTokenAddresses } from './evm-utils.ts';
+import { makeNowISO } from './utils.ts';
 
-const { Date } = globalThis;
 const { fromEntries, entries } = Object;
 
 const assertChainId = async (
@@ -84,7 +84,7 @@ export type SimplePowers = {
 };
 
 /** `makeNonce` defaults to the wall clock for debugging sent transactions. */
-const defaultMakeNonce = () => new Date().toISOString();
+const defaultMakeNonce = makeNowISO(Date.now);
 
 export const main = async (
   cliArgs: string[],
@@ -306,6 +306,7 @@ export const main = async (
     spectrumBlockchain,
     network: PROD_NETWORK,
     signingSmartWalletKit,
+    makeNonce,
     walletStore,
     getWalletInvocationUpdate: (messageId, opts) => {
       const { getLastUpdate } = signingSmartWalletKit.query;

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -52,6 +52,7 @@ import { makeSQLiteKeyValueStore } from './kv-store.ts';
 import { YdsNotifier } from './yds-notifier.ts';
 import { getPoolTokenAddresses } from './evm-utils.ts';
 
+const { Date } = globalThis;
 const { fromEntries, entries } = Object;
 
 const assertChainId = async (
@@ -82,13 +83,17 @@ export type SimplePowers = {
   makeAbortController: MakeAbortController;
 };
 
+/** `makeNonce` defaults to the wall clock for debugging sent transactions. */
+const defaultMakeNonce = () => new Date().toISOString();
+
 export const main = async (
   cliArgs: string[],
   {
     env = process.env,
     fetch = globalThis.fetch,
     generateInterval = timersPromises.setInterval,
-    now = Date.now,
+    makeNonce = defaultMakeNonce,
+    now = globalThis.performance.now.bind(globalThis.performance),
     setTimeout = globalThis.setTimeout,
     connectWithSigner = SigningStargateClient.connectWithSigner,
     AbortController = globalThis.AbortController,
@@ -211,7 +216,7 @@ export const main = async (
   console.warn('Signer address:', signingSmartWalletKit.address);
   const walletStore = reflectWalletStore(signingSmartWalletKit, {
     setTimeout,
-    makeNonce: () => new Date(now()).toISOString(),
+    makeNonce,
     fee: {
       // As of 2025-11, a planner transaction consumes 160_000 to 185_000 gas
       // units, so 400_000 includes a fudge factor of over 2x.

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -52,6 +52,8 @@ export type EvmContext = {
   evmProviders: Record<CaipChainId, WebSocketProvider>;
   retryProviders: Record<CaipChainId, EvmRpc>;
   signingSmartWalletKit: SigningSmartWalletKit;
+  /** Used to generate unique suffixes in agoric Smart Wallet OfferSpec ids. */
+  makeNonce: () => string;
   fetch: typeof fetch;
   setTimeout: typeof globalThis.setTimeout;
   /** Prefer monotonicity (e.g., `performance.now` rather than `Date.now`). */
@@ -85,19 +87,16 @@ type LookBackWatchOpts = {
 };
 type WatchOpts = LiveWatchOpts | LookBackWatchOpts;
 
-export type PendingTxMonitor<
-  T extends PendingTx = PendingTx,
-  C = EvmContext,
-> = {
+export type PendingTxMonitor<T extends PendingTx = PendingTx> = {
   watch: (
-    ctx: C,
+    ctx: EvmContext,
     tx: T,
     log: (...args: unknown[]) => void,
     opts: WatchOpts,
   ) => Promise<void>;
 };
 
-const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
+const cctpMonitor: PendingTxMonitor<CctpTx> = {
   watch: async (ctx, tx, log, opts) => {
     await null;
 
@@ -204,6 +203,7 @@ const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
         () =>
           resolvePendingTx({
             signingSmartWalletKit: ctx.signingSmartWalletKit,
+            makeNonce: ctx.makeNonce,
             txId,
             status:
               transferResult.success !== false
@@ -228,7 +228,7 @@ const cctpMonitor: PendingTxMonitor<CctpTx, EvmContext> = {
   },
 };
 
-const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
+const gmpMonitor: PendingTxMonitor<GmpTx> = {
   watch: async (ctx, tx, log, opts) => {
     await null;
 
@@ -344,6 +344,7 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
         () =>
           resolvePendingTx({
             signingSmartWalletKit: ctx.signingSmartWalletKit,
+            makeNonce: ctx.makeNonce,
             txId,
             status:
               transferResult.success !== false
@@ -368,7 +369,7 @@ const gmpMonitor: PendingTxMonitor<GmpTx, EvmContext> = {
   },
 };
 
-const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
+const makeAccountMonitor: PendingTxMonitor<MakeAccountTx> = {
   watch: async (ctx, tx, log, opts) => {
     await null;
 
@@ -489,6 +490,7 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
         () =>
           resolvePendingTx({
             signingSmartWalletKit: ctx.signingSmartWalletKit,
+            makeNonce: ctx.makeNonce,
             txId,
             status:
               walletResult.success !== false
@@ -513,7 +515,7 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx, EvmContext> = {
   },
 };
 
-const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
+const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx> = {
   watch: async (ctx, tx, log, opts) => {
     await null;
 
@@ -620,6 +622,7 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx, EvmContext> = {
         () =>
           resolvePendingTx({
             signingSmartWalletKit: ctx.signingSmartWalletKit,
+            makeNonce: ctx.makeNonce,
             txId,
             status:
               transferResult.success !== false
@@ -651,10 +654,7 @@ const ibcFromAgoricMonitor: PendingTxMonitor = {
   },
 };
 
-const MONITORS = new Map<
-  TxType,
-  PendingTxMonitor<PendingTx, EvmContext> | null
->([
+const MONITORS = new Map<TxType, PendingTxMonitor<PendingTx> | null>([
   [TxType.CCTP_TO_EVM, cctpMonitor],
   [TxType.GMP, gmpMonitor],
   [TxType.ROUTED_GMP, routedGmpMonitor],
@@ -698,7 +698,7 @@ export const handlePendingTx = async (
     timeoutMs = TX_TIMEOUT_MS,
     txTimestampMs,
     signal,
-    ...evmCtx
+    ...watchCtx
   }: HandlePendingTxOpts,
 ) => {
   await null;
@@ -723,13 +723,13 @@ export const handlePendingTx = async (
   const watchOpts: Omit<WatchOpts, 'mode'> = { timeoutMs, signal };
   try {
     if (txTimestampMs) {
-      await monitor.watch(evmCtx, tx, log, {
+      await monitor.watch(watchCtx, tx, log, {
         mode: 'lookback',
         publishTimeMs: txTimestampMs,
         ...watchOpts,
       });
     } else {
-      await monitor.watch(evmCtx, tx, log, { mode: 'live', ...watchOpts });
+      await monitor.watch(watchCtx, tx, log, { mode: 'live', ...watchOpts });
     }
   } catch (err) {
     const mode = txTimestampMs ? 'with lookback' : 'in live mode';

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -54,6 +54,7 @@ export type EvmContext = {
   signingSmartWalletKit: SigningSmartWalletKit;
   fetch: typeof fetch;
   setTimeout: typeof globalThis.setTimeout;
+  /** Prefer monotonicity (e.g., `performance.now` rather than `Date.now`). */
   now: () => number;
   kvStore: KVStore;
   makeAbortController: MakeAbortController;

--- a/services/ymax-planner/src/resolver.ts
+++ b/services/ymax-planner/src/resolver.ts
@@ -8,6 +8,7 @@ import { readStreamCellValue } from './vstorage-utils.ts';
 
 type ResolveTxParams = {
   signingSmartWalletKit: SigningSmartWalletKit;
+  makeNonce: () => string;
   txId: TxId;
   status: Omit<TxStatus, 'pending'>;
   rejectionReason?: string;
@@ -50,6 +51,7 @@ const getInvitationMakers = async (wallet: SigningSmartWalletKit) => {
 
 export const resolvePendingTx = async ({
   signingSmartWalletKit,
+  makeNonce,
   txId,
   status,
   rejectionReason,
@@ -60,7 +62,7 @@ export const resolvePendingTx = async ({
   );
 
   const action: OfferSpec = harden({
-    id: `offer-${Date.now()}`,
+    id: `offer-${makeNonce()}`,
     invitationSpec: {
       source: 'continuing',
       previousOffer: invitationMakersOffer.id,

--- a/services/ymax-planner/src/utils.ts
+++ b/services/ymax-planner/src/utils.ts
@@ -14,6 +14,11 @@ export const getOwn = <O, K extends PropertyKey>(
   // @ts-expect-error TS doesn't let `hasOwn(obj, key)` support `obj[key]`.
   hasOwn(obj, key) ? obj[key] : undefined;
 
+export const makeNowISO = (now: typeof Date.now): (() => string) => {
+  const nowISO = () => new Date(now()).toISOString();
+  return nowISO;
+};
+
 /**
  * Parse the contents of a GRAPHQL_ENDPOINTS environment variable.
  * @see {@link ../README.md}

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -384,7 +384,8 @@ export const mockEvmCtx = {
   retryProviders: defaultMockProviders.retryProviders,
   kvStore: makeKVStoreFromMap(new Map()),
   setTimeout: globalThis.setTimeout,
-  now: Date.now,
+  // XXX `now` should be mocked rather than real.
+  now: globalThis.performance.now.bind(globalThis.performance),
   makeAbortController,
   axelarApiUrl: mockAxelarApiAddress,
   ydsNotifier: {
@@ -470,7 +471,8 @@ export const createMockPendingTxOpts = (
     retryProviders,
     fetch: async () => ({ ok: true, json: async () => ({}) }) as Response,
     setTimeout: globalThis.setTimeout,
-    now: Date.now,
+    // XXX `now` should be mocked rather than real.
+    now: globalThis.performance.now.bind(globalThis.performance),
     marshaller: boardSlottingMarshaller(),
     signingSmartWalletKit: createMockSigningSmartWalletKit(),
     ydsNotifier: {

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -29,6 +29,7 @@ import type { YdsNotifier } from '../src/yds-notifier.ts';
 import type { Sdk as SpectrumBlockchainSdk } from '../src/graphql/api-spectrum-blockchain/__generated/sdk.ts';
 import { ERC20_BALANCE_ABI } from '../src/evm-utils.ts';
 import type { makeEvmRpc, EvmRpc } from '../src/evm-scanner.ts';
+import { makeNowISO } from '../src/utils.ts';
 
 const PENDING_TX_PATH_PREFIX = 'published.ymax1';
 
@@ -50,6 +51,8 @@ type GMPTxStatus =
   | 'executable'
   | 'executable_without_gas_paid'
   | 'insufficient_fee';
+
+const makeNonce = makeNowISO(Date.now);
 
 const makeAbortController = prepareAbortController({
   setTimeout,
@@ -102,6 +105,7 @@ export const createMockEnginePowers = (): EnginePowers => ({
   evmTokenAddresses: {},
   network: TEST_NETWORK,
   signingSmartWalletKit: {} as any,
+  makeNonce: () => '',
   walletStore: {} as any,
   getWalletInvocationUpdate: async () => undefined,
   now: () => NaN,
@@ -475,6 +479,7 @@ export const createMockPendingTxOpts = (
     now: globalThis.performance.now.bind(globalThis.performance),
     marshaller: boardSlottingMarshaller(),
     signingSmartWalletKit: createMockSigningSmartWalletKit(),
+    makeNonce,
     ydsNotifier: {
       notifySettlement: async () => true,
     } as unknown as YdsNotifier,


### PR DESCRIPTION
Ref https://github.com/Agoric/agoric-sdk/pull/12626#discussion_r3112802269

## Description
Pass down a monotonic `now` power as needed, and also (where applicable) a separate `makeNonce` based on the current wall clock time.

### Security Considerations
Ostensibly improved, but in practice probably irrelevant.

### Scaling Considerations
n/a

### Documentation Considerations
Implicitly covered by type signatures.

### Testing Considerations
No new tests are required, but a future change to avoid ambient clock access in testing will now be easier.

### Upgrade Considerations
Safe for immediate deployment.