### PR TITLE
chore(ts): simplify includes and update TS/TypeDoc tooling

### DIFF
--- a/a3p-integration/proposals/m:before-next-upgrade/package.json
+++ b/a3p-integration/proposals/m:before-next-upgrade/package.json
@@ -31,6 +31,6 @@
   "devDependencies": {
     "eslint": "^8.57.0",
     "npm-run-all": "^4.1.5",
-    "typescript": "~6.0.1-rc"
+    "typescript": "~6.0.3"
   }
 }

--- a/a3p-integration/proposals/m:before-next-upgrade/yarn.lock
+++ b/a3p-integration/proposals/m:before-next-upgrade/yarn.lock
@@ -6429,7 +6429,7 @@ __metadata:
     eslint: "npm:^8.57.0"
     execa: "npm:9.1.0"
     npm-run-all: "npm:^4.1.5"
-    typescript: "npm:~6.0.1-rc"
+    typescript: "npm:~6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7225,13 +7225,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~6.0.1-rc":
-  version: 6.0.1-rc
-  resolution: "typescript@npm:6.0.1-rc"
+"typescript@npm:~6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/8f042a30f2111700e2172c49d025f90c825fb5a44c17f4ef5092d3025f314ad7f503218c410720f491f209861c9083490741599da8c2395eef0e3d9d3808657e
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
@@ -7245,13 +7245,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~6.0.1-rc#optional!builtin<compat/typescript>":
-  version: 6.0.1-rc
-  resolution: "typescript@patch:typescript@npm%3A6.0.1-rc#optional!builtin<compat/typescript>::version=6.0.1-rc&hash=5786d5"
+"typescript@patch:typescript@npm%3A~6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/891d5e284e6c1a1215cc938a93926244de207c64ef78c349f09473e9040b4ef9f039b04b4445148133c63cb679d13c15230e73491ce7984f4e04ab09ea35c46d
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 

--- a/a3p-integration/proposals/n:upgrade-next/package.json
+++ b/a3p-integration/proposals/n:upgrade-next/package.json
@@ -88,6 +88,6 @@
   "devDependencies": {
     "eslint": "^8.57.0",
     "npm-run-all": "^4.1.5",
-    "typescript": "~6.0.1-rc"
+    "typescript": "~6.0.3"
   }
 }

--- a/a3p-integration/proposals/n:upgrade-next/yarn.lock
+++ b/a3p-integration/proposals/n:upgrade-next/yarn.lock
@@ -5275,7 +5275,7 @@ __metadata:
     execa: "npm:9.1.0"
     npm-run-all: "npm:^4.1.5"
     ts-blank-space: "npm:^0.6.2"
-    typescript: "npm:~6.0.1-rc"
+    typescript: "npm:~6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -6132,13 +6132,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~6.0.1-rc":
-  version: 6.0.1-rc
-  resolution: "typescript@npm:6.0.1-rc"
+"typescript@npm:~6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/8f042a30f2111700e2172c49d025f90c825fb5a44c17f4ef5092d3025f314ad7f503218c410720f491f209861c9083490741599da8c2395eef0e3d9d3808657e
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
@@ -6162,13 +6162,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~6.0.1-rc#optional!builtin<compat/typescript>":
-  version: 6.0.1-rc
-  resolution: "typescript@patch:typescript@npm%3A6.0.1-rc#optional!builtin<compat/typescript>::version=6.0.1-rc&hash=5786d5"
+"typescript@patch:typescript@npm%3A~6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/891d5e284e6c1a1215cc938a93926244de207c64ef78c349f09473e9040b4ef9f039b04b4445148133c63cb679d13c15230e73491ce7984f4e04ab09ea35c46d
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 

--- a/a3p-integration/proposals/z:acceptance/package.json
+++ b/a3p-integration/proposals/z:acceptance/package.json
@@ -104,6 +104,6 @@
   "devDependencies": {
     "eslint": "^8.57.0",
     "npm-run-all": "^4.1.5",
-    "typescript": "~6.0.1-rc"
+    "typescript": "~6.0.3"
   }
 }

--- a/a3p-integration/proposals/z:acceptance/yarn.lock
+++ b/a3p-integration/proposals/z:acceptance/yarn.lock
@@ -5233,7 +5233,7 @@ __metadata:
     eslint: "npm:^8.57.0"
     execa: "npm:9.1.0"
     npm-run-all: "npm:^4.1.5"
-    typescript: "npm:~6.0.1-rc"
+    typescript: "npm:~6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -5974,13 +5974,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~6.0.1-rc":
-  version: 6.0.1-rc
-  resolution: "typescript@npm:6.0.1-rc"
+"typescript@npm:~6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/8f042a30f2111700e2172c49d025f90c825fb5a44c17f4ef5092d3025f314ad7f503218c410720f491f209861c9083490741599da8c2395eef0e3d9d3808657e
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
@@ -5994,13 +5994,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~6.0.1-rc#optional!builtin<compat/typescript>":
-  version: 6.0.1-rc
-  resolution: "typescript@patch:typescript@npm%3A6.0.1-rc#optional!builtin<compat/typescript>::version=6.0.1-rc&hash=5786d5"
+"typescript@patch:typescript@npm%3A~6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/891d5e284e6c1a1215cc938a93926244de207c64ef78c349f09473e9040b4ef9f039b04b4445148133c63cb679d13c15230e73491ce7984f4e04ab09ea35c46d
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 

--- a/multichain-testing/package.json
+++ b/multichain-testing/package.json
@@ -67,7 +67,7 @@
     "fs-extra": "^11.2.0",
     "osmojs": "^16.15.0",
     "ts-blank-space": "^0.4.4",
-    "typescript": "~6.0.1-rc",
+    "typescript": "~6.0.3",
     "viem": "^2.43.4"
   },
   "resolutions": {

--- a/multichain-testing/yarn.lock
+++ b/multichain-testing/yarn.lock
@@ -5328,7 +5328,7 @@ __metadata:
     prettier: "npm:^3.7.4"
     starshipjs: "npm:^3.3.0"
     ts-blank-space: "npm:^0.4.4"
-    typescript: "npm:~6.0.1-rc"
+    typescript: "npm:~6.0.3"
     viem: "npm:^2.43.4"
   languageName: unknown
   linkType: soft
@@ -5821,13 +5821,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~6.0.1-rc":
-  version: 6.0.1-rc
-  resolution: "typescript@npm:6.0.1-rc"
+"typescript@npm:~6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/8f042a30f2111700e2172c49d025f90c825fb5a44c17f4ef5092d3025f314ad7f503218c410720f491f209861c9083490741599da8c2395eef0e3d9d3808657e
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
@@ -5851,13 +5851,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~6.0.1-rc#optional!builtin<compat/typescript>":
-  version: 6.0.1-rc
-  resolution: "typescript@patch:typescript@npm%3A6.0.1-rc#optional!builtin<compat/typescript>::version=6.0.1-rc&hash=5786d5"
+"typescript@patch:typescript@npm%3A~6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/891d5e284e6c1a1215cc938a93926244de207c64ef78c349f09473e9040b4ef9f039b04b4445148133c63cb679d13c15230e73491ce7984f4e04ab09ea35c46d
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ts-blank-space": "^0.6.2",
     "ts-morph": "^27.0.2",
     "type-coverage": "^2.29.7",
-    "typedoc": "^0.26.7",
+    "typedoc": "^0.28.19",
     "typedoc-plugin-markdown": "^4.2.1",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.2"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ts-morph": "^27.0.2",
     "type-coverage": "^2.29.7",
     "typedoc": "^0.28.19",
-    "typedoc-plugin-markdown": "^4.2.1",
+    "typedoc-plugin-markdown": "^4.11.0",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.2"
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typedoc": "^0.26.7",
     "typedoc-plugin-markdown": "^4.2.1",
     "typescript": "~6.0.3",
-    "typescript-eslint": "^8.57.1"
+    "typescript-eslint": "^8.59.2"
   },
   "resolutions": {
     "@agoric/wallet-ui@0.1.3-solo.0": "patch:@agoric/wallet-ui@npm%3A0.1.3-solo.0#~/.yarn/patches/@agoric-wallet-ui-npm-0.1.3-solo.0-00666f4b09.patch",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "type-coverage": "^2.29.7",
     "typedoc": "^0.26.7",
     "typedoc-plugin-markdown": "^4.2.1",
-    "typescript": "~6.0.1-rc",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.57.1"
   },
   "resolutions": {

--- a/packages/ERTP/tsconfig.json
+++ b/packages/ERTP/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "src/**/*.js",
     "src/**/*.ts",

--- a/packages/ERTP/tsconfig.json
+++ b/packages/ERTP/tsconfig.json
@@ -2,8 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
-    "src/**/*.js",
-    "src/**/*.ts",
+    "src",
     "test"
   ]
 }

