### PR TITLE
chore(ymax-planner): skip startup vstorage reads for already-resolved txs

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -75,6 +75,7 @@ import {
   planRebalanceToAllocations,
   planWithdrawFromAllocations,
 } from './plan-deposit.ts';
+import { getResolvedTx, setResolvedTx } from './kv-store.ts';
 import { UserInputError } from './support.ts';
 import {
   encodedKeyToPath,
@@ -546,6 +547,7 @@ export const processPendingTxEvents = async (
     log = () => {},
     vstoragePathPrefixes: { pendingTxPathPrefix },
     pendingTxAbortControllers,
+    kvStore,
   } = txPowers;
   for (const { path, value: cellJson } of events) {
     const errLabel = `🚨 Failed to process pending tx ${path}`;
@@ -568,6 +570,7 @@ export const processPendingTxEvents = async (
           abortController.abort(reason);
           pendingTxAbortControllers.delete(txId);
         }
+        setResolvedTx(kvStore, txId, String(data.status));
         continue;
       }
       if (!RESOLVER_SUPPORTED_TRANSACTIONS.includes(data.type)) continue;
@@ -703,6 +706,7 @@ export const startEngine = async (
     signingSmartWalletKit,
     makeNonce,
   } = powers;
+  const { kvStore } = evmCtx;
   const vstoragePathPrefixes = makeVstoragePathPrefixes(contractInstance);
   const { portfoliosPathPrefix, pendingTxPathPrefix } = vstoragePathPrefixes;
   await null;
@@ -835,6 +839,9 @@ export const startEngine = async (
     throttledPendingTxKeys,
     { capacity },
     async (txId: TxId) => {
+      // Skip if a prior run already observed this tx as resolved.
+      if (getResolvedTx(kvStore, txId) !== undefined) return;
+
       const path = `${pendingTxPathPrefix}.${txId}`;
       await null;
       let streamCellJson;
@@ -850,11 +857,12 @@ export const startEngine = async (
         const streamCell = parseStreamCell(streamCellJson, path);
         const marshalledData = parseStreamCellValue(streamCell, -1, path);
         data = marshaller.fromCapData(marshalledData);
-        if (
-          data?.status !== TxStatus.PENDING ||
-          !RESOLVER_SUPPORTED_TRANSACTIONS.includes(data.type)
-        )
+        if (data?.status !== TxStatus.PENDING) {
+          // Backfill the cache so subsequent restarts skip this read.
+          if (data?.status) setResolvedTx(kvStore, txId, String(data.status));
           return;
+        }
+        if (!RESOLVER_SUPPORTED_TRANSACTIONS.includes(data.type)) return;
         mustMatch(harden(data), PublishedTxShape, path);
         initialPendingTxData.push({
           blockHeight: BigInt(streamCell.blockHeight),

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -829,19 +829,20 @@ export const startEngine = async (
 
   const initialPendingTxData: PendingTxRecord[] = [];
   const capacity = 10;
+  // Filter out cache hits up front so they don't consume rate-limiter slots
+  const pendingTxKeysToRead = (pendingTxKeys as TxId[]).filter(
+    txId => getResolvedTx(kvStore, txId) === undefined,
+  );
   const throttledPendingTxKeys = rateLimitedSource({
     policy: { quota: capacity, windowMs: 1000 },
     powers: { now: powers.now, setTimeout: powers.setTimeout },
-    source: pendingTxKeys as Array<string>,
+    source: pendingTxKeysToRead,
   });
 
   await makeWorkPool(
     throttledPendingTxKeys,
     { capacity },
     async (txId: TxId) => {
-      // Skip if a prior run already observed this tx as resolved.
-      if (getResolvedTx(kvStore, txId) !== undefined) return;
-
       const path = `${pendingTxPathPrefix}.${txId}`;
       await null;
       let streamCellJson;

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -75,7 +75,12 @@ import {
   planRebalanceToAllocations,
   planWithdrawFromAllocations,
 } from './plan-deposit.ts';
-import { getResolvedTx, setResolvedTx } from './kv-store.ts';
+import {
+  getIgnoredTx,
+  getResolvedTx,
+  setIgnoredTx,
+  setResolvedTx,
+} from './kv-store.ts';
 import { UserInputError } from './support.ts';
 import {
   encodedKeyToPath,
@@ -578,7 +583,10 @@ export const processPendingTxEvents = async (
         }
         continue;
       }
-      if (!RESOLVER_SUPPORTED_TRANSACTIONS.includes(data.type)) continue;
+      if (!RESOLVER_SUPPORTED_TRANSACTIONS.includes(data.type)) {
+        setIgnoredTx(kvStore, txId, data.type);
+        continue;
+      }
 
       mustMatch(data, PublishedTxShape, `${path} index -1`);
       const tx = { txId, ...data } as PendingTx;
@@ -836,7 +844,13 @@ export const startEngine = async (
   const capacity = 10;
   // Filter out cache hits up front so they don't consume rate-limiter slots
   const pendingTxKeysToRead = (pendingTxKeys as TxId[]).filter(
-    txId => getResolvedTx(kvStore, txId) === undefined,
+    txId =>
+      getResolvedTx(kvStore, txId) === undefined &&
+      getIgnoredTx(kvStore, txId) === undefined,
+  );
+  const cacheHits = pendingTxKeys.length - pendingTxKeysToRead.length;
+  console.warn(
+    `pendingTx cache: ${cacheHits} hits, ${pendingTxKeysToRead.length} to read from vstorage`,
   );
   const throttledPendingTxKeys = rateLimitedSource({
     policy: { quota: capacity, windowMs: 1000 },
@@ -873,7 +887,10 @@ export const startEngine = async (
           }
           return;
         }
-        if (!RESOLVER_SUPPORTED_TRANSACTIONS.includes(data.type)) return;
+        if (!RESOLVER_SUPPORTED_TRANSACTIONS.includes(data.type)) {
+          setIgnoredTx(kvStore, txId, data.type);
+          return;
+        }
         mustMatch(harden(data), PublishedTxShape, path);
         initialPendingTxData.push({
           blockHeight: BigInt(streamCell.blockHeight),

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -570,7 +570,12 @@ export const processPendingTxEvents = async (
           abortController.abort(reason);
           pendingTxAbortControllers.delete(txId);
         }
-        setResolvedTx(kvStore, txId, String(data.status));
+        if (
+          data.status === TxStatus.SUCCESS ||
+          data.status === TxStatus.FAILED
+        ) {
+          setResolvedTx(kvStore, txId, data.status);
+        }
         continue;
       }
       if (!RESOLVER_SUPPORTED_TRANSACTIONS.includes(data.type)) continue;
@@ -860,7 +865,12 @@ export const startEngine = async (
         data = marshaller.fromCapData(marshalledData);
         if (data?.status !== TxStatus.PENDING) {
           // Backfill the cache so subsequent restarts skip this read.
-          if (data?.status) setResolvedTx(kvStore, txId, String(data.status));
+          if (
+            data?.status === TxStatus.SUCCESS ||
+            data?.status === TxStatus.FAILED
+          ) {
+            setResolvedTx(kvStore, txId, data.status);
+          }
           return;
         }
         if (!RESOLVER_SUPPORTED_TRANSACTIONS.includes(data.type)) return;

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -133,6 +133,17 @@ const RESOLVER_SUPPORTED_TRANSACTIONS: TxType[] = [
   TxType.MAKE_ACCOUNT,
 ];
 
+/**
+ * Tx types that are settled by the contract itself, not the planner. Entries
+ * of these types are safe to permanently cache as "ignored" so subsequent
+ * startups skip the vstorage read.
+ */
+const RESOLVER_IGNORED_PENDINGTX_TYPES: TxType[] = [
+  TxType.IBC_FROM_AGORIC,
+  TxType.IBC_FROM_REMOTE,
+  TxType.CCTP_TO_AGORIC,
+];
+
 const makeVstoragePathPrefixes = (contractInstance: string) => ({
   portfoliosPathPrefix: `published.${contractInstance}.portfolios`,
   pendingTxPathPrefix: `published.${contractInstance}.pendingTxs`,
@@ -583,7 +594,7 @@ export const processPendingTxEvents = async (
         }
         continue;
       }
-      if (!RESOLVER_SUPPORTED_TRANSACTIONS.includes(data.type)) {
+      if (RESOLVER_IGNORED_PENDINGTX_TYPES.includes(data.type)) {
         setIgnoredTx(kvStore, txId, data.type);
         continue;
       }
@@ -887,7 +898,7 @@ export const startEngine = async (
           }
           return;
         }
-        if (!RESOLVER_SUPPORTED_TRANSACTIONS.includes(data.type)) {
+        if (RESOLVER_IGNORED_PENDINGTX_TYPES.includes(data.type)) {
           setIgnoredTx(kvStore, txId, data.type);
           return;
         }

--- a/services/ymax-planner/src/kv-store.ts
+++ b/services/ymax-planner/src/kv-store.ts
@@ -4,7 +4,7 @@
  */
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import { makeKVStore } from '@agoric/internal/src/kv-store.js';
-import type { TxStatus } from '@agoric/portfolio-api/src/resolver.js';
+import type { TxStatus, TxType } from '@agoric/portfolio-api/src/resolver.js';
 import type { Database as SQLiteDatabase } from 'better-sqlite3';
 import Database from 'better-sqlite3';
 
@@ -122,4 +122,27 @@ export const setResolvedTx = (
 
 export const deleteResolvedTx = (store: KVStore, txId: `tx${number}`): void => {
   store.delete(getResolvedTxKey(txId));
+};
+
+const getIgnoredTxKey = (txId: `tx${number}`) => `${txId}.ignored`;
+
+export const getIgnoredTx = (
+  store: KVStore,
+  txId: `tx${number}`,
+): TxType | undefined => store.get(getIgnoredTxKey(txId)) as TxType | undefined;
+
+/**
+ * Mark a tx as one the planner does not act on (its `type` is not in
+ * `RESOLVER_SUPPORTED_TRANSACTIONS`).
+ */
+export const setIgnoredTx = (
+  store: KVStore,
+  txId: `tx${number}`,
+  type: TxType,
+): void => {
+  store.set(getIgnoredTxKey(txId), type);
+};
+
+export const deleteIgnoredTx = (store: KVStore, txId: `tx${number}`): void => {
+  store.delete(getIgnoredTxKey(txId));
 };

--- a/services/ymax-planner/src/kv-store.ts
+++ b/services/ymax-planner/src/kv-store.ts
@@ -4,8 +4,11 @@
  */
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import { makeKVStore } from '@agoric/internal/src/kv-store.js';
+import type { TxStatus } from '@agoric/portfolio-api/src/resolver.js';
 import type { Database as SQLiteDatabase } from 'better-sqlite3';
 import Database from 'better-sqlite3';
+
+type ResolvedTxStatus = Exclude<TxStatus, 'pending' | 'setup'>;
 
 type SQLiteKeyValueStoreOptions = {
   trace: (...args: string[]) => void;
@@ -102,17 +105,17 @@ const getResolvedTxKey = (txId: `tx${number}`) => `${txId}.resolved`;
 export const getResolvedTx = (
   store: KVStore,
   txId: `tx${number}`,
-): string | undefined => store.get(getResolvedTxKey(txId));
+): ResolvedTxStatus | undefined =>
+  store.get(getResolvedTxKey(txId)) as ResolvedTxStatus | undefined;
 
 /**
- * Mark a tx as no longer PENDING so future startups can skip the per-tx
- * vstorage read. The contract never moves a tx back to PENDING, so cached
- * entries are always trustworthy.
+ * Mark a tx as settled so future startups can skip the per-tx vstorage read.
+ * Only `success` and `failed` are terminal;
  */
 export const setResolvedTx = (
   store: KVStore,
   txId: `tx${number}`,
-  status: string,
+  status: ResolvedTxStatus,
 ): void => {
   store.set(getResolvedTxKey(txId), status);
 };

--- a/services/ymax-planner/src/kv-store.ts
+++ b/services/ymax-planner/src/kv-store.ts
@@ -96,3 +96,27 @@ export const deleteTxBlockLowerBound = (
 ): void => {
   store.delete(getTxBlockLowerBoundKey(txId, scope));
 };
+
+const getResolvedTxKey = (txId: `tx${number}`) => `${txId}.resolved`;
+
+export const getResolvedTx = (
+  store: KVStore,
+  txId: `tx${number}`,
+): string | undefined => store.get(getResolvedTxKey(txId));
+
+/**
+ * Mark a tx as no longer PENDING so future startups can skip the per-tx
+ * vstorage read. The contract never moves a tx back to PENDING, so cached
+ * entries are always trustworthy.
+ */
+export const setResolvedTx = (
+  store: KVStore,
+  txId: `tx${number}`,
+  status: string,
+): void => {
+  store.set(getResolvedTxKey(txId), status);
+};
+
+export const deleteResolvedTx = (store: KVStore, txId: `tx${number}`): void => {
+  store.delete(getResolvedTxKey(txId));
+};

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -17,6 +17,7 @@ import type {
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
 
 import type { WebSocketProvider } from 'ethers';
+import { setResolvedTx } from './kv-store.ts';
 import { resolvePendingTx } from './resolver.ts';
 import { submitWithRetry } from './retry-settlement.ts';
 import { waitForBlock, type EvmRpc } from './evm-scanner.ts';
@@ -202,17 +203,16 @@ const cctpMonitor: PendingTxMonitor<CctpTx> = {
     }
 
     if (transferResult.settled) {
-      await submitWithRetry(
+      const finalStatus =
+        transferResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED;
+      const submitted = await submitWithRetry(
         `${logPrefix} CCTP settlement`,
         () =>
           resolvePendingTx({
             signingSmartWalletKit: ctx.signingSmartWalletKit,
             makeNonce: ctx.makeNonce,
             txId,
-            status:
-              transferResult.success !== false
-                ? TxStatus.SUCCESS
-                : TxStatus.FAILED,
+            status: finalStatus,
           }),
         {
           log,
@@ -222,6 +222,9 @@ const cctpMonitor: PendingTxMonitor<CctpTx> = {
           signal: opts.signal,
         },
       );
+      if (submitted !== undefined) {
+        setResolvedTx(ctx.kvStore, txId, finalStatus);
+      }
     }
 
     if (transferResult?.txHash) {
@@ -350,17 +353,16 @@ const gmpMonitor: PendingTxMonitor<GmpTx> = {
     }
 
     if (transferResult.settled) {
-      await submitWithRetry(
+      const finalStatus =
+        transferResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED;
+      const submitted = await submitWithRetry(
         `${logPrefix} GMP settlement`,
         () =>
           resolvePendingTx({
             signingSmartWalletKit: ctx.signingSmartWalletKit,
             makeNonce: ctx.makeNonce,
             txId,
-            status:
-              transferResult.success !== false
-                ? TxStatus.SUCCESS
-                : TxStatus.FAILED,
+            status: finalStatus,
           }),
         {
           log,
@@ -370,6 +372,9 @@ const gmpMonitor: PendingTxMonitor<GmpTx> = {
           signal: opts.signal,
         },
       );
+      if (submitted !== undefined) {
+        setResolvedTx(ctx.kvStore, txId, finalStatus);
+      }
     }
 
     if (transferResult?.txHash) {
@@ -503,17 +508,16 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx> = {
     }
 
     if (walletResult.settled) {
-      await submitWithRetry(
+      const finalStatus =
+        walletResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED;
+      const submitted = await submitWithRetry(
         `${logPrefix} MAKE_ACCOUNT settlement`,
         () =>
           resolvePendingTx({
             signingSmartWalletKit: ctx.signingSmartWalletKit,
             makeNonce: ctx.makeNonce,
             txId,
-            status:
-              walletResult.success !== false
-                ? TxStatus.SUCCESS
-                : TxStatus.FAILED,
+            status: finalStatus,
           }),
         {
           log,
@@ -523,6 +527,9 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx> = {
           signal: opts.signal,
         },
       );
+      if (submitted !== undefined) {
+        setResolvedTx(ctx.kvStore, txId, finalStatus);
+      }
     }
 
     if (walletResult?.txHash) {
@@ -642,17 +649,16 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx> = {
     }
 
     if (transferResult.settled) {
-      await submitWithRetry(
+      const finalStatus =
+        transferResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED;
+      const submitted = await submitWithRetry(
         `${logPrefix} ROUTED_GMP settlement`,
         () =>
           resolvePendingTx({
             signingSmartWalletKit: ctx.signingSmartWalletKit,
             makeNonce: ctx.makeNonce,
             txId,
-            status:
-              transferResult.success !== false
-                ? TxStatus.SUCCESS
-                : TxStatus.FAILED,
+            status: finalStatus,
           }),
         {
           log,
@@ -662,6 +668,9 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx> = {
           signal: opts.signal,
         },
       );
+      if (submitted !== undefined) {
+        setResolvedTx(ctx.kvStore, txId, finalStatus);
+      }
     }
 
     if (transferResult?.txHash) {

--- a/services/ymax-planner/test/cctp-watcher.test.ts
+++ b/services/ymax-planner/test/cctp-watcher.test.ts
@@ -10,6 +10,7 @@ import {
   mockFetch,
 } from './mocks.ts';
 import { handlePendingTx } from '../src/pending-tx-manager.ts';
+import { getResolvedTx } from '../src/kv-store.ts';
 
 const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const toAddress = '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64';
@@ -78,6 +79,8 @@ test('handlePendingTx processes CCTP transaction successfully', async t => {
     `[${txId}] ✓ Amount matches! Expected: ${amount}, Received: ${amount}`,
     `[${txId}] CCTP tx resolved`,
   ]);
+
+  t.is(getResolvedTx(opts.kvStore, txId), 'success');
 });
 
 test('handlePendingTx keeps tx pending on amount mismatch until timeout and then logs it', async t => {

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -133,14 +133,17 @@ test('processPendingTxEvents errors do not disrupt processing valid transactions
     ...createMockPendingTxOpts(),
     error: (...args) => errorLog.push(args),
   });
-  if (errorLog.length !== 1) {
-    t.log(errorLog);
-  }
-  t.is(errorLog.length, 1);
-  t.regex(
-    errorLog[0].at(-1).message,
-    /\btx3\b.*Must have missing properties.*blockHeight/,
-  );
+  // tx2: malformed record (status=pending but no `type`) surfaces through
+  // mustMatch(data, PublishedTxShape, ...) — previously silently skipped.
+  // tx3: streamCell missing the required `blockHeight` field.
+  const messages = errorLog.map(args => args.at(-1).message);
+  const tx2Msg = messages.find(m => /\btx2\b/.test(m));
+  const tx3Msg = messages.find(m => /\btx3\b/.test(m));
+  t.truthy(tx2Msg, 'expected an error for tx2');
+  t.truthy(tx3Msg, 'expected an error for tx3');
+  t.regex(tx2Msg!, /Must match one of/);
+  t.regex(tx3Msg!, /Must have missing properties.*blockHeight/);
+  t.is(errorLog.length, 2);
 
   t.is(handledTxs.length, 2);
 });

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -19,6 +19,7 @@ import {
   processPendingTxEvents,
   processInitialPendingTransactions,
 } from '../src/engine.ts';
+import { getResolvedTx } from '../src/kv-store.ts';
 import {
   createMockPendingTxOpts,
   createMockPendingTxEvent,
@@ -172,6 +173,31 @@ test('processPendingTxEvents handles only pending transactions', async t => {
 
   t.is(handledTxs.length, 1);
   t.is(handledTxs[0].status, 'pending');
+});
+
+test('processPendingTxEvents caches resolved-tx status when status flips to non-pending', async t => {
+  const { mockHandlePendingTx, handledTxs } = makeMockHandlePendingTx();
+
+  const opts = createMockPendingTxOpts();
+  const settledTx = createMockPendingTxData({
+    type: TxType.CCTP_TO_EVM,
+    status: 'success',
+  });
+  const events = [
+    createMockPendingTxEvent(
+      'tx99',
+      JSON.stringify(
+        createMockStreamCell([JSON.stringify(marshaller.toCapData(settledTx))]),
+      ),
+    ),
+  ];
+
+  t.is(getResolvedTx(opts.kvStore, 'tx99'), undefined);
+
+  await processPendingTxEvents(events, mockHandlePendingTx, opts);
+
+  t.is(handledTxs.length, 0);
+  t.is(getResolvedTx(opts.kvStore, 'tx99'), 'success');
 });
 
 // --- Unit tests for handlePendingTx ---

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -200,6 +200,29 @@ test('processPendingTxEvents caches resolved-tx status when status flips to non-
   t.is(getResolvedTx(opts.kvStore, 'tx99'), 'success');
 });
 
+test('processPendingTxEvents does not cache `setup` status', async t => {
+  const { mockHandlePendingTx, handledTxs } = makeMockHandlePendingTx();
+
+  const opts = createMockPendingTxOpts();
+  const setupTx = createMockPendingTxData({
+    type: TxType.CCTP_TO_EVM,
+    status: 'setup',
+  });
+  const events = [
+    createMockPendingTxEvent(
+      'tx100',
+      JSON.stringify(
+        createMockStreamCell([JSON.stringify(marshaller.toCapData(setupTx))]),
+      ),
+    ),
+  ];
+
+  await processPendingTxEvents(events, mockHandlePendingTx, opts);
+
+  t.is(handledTxs.length, 0);
+  t.is(getResolvedTx(opts.kvStore, 'tx100'), undefined);
+});
+
 // --- Unit tests for handlePendingTx ---
 test('handlePendingTx prints error for unsupported transaction type', async t => {
   const mockLog = () => {};

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -19,7 +19,7 @@ import {
   processPendingTxEvents,
   processInitialPendingTransactions,
 } from '../src/engine.ts';
-import { getResolvedTx } from '../src/kv-store.ts';
+import { getIgnoredTx, getResolvedTx } from '../src/kv-store.ts';
 import {
   createMockPendingTxOpts,
   createMockPendingTxEvent,
@@ -198,6 +198,33 @@ test('processPendingTxEvents caches resolved-tx status when status flips to non-
 
   t.is(handledTxs.length, 0);
   t.is(getResolvedTx(opts.kvStore, 'tx99'), 'success');
+});
+
+test('processPendingTxEvents caches unsupported tx types so future startups skip them', async t => {
+  const { mockHandlePendingTx, handledTxs } = makeMockHandlePendingTx();
+
+  const opts = createMockPendingTxOpts();
+  // IBC_FROM_AGORIC is in MONITORS but not in RESOLVER_SUPPORTED_TRANSACTIONS,
+  // so events for it should be cached as ignored and never handled.
+  const ibcTx = createMockPendingTxData({
+    type: TxType.IBC_FROM_AGORIC,
+    status: 'pending',
+  });
+  const events = [
+    createMockPendingTxEvent(
+      'tx101',
+      JSON.stringify(
+        createMockStreamCell([JSON.stringify(marshaller.toCapData(ibcTx))]),
+      ),
+    ),
+  ];
+
+  t.is(getIgnoredTx(opts.kvStore, 'tx101'), undefined);
+
+  await processPendingTxEvents(events, mockHandlePendingTx, opts);
+
+  t.is(handledTxs.length, 0);
+  t.is(getIgnoredTx(opts.kvStore, 'tx101'), TxType.IBC_FROM_AGORIC);
 });
 
 test('processPendingTxEvents does not cache `setup` status', async t => {

--- a/services/ymax-planner/test/resolved-tx.test.ts
+++ b/services/ymax-planner/test/resolved-tx.test.ts
@@ -1,13 +1,18 @@
 /**
- * Unit tests for `getResolvedTx`, `setResolvedTx`, `deleteResolvedTx`.
+ * Unit tests for `getResolvedTx`, `setResolvedTx`, `deleteResolvedTx`,
+ * `getIgnoredTx`, `setIgnoredTx`, `deleteIgnoredTx`.
  */
 import test from 'ava';
 
 import { makeKVStoreFromMap } from '@agoric/internal/src/kv-store.js';
+import { TxType } from '@agoric/portfolio-api/src/resolver.js';
 
 import {
+  deleteIgnoredTx,
   deleteResolvedTx,
+  getIgnoredTx,
   getResolvedTx,
+  setIgnoredTx,
   setResolvedTx,
 } from '../src/kv-store.ts';
 
@@ -46,4 +51,31 @@ test('entries are keyed independently per txId', t => {
   deleteResolvedTx(store, 'tx1');
   t.is(getResolvedTx(store, 'tx1'), undefined);
   t.is(getResolvedTx(store, 'tx2'), 'failed');
+});
+
+test('getIgnoredTx returns undefined for an unknown txId', t => {
+  const store = makeKVStoreFromMap(new Map());
+  t.is(getIgnoredTx(store, 'tx1'), undefined);
+});
+
+test('setIgnoredTx then getIgnoredTx roundtrips the type', t => {
+  const store = makeKVStoreFromMap(new Map());
+  setIgnoredTx(store, 'tx1', TxType.IBC_FROM_AGORIC);
+  t.is(getIgnoredTx(store, 'tx1'), TxType.IBC_FROM_AGORIC);
+});
+
+test('deleteIgnoredTx removes the entry', t => {
+  const store = makeKVStoreFromMap(new Map());
+  setIgnoredTx(store, 'tx1', TxType.IBC_FROM_AGORIC);
+  deleteIgnoredTx(store, 'tx1');
+  t.is(getIgnoredTx(store, 'tx1'), undefined);
+});
+
+test('resolved and ignored caches are keyed independently', t => {
+  const store = makeKVStoreFromMap(new Map());
+  setResolvedTx(store, 'tx1', 'success');
+  setIgnoredTx(store, 'tx1', TxType.IBC_FROM_AGORIC);
+  // Both helpers see their own value for the same txId.
+  t.is(getResolvedTx(store, 'tx1'), 'success');
+  t.is(getIgnoredTx(store, 'tx1'), TxType.IBC_FROM_AGORIC);
 });

--- a/services/ymax-planner/test/resolved-tx.test.ts
+++ b/services/ymax-planner/test/resolved-tx.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for `getResolvedTx`, `setResolvedTx`, `deleteResolvedTx`.
+ */
+import test from 'ava';
+
+import { makeKVStoreFromMap } from '@agoric/internal/src/kv-store.js';
+
+import {
+  deleteResolvedTx,
+  getResolvedTx,
+  setResolvedTx,
+} from '../src/kv-store.ts';
+
+test('getResolvedTx returns undefined for an unknown txId', t => {
+  const store = makeKVStoreFromMap(new Map());
+  t.is(getResolvedTx(store, 'tx1'), undefined);
+});
+
+test('setResolvedTx then getResolvedTx roundtrips the status', t => {
+  const store = makeKVStoreFromMap(new Map());
+  setResolvedTx(store, 'tx1', 'success');
+  t.is(getResolvedTx(store, 'tx1'), 'success');
+});
+
+test('setResolvedTx overwrites a prior entry', t => {
+  const store = makeKVStoreFromMap(new Map());
+  setResolvedTx(store, 'tx1', 'success');
+  setResolvedTx(store, 'tx1', 'failed');
+  t.is(getResolvedTx(store, 'tx1'), 'failed');
+});
+
+test('deleteResolvedTx removes the entry', t => {
+  const store = makeKVStoreFromMap(new Map());
+  setResolvedTx(store, 'tx1', 'success');
+  deleteResolvedTx(store, 'tx1');
+  t.is(getResolvedTx(store, 'tx1'), undefined);
+});
+
+test('entries are keyed independently per txId', t => {
+  const store = makeKVStoreFromMap(new Map());
+  setResolvedTx(store, 'tx1', 'success');
+  setResolvedTx(store, 'tx2', 'failed');
+  t.is(getResolvedTx(store, 'tx1'), 'success');
+  t.is(getResolvedTx(store, 'tx2'), 'failed');
+
+  deleteResolvedTx(store, 'tx1');
+  t.is(getResolvedTx(store, 'tx1'), undefined);
+  t.is(getResolvedTx(store, 'tx2'), 'failed');
+});


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://linear.app/agoric/issue/AGO-547/ymax-planner-remember-last-resolved-transaction

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
The PR ensures that the planner records each settled `txId` in its SQLite KV store, so subsequent restarts skip the per-tx vstorage read for anything already known to be resolved.

### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
- Unit tests were added for the new helpers created.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment.