### PR TITLE
chore(docs): drop unused markdown API docs pipeline

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -154,8 +154,6 @@ jobs:
       # landing on master
       - name: build API docs
         run: yarn docs
-      - name: build API docs in markdown
-        run: yarn docs:markdown-for-agoric-documentation-repo
 
   # Build the package lockfiles, and check that they are clean.
   check-lockfiles:

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "ts-morph": "^27.0.2",
     "type-coverage": "^2.29.7",
     "typedoc": "^0.28.19",
-    "typedoc-plugin-markdown": "^4.11.0",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.2"
   },
@@ -122,8 +121,6 @@
     "clean": "yarn lerna run --no-bail clean",
     "docs": "run-s docs:build docs:update-functions-path",
     "docs:build": "typedoc --tsconfig tsconfig.build.json",
-    "docs:markdown-for-agoric-documentation-repo": "run-s docs:markdown-build 'docs:update-functions-path md'",
-    "docs:markdown-build": "typedoc --plugin typedoc-plugin-markdown --tsconfig tsconfig.build.json",
     "docs:update-functions-path": "node ./scripts/update-typedoc-functions-path.cjs",
     "doctor": "./scripts/env-doctor.sh",
     "hooks:install": "./scripts/install-git-hooks.sh",

--- a/scripts/update-typedoc-functions-path.cjs
+++ b/scripts/update-typedoc-functions-path.cjs
@@ -12,9 +12,6 @@
  * 2. updates generated urls in html files to reference new url path
  * 3. updates base64 encoded navigation and search data to reference new url path
  *
- * If an `md` argument is supplied - versus the optional default `html` document -
- * a different set of logic will run to update paths are links for markdown files.
- *
  * See https://github.com/TypeStrong/typedoc/issues/2111 for more solutions
  * on how to workaround this.
  *
@@ -176,27 +173,6 @@ async function updateFiles(dir, fileExtension, updateFunction) {
 }
 
 /**
- * Updates content in Markdown files
- * @param {string} content - The Markdown content to update
- * @returns {string} - The updated Markdown content
- */
-function updateMarkdownContentLinks(content) {
-  return (
-    content
-      // Update links like [text](functions/file.md)
-      .replace(
-        new RegExp(`\\[(.*?)\\]\\(${config.oldDirName}/`, 'g'),
-        `[$1](${config.newDirName}/`,
-      )
-      // Update links like [text](../functions/file.md)
-      .replace(
-        new RegExp(`\\[(.*?)\\]\\(\\.\\./${config.oldDirName}/`, 'g'),
-        `[$1](../${config.newDirName}/`,
-      )
-  );
-}
-
-/**
  * Updates content in HTML files
  * @param {string} content - The HTML content to update
  * @returns {string} - The updated HTML content
@@ -212,19 +188,9 @@ function updateHtmlContentLinks(content) {
  * Main function to run the script
  */
 async function main() {
-  const fileType = process.argv[2] || 'html';
-  await null;
-  switch (fileType) {
-    case 'html':
-      await updateFiles(config.apiDocsDir, '.html', updateHtmlContentLinks);
-      for (const dataFile of config.dataFiles) {
-        await updateDataFile(dataFile.path, dataFile.windowKey);
-      }
-      return;
-    case 'md':
-      return updateFiles(config.apiDocsDir, '.md', updateMarkdownContentLinks);
-    default:
-      throw new Error('Invalid file type. Use "html" or "md".');
+  await updateFiles(config.apiDocsDir, '.html', updateHtmlContentLinks);
+  for (const dataFile of config.dataFiles) {
+    await updateDataFile(dataFile.path, dataFile.windowKey);
   }
 }
 
@@ -232,7 +198,6 @@ module.exports = {
   decodeTypeDocData,
   encodeTypeDocData,
   updateHtmlContentLinks,
-  updateMarkdownContentLinks,
   updateUrls,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,7 +1045,6 @@ __metadata:
     ts-morph: "npm:^27.0.2"
     type-coverage: "npm:^2.29.7"
     typedoc: "npm:^0.28.19"
-    typedoc-plugin-markdown: "npm:^4.11.0"
     typescript: "npm:~6.0.3"
     typescript-eslint: "npm:^8.59.2"
   dependenciesMeta:
@@ -18144,15 +18143,6 @@ __metadata:
     possible-typed-array-names: "npm:^1.0.0"
     reflect.getprototypeof: "npm:^1.0.6"
   checksum: 10c0/e38f2ae3779584c138a2d8adfa8ecf749f494af3cd3cdafe4e688ce51418c7d2c5c88df1bd6be2bbea099c3f7cea58c02ca02ed438119e91f162a9de23f61295
-  languageName: node
-  linkType: hard
-
-"typedoc-plugin-markdown@npm:^4.11.0":
-  version: 4.11.0
-  resolution: "typedoc-plugin-markdown@npm:4.11.0"
-  peerDependencies:
-    typedoc: 0.28.x
-  checksum: 10c0/03374acfd0b5bd5af13198c043ffc31324b097647f5ffd92959647a9a277f0ece665331ff6a650ddaefdf9ff33928e138c5483e7cddbac830eb77e69b6067803
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
refs: #9146, Agoric/documentation#927

## Description

Removes the `docs:markdown-for-agoric-documentation-repo` script and everything that exists solely to support it:

- `typedoc-plugin-markdown` devDependency
- `docs:markdown-build` script
- the `md` branch (and `updateMarkdownContentLinks`) in `scripts/update-typedoc-functions-path.cjs`
- the "build API docs in markdown" step in `.github/workflows/test-all-packages.yml`

The markdown output was introduced in #9146 to feed Agoric/documentation#927, but that integration has stalled and the markdown artifact is unused. Meanwhile `yarn docs` already takes ~15 minutes, and CI was running it twice (HTML + markdown), so `lint-rest` was paying that cost twice for no benefit.

The HTML docs pipeline (`yarn docs`, used by Cloudflare Pages) is unchanged. The unit tests for `update-typedoc-functions-path.cjs` still pass — they exercise the encode/decode/URL-rewrite helpers, not the markdown branch.

### Security Considerations

None. Removes a build-time tool and a CI step; no runtime code paths change.

### Scaling Considerations

Cuts CI time on `lint-rest` by ~15 minutes per run by eliminating a duplicate TypeDoc invocation.

### Documentation Considerations

The HTML API docs site is unaffected. If/when the Agoric/documentation#927 integration is revived, this pipeline can be reintroduced — but it should not be carried as dead weight in the meantime.

### Testing Considerations

`node --test scripts/test/update-typedoc-functions-path/` passes locally. CI's `build API docs` step still runs the HTML path.

### Upgrade Considerations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)