--- a/packages/SwingSet/tsconfig.json
+++ b/packages/SwingSet/tsconfig.json
@@ -2,11 +2,10 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
-    "demo/**/*.js",
-    "lib/**/*.js",
-    "misc-tools/**/*.js",
-    "src/**/*.js",
-    "src/**/*.ts",
+    "demo",
+    "lib",
+    "misc-tools",
+    "src",
     "test",
     "tools",
   ]

--- a/packages/access-token/tsconfig.json
+++ b/packages/access-token/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "src/**/*.js",
     "test/**/*.js"

--- a/packages/access-token/tsconfig.json
+++ b/packages/access-token/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
-    "src/**/*.js",
-    "test/**/*.js"
+    "src",
+    "test"
   ]
 }

--- a/packages/agoric-cli/tsconfig.json
+++ b/packages/agoric-cli/tsconfig.json
@@ -3,10 +3,10 @@
   "extends": "../../tsconfig.json",
   "include": [
     "*.js",
-    "integration-tests/**/*.js",
-    "scripts/**/*.js",
-    "src/**/*.js",
-    "test/**/*.js",
-    "tools/**/*.js",
+    "integration-tests",
+    "scripts",
+    "src",
+    "test",
+    "tools",
   ],
 }

--- a/packages/agoric-cli/tsconfig.json
+++ b/packages/agoric-cli/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "*.js",
     "integration-tests/**/*.js",

--- a/packages/agoric-cli/tsconfig.json
+++ b/packages/agoric-cli/tsconfig.json
@@ -2,7 +2,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "checkJs": true,
   },
   "include": [
     "*.js",

--- a/packages/async-flow/tsconfig.build.json
+++ b/packages/async-flow/tsconfig.build.json
@@ -4,6 +4,7 @@
         "../../tsconfig-build-options.json"
     ],
     "exclude": [
+        "**/types-index.js",
         "scripts",
         "test",
         "**/exports.js",

--- a/packages/async-flow/tsconfig.json
+++ b/packages/async-flow/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "*.js",
     "scripts",

--- a/packages/async-flow/tsconfig.json
+++ b/packages/async-flow/tsconfig.json
@@ -4,9 +4,7 @@
   "include": [
     "*.js",
     "scripts",
-    "src/**/*.js",
-    "test/**/*.js",
-    "src/**/*.ts",
-    "test/**/*.ts",
+    "src",
+    "test",
   ],
 }

--- a/packages/base-zone/tsconfig.json
+++ b/packages/base-zone/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "*.js",
     "scripts",

--- a/packages/base-zone/tsconfig.json
+++ b/packages/base-zone/tsconfig.json
@@ -4,7 +4,7 @@
   "include": [
     "*.js",
     "scripts",
-    "src/**/*.js",
-    "test/**/*.js",
+    "src",
+    "test",
   ],
 }

--- a/packages/benchmark/tsconfig.json
+++ b/packages/benchmark/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/benchmark/tsconfig.json
+++ b/packages/benchmark/tsconfig.json
@@ -2,13 +2,10 @@
   "extends": "../../tsconfig.json",
   "include": [
     "*.js",
-    "scripts/**/*.js",
-    "src/**/*.js",
-    "benchmark/**/*.js",
-    "benchmark/**/*.ts",
-    "test/**/*.js",
-    "test/**/*.ts",
-    "tools/**/*.js",
-    "tools/**/*.ts",
+    "scripts",
+    "src",
+    "benchmark",
+    "test",
+    "tools",
   ],
 }

--- a/packages/benchmark/tsconfig.json
+++ b/packages/benchmark/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "checkJs": true,
   },
   "include": [
     "*.js",

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "*.js",
     "*.mjs",

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "checkJs": true,
   },
   "include": [
     "*.js",

--- a/packages/builders/tsconfig.json
+++ b/packages/builders/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/builders/tsconfig.json
+++ b/packages/builders/tsconfig.json
@@ -2,10 +2,10 @@
   "extends": "../../tsconfig.json",
   "include": [
     "*.js",
-    "scripts/**/*.js",
-    "src/**/*.js",
-    "test/**/*.js",
-    "tools/**/*.js",
+    "scripts",
+    "src",
+    "test",
+    "tools",
   ],
   "exclude": [
     "scripts/zips-before/**",

--- a/packages/builders/tsconfig.json
+++ b/packages/builders/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "checkJs": true,
   },
   "include": [
     "*.js",

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -3,8 +3,8 @@
   "extends": "../../tsconfig.json",
   "include": [
     "*.js",
-    "public/**/*.js",
-    "src/**/*.js",
-    "test/**/*.js",
+    "public",
+    "src",
+    "test",
   ],
 }

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -1,7 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "*.js",
     "public/**/*.js",

--- a/packages/casting/tsconfig.json
+++ b/packages/casting/tsconfig.json
@@ -3,7 +3,7 @@
   "extends": "../../tsconfig.json",
   "include": [
     "*.js",
-    "public/**/*.js",
+    "public",
     "src",
     "test",
   ],

--- a/packages/casting/tsconfig.json
+++ b/packages/casting/tsconfig.json
@@ -1,7 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "*.js",
     "public/**/*.js",

--- a/packages/client-utils/tsconfig.json
+++ b/packages/client-utils/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "src",
     "test",

--- a/packages/cosmic-proto/package.json
+++ b/packages/cosmic-proto/package.json
@@ -235,7 +235,7 @@
     "esbuild": "^0.25.2",
     "rimraf": "^5.0.0",
     "tsd": "^0.33.0",
-    "typescript": "~6.0.1-rc"
+    "typescript": "~6.0.3"
   },
   "dependencies": {
     "@chain-registry/v2": "^1.71.186",

--- a/packages/cosmic-swingset/tsconfig.json
+++ b/packages/cosmic-swingset/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "*.cjs",
     "*.js",

--- a/packages/create-dapp/tsconfig.json
+++ b/packages/create-dapp/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
-    "scripts/**/*.js",
-    "src/**/*.js",
-    "test/**/*.js",
-    "tools/**/*.js",
+    "scripts",
+    "src",
+    "test",
+    "tools",
   ],
 }

--- a/packages/create-dapp/tsconfig.json
+++ b/packages/create-dapp/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "scripts/**/*.js",
     "src/**/*.js",

--- a/packages/create-dapp/tsconfig.json
+++ b/packages/create-dapp/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "checkJs": true,
   },
   "include": [
     "scripts/**/*.js",

--- a/packages/deploy-script-support/tsconfig.json
+++ b/packages/deploy-script-support/tsconfig.json
@@ -1,7 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "*.js",
     "src/**/*.js",

--- a/packages/deploy-script-support/tsconfig.json
+++ b/packages/deploy-script-support/tsconfig.json
@@ -3,7 +3,7 @@
   "extends": "../../tsconfig.json",
   "include": [
     "*.js",
-    "src/**/*.js",
-    "test/**/*.js",
+    "src",
+    "test",
   ],
 }

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "src",
     "test",

--- a/packages/fast-usdc-deploy/tsconfig.json
+++ b/packages/fast-usdc-deploy/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "scripts",
     "src",

--- a/packages/fast-usdc/tsconfig.json
+++ b/packages/fast-usdc/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "src",
     "test",

--- a/packages/governance/tsconfig.json
+++ b/packages/governance/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "build",
     "scripts",

--- a/packages/inter-protocol/tsconfig.json
+++ b/packages/inter-protocol/tsconfig.json
@@ -3,8 +3,8 @@
   "extends": "../../tsconfig.json",
   "include": [
     "globals.d.ts",
-    "scripts/**/*.js",
-    "src/**/*.js",
-    "test/**/*.js"
+    "scripts",
+    "src",
+    "test"
   ]
 }

--- a/packages/inter-protocol/tsconfig.json
+++ b/packages/inter-protocol/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "globals.d.ts",
     "scripts/**/*.js",

--- a/packages/internal/tsconfig.json
+++ b/packages/internal/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "src",
     "test",

--- a/packages/kmarshal/tsconfig.json
+++ b/packages/kmarshal/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "src/**/*.js",
     "test/**/*.js"

--- a/packages/kmarshal/tsconfig.json
+++ b/packages/kmarshal/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
-    "src/**/*.js",
-    "test/**/*.js"
+    "src",
+    "test"
   ]
 }

--- a/packages/notifier/tsconfig.json
+++ b/packages/notifier/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "src/**/*.js",
     "subscribe.*",

--- a/packages/notifier/tsconfig.json
+++ b/packages/notifier/tsconfig.json
@@ -2,9 +2,9 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
-    "src/**/*.js",
     "subscribe.*",
-    "test/**/*.js",
-    "tools/**/*.js",
+    "src",
+    "test",
+    "tools",
   ],
 }

