### PR TITLE
chore(ymax-planner): retry vstorage reads during planner startup

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -736,9 +736,14 @@ export const startEngine = async (
   await null;
   const { query, marshaller } = signingSmartWalletKit;
 
-  const vbankAssets: AssetInfo[] = (
-    await query.readPublished('agoricNames.vbankAsset')
-  ).map(([_ibcDenom, asset]) => asset);
+  const vbankAssetCapData = await readStreamCellValue(
+    query.vstorage,
+    'published.agoricNames.vbankAsset',
+    { retries: 4 },
+  );
+  const vbankAssets: AssetInfo[] = marshaller
+    .fromCapData(vbankAssetCapData)
+    .map(([_ibcDenom, asset]) => asset);
   const depositAsset =
     vbankAssets.find(asset => asset.issuerName === depositBrandName) ||
     Fail`Could not find vbankAsset for ${q(depositBrandName)}`;
@@ -783,13 +788,11 @@ export const startEngine = async (
 
   // TODO(#12391): Verify consumption of paginated data.
   const [pendingTxKeysResp, portfolioKeysResp] = await Promise.all(
-    [pendingTxPathPrefix, portfoliosPathPrefix].map(async vstoragePath => {
-      const opts = { kind: 'children' } as const;
-      const resp = await query.vstorage.readStorageMeta(vstoragePath, opts);
-      typeof resp.blockHeight === 'bigint' ||
-        Fail`blockHeight ${resp.blockHeight} must be a bigint`;
-      return resp;
-    }),
+    [pendingTxPathPrefix, portfoliosPathPrefix].map(vstoragePath =>
+      readStorageMeta(query.vstorage, vstoragePath, 'children', {
+        retries: 4,
+      }),
+    ),
   );
   const initialBlockHeight = [pendingTxKeysResp, portfolioKeysResp]
     .map(r => r.blockHeight as bigint)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://linear.app/agoric/issue/AGO-579/ymax-planner-add-retries-to-startup-vstorage-calls

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
The startup reads for `agoricNames.vbankAsset` and the initial `pendingTxs`/`portfolios` children went straight to the underlying vstorage client and aborted on the first transient RPC failure, while every other vstorage read in the planner already retries up to 4 times.
  
The PR routes both through the local `readStreamCellValue` / `readStorageMeta` helpers with `retries: 4` so a flaky node during boot no longer crashes the planner before it can subscribe to NewBlock events.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment.