### PR TITLE
chore: retry watchers on transient failures

### DIFF
--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -20,7 +20,11 @@ import type { WebSocketProvider } from 'ethers';
 import { resolvePendingTx } from './resolver.ts';
 import { submitWithRetry } from './retry-settlement.ts';
 import { waitForBlock, type EvmRpc } from './evm-scanner.ts';
-import type { MakeAbortController, UsdcAddresses } from './support.ts';
+import {
+  prepareAbortController,
+  type MakeAbortController,
+  type UsdcAddresses,
+} from './support.ts';
 import { lookBackCctp, watchCctpTransfer } from './watchers/cctp-watcher.ts';
 import { lookBackGmp, watchGmp } from './watchers/gmp-watcher.ts';
 import {
@@ -741,6 +745,7 @@ export const watchWithRetry = async <T>(
   }: TransportRetryOpts,
 ): Promise<T | undefined> => {
   await null;
+  const makeAbortController = prepareAbortController({ setTimeout });
   let attempt = 0;
   while (true) {
     try {
@@ -756,7 +761,7 @@ export const watchWithRetry = async <T>(
         `⚠️  Watcher transport failure (attempt ${attempt}/${limit}), retrying in ${delay}ms`,
         err,
       );
-      await abortableSleep(delay, setTimeout, signal);
+      await abortableSleep(makeAbortController, delay, signal);
       if (signal?.aborted) return undefined;
     }
   }

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -20,11 +20,7 @@ import type { WebSocketProvider } from 'ethers';
 import { resolvePendingTx } from './resolver.ts';
 import { submitWithRetry } from './retry-settlement.ts';
 import { waitForBlock, type EvmRpc } from './evm-scanner.ts';
-import {
-  prepareAbortController,
-  type MakeAbortController,
-  type UsdcAddresses,
-} from './support.ts';
+import type { MakeAbortController, UsdcAddresses } from './support.ts';
 import { lookBackCctp, watchCctpTransfer } from './watchers/cctp-watcher.ts';
 import { lookBackGmp, watchGmp } from './watchers/gmp-watcher.ts';
 import {
@@ -299,7 +295,7 @@ const gmpMonitor: PendingTxMonitor<GmpTx> = {
             makeAbortController: ctx.makeAbortController,
           }),
         {
-          setTimeout: ctx.setTimeout,
+          makeAbortController: ctx.makeAbortController,
           signal: abortController.signal,
           log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
         },
@@ -462,7 +458,7 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx> = {
             txId,
           }),
         {
-          setTimeout: ctx.setTimeout,
+          makeAbortController: ctx.makeAbortController,
           signal: abortController.signal,
           log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
         },
@@ -599,7 +595,7 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx> = {
             signal: abortController.signal,
           }),
         {
-          setTimeout: ctx.setTimeout,
+          makeAbortController: ctx.makeAbortController,
           signal: abortController.signal,
           log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
         },