--- a/packages/orchestration/tsconfig.json
+++ b/packages/orchestration/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "exclude": [
     "tsup.config.ts",
     "src/stubs/",

--- a/packages/pegasus/tsconfig.json
+++ b/packages/pegasus/tsconfig.json
@@ -3,9 +3,9 @@
   "extends": "../../tsconfig.json",
   "include": [
     "*.js",
-    "scripts/**/*.js",
-    "src/**/*.js",
-    "test/**/*.js",
-    "tools/**/*.js",
+    "scripts",
+    "src",
+    "test",
+    "tools",
   ],
 }

--- a/packages/pola-io/tsconfig.json
+++ b/packages/pola-io/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "src",
     "test",

--- a/packages/portfolio-api/tsconfig.json
+++ b/packages/portfolio-api/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "src",
     "test",

--- a/packages/portfolio-contract/tsconfig.json
+++ b/packages/portfolio-contract/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "src",
     "test",

--- a/packages/portfolio-deploy/tsconfig.json
+++ b/packages/portfolio-deploy/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "scripts",
     "src",

--- a/packages/smart-wallet/tsconfig.json
+++ b/packages/smart-wallet/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "*.js",
     "scripts",

--- a/packages/solo/tsconfig.json
+++ b/packages/solo/tsconfig.json
@@ -2,8 +2,8 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
-    "public/**/*.js",
-    "src/**/*.js",
-    "test/**/*.js",
+    "public",
+    "src",
+    "test",
   ],
 }

--- a/packages/store/tsconfig.json
+++ b/packages/store/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
-    "src/**/*.js",
-    "test/**/*.js",
+    "src",
+    "test",
   ],
 }

--- a/packages/store/tsconfig.json
+++ b/packages/store/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "src/**/*.js",
     "test/**/*.js",

--- a/packages/swing-store/tsconfig.json
+++ b/packages/swing-store/tsconfig.json
@@ -2,7 +2,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
-    "src/**/*.js",
-    "test/**/*.js",
+    "src",
+    "test",
   ],
 }

--- a/packages/swing-store/tsconfig.json
+++ b/packages/swing-store/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "src/**/*.js",
     "test/**/*.js",

--- a/packages/swingset-liveslots/tsconfig.json
+++ b/packages/swingset-liveslots/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "scripts",
     "src",

--- a/packages/swingset-runner/tsconfig.json
+++ b/packages/swingset-runner/tsconfig.json
@@ -3,8 +3,8 @@
   "extends": "../../tsconfig.json",
   "include": [
     "*.js",
-    "demo/**/*.js",
-    "src/**/*.js",
-    "test/**/*.js"
+    "demo",
+    "src",
+    "test"
   ]
 }

--- a/packages/swingset-xsnap-supervisor/tsconfig.json
+++ b/packages/swingset-xsnap-supervisor/tsconfig.json
@@ -3,11 +3,10 @@
   "extends": "../../tsconfig.json",
   "include": [
     "*.js",
-    "lib/**/*.js",
-    "scripts/**/*.js",
-    "src/**/*.d.ts",
-    "src/**/*.js",
-    "test/**/*.js",
-    "tools/**/*.js",
+    "lib",
+    "scripts",
+    "src",
+    "test",
+    "tools",
   ],
 }

--- a/packages/swingset-xsnap-supervisor/tsconfig.json
+++ b/packages/swingset-xsnap-supervisor/tsconfig.json
@@ -1,7 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "*.js",
     "lib/**/*.js",

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "*.js",
     "scripts",

--- a/packages/time/tsconfig.json
+++ b/packages/time/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "build",
     "index.js",

--- a/packages/vat-data/tsconfig.json
+++ b/packages/vat-data/tsconfig.json
@@ -6,9 +6,7 @@
     // "noImplicitAny": false, // for compat with peer packages using ambient types
   },
   "include": [
-    "src/**/*.js",
-    "src/**/*.ts",
-    "test/**/*.js",
-    "test/**/*.ts",
+    "src",
+    "test",
   ]
 }

--- a/packages/vats/tsconfig.build.json
+++ b/packages/vats/tsconfig.build.json
@@ -3,6 +3,9 @@
         "./tsconfig.json",
         "../../tsconfig-build-options.json"
     ],
-    // FIXME: https://github.com/Agoric/agoric-sdk/issues/10351
-    "exclude": ["tools/bootstrap-chain-reflective.js"]
+    "exclude": [
+        "**/types-index.js",
+        // FIXME: https://github.com/Agoric/agoric-sdk/issues/10351
+        "tools/bootstrap-chain-reflective.js"
+    ]
 }

--- a/packages/vats/tsconfig.json
+++ b/packages/vats/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "*.js",
     "scripts",

--- a/packages/vats/tsconfig.json
+++ b/packages/vats/tsconfig.json
@@ -3,9 +3,7 @@
   "include": [
     "*.js",
     "scripts",
-    // XXX we need both globs or tsc will ignore the .d.ts twin
-    "src/**/*.js",
-    "src/**/*.ts",
+    "src",
     "test",
     "tools",
   ],

--- a/packages/vm-config/tsconfig.json
+++ b/packages/vm-config/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../../tsconfig.json",
   "include": [
     "*.js",
-    "scripts/**/*.js",
-    "src/**/*.js",
-    "test/**/*.js",
-    "tools/**/*.js",
+    "scripts",
+    "src",
+    "test",
+    "tools",
   ],
 }

--- a/packages/wallet/api/tsconfig.json
+++ b/packages/wallet/api/tsconfig.json
@@ -1,7 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "*.js",
     "scripts/**/*.js",

--- a/packages/xsnap-lockdown/tsconfig.json
+++ b/packages/xsnap-lockdown/tsconfig.json
@@ -3,11 +3,10 @@
   "extends": "../../tsconfig.json",
   "include": [
     "*.js",
-    "lib/**/*.js",
-    "scripts/**/*.js",
-    "src/**/*.d.ts",
-    "src/**/*.js",
-    "test/**/*.js",
-    "tools/**/*.js",
+    "lib",
+    "scripts",
+    "src",
+    "test",
+    "tools",
   ],
 }

--- a/packages/xsnap-lockdown/tsconfig.json
+++ b/packages/xsnap-lockdown/tsconfig.json
@@ -1,7 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "*.js",
     "lib/**/*.js",

--- a/packages/xsnap/tsconfig.json
+++ b/packages/xsnap/tsconfig.json
@@ -1,7 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
   "include": [
     "*.js",
     "lib",

--- a/packages/zoe/tsconfig.json
+++ b/packages/zoe/tsconfig.json
@@ -3,9 +3,7 @@
   "include": [
     "contractFacet.js",
     "scripts",
-    // XXX we need both globs or tsc will ignore the .d.ts twin
-    "src/**/*.js",
-    "src/**/*.ts",
+    "src",
     "test",
     "tools",
   ],

--- a/packages/zoe/tsconfig.json
+++ b/packages/zoe/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "contractFacet.js",
     "scripts",

--- a/packages/zone/tsconfig.json
+++ b/packages/zone/tsconfig.json
@@ -1,8 +1,6 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-  },
   "include": [
     "*.js",
     "scripts",

--- a/packages/zone/tsconfig.json
+++ b/packages/zone/tsconfig.json
@@ -4,7 +4,7 @@
   "include": [
     "*.js",
     "scripts",
-    "src/**/*.js",
-    "test/**/*.js",
+    "src",
+    "test",
   ],
 }

--- a/scripts/test/README.md
+++ b/scripts/test/README.md
@@ -3,4 +3,4 @@ This directory contains shell-based tests for scripts.
 test.sh looks for a test.sh in each subdirectory and executes it,
 expecting an exit status code of 0 to indicate success.
 
-It exit with status 0 if all tests pass and status 1 if any fail.
+It exits with status 0 if all tests pass and status 1 if any fail.

--- a/scripts/test/refork.test.js
+++ b/scripts/test/refork.test.js
@@ -10,7 +10,7 @@ import {
   writePairedDiffOfDiffs,
 } from '../forks/refork.js';
 
