### PR TITLE
chore(ymax-planner): add cache subcommand to tx-tool

### DIFF
--- a/services/ymax-planner/scripts/cache-tool-lib.ts
+++ b/services/ymax-planner/scripts/cache-tool-lib.ts
@@ -1,0 +1,112 @@
+/**
+ * Operator tools for inspecting and invalidating the planner's pendingTx
+ * caches (`resolved` and `ignored`) stored in the SQLite KV store.
+ *
+ * Driven from `scripts/tx-tool.ts cache <subcommand>`.
+ */
+/* global process */
+
+import { Fail, q } from '@endo/errors';
+
+import {
+  deleteIgnoredTx,
+  deleteResolvedTx,
+  deleteTxBlockLowerBound,
+  getIgnoredTx,
+  getResolvedTx,
+  getTxBlockLowerBound,
+  makeSQLiteKeyValueStore,
+} from '../src/kv-store.ts';
+
+type Env = Record<string, string | undefined>;
+
+const openCache = (env: Env) => {
+  const dbPath = env.SQLITE_DB_PATH || Fail`SQLITE_DB_PATH is required`;
+  return makeSQLiteKeyValueStore(dbPath, { trace: () => {} });
+};
+
+const isTxId = (s: string): s is `tx${number}` => /^tx\d+$/.test(s);
+
+const assertTxId = (txId: string): `tx${number}` => {
+  isTxId(txId) || Fail`Invalid txId: ${q(txId)} (expected "tx<number>")`;
+  return txId as `tx${number}`;
+};
+
+export const inspectCache = (
+  txIdArg: string,
+  { env = process.env }: { env?: Env } = {},
+) => {
+  const txId = assertTxId(txIdArg);
+  const { db, kvStore } = openCache(env);
+  try {
+    const resolved = getResolvedTx(kvStore, txId);
+    const ignored = getIgnoredTx(kvStore, txId);
+    const blockLowerBound = getTxBlockLowerBound(kvStore, txId);
+    console.log(`Cache state for ${txId}:`);
+    console.log(`  resolved:        ${resolved ?? '(none)'}`);
+    console.log(`  ignored:         ${ignored ?? '(none)'}`);
+    console.log(`  blockLowerBound: ${blockLowerBound ?? '(none)'}`);
+  } finally {
+    db.close();
+  }
+};
+
+export const deleteCachedTx = (
+  txIdArg: string,
+  { env = process.env }: { env?: Env } = {},
+) => {
+  const txId = assertTxId(txIdArg);
+  const { db, kvStore } = openCache(env);
+  try {
+    const before = {
+      resolved: getResolvedTx(kvStore, txId),
+      ignored: getIgnoredTx(kvStore, txId),
+      blockLowerBound: getTxBlockLowerBound(kvStore, txId),
+    };
+    deleteResolvedTx(kvStore, txId);
+    deleteIgnoredTx(kvStore, txId);
+    deleteTxBlockLowerBound(kvStore, txId);
+    const removed = Object.entries(before)
+      .filter(([_, v]) => v !== undefined)
+      .map(([k]) => k);
+    if (removed.length === 0) {
+      console.log(`No cache entries found for ${txId}`);
+    } else {
+      console.log(`Removed cache entries for ${txId}: ${removed.join(', ')}`);
+    }
+  } finally {
+    db.close();
+  }
+};
+
+export const cacheStats = ({ env = process.env }: { env?: Env } = {}) => {
+  const { db } = openCache(env);
+  try {
+    const tally = (suffix: 'resolved' | 'ignored') =>
+      db
+        .prepare(
+          `SELECT value, COUNT(*) AS n FROM kvStore
+           WHERE key LIKE ? GROUP BY value ORDER BY n DESC`,
+        )
+        .all(`%.${suffix}`) as Array<{ value: string; n: number }>;
+
+    const print = (
+      label: string,
+      rows: Array<{ value: string; n: number }>,
+    ) => {
+      console.log(`${label}:`);
+      if (rows.length === 0) {
+        console.log('  (none)');
+        return;
+      }
+      const total = rows.reduce((sum, { n }) => sum + n, 0);
+      for (const { value, n } of rows) console.log(`  ${value}: ${n}`);
+      console.log(`  total: ${total}`);
+    };
+
+    print('resolved', tally('resolved'));
+    print('ignored', tally('ignored'));
+  } finally {
+    db.close();
+  }
+};

--- a/services/ymax-planner/scripts/tx-tool.ts
+++ b/services/ymax-planner/scripts/tx-tool.ts
@@ -5,6 +5,7 @@ import '@endo/init/pre-remoting.js';
 import '../src/shims.cjs';
 import '../src/lockdown.js';
 
+import { cacheStats, deleteCachedTx, inspectCache } from './cache-tool-lib.ts';
 import { processTx } from './process-tx-lib.ts';
 import { resolveTx } from './resolve-tx-lib.ts';
 
@@ -27,6 +28,19 @@ const showUsage = () => {
   console.error('    status: "success" or "fail"');
   console.error('    reason: required when status is "fail"');
   console.error('');
+  console.error('  cache inspect <txId>');
+  console.error(
+    '    Print resolved / ignored / blockLowerBound cache state for a txId',
+  );
+  console.error('');
+  console.error('  cache delete <txId>');
+  console.error(
+    '    Remove all cache entries for a txId so the next startup re-reads it',
+  );
+  console.error('');
+  console.error('  cache stats');
+  console.error('    Show counts of cached entries grouped by status / type');
+  console.error('');
   console.error('Examples:');
   console.error('  ./scripts/tx-tool.ts scan tx233');
   console.error('  ./scripts/tx-tool.ts scan tx233 --verbose');
@@ -34,6 +48,9 @@ const showUsage = () => {
   console.error(
     '  ./scripts/tx-tool.ts settle tx400 fail "Transaction timeout"',
   );
+  console.error('  ./scripts/tx-tool.ts cache inspect tx233');
+  console.error('  ./scripts/tx-tool.ts cache delete tx233');
+  console.error('  ./scripts/tx-tool.ts cache stats');
 };
 
 const args = process.argv.slice(2);
@@ -99,6 +116,44 @@ if (command === 'scan') {
     console.error(err);
     process.exit(1);
   });
+} else if (command === 'cache') {
+  const sub = commandArgs[0];
+  const rest = commandArgs.slice(1);
+  try {
+    switch (sub) {
+      case 'inspect': {
+        rest.length === 1 ||
+          (() => {
+            console.error('Usage: ./scripts/tx-tool.ts cache inspect <txId>');
+            process.exit(1);
+          })();
+        inspectCache(rest[0], { env });
+        break;
+      }
+      case 'delete': {
+        rest.length === 1 ||
+          (() => {
+            console.error('Usage: ./scripts/tx-tool.ts cache delete <txId>');
+            process.exit(1);
+          })();
+        deleteCachedTx(rest[0], { env });
+        break;
+      }
+      case 'stats': {
+        cacheStats({ env });
+        break;
+      }
+      default: {
+        console.error(`Error: Unknown cache subcommand "${sub ?? ''}"`);
+        console.error('');
+        showUsage();
+        process.exit(1);
+      }
+    }
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
 } else {
   console.error(`Error: Unknown command "${command}"`);
   console.error('');


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Adds a `cache` subcommand to `tx-tool.ts` with `inspect`, `delete`, and `stats` operations so operators can manage the planner's pendingTx caches without dropping into raw `sqlite3`.