### PR TITLE
fix(ymax-planner): Update `refineModel` to exclude spurious flows

### DIFF
--- a/packages/portfolio-contract/tools/plan-solve.ts
+++ b/packages/portfolio-contract/tools/plan-solve.ts
@@ -334,7 +334,7 @@ const refineModel = (
     const { id, capacity, min } = edge;
     const pickVar = `pick_${id}`;
     const flowVar = `via_${id}`;
-    if ((solution[flowVar] ?? 0) > 0) {
+    if ((solution[flowVar] ?? 0) >= FLOW_EPS) {
       cloned.binaries[pickVar] = true;
       cloned.ints[flowVar] = true;
       cloned.constraints[`through_${id}`] = {

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -52,6 +52,7 @@ import {
   createMockProviderSets,
 } from './mocks.ts';
 import type { Sdk as SpectrumBlockchainSdk } from '../src/graphql/api-spectrum-blockchain/__generated/sdk.ts';
+import PROD_NETWORK_202604 from '../tools/network-snapshots/prod-network-2026-04.ts';
 
 const depositBrand = Far('mock brand') as Brand<'nat'>;
 const makeDeposit = value => AmountMath.make(depositBrand, value);
@@ -714,7 +715,7 @@ test('planRebalanceToAllocations regression - single source, 10x', async t => {
   t.snapshot(plan, 'raw plan');
 });
 
-test('solver regressions - AGO-496', async t => {
+test('solver regressions', async t => {
   // PoolKey names have been changed to align with TEST_NETWORK, but the numbers
   // all match.
 
@@ -800,6 +801,24 @@ test('solver regressions - AGO-496', async t => {
     makeMovementDesc('@agoric', '@noble', scale6(8250)),
     makeMovementDesc('@noble', '@Base', scale6(8250)),
     makeMovementDesc('@Base', 'Aave_Base', scale6(8250)),
+  ]);
+
+  // 2026-04-28T10:09Z
+  const ymax0Portfolio35Flow76 = await planRebalanceToAllocations({
+    ...plannerContext,
+    network: PROD_NETWORK_202604,
+    targetAllocation: {
+      '@Arbitrum': 0n,
+      '@Avalanche': 0n,
+      '@Ethereum': 0n,
+      Aave_Arbitrum: 0n,
+      Aave_Avalanche: 100n,
+      ERC4626_morphoClearstarHighYieldUsdc_Ethereum: 0n,
+    },
+    currentBalances: { '@Avalanche': makeDeposit(3900011n) },
+  });
+  assertPlanFlow(t, 'ymax0 portfolio35 flow76', ymax0Portfolio35Flow76.flow, [
+    makeMovementDesc('@Avalanche', 'Aave_Avalanche', 3900011n),
   ]);
 });
 

--- a/services/ymax-planner/tools/network-snapshots/prod-network-2026-04.ts
+++ b/services/ymax-planner/tools/network-snapshots/prod-network-2026-04.ts
@@ -1,0 +1,377 @@
+import type { NetworkSpec } from '@aglocal/portfolio-contract/tools/network/network-spec.js';
+
+export const PROD_NETWORK: NetworkSpec = harden({
+  // Enable debug diagnostics to aid troubleshooting in tests
+  debug: true,
+  environment: 'prod',
+  chains: [
+    { name: 'agoric', control: 'local' },
+    { name: 'noble', control: 'ibc' },
+    { name: 'Arbitrum', control: 'axelar' },
+    { name: 'Avalanche', control: 'axelar' },
+    { name: 'Base', control: 'axelar' },
+    { name: 'Ethereum', control: 'axelar' },
+    { name: 'Optimism', control: 'axelar' },
+  ],
+  pools: [
+    { pool: 'Aave_Arbitrum', chain: 'Arbitrum', protocol: 'Aave' },
+    { pool: 'Aave_Avalanche', chain: 'Avalanche', protocol: 'Aave' },
+    { pool: 'Aave_Base', chain: 'Base', protocol: 'Aave' },
+    { pool: 'Aave_Ethereum', chain: 'Ethereum', protocol: 'Aave' },
+    { pool: 'Aave_Optimism', chain: 'Optimism', protocol: 'Aave' },
+    { pool: 'Beefy_re7_Avalanche', chain: 'Avalanche', protocol: 'Beefy' },
+    {
+      pool: 'Beefy_morphoGauntletUsdc_Ethereum',
+      chain: 'Ethereum',
+      protocol: 'Beefy',
+    },
+    {
+      pool: 'Beefy_morphoSmokehouseUsdc_Ethereum',
+      chain: 'Ethereum',
+      protocol: 'Beefy',
+    },
+    { pool: 'Beefy_morphoSeamlessUsdc_Base', chain: 'Base', protocol: 'Beefy' },
+    {
+      pool: 'Beefy_compoundUsdc_Optimism',
+      chain: 'Optimism',
+      protocol: 'Beefy',
+    },
+    {
+      pool: 'Beefy_compoundUsdc_Arbitrum',
+      chain: 'Arbitrum',
+      protocol: 'Beefy',
+    },
+    { pool: 'Compound_Arbitrum', chain: 'Arbitrum', protocol: 'Compound' },
+    { pool: 'Compound_Base', chain: 'Base', protocol: 'Compound' },
+    { pool: 'Compound_Ethereum', chain: 'Ethereum', protocol: 'Compound' },
+    { pool: 'Compound_Optimism', chain: 'Optimism', protocol: 'Compound' },
+    { pool: 'USDN', chain: 'noble', protocol: 'USDN' },
+    { pool: 'USDNVault', chain: 'noble', protocol: 'USDN' },
+  ],
+  localPlaces: [
+    { id: '<Deposit>', chain: 'agoric' },
+    { id: '<Cash>', chain: 'agoric' },
+    { id: '+agoric', chain: 'agoric' },
+  ],
+  links: [
+    // USDN costs a fee to get into
+    {
+      src: '@noble',
+      dest: 'USDN',
+      transfer: 'local',
+      variableFeeBps: 10,
+      timeSec: 0,
+      feeMode: 'toUSDN',
+    },
+    {
+      src: '@noble',
+      dest: 'USDNVault',
+      transfer: 'local',
+      variableFeeBps: 10,
+      timeSec: 0,
+      feeMode: 'toUSDN',
+    },
+
+    // CCTP slow (inbound auto-forward compressed: EVM -> @agoric)
+    // Latency kept at 1080s (assuming IBC forward overlaps); adjust if sequential.
+    {
+      src: '@Arbitrum',
+      dest: '@agoric',
+      transfer: 'cctpToNoble',
+      variableFeeBps: 0,
+      timeSec: 1080,
+      feeMode: 'evmToNoble',
+    },
+    {
+      src: '@Avalanche',
+      dest: '@agoric',
+      transfer: 'cctpToNoble',
+      variableFeeBps: 0,
+      timeSec: 30, // Avalanche has instant finality (~7 seconds observed)
+      feeMode: 'evmToNoble',
+    },
+    {
+      src: '@Ethereum',
+      dest: '@agoric',
+      transfer: 'cctpToNoble',
+      variableFeeBps: 0,
+      timeSec: 1080,
+      feeMode: 'evmToNoble',
+    },
+    {
+      src: '@Optimism',
+      dest: '@agoric',
+      transfer: 'cctpToNoble',
+      variableFeeBps: 0,
+      timeSec: 1080,
+      feeMode: 'evmToNoble',
+    },
+    {
+      src: '@Base',
+      dest: '@agoric',
+      transfer: 'cctpToNoble',
+      variableFeeBps: 0,
+      timeSec: 1080,
+      feeMode: 'evmToNoble',
+    },
+    // CCTP return (fast on return path); 1 USDC minimum
+    {
+      src: '@noble',
+      dest: '@Arbitrum',
+      transfer: 'cctpFromNoble',
+      variableFeeBps: 0,
+      timeSec: 20,
+      min: 1_000_000n,
+      feeMode: 'makeEvmAccount',
+    },
+    {
+      src: '@noble',
+      dest: '@Avalanche',
+      transfer: 'cctpFromNoble',
+      variableFeeBps: 0,
+      timeSec: 20,
+      min: 1_000_000n,
+      feeMode: 'makeEvmAccount',
+    },
+    {
+      src: '@noble',
+      dest: '@Ethereum',
+      transfer: 'cctpFromNoble',
+      variableFeeBps: 0,
+      timeSec: 20,
+      min: 1_000_000n,
+      feeMode: 'makeEvmAccount',
+    },
+    {
+      src: '@noble',
+      dest: '@Optimism',
+      transfer: 'cctpFromNoble',
+      variableFeeBps: 0,
+      timeSec: 20,
+      min: 1_000_000n,
+      feeMode: 'makeEvmAccount',
+    },
+    {
+      src: '@noble',
+      dest: '@Base',
+      transfer: 'cctpFromNoble',
+      variableFeeBps: 0,
+      timeSec: 20,
+      min: 1_000_000n,
+      feeMode: 'makeEvmAccount',
+    },
+    // IBC connectivity (explicit both directions required for USDN and other noble-origin flows)
+    {
+      src: '@agoric',
+      dest: '@noble',
+      transfer: 'ibc',
+      variableFeeBps: 0,
+      timeSec: 10,
+    },
+    {
+      src: '@noble',
+      dest: '@agoric',
+      transfer: 'ibc',
+      variableFeeBps: 0,
+      timeSec: 10,
+    },
+
+    // CCTPv2 direct EVM-to-EVM routes (full mesh connectivity)
+    // Estimated time: ~13-60 seconds depending on finality threshold
+    // Note: CCTPv2 contracts must be deployed on both source and destination chains
+
+    /* DIRECT CCTPv2 TEMPORARILY DISABLED
+
+    // Arbitrum ↔ other EVM chains
+    {
+      src: '@Arbitrum',
+      dest: '@Ethereum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Ethereum',
+      dest: '@Arbitrum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Arbitrum',
+      dest: '@Base',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Base',
+      dest: '@Arbitrum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Arbitrum',
+      dest: '@Avalanche',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 30, // Avalanche has instant finality
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Avalanche',
+      dest: '@Arbitrum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Arbitrum',
+      dest: '@Optimism',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Optimism',
+      dest: '@Arbitrum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+
+    // Base ↔ other EVM chains (excluding Arbitrum, already defined)
+    {
+      src: '@Base',
+      dest: '@Ethereum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Ethereum',
+      dest: '@Base',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Base',
+      dest: '@Avalanche',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 30, // Avalanche has instant finality
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Avalanche',
+      dest: '@Base',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Base',
+      dest: '@Optimism',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Optimism',
+      dest: '@Base',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+
+    // Ethereum ↔ other EVM chains (excluding Arbitrum, Base already defined)
+    {
+      src: '@Ethereum',
+      dest: '@Avalanche',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 30, // Avalanche has instant finality
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Avalanche',
+      dest: '@Ethereum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Ethereum',
+      dest: '@Optimism',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Optimism',
+      dest: '@Ethereum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+
+    // Avalanche ↔ Optimism (remaining pair)
+    {
+      src: '@Avalanche',
+      dest: '@Optimism',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Optimism',
+      dest: '@Avalanche',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 30, // Avalanche has instant finality
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+
+    */
+  ],
+});
+
+export default PROD_NETWORK;


### PR DESCRIPTION
Fixes AGO-513

## Description
In `solveRebalance`, the major-unit `pickSolution` can include spurious flows like `via_e89: 1e-15`, which as of this change will be filtered away in conversion to the integer-constrained minor-unit model by `refineModel`.