-test('splitPatchIntoFileDiffs indexes per-file diffs by filename', () => {
+void test('splitPatchIntoFileDiffs indexes per-file diffs by filename', () => {
   const patch = [
     'diff --git a/alpha.txt b/alpha.txt',
     'index 1111111..2222222 100644',
@@ -42,7 +42,7 @@ test('splitPatchIntoFileDiffs indexes per-file diffs by filename', () => {
   );
 });
 
-test('splitPatchIntoFileDiffs prefers added filename and falls back from /dev/null', () => {
+void test('splitPatchIntoFileDiffs prefers added filename and falls back from /dev/null', () => {
   const patch = [
     'diff --git a/new.txt b/newer.txt',
     'similarity index 90%',
@@ -76,7 +76,7 @@ test('splitPatchIntoFileDiffs prefers added filename and falls back from /dev/nu
   );
 });
 
-test('streamPatchFileDiffs yields file diffs in input order', async () => {
+void test('streamPatchFileDiffs yields file diffs in input order', async () => {
   const workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'refork-test-'));
   const patchPath = path.join(workspaceDir, 'fork-base.patch');
 
@@ -113,7 +113,7 @@ test('streamPatchFileDiffs yields file diffs in input order', async () => {
   }
 });
 
-test('writePairedDiffOfDiffs summarizes /dev/null pairs by default', async () => {
+void test('writePairedDiffOfDiffs summarizes /dev/null pairs by default', async () => {
   const workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'refork-test-'));
   const forkBasePatchPath = path.join(workspaceDir, 'fork-base.patch');
   const diffMergePatchPath = path.join(workspaceDir, 'merge-fork.patch');
@@ -189,7 +189,7 @@ test('writePairedDiffOfDiffs summarizes /dev/null pairs by default', async () =>
   }
 });
 
-test('writePairedDiffOfDiffs emits full /dev/null diffs when diffDevNull is enabled', async () => {
+void test('writePairedDiffOfDiffs emits full /dev/null diffs when diffDevNull is enabled', async () => {
   const workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'refork-test-'));
   const forkBasePatchPath = path.join(workspaceDir, 'fork-base.patch');
   const diffMergePatchPath = path.join(workspaceDir, 'merge-fork.patch');
@@ -230,7 +230,7 @@ test('writePairedDiffOfDiffs emits full /dev/null diffs when diffDevNull is enab
   }
 });
 
-test('writePairedDiffOfDiffs writes No diff when both patch inputs are empty', async () => {
+void test('writePairedDiffOfDiffs writes No diff when both patch inputs are empty', async () => {
   const workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'refork-test-'));
   const forkBasePatchPath = path.join(workspaceDir, 'fork-base.patch');
   const diffMergePatchPath = path.join(workspaceDir, 'merge-fork.patch');

--- a/scripts/test/update-typedoc-functions-path/test.sh
+++ b/scripts/test/update-typedoc-functions-path/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
+node --test update-typedoc-functions-path.test.js

--- a/scripts/test/update-typedoc-functions-path/update-typedoc-functions-path.test.js
+++ b/scripts/test/update-typedoc-functions-path/update-typedoc-functions-path.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  decodeTypeDocData,
+  encodeTypeDocData,
+  updateUrls,
+} = require('../../update-typedoc-functions-path.cjs');
+
+void test('TypeDoc deflate data stays deflate encoded', async () => {
+  const data = [{ text: 'functions/foo.html', path: 'functions/foo.html' }];
+
+  const encoded = await encodeTypeDocData(data, 'deflate-base64');
+  const decoded = await decodeTypeDocData(encoded);
+
+  assert.equal(encoded.startsWith('data:'), false);
+  assert.deepEqual(decoded, { data, format: 'deflate-base64' });
+});
+
+void test('legacy gzip data URI stays gzip data URI encoded', async () => {
+  const data = [{ text: 'functions/foo.html', path: 'functions/foo.html' }];
+
+  const encoded = await encodeTypeDocData(data, 'gzip-data-uri');
+  const decoded = await decodeTypeDocData(encoded);
+
+  assert.match(encoded, /^data:application\/octet-stream;base64,/);
+  assert.deepEqual(decoded, { data, format: 'gzip-data-uri' });
+});
+
+void test('updateUrls rewrites nested TypeDoc paths', () => {
+  const data = {
+    children: [{ path: 'functions/foo.html' }, { path: 'modules/bar.html' }],
+  };
+
+  assert.deepEqual(updateUrls(data, 'functions', 'funcs'), {
+    children: [{ path: 'funcs/foo.html' }, { path: 'modules/bar.html' }],
+  });
+});

--- a/scripts/update-typedoc-functions-path.cjs
+++ b/scripts/update-typedoc-functions-path.cjs
@@ -28,6 +28,8 @@ const path = require('node:path');
 const zlib = require('node:zlib');
 const process = require('node:process');
 
+const dataUriPrefix = 'data:application/octet-stream;base64,';
+
 const config = {
   oldDirName: 'functions',
   newDirName: 'funcs',
@@ -44,46 +46,59 @@ const config = {
   ],
 };
 
-// Decodes and decompresses the TypeDoc data
-function decodeTypeDocData(encodedData) {
+function zlibAsync(operation, buffer, errorLabel) {
   return new Promise((resolve, reject) => {
-    const base64Data = encodedData.replace(
-      /^data:application\/octet-stream;base64,/,
-      '',
-    );
-    const buffer = Buffer.from(base64Data, 'base64');
-
-    zlib.gunzip(buffer, (err, decompressed) => {
+    operation(buffer, (err, data) => {
       if (err) {
-        reject(new Error(`Failed to decompress data: ${err.message}`));
+        reject(new Error(`Failed to ${errorLabel} data: ${err.message}`));
         return;
       }
-
-      try {
-        const jsonData = JSON.parse(decompressed.toString('utf-8'));
-        resolve(jsonData);
-      } catch (parseError) {
-        reject(new Error(`Failed to parse JSON: ${parseError.message}`));
-      }
+      resolve(data);
     });
   });
 }
 
+function getTypeDocDataFormat(encodedData) {
+  return encodedData.startsWith(dataUriPrefix)
+    ? 'gzip-data-uri'
+    : 'deflate-base64';
+}
+
+// Decodes and decompresses the TypeDoc data
+async function decodeTypeDocData(encodedData) {
+  const format = getTypeDocDataFormat(encodedData);
+  const base64Data =
+    format === 'gzip-data-uri'
+      ? encodedData.slice(dataUriPrefix.length)
+      : encodedData;
+  const buffer = Buffer.from(base64Data, 'base64');
+  const operation = format === 'gzip-data-uri' ? zlib.gunzip : zlib.inflate;
+  const decompressed = await zlibAsync(operation, buffer, 'decompress');
+
+  try {
+    return {
+      data: JSON.parse(decompressed.toString('utf-8')),
+      format,
+    };
+  } catch (parseError) {
+    throw new Error(`Failed to parse JSON: ${parseError.message}`);
+  }
+}
+
 // Compresses and encodes the TypeDoc data
-function encodeTypeDocData(jsonData) {
-  return new Promise((resolve, reject) => {
-    const jsonString = JSON.stringify(jsonData);
+async function encodeTypeDocData(jsonData, format) {
+  const jsonString = JSON.stringify(jsonData);
+  const operation = format === 'gzip-data-uri' ? zlib.gzip : zlib.deflate;
+  const compressed = await zlibAsync(
+    operation,
+    Buffer.from(jsonString),
+    'compress',
+  );
+  const base64Data = compressed.toString('base64');
 
-    zlib.gzip(jsonString, (err, compressed) => {
-      if (err) {
-        reject(new Error(`Failed to compress data: ${err.message}`));
-        return;
-      }
-
-      const base64Data = compressed.toString('base64');
-      resolve(`data:application/octet-stream;base64,${base64Data}`);
-    });
-  });
+  return format === 'gzip-data-uri'
+    ? `${dataUriPrefix}${base64Data}`
+    : base64Data;
 }
 
 // Recursively updates URLs in the data
@@ -117,13 +132,13 @@ async function updateDataFile(filePath, windowKey) {
   }
   const encodedData = match[1];
 
-  const decodedData = await decodeTypeDocData(encodedData);
+  const { data: decodedData, format } = await decodeTypeDocData(encodedData);
   const updatedData = updateUrls(
     decodedData,
     config.oldDirName,
     config.newDirName,
   );
-  const newEncodedData = await encodeTypeDocData(updatedData);
+  const newEncodedData = await encodeTypeDocData(updatedData, format);
   const newFileContent = `window.${windowKey} = "${newEncodedData}"`;
   await fsp.writeFile(filePath, newFileContent);
   console.log(`${windowKey} updated successfully`);
@@ -213,7 +228,17 @@ async function main() {
   }
 }
 
-main().catch(e => {
-  console.error(`Error: ${e.message}`);
-  process.exit(1);
-});
+module.exports = {
+  decodeTypeDocData,
+  encodeTypeDocData,
+  updateHtmlContentLinks,
+  updateMarkdownContentLinks,
+  updateUrls,
+};
+
+if (require.main === module) {
+  main().catch(e => {
+    console.error(`Error: ${e.message}`);
+    process.exit(1);
+  });
+}

--- a/services/ymax-planner/package.json
+++ b/services/ymax-planner/package.json
@@ -47,7 +47,7 @@
     "graphql": "^16.12.0",
     "nodemon": "^3.1.10",
     "ts-blank-space": "^0.6.2",
-    "typescript": "~6.0.1-rc"
+    "typescript": "~6.0.3"
   },
   "dependencies": {
     "@aglocal/portfolio-contract": "workspace:*",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,6 @@
 {
   "entryPoints": [
-    "packages/*"
+    "packages/!(swingset-runner)"
   ],
   "exclude": [
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1047,7 +1047,7 @@ __metadata:
     typedoc: "npm:^0.26.7"
     typedoc-plugin-markdown: "npm:^4.2.1"
     typescript: "npm:~6.0.3"
-    typescript-eslint: "npm:^8.57.1"
+    typescript-eslint: "npm:^8.59.2"
   dependenciesMeta:
     better-sqlite3@10.1.0:
       built: true
@@ -6900,26 +6900,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.57.1":
-  version: 8.57.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.57.1"
-  dependencies:
-    "@eslint-community/regexpp": "npm:^4.12.2"
-    "@typescript-eslint/scope-manager": "npm:8.57.1"
-    "@typescript-eslint/type-utils": "npm:8.57.1"
-    "@typescript-eslint/utils": "npm:8.57.1"
-    "@typescript-eslint/visitor-keys": "npm:8.57.1"
-    ignore: "npm:^7.0.5"
-    natural-compare: "npm:^1.4.0"
-    ts-api-utils: "npm:^2.4.0"
-  peerDependencies:
-    "@typescript-eslint/parser": ^8.57.1
-    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-    typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/5bf9227f5d608d4313c9f898da3a2f6737eca985aa925df9e90b73499b9d552221781d3d09245543c6d09995ab262ea0d6773d2dae4b8bdf319765d46b22d0e1
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/eslint-plugin@npm:8.59.2":
   version: 8.59.2
   resolution: "@typescript-eslint/eslint-plugin@npm:8.59.2"
@@ -6940,22 +6920,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.57.1":
-  version: 8.57.1
-  resolution: "@typescript-eslint/parser@npm:8.57.1"
-  dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.57.1"
-    "@typescript-eslint/types": "npm:8.57.1"
-    "@typescript-eslint/typescript-estree": "npm:8.57.1"
-    "@typescript-eslint/visitor-keys": "npm:8.57.1"
-    debug: "npm:^4.4.3"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-    typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/ab624f5ad6f3585ee690d11be36597135779a373e7f07810ed921163de2e879000f6d3213db67413ee630bcf25d5cfaa24b089ee49596cd11b0456372bc17163
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/parser@npm:8.59.2":
   version: 8.59.2
   resolution: "@typescript-eslint/parser@npm:8.59.2"
@@ -6972,19 +6936,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.57.1":
-  version: 8.57.1
-  resolution: "@typescript-eslint/project-service@npm:8.57.1"
-  dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.57.1"
-    "@typescript-eslint/types": "npm:^8.57.1"
-    debug: "npm:^4.4.3"
-  peerDependencies:
-    typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/7830f61e35364ba77799f4badeaca8bd8914bbcda6afe37b788821f94f4b88b9c49817c50f4bdba497e8e542a705e9d921d36f5e67960ebf33f4f3d3111cdfee
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/project-service@npm:8.59.2":
   version: 8.59.2
   resolution: "@typescript-eslint/project-service@npm:8.59.2"
@@ -6998,16 +6949,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.57.1":
-  version: 8.57.1
-  resolution: "@typescript-eslint/scope-manager@npm:8.57.1"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.57.1"
-    "@typescript-eslint/visitor-keys": "npm:8.57.1"
-  checksum: 10c0/42b0b54981318bf21be6b107df82910718497b7b7b2b60df635aa06d78e313759e4b675830c0e542b6d87104d35b49df41b9fb7739b8ae326eaba2d6f7116166
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:8.59.2":
   version: 8.59.2
   resolution: "@typescript-eslint/scope-manager@npm:8.59.2"
@@ -7018,37 +6959,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.57.1, @typescript-eslint/tsconfig-utils@npm:^8.57.1":
-  version: 8.57.1
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.57.1"
-  peerDependencies:
-    typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/3d3c8d80621507d31e4656c693534f28a1c04dfb047538cb79b0b6da874ef41875f5df5e814fa3a38812451cff6d5a7ae38d0bf77eb7fec7867f9c80af361b00
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/tsconfig-utils@npm:8.59.2, @typescript-eslint/tsconfig-utils@npm:^8.59.2":
   version: 8.59.2
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.2"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
   checksum: 10c0/ca7f386cdc9fa4b8c5de3622e2019b9729b8f5682292e01cc42b7cee4a7fc13005642b9dde733b429ad4e6f8600608930d9c33711d8c20c4f9d0af6520ba78d8
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/type-utils@npm:8.57.1":
-  version: 8.57.1
-  resolution: "@typescript-eslint/type-utils@npm:8.57.1"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.57.1"
-    "@typescript-eslint/typescript-estree": "npm:8.57.1"
-    "@typescript-eslint/utils": "npm:8.57.1"
-    debug: "npm:^4.4.3"
-    ts-api-utils: "npm:^2.4.0"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-    typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/e8eae4e3b9ca71ad065c307fd3cdefdcc6abc31bda2ef74f0e54b5c9ac0ee6bc0e2d69ec9097899f4d7a99d4a8a72391503b47f4317b3b6b9ba41cea24e6b9e9
   languageName: node
   linkType: hard
 
@@ -7068,36 +6984,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.57.1, @typescript-eslint/types@npm:^8.57.1":
-  version: 8.57.1
-  resolution: "@typescript-eslint/types@npm:8.57.1"
-  checksum: 10c0/f447015276a31871440b07e328c2bbcee8337d72dca90ae00ac91e87d09e28a8a9c2fe44726a5226fcaa7db9d5347aafa650d59f7577a074dc65ea1414d24da1
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/types@npm:8.59.2, @typescript-eslint/types@npm:^8.54.0, @typescript-eslint/types@npm:^8.59.2":
   version: 8.59.2
   resolution: "@typescript-eslint/types@npm:8.59.2"
   checksum: 10c0/ee6889a22b237ef426c45f11dc167f7f220007c2a8f77c8b1ab9e57ac32a2b47fad29f53c4230847cbe49bcd30a35fc2f276e01611d0dab9918d7ef72334f423
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/typescript-estree@npm:8.57.1":
-  version: 8.57.1
-  resolution: "@typescript-eslint/typescript-estree@npm:8.57.1"
-  dependencies:
-    "@typescript-eslint/project-service": "npm:8.57.1"
-    "@typescript-eslint/tsconfig-utils": "npm:8.57.1"
-    "@typescript-eslint/types": "npm:8.57.1"
-    "@typescript-eslint/visitor-keys": "npm:8.57.1"
-    debug: "npm:^4.4.3"
-    minimatch: "npm:^10.2.2"
-    semver: "npm:^7.7.3"
-    tinyglobby: "npm:^0.2.15"
-    ts-api-utils: "npm:^2.4.0"
-  peerDependencies:
-    typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/a87e1d920a8fd2231b6a98b279dc7680d10ceac072001e85a72cd43adce288ed471afcaf8f171378f5a3221c500b3cf0ffc10a75fd521fb69fbd8b26d4626677
   languageName: node
   linkType: hard
 
@@ -7120,21 +7010,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.57.1":
-  version: 8.57.1
-  resolution: "@typescript-eslint/utils@npm:8.57.1"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.9.1"
-    "@typescript-eslint/scope-manager": "npm:8.57.1"
-    "@typescript-eslint/types": "npm:8.57.1"
-    "@typescript-eslint/typescript-estree": "npm:8.57.1"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-    typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/c85d6e7c618dbf902fda98cc795883388bc512bc2c34c7ac0481ea43acb6dd3cd38d60bdb571b586f392419a17998c89330fd7b0b9a344161f4a595637dd3f55
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/utils@npm:8.59.2":
   version: 8.59.2
   resolution: "@typescript-eslint/utils@npm:8.59.2"
@@ -7147,16 +7022,6 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
   checksum: 10c0/d972d6f2ade6639088e3d2acf319c82cd981455a282d245dd715c5d77365647240d2cb34be00ab0d3a3c16593fb5050fcd698d399ff8451801825211d653ce64
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:8.57.1":
-  version: 8.57.1
-  resolution: "@typescript-eslint/visitor-keys@npm:8.57.1"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.57.1"
-    eslint-visitor-keys: "npm:^5.0.0"
-  checksum: 10c0/088a545c4aec6d9cabb266e1e40634f5fafa06cb05ef172526555957b0d99ac08822733fb788a09227071fdd6bd8b63f054393a0ecf9d4599c54b57918aa0e57
   languageName: node
   linkType: hard
 
@@ -17902,7 +17767,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-api-utils@npm:^2.4.0, ts-api-utils@npm:^2.5.0":
+"ts-api-utils@npm:^2.5.0":
   version: 2.5.0
   resolution: "ts-api-utils@npm:2.5.0"
   peerDependencies:
@@ -18294,7 +18159,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.33.0":
+"typescript-eslint@npm:^8.33.0, typescript-eslint@npm:^8.59.2":
   version: 8.59.2
   resolution: "typescript-eslint@npm:8.59.2"
   dependencies:
@@ -18306,21 +18171,6 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
   checksum: 10c0/c2736b839fa268da75df0ca8a1b8cfd658a6c6210c676412ed902c7ff8fea716f36a7e135133000a8f72091255f395d7c85783c4d6a9b1be79e8989abde1cd43
-  languageName: node
-  linkType: hard
-
-"typescript-eslint@npm:^8.57.1":
-  version: 8.57.1
-  resolution: "typescript-eslint@npm:8.57.1"
-  dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.57.1"
-    "@typescript-eslint/parser": "npm:8.57.1"
-    "@typescript-eslint/typescript-estree": "npm:8.57.1"
-    "@typescript-eslint/utils": "npm:8.57.1"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-    typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/be5a19738a785a2695e01874cbedbddbb63ea0a1c2eac331be7d251bda35116505f4d4d8de5a25a77a09392396247af4b89d2a793580217af4891e9e5036a716
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,7 +1045,7 @@ __metadata:
     ts-morph: "npm:^27.0.2"
     type-coverage: "npm:^2.29.7"
     typedoc: "npm:^0.28.19"
-    typedoc-plugin-markdown: "npm:^4.2.1"
+    typedoc-plugin-markdown: "npm:^4.11.0"
     typescript: "npm:~6.0.3"
     typescript-eslint: "npm:^8.59.2"
   dependenciesMeta:
@@ -18147,12 +18147,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-markdown@npm:^4.2.1":
-  version: 4.2.9
-  resolution: "typedoc-plugin-markdown@npm:4.2.9"
+"typedoc-plugin-markdown@npm:^4.11.0":
+  version: 4.11.0
+  resolution: "typedoc-plugin-markdown@npm:4.11.0"
   peerDependencies:
-    typedoc: 0.26.x
-  checksum: 10c0/68e49a7347b30fc4d7f1bfecc674fdbb2cfa0d6f62d09d13f24deff4ed6eeb56fbad5dbbc5bab084507eadf178dc25e64833a3b2222be572a3a7fe269d7bc6fd
+    typedoc: 0.28.x
+  checksum: 10c0/03374acfd0b5bd5af13198c043ffc31324b097647f5ffd92959647a9a277f0ece665331ff6a650ddaefdf9ff33928e138c5483e7cddbac830eb77e69b6067803
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,7 +348,7 @@ __metadata:
     ky: "npm:^1.13.0"
     nodemon: "npm:^3.1.10"
     ts-blank-space: "npm:^0.6.2"
-    typescript: "npm:~6.0.1-rc"
+    typescript: "npm:~6.0.3"
     viem: "npm:^2.41.2"
     ws: "npm:^8.18.3"
   languageName: unknown
@@ -543,7 +543,7 @@ __metadata:
     query-string: "npm:^9.1.1"
     rimraf: "npm:^5.0.0"
     tsd: "npm:^0.33.0"
-    typescript: "npm:~6.0.1-rc"
+    typescript: "npm:~6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -1046,7 +1046,7 @@ __metadata:
     type-coverage: "npm:^2.29.7"
     typedoc: "npm:^0.26.7"
     typedoc-plugin-markdown: "npm:^4.2.1"
-    typescript: "npm:~6.0.1-rc"
+    typescript: "npm:~6.0.3"
     typescript-eslint: "npm:^8.57.1"
   dependenciesMeta:
     better-sqlite3@10.1.0:
@@ -6920,6 +6920,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/eslint-plugin@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.2"
+  dependencies:
+    "@eslint-community/regexpp": "npm:^4.12.2"
+    "@typescript-eslint/scope-manager": "npm:8.59.2"
+    "@typescript-eslint/type-utils": "npm:8.59.2"
+    "@typescript-eslint/utils": "npm:8.59.2"
+    "@typescript-eslint/visitor-keys": "npm:8.59.2"
+    ignore: "npm:^7.0.5"
+    natural-compare: "npm:^1.4.0"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    "@typescript-eslint/parser": ^8.59.2
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/c4c2a67d0ae47ab27e47c46a4cd59eb9941592595d3440cd4dcbccc1983a08c5c9bd276304797964fa2c9276be4cd60077f3087efc6a5370d5b8869720759bc8
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/parser@npm:8.57.1":
   version: 8.57.1
   resolution: "@typescript-eslint/parser@npm:8.57.1"
@@ -6936,6 +6956,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/parser@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/parser@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/scope-manager": "npm:8.59.2"
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/typescript-estree": "npm:8.59.2"
+    "@typescript-eslint/visitor-keys": "npm:8.59.2"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/baf8da8ad233908f00bdfe5835c1e03fd7c9256f675a27b0d10d40d0245c158efc847dee1331c61992fbb152d55bfda3111795f8422e9d341f09ec9729364800
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/project-service@npm:8.57.1":
   version: 8.57.1
   resolution: "@typescript-eslint/project-service@npm:8.57.1"
@@ -6949,6 +6985,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/project-service@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/project-service@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.59.2"
+    "@typescript-eslint/types": "npm:^8.59.2"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/0228f01c61e5ef9022b06510f79f97e37daafd165c592927b640e3587d5cec65a8394a541e1fd21bf65df9f6f1948523569966c9e2181d9cfe911240969cebdb
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:8.57.1":
   version: 8.57.1
   resolution: "@typescript-eslint/scope-manager@npm:8.57.1"
@@ -6959,12 +7008,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/scope-manager@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/visitor-keys": "npm:8.59.2"
+  checksum: 10c0/eec819a96442e98879a66d908a9a388502dc4398005af360dd177907f021ee12e4f2967413b123c4ad4567e7f294b177cf6ee559eed2e86d38ab1af3ed5588a5
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/tsconfig-utils@npm:8.57.1, @typescript-eslint/tsconfig-utils@npm:^8.57.1":
   version: 8.57.1
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.57.1"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
   checksum: 10c0/3d3c8d80621507d31e4656c693534f28a1c04dfb047538cb79b0b6da874ef41875f5df5e814fa3a38812451cff6d5a7ae38d0bf77eb7fec7867f9c80af361b00
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.59.2, @typescript-eslint/tsconfig-utils@npm:^8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.2"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/ca7f386cdc9fa4b8c5de3622e2019b9729b8f5682292e01cc42b7cee4a7fc13005642b9dde733b429ad4e6f8600608930d9c33711d8c20c4f9d0af6520ba78d8
   languageName: node
   linkType: hard
 
@@ -6984,10 +7052,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.57.1, @typescript-eslint/types@npm:^8.54.0, @typescript-eslint/types@npm:^8.57.1":
+"@typescript-eslint/type-utils@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/type-utils@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/typescript-estree": "npm:8.59.2"
+    "@typescript-eslint/utils": "npm:8.59.2"
+    debug: "npm:^4.4.3"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/373ea2b03363e0c16ba75946327f01a130820f8b65976e831294c9e931d22d88d40f67a651a2151f0fcc9c91744019311fddadb608fe63ff6c0a65130417c34e
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.57.1, @typescript-eslint/types@npm:^8.57.1":
   version: 8.57.1
   resolution: "@typescript-eslint/types@npm:8.57.1"
   checksum: 10c0/f447015276a31871440b07e328c2bbcee8337d72dca90ae00ac91e87d09e28a8a9c2fe44726a5226fcaa7db9d5347aafa650d59f7577a074dc65ea1414d24da1
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.59.2, @typescript-eslint/types@npm:^8.54.0, @typescript-eslint/types@npm:^8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/types@npm:8.59.2"
+  checksum: 10c0/ee6889a22b237ef426c45f11dc167f7f220007c2a8f77c8b1ab9e57ac32a2b47fad29f53c4230847cbe49bcd30a35fc2f276e01611d0dab9918d7ef72334f423
   languageName: node
   linkType: hard
 
@@ -7010,6 +7101,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/typescript-estree@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.59.2"
+    "@typescript-eslint/tsconfig-utils": "npm:8.59.2"
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/visitor-keys": "npm:8.59.2"
+    debug: "npm:^4.4.3"
+    minimatch: "npm:^10.2.2"
+    semver: "npm:^7.7.3"
+    tinyglobby: "npm:^0.2.15"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/8bde0e7d184e4e9d98b1ef32b8692b433c8dc5c54439f4a34ae49cf4cb6117435b86d8d891b58a73676fbcf1162717365945053d48139cafb265f775e6c8d2af
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:8.57.1":
   version: 8.57.1
   resolution: "@typescript-eslint/utils@npm:8.57.1"
@@ -7025,6 +7135,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/utils@npm:8.59.2"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
+    "@typescript-eslint/scope-manager": "npm:8.59.2"
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/typescript-estree": "npm:8.59.2"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/d972d6f2ade6639088e3d2acf319c82cd981455a282d245dd715c5d77365647240d2cb34be00ab0d3a3c16593fb5050fcd698d399ff8451801825211d653ce64
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:8.57.1":
   version: 8.57.1
   resolution: "@typescript-eslint/visitor-keys@npm:8.57.1"
@@ -7032,6 +7157,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.57.1"
     eslint-visitor-keys: "npm:^5.0.0"
   checksum: 10c0/088a545c4aec6d9cabb266e1e40634f5fafa06cb05ef172526555957b0d99ac08822733fb788a09227071fdd6bd8b63f054393a0ecf9d4599c54b57918aa0e57
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/visitor-keys@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.59.2"
+    eslint-visitor-keys: "npm:^5.0.0"
+  checksum: 10c0/5863ea98ac642d94fd100f0077c5cfcbe168c3e2ac9bd05da7fc9878c32c20b6d4fc6916df44ffe79c538c4f367a083489d70dab07aa09c51e4e7729716d106e
   languageName: node
   linkType: hard
 
@@ -8016,12 +8151,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.4
-  resolution: "brace-expansion@npm:5.0.4"
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/359cbcfa80b2eb914ca1f3440e92313fbfe7919ee6b274c35db55bec555aded69dac5ee78f102cec90c35f98c20fa43d10936d0cd9978158823c249257e1643a
+  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
   languageName: node
   linkType: hard
 
@@ -14023,11 +14158,11 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:6 || 7 || 8 || 9 || 10, minimatch@npm:^10.0.1, minimatch@npm:^10.0.3, minimatch@npm:^10.2.2":
-  version: 10.2.4
-  resolution: "minimatch@npm:10.2.4"
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
   dependencies:
-    brace-expansion: "npm:^5.0.2"
-  checksum: 10c0/35f3dfb7b99b51efd46afd378486889f590e7efb10e0f6a10ba6800428cf65c9a8dedb74427d0570b318d749b543dc4e85f06d46d2858bc8cac7e1eb49a95945
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
   languageName: node
   linkType: hard
 
@@ -17767,7 +17902,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-api-utils@npm:^2.4.0":
+"ts-api-utils@npm:^2.4.0, ts-api-utils@npm:^2.5.0":
   version: 2.5.0
   resolution: "ts-api-utils@npm:2.5.0"
   peerDependencies:
@@ -18159,7 +18294,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.33.0, typescript-eslint@npm:^8.57.1":
+"typescript-eslint@npm:^8.33.0":
+  version: 8.59.2
+  resolution: "typescript-eslint@npm:8.59.2"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": "npm:8.59.2"
+    "@typescript-eslint/parser": "npm:8.59.2"
+    "@typescript-eslint/typescript-estree": "npm:8.59.2"
+    "@typescript-eslint/utils": "npm:8.59.2"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/c2736b839fa268da75df0ca8a1b8cfd658a6c6210c676412ed902c7ff8fea716f36a7e135133000a8f72091255f395d7c85783c4d6a9b1be79e8989abde1cd43
+  languageName: node
+  linkType: hard
+
+"typescript-eslint@npm:^8.57.1":
   version: 8.57.1
   resolution: "typescript-eslint@npm:8.57.1"
   dependencies:
@@ -18204,13 +18354,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~6.0.1-rc":
-  version: 6.0.1-rc
-  resolution: "typescript@npm:6.0.1-rc"
+"typescript@npm:~6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/8f042a30f2111700e2172c49d025f90c825fb5a44c17f4ef5092d3025f314ad7f503218c410720f491f209861c9083490741599da8c2395eef0e3d9d3808657e
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
@@ -18244,13 +18394,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~6.0.1-rc#optional!builtin<compat/typescript>":
-  version: 6.0.1-rc
-  resolution: "typescript@patch:typescript@npm%3A6.0.1-rc#optional!builtin<compat/typescript>::version=6.0.1-rc&hash=5786d5"
+"typescript@patch:typescript@npm%3A~6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/891d5e284e6c1a1215cc938a93926244de207c64ef78c349f09473e9040b4ef9f039b04b4445148133c63cb679d13c15230e73491ce7984f4e04ab09ea35c46d
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 
@@ -18978,21 +19128,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.3.1, yaml@npm:^2.3.4, yaml@npm:^2.5.1, yaml@npm:^2.8.0":
-  version: 2.8.1
-  resolution: "yaml@npm:2.8.1"
-  bin:
-    yaml: bin.mjs
-  checksum: 10c0/7c587be00d9303d2ae1566e03bc5bc7fe978ba0d9bf39cc418c3139d37929dfcb93a230d9749f2cb578b6aa5d9ebebc322415e4b653cb83acd8bc0bc321707f3
-  languageName: node
-  linkType: hard
-
-"yaml@npm:^2.8.3":
+"yaml@npm:^2.3.1, yaml@npm:^2.3.4, yaml@npm:^2.8.0, yaml@npm:^2.8.3":
   version: 2.8.3
   resolution: "yaml@npm:2.8.3"
   bin:
     yaml: bin.mjs
   checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.5.1":
+  version: 2.8.1
+  resolution: "yaml@npm:2.8.1"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/7c587be00d9303d2ae1566e03bc5bc7fe978ba0d9bf39cc418c3139d37929dfcb93a230d9749f2cb578b6aa5d9ebebc322415e4b653cb83acd8bc0bc321707f3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,7 +1044,7 @@ __metadata:
     ts-blank-space: "npm:^0.6.2"
     ts-morph: "npm:^27.0.2"
     type-coverage: "npm:^2.29.7"
-    typedoc: "npm:^0.26.7"
+    typedoc: "npm:^0.28.19"
     typedoc-plugin-markdown: "npm:^4.2.1"
     typescript: "npm:~6.0.3"
     typescript-eslint: "npm:^8.59.2"
@@ -3204,6 +3204,19 @@ __metadata:
   version: 3.2.0
   resolution: "@fastify/busboy@npm:3.2.0"
   checksum: 10c0/3e4fb00a27e3149d1c68de8ff14007d2bbcbbc171a9d050d0a8772e836727329d4d3f130995ebaa19cf537d5d2f5ce2a88000366e6192e751457bfcc2125f351
+  languageName: node
+  linkType: hard
+
+"@gerrit0/mini-shiki@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@gerrit0/mini-shiki@npm:3.23.0"
+  dependencies:
+    "@shikijs/engine-oniguruma": "npm:^3.23.0"
+    "@shikijs/langs": "npm:^3.23.0"
+    "@shikijs/themes": "npm:^3.23.0"
+    "@shikijs/types": "npm:^3.23.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+  checksum: 10c0/f9663e0e179edd2d7733207843f1bceda24311ab7b5495d50e0531305129fba8663388784c80645383ac6ae5e3a97c138faefeea8c328e7664da882f4ecb1c3a
   languageName: node
   linkType: hard
 
@@ -6366,22 +6379,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/core@npm:1.16.3":
-  version: 1.16.3
-  resolution: "@shikijs/core@npm:1.16.3"
+"@shikijs/engine-oniguruma@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@shikijs/engine-oniguruma@npm:3.23.0"
   dependencies:
-    "@shikijs/vscode-textmate": "npm:^9.2.0"
-    "@types/hast": "npm:^3.0.4"
-    oniguruma-to-js: "npm:0.3.3"
-    regex: "npm:4.3.2"
-  checksum: 10c0/69be7d81ac3d3e73a9e3d5d6298d2bdff805cf10b7af29117e6182a381644d01b471633e19d0a0055a5a009c3283832ff769ded6083298f76bed0e9a9bc3a026
+    "@shikijs/types": "npm:3.23.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+  checksum: 10c0/40dbda7aef55d5946c45b8cfe56f484eadb611f9f7c9eb77ff21f0dfce2bcc775686a61eda9e06401ddd71195945a522293f51d6522fce49244b1a6b9c0f61f7
   languageName: node
   linkType: hard
 
-"@shikijs/vscode-textmate@npm:^9.2.0":
-  version: 9.2.2
-  resolution: "@shikijs/vscode-textmate@npm:9.2.2"
-  checksum: 10c0/db4471da582c16c4b49361fcb3a4acfa47af9c3566f308faca7373ed7c1d13232e723749dd5c62b78aa76e365f2b8af3426f63e51cccfc5755981636c851eebf
+"@shikijs/langs@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@shikijs/langs@npm:3.23.0"
+  dependencies:
+    "@shikijs/types": "npm:3.23.0"
+  checksum: 10c0/513b90cfee0fa167d2063b7fbc2318b303a604f2e1fa156aa8b4659b49792401531a74acf68de622ecfff15738e1947a46cfe92a32fcd6a4ee5e70bcf1d06c66
+  languageName: node
+  linkType: hard
+
+"@shikijs/themes@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@shikijs/themes@npm:3.23.0"
+  dependencies:
+    "@shikijs/types": "npm:3.23.0"
+  checksum: 10c0/5c99036d4a765765018f9106a354ebe5ccac204c69f00e3cda265828d493f005412659213f6574fa0e187c7d4437b3327bd6dad2e2146b2c472d2bf493d790dd
+  languageName: node
+  linkType: hard
+
+"@shikijs/types@npm:3.23.0, @shikijs/types@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@shikijs/types@npm:3.23.0"
+  dependencies:
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 10c0/bd0d1593f830a6b4e55c77871ec1b95cc44855d6e0e26282a948a3c58827237826e4110af27eb4d3231361f1e182c4410434a1dc15ec40aea988dc92dc97e9d6
+  languageName: node
+  linkType: hard
+
+"@shikijs/vscode-textmate@npm:^10.0.2":
+  version: 10.0.2
+  resolution: "@shikijs/vscode-textmate@npm:10.0.2"
+  checksum: 10c0/36b682d691088ec244de292dc8f91b808f95c89466af421cf84cbab92230f03c8348649c14b3251991b10ce632b0c715e416e992dd5f28ff3221dc2693fd9462
   languageName: node
   linkType: hard
 
@@ -13501,9 +13540,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-it@npm:^14.1.0":
-  version: 14.1.0
-  resolution: "markdown-it@npm:14.1.0"
+"markdown-it@npm:^14.1.1":
+  version: 14.1.1
+  resolution: "markdown-it@npm:14.1.1"
   dependencies:
     argparse: "npm:^2.0.1"
     entities: "npm:^4.4.0"
@@ -13513,7 +13552,7 @@ __metadata:
     uc.micro: "npm:^2.1.0"
   bin:
     markdown-it: bin/markdown-it.mjs
-  checksum: 10c0/9a6bb444181d2db7016a4173ae56a95a62c84d4cbfb6916a399b11d3e6581bf1cc2e4e1d07a2f022ae72c25f56db90fbe1e529fca16fbf9541659dc53480d4b4
+  checksum: 10c0/c67f2a4c8069a307c78d8c15104bbcb15a2c6b17f4c904364ca218ec2eccf76a397eba1ea05f5ac5de72c4b67fcf115d422d22df0bfb86a09b663f55b9478d4f
   languageName: node
   linkType: hard
 
@@ -14022,7 +14061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:6 || 7 || 8 || 9 || 10, minimatch@npm:^10.0.1, minimatch@npm:^10.0.3, minimatch@npm:^10.2.2":
+"minimatch@npm:6 || 7 || 8 || 9 || 10, minimatch@npm:^10.0.1, minimatch@npm:^10.0.3, minimatch@npm:^10.2.2, minimatch@npm:^10.2.5":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:
@@ -14924,13 +14963,6 @@ __metadata:
   dependencies:
     mimic-function: "npm:^5.0.0"
   checksum: 10c0/5cb9179d74b63f52a196a2e7037ba2b9a893245a5532d3f44360012005c9cadb60851d56716ebff18a6f47129dab7168022445df47c2aff3b276d92585ed1221
-  languageName: node
-  linkType: hard
-
-"oniguruma-to-js@npm:0.3.3":
-  version: 0.3.3
-  resolution: "oniguruma-to-js@npm:0.3.3"
-  checksum: 10c0/98936af22e83369690fbc47f0b5e74775d7f9b305b481706f3e54c38e61920fab23be73c6c832586adcf2d0f81cfead0312e5dad506b38a4390003d4c8e7e269
   languageName: node
   linkType: hard
 
@@ -16083,13 +16115,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regex@npm:4.3.2":
-  version: 4.3.2
-  resolution: "regex@npm:4.3.2"
-  checksum: 10c0/bbc1dd348f85ce05407a072324b37cf79fe6506c90a66f520091feff6f3be8b2e04696f7cfa464a9de1ca4291c01390c8c090bbebfcea25affc03a38c94dd5dc
-  languageName: node
-  linkType: hard
-
 "regexp.prototype.flags@npm:^1.5.4":
   version: 1.5.4
   resolution: "regexp.prototype.flags@npm:1.5.4"
@@ -16767,17 +16792,6 @@ __metadata:
   bin:
     shjs: bin/shjs
   checksum: 10c0/feb25289a12e4bcd04c40ddfab51aff98a3729f5c2602d5b1a1b95f6819ec7804ac8147ebd8d9a85dfab69d501bcf92d7acef03247320f51c1552cec8d8e2382
-  languageName: node
-  linkType: hard
-
-"shiki@npm:^1.16.2":
-  version: 1.16.3
-  resolution: "shiki@npm:1.16.3"
-  dependencies:
-    "@shikijs/core": "npm:1.16.3"
-    "@shikijs/vscode-textmate": "npm:^9.2.0"
-    "@types/hast": "npm:^3.0.4"
-  checksum: 10c0/fef43b0bbd3bf95d14265a12b27653b8d43753a597d7973e1aefc0f1ced7f701686eee77cee3fdf7d0bf11d8520165edb9fc0c6d87c92955607aafe526c590c4
   languageName: node
   linkType: hard
 
@@ -18142,20 +18156,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:^0.26.7":
-  version: 0.26.8
-  resolution: "typedoc@npm:0.26.8"
+"typedoc@npm:^0.28.19":
+  version: 0.28.19
+  resolution: "typedoc@npm:0.28.19"
   dependencies:
+    "@gerrit0/mini-shiki": "npm:^3.23.0"
     lunr: "npm:^2.3.9"
-    markdown-it: "npm:^14.1.0"
-    minimatch: "npm:^9.0.5"
-    shiki: "npm:^1.16.2"
-    yaml: "npm:^2.5.1"
+    markdown-it: "npm:^14.1.1"
+    minimatch: "npm:^10.2.5"
+    yaml: "npm:^2.8.3"
   peerDependencies:
-    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x
+    typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
   bin:
     typedoc: bin/typedoc
-  checksum: 10c0/8381e50139ca8df9e9dfcaff35d6a5d1a226b32969ed2dcbc65aafacd1aaef2ecc4712f229229e8bb3850971b530af2e79312fcd2e18febe950c03710c504eec
+  checksum: 10c0/a46ea8ec4e661320dacf27f1d68595bdf9d671383f20060b590f212e6ebbf9a65d4962e698e8a43804a14add1f04a3528381c338801350dc03ddc6baf33fb898
   languageName: node
   linkType: hard
 
@@ -18984,15 +18998,6 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
-  languageName: node
-  linkType: hard
-
-"yaml@npm:^2.5.1":
-  version: 2.8.1
-  resolution: "yaml@npm:2.8.1"
-  bin:
-    yaml: bin.mjs
-  checksum: 10c0/7c587be00d9303d2ae1566e03bc5bc7fe978ba0d9bf39cc418c3139d37929dfcb93a230d9749f2cb578b6aa5d9ebebc322415e4b653cb83acd8bc0bc321707f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
_evergreen_

## Description
This PR updates the repo's TypeScript toolchain and cleans up `tsconfig.json` files by simplifying recursive `include` globs to directory paths while preserving root-level globs where they are intentional.

The most relevant files to review are:
- `package.json` and `yarn.lock` for the TypeScript/TypeDoc dependency bumps.
- `packages/*/tsconfig.json` for the `include` simplification and removal of redundant config.
- `typedoc.json` for excluding `swingset-runner` from package-based doc generation.

### Security Considerations
This change does not introduce new runtime authorities or change trust boundaries. It is limited to build, typecheck, and documentation tooling configuration.

### Scaling Considerations
The change should slightly reduce config complexity without increasing runtime resource consumption. The only behavioral change is in tooling inputs for typechecking and doc generation.

### Documentation Considerations
Generated API docs no longer attempt to traverse `swingset-runner`, which avoids a failing doc-generation path. There are no downstream user-facing API changes from the `tsconfig` cleanup itself.

### Testing Considerations
`yarn lint:types` was rerun in the packages affected by the `tsconfig` simplifications, including `packages/SwingSet`. TypeDoc entrypoint expansion was also checked after excluding `swingset-runner` to confirm it is no longer discovered.

### Upgrade Considerations
There is no production upgrade impact. This PR affects repository tooling only.