@@ -725,7 +721,7 @@ export const TRANSPORT_RETRY_INITIAL_MS = 1_000;
 export const TRANSPORT_RETRY_MAX_MS = 60_000;
 
 type TransportRetryOpts = {
-  setTimeout: typeof globalThis.setTimeout;
+  makeAbortController: MakeAbortController;
   signal?: AbortSignal;
   log?: (...args: unknown[]) => void;
   limit?: number;
@@ -736,7 +732,7 @@ type TransportRetryOpts = {
 export const watchWithRetry = async <T>(
   runWatch: () => Promise<T>,
   {
-    setTimeout,
+    makeAbortController,
     signal,
     log = () => {},
     limit = TRANSPORT_RETRY_LIMIT,
@@ -745,7 +741,6 @@ export const watchWithRetry = async <T>(
   }: TransportRetryOpts,
 ): Promise<T | undefined> => {
   await null;
-  const makeAbortController = prepareAbortController({ setTimeout });
   let attempt = 0;
   while (true) {
     try {
@@ -828,7 +823,7 @@ export const handlePendingTx = async (
 
   try {
     await watchWithRetry(runWatch, {
-      setTimeout: watchCtx.setTimeout,
+      makeAbortController: watchCtx.makeAbortController,
       signal,
       log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
     });

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -31,6 +31,10 @@ import {
   watchOperationResult,
   lookBackOperationResult,
 } from './watchers/operation-watcher.ts';
+import {
+  abortableSleep,
+  WatcherTransportError,
+} from './watchers/watcher-utils.ts';
 import type { YdsNotifier } from './yds-notifier.ts';
 
 export type EvmChain = keyof typeof AxelarChain;
@@ -281,26 +285,33 @@ const gmpMonitor: PendingTxMonitor<GmpTx> = {
         opts.signal ? [opts.signal] : undefined,
       );
 
-      const liveResultP = watchGmp({
-        ...watchArgs,
-        timeoutMs: opts.timeoutMs,
-        signal: abortController.signal,
-        kvStore: ctx.kvStore,
-        makeAbortController: ctx.makeAbortController,
-      });
+      const liveResultP = liveWatchWithRetry(
+        () =>
+          watchGmp({
+            ...watchArgs,
+            timeoutMs: opts.timeoutMs,
+            signal: abortController.signal,
+            kvStore: ctx.kvStore,
+            makeAbortController: ctx.makeAbortController,
+          }),
+        {
+          setTimeout: ctx.setTimeout,
+          signal: abortController.signal,
+          log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
+        },
+        err => log(`${logPrefix} Live watcher failed:`, err),
+      );
 
       // Attach handler to abort lookback if live mode completes first with
       // a definitive result. This handler does NOT resolve the transaction -
       // resolution happens once at the end to prevent duplicate resolutions.
-      void liveResultP
-        .then(result => {
-          if (result.settled) {
-            const reason = `${logPrefix} Live mode completed`;
-            log(reason);
-            abortController.abort(reason);
-          }
-        })
-        .catch(e => log(`${logPrefix} Live watcher failed:`, e));
+      void liveResultP.then(result => {
+        if (result.settled) {
+          const reason = `${logPrefix} Live mode completed`;
+          log(reason);
+          abortController.abort(reason);
+        }
+      });
 
       await null;
       // Wait for at least one block to ensure overlap between lookback and live mode
@@ -438,20 +449,27 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx> = {
         opts.signal ? [opts.signal] : undefined,
       );
 
-      const liveResultP = watchSmartWalletTx({
-        ...watchArgs,
-        timeoutMs: opts.timeoutMs,
-        signal: abortController.signal,
-        txId,
+      const liveResultP = liveWatchWithRetry(
+        () =>
+          watchSmartWalletTx({
+            ...watchArgs,
+            timeoutMs: opts.timeoutMs,
+            signal: abortController.signal,
+            txId,
+          }),
+        {
+          setTimeout: ctx.setTimeout,
+          signal: abortController.signal,
+          log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
+        },
+        err => log(`${logPrefix} Live watcher failed:`, err),
+      );
+      void liveResultP.then(result => {
+        if (result.settled) {
+          log(`${logPrefix} Live mode completed`);
+          abortController.abort();
+        }
       });
-      void liveResultP
-        .then(result => {
-          if (result.settled) {
-            log(`${logPrefix} Live mode completed`);
-            abortController.abort();
-          }
-        })
-        .catch(e => log(`${logPrefix} Live watcher failed:`, e));
 
       await null;
 
@@ -569,21 +587,28 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx> = {
         opts.signal ? [opts.signal] : undefined,
       );
 
-      const liveResultP = watchOperationResult({
-        ...watchArgs,
-        timeoutMs: opts.timeoutMs,
-        signal: abortController.signal,
-      });
+      const liveResultP = liveWatchWithRetry(
+        () =>
+          watchOperationResult({
+            ...watchArgs,
+            timeoutMs: opts.timeoutMs,
+            signal: abortController.signal,
+          }),
+        {
+          setTimeout: ctx.setTimeout,
+          signal: abortController.signal,
+          log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
+        },
+        err => log(`${logPrefix} Live watcher failed:`, err),
+      );
 
-      void liveResultP
-        .then(result => {
-          if (result.settled) {
-            const reason = `${logPrefix} Live mode completed`;
-            log(reason);
-            abortController.abort(reason);
-          }
-        })
-        .catch(e => log(`${logPrefix} Live watcher failed:`, e));
+      void liveResultP.then(result => {
+        if (result.settled) {
+          const reason = `${logPrefix} Live mode completed`;
+          log(reason);
+          abortController.abort(reason);
+        }
+      });
 
       await null;
       // Wait for at least one block to ensure overlap between lookback and live mode
@@ -690,6 +715,72 @@ export const PendingTxCode = {
 } as const;
 
 export const TX_TIMEOUT_MS = 30 * 60 * 1000; // 30 min
+
+export const TRANSPORT_RETRY_LIMIT = 5;
+export const TRANSPORT_RETRY_INITIAL_MS = 1_000;
+export const TRANSPORT_RETRY_MAX_MS = 60_000;
+
+type TransportRetryOpts = {
+  setTimeout: typeof globalThis.setTimeout;
+  signal?: AbortSignal;
+  log?: (...args: unknown[]) => void;
+  limit?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+};
+
+export const watchWithRetry = async <T>(
+  runWatch: () => Promise<T>,
+  {
+    setTimeout,
+    signal,
+    log = () => {},
+    limit = TRANSPORT_RETRY_LIMIT,
+    initialDelayMs = TRANSPORT_RETRY_INITIAL_MS,
+    maxDelayMs = TRANSPORT_RETRY_MAX_MS,
+  }: TransportRetryOpts,
+): Promise<T | undefined> => {
+  await null;
+  let attempt = 0;
+  while (true) {
+    try {
+      return await runWatch();
+    } catch (err) {
+      if (signal?.aborted) return undefined;
+      if (!(err instanceof WatcherTransportError) || attempt >= limit) {
+        throw err;
+      }
+      const delay = Math.min(initialDelayMs * 2 ** attempt, maxDelayMs);
+      attempt += 1;
+      log(
+        `⚠️  Watcher transport failure (attempt ${attempt}/${limit}), retrying in ${delay}ms`,
+        err,
+      );
+      await abortableSleep(delay, setTimeout, signal);
+      if (signal?.aborted) return undefined;
+    }
+  }
+};
+
+/**
+ * Wrap a watcher invocation with transport-failure retry, smoothing the result
+ * so the returned promise always resolves with a `WatcherResult`. Used by
+ * lookback monitors to keep the concurrent live arm restartable on transient
+ * WebSocket failures without bubbling errors out of the parent watch.
+ */
+const liveWatchWithRetry = <R extends WatcherResult>(
+  runWatch: () => Promise<R>,
+  opts: TransportRetryOpts,
+  onFailure: (err: unknown) => void,
+): Promise<R | WatcherResult> =>
+  watchWithRetry(runWatch, opts).then(
+    result => result ?? { settled: false },
+    err => {
+      onFailure(err);
+      return { settled: false };
+    },
+  );
+
 export const handlePendingTx = async (
   tx: PendingTx,
   {
@@ -721,16 +812,21 @@ export const handlePendingTx = async (
   }
 
   const watchOpts: Omit<WatchOpts, 'mode'> = { timeoutMs, signal };
+  const runWatch = () =>
+    txTimestampMs
+      ? monitor.watch(watchCtx, tx, log, {
+          mode: 'lookback',
+          publishTimeMs: txTimestampMs,
+          ...watchOpts,
+        })
+      : monitor.watch(watchCtx, tx, log, { mode: 'live', ...watchOpts });
+
   try {
-    if (txTimestampMs) {
-      await monitor.watch(watchCtx, tx, log, {
-        mode: 'lookback',
-        publishTimeMs: txTimestampMs,
-        ...watchOpts,
-      });
-    } else {
-      await monitor.watch(watchCtx, tx, log, { mode: 'live', ...watchOpts });
-    }
+    await watchWithRetry(runWatch, {
+      setTimeout: watchCtx.setTimeout,
+      signal,
+      log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
+    });
   } catch (err) {
     const mode = txTimestampMs ? 'with lookback' : 'in live mode';
     error(`🚨 Failed to process pending tx ${tx.txId} ${mode}`, err);

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -25,6 +25,7 @@ import {
   extractGmpExecuteData,
   DEFAULT_RETRY_OPTIONS,
   FAILED_TX_SCOPE,
+  WatcherTransportError,
   type AlchemySubscriptionMessage,
   type RetryOptions,
   handleTxRevert,
@@ -103,14 +104,20 @@ export const watchGmp = ({
     const onWsError = (e: any) => {
       const errorMsg = e?.message || String(e);
       log(`WebSocket error during GMP watch: ${errorMsg}`);
-      fail(new Error(`WebSocket connection error: ${errorMsg}`));
+      fail(
+        new WatcherTransportError(`WebSocket connection error: ${errorMsg}`, {
+          cause: e,
+        }),
+      );
     };
 
     const onWsClose = (code?: number, reason?: any) => {
       if (done) return;
       log(`WebSocket closed during GMP watch (code=${code}, reason=${reason})`);
       fail(
-        new Error(`WebSocket closed unexpectedly: ${reason} (code=${code})`),
+        new WatcherTransportError(
+          `WebSocket closed unexpectedly: ${reason} (code=${code})`,
+        ),
       );
     };
 

--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -27,6 +27,7 @@ import {
   handleOperationFailure,
   FAILED_TX_SCOPE,
   DEFAULT_RETRY_OPTIONS,
+  WatcherTransportError,
   type AlchemySubscriptionMessage,
   type RetryOptions,
 } from './watcher-utils.ts';
@@ -216,7 +217,11 @@ export const watchOperationResult = ({
     const onWsError = (e: any) => {
       const errorMsg = e?.message || String(e);
       log(`WebSocket error during OperationResult watch: ${errorMsg}`);
-      fail(new Error(`WebSocket connection error: ${errorMsg}`));
+      fail(
+        new WatcherTransportError(`WebSocket connection error: ${errorMsg}`, {
+          cause: e,
+        }),
+      );
     };
 
     const onWsClose = (code?: number, reason?: any) => {
@@ -225,7 +230,9 @@ export const watchOperationResult = ({
         `WebSocket closed during OperationResult watch (code=${code}, reason=${reason})`,
       );
       fail(
-        new Error(`WebSocket closed unexpectedly: ${reason} (code=${code})`),
+        new WatcherTransportError(
+          `WebSocket closed unexpectedly: ${reason} (code=${code})`,
+        ),
       );
     };
 

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -25,6 +25,7 @@ import {
   extractDepositFactoryExecuteData,
   DEFAULT_RETRY_OPTIONS,
   FAILED_TX_SCOPE,
+  WatcherTransportError,
   type AlchemySubscriptionMessage,
   type RetryOptions,
   handleTxRevert,
@@ -158,7 +159,11 @@ export const watchSmartWalletTx = ({
       log(
         `WebSocket error during wallet watch for expectedAddr=${expectedAddr}: ${errorMsg}`,
       );
-      fail(new Error(`WebSocket connection error: ${errorMsg}`));
+      fail(
+        new WatcherTransportError(`WebSocket connection error: ${errorMsg}`, {
+          cause: e,
+        }),
+      );
     };
 
     const onWsClose = (code?: number, reason?: any) => {
@@ -167,7 +172,9 @@ export const watchSmartWalletTx = ({
         `WebSocket closed during wallet watch for expectedAddr=${expectedAddr} (code=${code}, reason=${reason})`,
       );
       fail(
-        new Error(`WebSocket closed unexpectedly: ${reason} (code=${code})`),
+        new WatcherTransportError(
+          `WebSocket closed unexpectedly: ${reason} (code=${code})`,
+        ),
       );
     };
 

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -14,6 +14,35 @@ import {
 /** Scope tag for failed-transaction lookback searches. */
 export const FAILED_TX_SCOPE = 'failedTx';
 
+/**
+ * Signals that a watcher's underlying transport (WebSocket) failed.
+ * Distinct from a transaction-level failure: the watch could not continue,
+ * so the caller may safely restart it.
+ */
+export const WatcherTransportError = class WatcherTransportError extends Error {};
+WatcherTransportError.prototype.name = 'WatcherTransportError';
+
+/**
+ * Sleep `ms` milliseconds, returning early if `signal` aborts.
+ */
+export const abortableSleep = (
+  ms: number,
+  setTimeout: typeof globalThis.setTimeout,
+  signal?: AbortSignal,
+): Promise<void> =>
+  new Promise(resolve => {
+    if (signal?.aborted) return resolve();
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort);
+  });
+
 //#region Axelar execute calldata extraction
 // AxelarExecutable entrypoint (standard)
 // See https://docs.axelar.dev/dev/general-message-passing/executable

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -9,6 +9,7 @@ import {
   getBlockTimeMs,
   getConfirmationsRequired,
   getRevertConfirmationsRequired,
+  type MakeAbortController,
 } from '../support.ts';
 
 /** Scope tag for failed-transaction lookback searches. */
@@ -23,25 +24,19 @@ export const WatcherTransportError = class WatcherTransportError extends Error {
 WatcherTransportError.prototype.name = 'WatcherTransportError';
 
 /**
- * Sleep `ms` milliseconds, returning early if `signal` aborts.
+ * Sleep for `ms` milliseconds or until `signal` aborts (whichever comes first).
  */
-export const abortableSleep = (
+export const abortableSleep = async (
+  makeAbortController: MakeAbortController,
   ms: number,
-  setTimeout: typeof globalThis.setTimeout,
   signal?: AbortSignal,
-): Promise<void> =>
-  new Promise(resolve => {
-    if (signal?.aborted) return resolve();
-    const onAbort = () => {
-      clearTimeout(timer);
-      resolve();
-    };
-    const timer = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
-    signal?.addEventListener('abort', onAbort);
-  });
+): Promise<void> => {
+  if (signal?.aborted) return;
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const { signal: timeout } = makeAbortController(ms, signal ? [signal] : []);
+  timeout.addEventListener('abort', () => resolve());
+  return promise;
+};
 
 //#region Axelar execute calldata extraction
 // AxelarExecutable entrypoint (standard)

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -21,7 +21,7 @@ export const FAILED_TX_SCOPE = 'failedTx';
  * so the caller may safely restart it.
  */
 export const WatcherTransportError = class WatcherTransportError extends Error {};
-WatcherTransportError.prototype.name = 'WatcherTransportError';
+WatcherTransportError.prototype.name = WatcherTransportError.name;
 
 /**
  * Sleep for `ms` milliseconds or until `signal` aborts (whichever comes first).

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -2,6 +2,7 @@ import type { TransactionReceipt, Filter, Log } from 'ethers';
 import { Interface, AbiCoder, getAddress, keccak256 } from 'ethers';
 import type { CaipChainId } from '@agoric/orchestration';
 import { depositFactoryCreateAndDepositInputs } from '@aglocal/portfolio-contract/src/utils/evm-orch-factory.ts';
+import { makePromiseKit } from '@endo/promise-kit';
 import { decodeAbiParameters } from 'viem';
 import type { EvmRpc } from '../evm-scanner.ts';
 import { waitForConfirmations } from '../evm-scanner.ts';
@@ -32,7 +33,7 @@ export const abortableSleep = async (
   signal?: AbortSignal,
 ): Promise<void> => {
   if (signal?.aborted) return;
-  const { promise, resolve } = Promise.withResolvers<void>();
+  const { promise, resolve } = makePromiseKit<void>();
   const { signal: timeout } = makeAbortController(ms, signal ? [signal] : []);
   timeout.addEventListener('abort', () => resolve());
   return promise;

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -10,7 +10,8 @@ import type {
 } from '@aglocal/portfolio-contract/src/resolver/types.ts';
 import { createMockPendingTxData } from '@aglocal/portfolio-contract/tools/mocks.ts';
 import type { CaipChainId } from '@agoric/orchestration';
-import { handlePendingTx } from '../src/pending-tx-manager.ts';
+import { handlePendingTx, watchWithRetry } from '../src/pending-tx-manager.ts';
+import { WatcherTransportError } from '../src/watchers/watcher-utils.ts';
 import type { EvmRpc } from '../src/evm-scanner.ts';
 import {
   processPendingTxEvents,
@@ -196,6 +197,80 @@ test('handlePendingTx prints error for unsupported transaction type', async t =>
       `🚨 [${unsupportedTx.txId}] No monitor registered for tx type: ${unsupportedTx.type}`,
     ],
   ]);
+});
+
+const immediateSetTimeout: typeof globalThis.setTimeout = ((
+  fn: (...args: any[]) => void,
+) => {
+  void Promise.resolve().then(() => fn());
+  return 0 as unknown as ReturnType<typeof globalThis.setTimeout>;
+}) as any;
+
+test('watchWithRetry retries on transport error then succeeds', async t => {
+  let attempts = 0;
+  await watchWithRetry(
+    async () => {
+      attempts += 1;
+      if (attempts < 3) throw new WatcherTransportError('boom');
+    },
+    { setTimeout: immediateSetTimeout },
+  );
+  t.is(attempts, 3);
+});
+
+test('watchWithRetry rethrows non-transport errors immediately', async t => {
+  let attempts = 0;
+  const otherErr = new Error('not a transport failure');
+  await t.throwsAsync(
+    watchWithRetry(
+      async () => {
+        attempts += 1;
+        throw otherErr;
+      },
+      { setTimeout: immediateSetTimeout },
+    ),
+    { is: otherErr },
+  );
+  t.is(attempts, 1);
+});
+
+test('watchWithRetry rethrows transport error after exhausting limit', async t => {
+  let attempts = 0;
+  await t.throwsAsync(
+    watchWithRetry(
+      async () => {
+        attempts += 1;
+        throw new WatcherTransportError('boom');
+      },
+      { setTimeout: immediateSetTimeout, limit: 2 },
+    ),
+    { instanceOf: WatcherTransportError },
+  );
+  t.is(attempts, 3); // initial + 2 retries
+});
+
+test('watchWithRetry exits cleanly when signal aborts during backoff', async t => {
+  const ac = new AbortController();
+  let attempts = 0;
+  const slowTimeout: typeof globalThis.setTimeout = ((
+    fn: (...args: any[]) => void,
+    _ms: number,
+  ) => {
+    const id = globalThis.setTimeout(fn, 1_000_000);
+    return id;
+  }) as any;
+  const result = watchWithRetry(
+    async () => {
+      attempts += 1;
+      throw new WatcherTransportError('boom');
+    },
+    { setTimeout: slowTimeout, signal: ac.signal },
+  );
+  // Yield so the first attempt runs and we enter the backoff sleep.
+  await new Promise(resolve => globalThis.setTimeout(resolve, 10));
+  ac.abort();
+  await result; // resolves cleanly, does not throw
+  t.is(attempts, 1);
 });
 
 test('resolves a 31 min old pending CCTP transaction in lookback mode', async t => {

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -2,6 +2,7 @@ import test from 'ava';
 import { ethers } from 'ethers';
 import { boardSlottingMarshaller } from '@agoric/client-utils';
 import { objectMap } from '@endo/patterns';
+import { makePromiseKit } from '@endo/promise-kit';
 import type { WebSocketProvider } from 'ethers';
 import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import type {
@@ -257,9 +258,8 @@ test('watchWithRetry rethrows transport error after exhausting limit', async t =
 test('watchWithRetry exits cleanly when signal aborts during backoff', async t => {
   const ac = new AbortController();
   let attempts = 0;
-  const { promise: sleepStarted, resolve: startSleep } =
-    Promise.withResolvers();
-  const { promise: sleepEnded, resolve: endSleep } = Promise.withResolvers();
+  const { promise: sleepStarted, resolve: startSleep } = makePromiseKit();
+  const { promise: sleepEnded, resolve: endSleep } = makePromiseKit();
   const mockSetTimeout: typeof globalThis.setTimeout = ((
     fn: (...args: any[]) => void,
     _ms: number,

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -252,23 +252,29 @@ test('watchWithRetry rethrows transport error after exhausting limit', async t =
 test('watchWithRetry exits cleanly when signal aborts during backoff', async t => {
   const ac = new AbortController();
   let attempts = 0;
-  const slowTimeout: typeof globalThis.setTimeout = ((
+  let { promise: sleepStarted, resolve: startSleep } = Promise.withResolvers();
+  let endSleep: undefined | (() => void);
+  const mockSetTimeout: typeof globalThis.setTimeout = ((
     fn: (...args: any[]) => void,
     _ms: number,
   ) => {
-    const id = globalThis.setTimeout(fn, 1_000_000);
-    return id;
+    const { promise: sleepEnded, resolve } = Promise.withResolvers();
+    endSleep = resolve as any;
+    (startSleep as () => void)();
+    void sleepEnded.then(() => fn());
+    return 0;
   }) as any;
   const result = watchWithRetry(
     async () => {
       attempts += 1;
       throw new WatcherTransportError('boom');
     },
-    { setTimeout: slowTimeout, signal: ac.signal },
+    { setTimeout: mockSetTimeout, signal: ac.signal },
   );
-  // Yield so the first attempt runs and we enter the backoff sleep.
-  await new Promise(resolve => globalThis.setTimeout(resolve, 10));
+  // Enter the backoff sleep.
+  await sleepStarted;
   ac.abort();
+  endSleep!();
   await result; // resolves cleanly, does not throw
   t.is(attempts, 1);
 });

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -252,15 +252,14 @@ test('watchWithRetry rethrows transport error after exhausting limit', async t =
 test('watchWithRetry exits cleanly when signal aborts during backoff', async t => {
   const ac = new AbortController();
   let attempts = 0;
-  let { promise: sleepStarted, resolve: startSleep } = Promise.withResolvers();
-  let endSleep: undefined | (() => void);
+  const { promise: sleepStarted, resolve: startSleep } =
+    Promise.withResolvers();
+  const { promise: sleepEnded, resolve: endSleep } = Promise.withResolvers();
   const mockSetTimeout: typeof globalThis.setTimeout = ((
     fn: (...args: any[]) => void,
     _ms: number,
   ) => {
-    const { promise: sleepEnded, resolve } = Promise.withResolvers();
-    endSleep = resolve as any;
-    (startSleep as () => void)();
+    startSleep(null);
     void sleepEnded.then(() => fn());
     return 0;
   }) as any;
@@ -271,10 +270,10 @@ test('watchWithRetry exits cleanly when signal aborts during backoff', async t =
     },
     { setTimeout: mockSetTimeout, signal: ac.signal },
   );
-  // Enter the backoff sleep.
+  // Abort inside the sleep (after it starts but before it ends).
   await sleepStarted;
   ac.abort();
-  endSleep!();
+  endSleep(null);
   await result; // resolves cleanly, does not throw
   t.is(attempts, 1);
 });

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -12,6 +12,7 @@ import { createMockPendingTxData } from '@aglocal/portfolio-contract/tools/mocks
 import type { CaipChainId } from '@agoric/orchestration';
 import { handlePendingTx, watchWithRetry } from '../src/pending-tx-manager.ts';
 import { WatcherTransportError } from '../src/watchers/watcher-utils.ts';
+import { prepareAbortController } from '../src/support.ts';
 import type { EvmRpc } from '../src/evm-scanner.ts';
 import {
   processPendingTxEvents,
@@ -206,6 +207,10 @@ const immediateSetTimeout: typeof globalThis.setTimeout = ((
   return 0 as unknown as ReturnType<typeof globalThis.setTimeout>;
 }) as any;
 
+const immediateMakeAbortController = prepareAbortController({
+  setTimeout: immediateSetTimeout,
+});
+
 test('watchWithRetry retries on transport error then succeeds', async t => {
   let attempts = 0;
   await watchWithRetry(
@@ -213,7 +218,7 @@ test('watchWithRetry retries on transport error then succeeds', async t => {
       attempts += 1;
       if (attempts < 3) throw new WatcherTransportError('boom');
     },
-    { setTimeout: immediateSetTimeout },
+    { makeAbortController: immediateMakeAbortController },
   );
   t.is(attempts, 3);
 });
@@ -227,7 +232,7 @@ test('watchWithRetry rethrows non-transport errors immediately', async t => {
         attempts += 1;
         throw otherErr;
       },
-      { setTimeout: immediateSetTimeout },
+      { makeAbortController: immediateMakeAbortController },
     ),
     { is: otherErr },
   );
@@ -242,7 +247,7 @@ test('watchWithRetry rethrows transport error after exhausting limit', async t =
         attempts += 1;
         throw new WatcherTransportError('boom');
       },
-      { setTimeout: immediateSetTimeout, limit: 2 },
+      { makeAbortController: immediateMakeAbortController, limit: 2 },
     ),
     { instanceOf: WatcherTransportError },
   );
@@ -268,7 +273,12 @@ test('watchWithRetry exits cleanly when signal aborts during backoff', async t =
       attempts += 1;
       throw new WatcherTransportError('boom');
     },
-    { setTimeout: mockSetTimeout, signal: ac.signal },
+    {
+      makeAbortController: prepareAbortController({
+        setTimeout: mockSetTimeout,
+      }),
+      signal: ac.signal,
+    },
   );
   // Abort inside the sleep (after it starts but before it ends).
   await sleepStarted;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://linear.app/agoric/issue/AGO-505/routed-gmp-watcher-can-abandon-pending-tx-after-transient-websocket

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

- Restart watchers on transient WebSocket failures instead of dropping the pending tx.
- New `WatcherTransportError` distinguishes transport failures from tx-level failures; the three WS watchers (`gmp`, `operation`, `wallet`) throw it on `ws.error`/`ws.close`.


### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
Currently, the change is unit tested.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment.