### PR TITLE
chore: Override prod-network for testing blocked instruments on ymax0

### DIFF
--- a/packages/portfolio-contract/tools/network/prod-network.ts
+++ b/packages/portfolio-contract/tools/network/prod-network.ts
@@ -43,6 +43,18 @@ export const PROD_NETWORK: NetworkSpec = harden({
       protocol: 'Beefy',
     },
     {
+      pool: 'ERC4626_morphoAlphaUsdcCore_Ethereum',
+      chain: 'Ethereum',
+      protocol: 'ERC4626',
+      blockDepositReason: 'AT_CAPACITY',
+    },
+    {
+      pool: 'ERC4626_morphoClearstarUsdcReactor_Ethereum',
+      chain: 'Ethereum',
+      protocol: 'ERC4626',
+      blockWithdrawReason: 'LOW_LIQUIDITY',
+    },
+    {
       pool: 'ERC4626_morphoClearstarHighYieldUsdc_Ethereum',
       chain: 'Ethereum',
       protocol: 'ERC4626',


### PR DESCRIPTION
Ref #12652

Note that this should *not* be deployed to ymax1, but rather reverted after verifying ymax0.

The ymax0 verification will run against an existing portfolio with $2.11 each in ERC4626_morphoAlphaUsdcCore_Ethereum and ERC4626_morphoClearstarUsdcReactor_Ethereum.

| Action            | Alpha USDC Core<br>(deposit-blocked) | Clearstar USDC Reactor<br>(withdraw-blocked) | Unblocked Position | Agoric Chain Account | Total | Explanation |
|-------------------|-------:|--------:|-------:|-------:|-------:|--------|
| initial           |  $2.11 |  $2.11  |  $0.00 |  $0.00 |  $4.22 |
| target 34%/33%/33% with empty `flow` |  $2.11 |  $2.11 |  $0.00 |  $0.00 |  $4.22 |
| deposit $2.38     |  $2.11 |  $2.11  |  $2.20 |  $0.18 |  $6.60 | suppress small deltas
| withdraw $1       |  $2.11 |  $2.11  |  $1.38 |  $0.00 |  $5.60 | fallback by descending balance
| withdraw $5.60    |  $2.11 |  $2.11  |  $1.38 |  $0.00 |  $5.60 | fail (until AGO-535)
| withdraw $3.49    |  $0.00 |  $2.11  |  $0.00 |  $0.00 |  $2.11 | Clearstar USDC Reactor is withdraw-blocked
| deposit $4.49     |  $0.00 |  $2.11  |  $2.20 |  $2.29 |  $6.60 | Alpha USDC Core is deposit-blocked, Clearstar USDC Reactor delta is small
| target 0%/50%/50% |  $0.00 |  $3.30  |  $3.30 |  $0.00 |  $6.60 | deltas are not too small