### PR TITLE
chore(portfolio-deploy): better devnet pod

### DIFF
--- a/packages/portfolio-deploy/scripts/ymax-upgrade-run-logs.ts
+++ b/packages/portfolio-deploy/scripts/ymax-upgrade-run-logs.ts
@@ -17,7 +17,7 @@ Options:
   --address <bech32>           Override ymaxControl address
   --tx-hash <hash>             Use a specific tx hash instead of latest sender tx
   --namespace <name>           Kubernetes namespace label (default: network)
-  --pod <name>                 Pod name filter (default: validator-0 on devnet)
+  --pod <name>                 Pod name filter (default: validator-primary-0 on devnet)
   --pretty                     Print a single pretty JSON object instead of NDJSON
   --tx-limit <n>               Recent txs to inspect from sender (default: 20)
   --window-minutes <n>         Minutes before/after tx time for log query (default: 15)
@@ -324,7 +324,7 @@ const queryGrafana = async ({
 const toIso = (ms: number) => new Date(ms).toISOString();
 
 const defaultPodForNetwork = (network: Network) =>
-  network === 'devnet' ? 'validator-0' : undefined;
+  network === 'devnet' ? 'validator-primary-0' : undefined;
 
 const main = async (argv = process.argv) => {
   const { values } = parseArgs({ args: argv.slice(2), options });


### PR DESCRIPTION
refs:
 - #12622

esp https://github.com/Agoric/agoric-sdk/pull/12622/changes#diff-3167275016b836270b8271d147b9acdf6ff7760c802ba9beb1fd0ca17d4a2321R326

## Description

update `resource.labels.pod_name="validator-0"` to use `validator-primary-0`.

### Security / Scaling / Documentation / Testing / Upgrade Considerations

n/a