### PR TITLE
chore(ymax-resolver): resolve pending transaction if tx status is known

### DIFF
--- a/services/ymax-planner/scripts/cache-tool-lib.ts
+++ b/services/ymax-planner/scripts/cache-tool-lib.ts
@@ -9,9 +9,11 @@
 import { Fail, q } from '@endo/errors';
 
 import {
+  deleteDerivedOutcome,
   deleteIgnoredTx,
   deleteResolvedTx,
   deleteTxBlockLowerBound,
+  getDerivedOutcome,
   getIgnoredTx,
   getResolvedTx,
   getTxBlockLowerBound,
@@ -42,10 +44,14 @@ export const inspectCache = (
     const resolved = getResolvedTx(kvStore, txId);
     const ignored = getIgnoredTx(kvStore, txId);
     const blockLowerBound = getTxBlockLowerBound(kvStore, txId);
+    const derivedOutcome = getDerivedOutcome(kvStore, txId);
     console.log(`Cache state for ${txId}:`);
     console.log(`  resolved:        ${resolved ?? '(none)'}`);
     console.log(`  ignored:         ${ignored ?? '(none)'}`);
     console.log(`  blockLowerBound: ${blockLowerBound ?? '(none)'}`);
+    console.log(
+      `  derivedOutcome:  ${derivedOutcome ? JSON.stringify(derivedOutcome) : '(none)'}`,
+    );
   } finally {
     db.close();
   }
@@ -62,10 +68,12 @@ export const deleteCachedTx = (
       resolved: getResolvedTx(kvStore, txId),
       ignored: getIgnoredTx(kvStore, txId),
       blockLowerBound: getTxBlockLowerBound(kvStore, txId),
+      derivedOutcome: getDerivedOutcome(kvStore, txId),
     };
     deleteResolvedTx(kvStore, txId);
     deleteIgnoredTx(kvStore, txId);
     deleteTxBlockLowerBound(kvStore, txId);
+    deleteDerivedOutcome(kvStore, txId);
     const removed = Object.entries(before)
       .filter(([_, v]) => v !== undefined)
       .map(([k]) => k);

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -76,6 +76,7 @@ import {
   planWithdrawFromAllocations,
 } from './plan-deposit.ts';
 import {
+  deleteDerivedOutcome,
   getIgnoredTx,
   getResolvedTx,
   setIgnoredTx,
@@ -591,6 +592,7 @@ export const processPendingTxEvents = async (
           data.status === TxStatus.FAILED
         ) {
           setResolvedTx(kvStore, txId, data.status);
+          deleteDerivedOutcome(kvStore, txId);
         }
         continue;
       }
@@ -898,6 +900,7 @@ export const startEngine = async (
             data?.status === TxStatus.FAILED
           ) {
             setResolvedTx(kvStore, txId, data.status);
+            deleteDerivedOutcome(kvStore, txId);
           }
           return;
         }

--- a/services/ymax-planner/src/kv-store.ts
+++ b/services/ymax-planner/src/kv-store.ts
@@ -146,3 +146,44 @@ export const setIgnoredTx = (
 export const deleteIgnoredTx = (store: KVStore, txId: `tx${number}`): void => {
   store.delete(getIgnoredTxKey(txId));
 };
+
+/**
+ * The outcome derived by a watcher but not yet confirmed as settled on-chain.
+ * Persisted between the watcher resolving the outcome and the resolver
+ * smart-wallet submission succeeding, so a restart in that window can skip
+ * the (expensive) watcher and just retry the submission.
+ */
+export type DerivedOutcome = {
+  status: ResolvedTxStatus;
+  txHash?: string;
+};
+
+const getDerivedOutcomeKey = (txId: `tx${number}`) => `${txId}.derivedOutcome`;
+
+export const getDerivedOutcome = (
+  store: KVStore,
+  txId: `tx${number}`,
+): DerivedOutcome | undefined => {
+  const raw = store.get(getDerivedOutcomeKey(txId));
+  if (raw === undefined) return undefined;
+  try {
+    return JSON.parse(raw) as DerivedOutcome;
+  } catch (cause) {
+    throw Error(`Invalid derivedOutcome for ${txId}: ${raw}`, { cause });
+  }
+};
+
+export const setDerivedOutcome = (
+  store: KVStore,
+  txId: `tx${number}`,
+  outcome: DerivedOutcome,
+): void => {
+  store.set(getDerivedOutcomeKey(txId), JSON.stringify(outcome));
+};
+
+export const deleteDerivedOutcome = (
+  store: KVStore,
+  txId: `tx${number}`,
+): void => {
+  store.delete(getDerivedOutcomeKey(txId));
+};

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -17,7 +17,12 @@ import type {
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
 
 import type { WebSocketProvider } from 'ethers';
-import { setResolvedTx } from './kv-store.ts';
+import {
+  deleteDerivedOutcome,
+  getDerivedOutcome,
+  setDerivedOutcome,
+  setResolvedTx,
+} from './kv-store.ts';
 import { resolvePendingTx } from './resolver.ts';
 import { withRetriesForAlerting } from './retries.ts';
 import { waitForBlock, type EvmRpc } from './evm-scanner.ts';
@@ -99,6 +104,57 @@ export type PendingTxMonitor<T extends PendingTx = PendingTx> = {
     log: (...args: unknown[]) => void,
     opts: WatchOpts,
   ) => Promise<void>;
+};
+
+/**
+ * Settle a watcher's outcome on-chain and notify YDS.
+ *
+ * Persists the derived outcome to the kv store BEFORE attempting submission,
+ * so a restart during a stuck submission can skip the (expensive) watcher
+ * next time and just retry the submit. Clears the derived-outcome entry once
+ * the on-chain settlement confirms.
+ */
+export const settleWatcherResult = async (
+  ctx: EvmContext,
+  txId: TxId,
+  result: WatcherResult,
+  label: string,
+  log: (...args: unknown[]) => void,
+  signal?: AbortSignal,
+): Promise<void> => {
+  await null;
+  if (!result.settled) return;
+
+  const logPrefix = `[${txId}]`;
+  const status = result.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED;
+
+  setDerivedOutcome(ctx.kvStore, txId, { status, txHash: result.txHash });
+
+  const submitted = await withRetriesForAlerting(
+    `${logPrefix} ${label} settlement`,
+    () =>
+      resolvePendingTx({
+        signingSmartWalletKit: ctx.signingSmartWalletKit,
+        makeNonce: ctx.makeNonce,
+        txId,
+        status,
+      }),
+    {
+      log,
+      setTimeout: ctx.setTimeout,
+      now: ctx.now,
+      alertingPrefix: `[${PendingTxCode.RESOLVER_SETTLEMENT_FAILED}]`,
+      signal,
+    },
+  );
+  if (submitted !== undefined) {
+    setResolvedTx(ctx.kvStore, txId, status);
+    deleteDerivedOutcome(ctx.kvStore, txId);
+  }
+
+  if (result.txHash) {
+    await ctx.ydsNotifier?.notifySettlement(txId, result.txHash);
+  }
 };
 
 const cctpMonitor: PendingTxMonitor<CctpTx> = {
@@ -202,34 +258,14 @@ const cctpMonitor: PendingTxMonitor<CctpTx> = {
       return;
     }
 
-    if (transferResult.settled) {
-      const finalStatus =
-        transferResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED;
-      const submitted = await withRetriesForAlerting(
-        `${logPrefix} CCTP settlement`,
-        () =>
-          resolvePendingTx({
-            signingSmartWalletKit: ctx.signingSmartWalletKit,
-            makeNonce: ctx.makeNonce,
-            txId,
-            status: finalStatus,
-          }),
-        {
-          log,
-          setTimeout: ctx.setTimeout,
-          now: ctx.now,
-          alertingPrefix: `[${PendingTxCode.RESOLVER_SETTLEMENT_FAILED}]`,
-          signal: opts.signal,
-        },
-      );
-      if (submitted !== undefined) {
-        setResolvedTx(ctx.kvStore, txId, finalStatus);
-      }
-    }
-
-    if (transferResult?.txHash) {
-      await ctx.ydsNotifier?.notifySettlement(txId, transferResult.txHash);
-    }
+    await settleWatcherResult(
+      ctx,
+      txId,
+      transferResult,
+      'CCTP',
+      log,
+      opts.signal,
+    );
 
     log(`${logPrefix} CCTP tx resolved`);
   },
@@ -352,34 +388,14 @@ const gmpMonitor: PendingTxMonitor<GmpTx> = {
       return;
     }
 
-    if (transferResult.settled) {
-      const finalStatus =
-        transferResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED;
-      const submitted = await withRetriesForAlerting(
-        `${logPrefix} GMP settlement`,
-        () =>
-          resolvePendingTx({
-            signingSmartWalletKit: ctx.signingSmartWalletKit,
-            makeNonce: ctx.makeNonce,
-            txId,
-            status: finalStatus,
-          }),
-        {
-          log,
-          setTimeout: ctx.setTimeout,
-          now: ctx.now,
-          alertingPrefix: `[${PendingTxCode.RESOLVER_SETTLEMENT_FAILED}]`,
-          signal: opts.signal,
-        },
-      );
-      if (submitted !== undefined) {
-        setResolvedTx(ctx.kvStore, txId, finalStatus);
-      }
-    }
-
-    if (transferResult?.txHash) {
-      await ctx.ydsNotifier?.notifySettlement(txId, transferResult.txHash);
-    }
+    await settleWatcherResult(
+      ctx,
+      txId,
+      transferResult,
+      'GMP',
+      log,
+      opts.signal,
+    );
 
     log(`${logPrefix} GMP tx resolved`);
   },
@@ -507,34 +523,14 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx> = {
       return;
     }
 
-    if (walletResult.settled) {
-      const finalStatus =
-        walletResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED;
-      const submitted = await withRetriesForAlerting(
-        `${logPrefix} MAKE_ACCOUNT settlement`,
-        () =>
-          resolvePendingTx({
-            signingSmartWalletKit: ctx.signingSmartWalletKit,
-            makeNonce: ctx.makeNonce,
-            txId,
-            status: finalStatus,
-          }),
-        {
-          log,
-          setTimeout: ctx.setTimeout,
-          now: ctx.now,
-          alertingPrefix: `[${PendingTxCode.RESOLVER_SETTLEMENT_FAILED}]`,
-          signal: opts.signal,
-        },
-      );
-      if (submitted !== undefined) {
-        setResolvedTx(ctx.kvStore, txId, finalStatus);
-      }
-    }
-
-    if (walletResult?.txHash) {
-      await ctx.ydsNotifier?.notifySettlement(txId, walletResult.txHash);
-    }
+    await settleWatcherResult(
+      ctx,
+      txId,
+      walletResult,
+      'MAKE_ACCOUNT',
+      log,
+      opts.signal,
+    );
 
     log(`${logPrefix} MAKE_ACCOUNT tx resolved`);
   },
@@ -648,34 +644,14 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx> = {
       return;
     }
 
-    if (transferResult.settled) {
-      const finalStatus =
-        transferResult.success !== false ? TxStatus.SUCCESS : TxStatus.FAILED;
-      const submitted = await withRetriesForAlerting(
-        `${logPrefix} ROUTED_GMP settlement`,
-        () =>
-          resolvePendingTx({
-            signingSmartWalletKit: ctx.signingSmartWalletKit,
-            makeNonce: ctx.makeNonce,
-            txId,
-            status: finalStatus,
-          }),
-        {
-          log,
-          setTimeout: ctx.setTimeout,
-          now: ctx.now,
-          alertingPrefix: `[${PendingTxCode.RESOLVER_SETTLEMENT_FAILED}]`,
-          signal: opts.signal,
-        },
-      );
-      if (submitted !== undefined) {
-        setResolvedTx(ctx.kvStore, txId, finalStatus);
-      }
-    }
-
-    if (transferResult?.txHash) {
-      await ctx.ydsNotifier?.notifySettlement(txId, transferResult.txHash);
-    }
+    await settleWatcherResult(
+      ctx,
+      txId,
+      transferResult,
+      'ROUTED_GMP',
+      log,
+      opts.signal,
+    );
 
     log(`${logPrefix} ROUTED_GMP watch completed`);
   },
@@ -803,6 +779,28 @@ export const handlePendingTx = async (
 ) => {
   await null;
   const logPrefix = `[${tx.txId}]`;
+
+  // Fast path: if a prior watcher derived an outcome but the on-chain
+  // submission never confirmed, skip the watcher and just retry the submit.
+  const cached = getDerivedOutcome(watchCtx.kvStore, tx.txId);
+  if (cached) {
+    log(
+      `${logPrefix} reusing cached outcome ${cached.status}; skipping watcher`,
+    );
+    await settleWatcherResult(
+      watchCtx,
+      tx.txId,
+      {
+        settled: true,
+        success: cached.status === TxStatus.SUCCESS,
+        txHash: cached.txHash,
+      },
+      'cached-outcome',
+      (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
+      signal,
+    );
+    return;
+  }
 
   const monitor = MONITORS.get(tx.type);
   if (monitor === null) {

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -4,7 +4,10 @@ import { boardSlottingMarshaller } from '@agoric/client-utils';
 import { objectMap } from '@endo/patterns';
 import { makePromiseKit } from '@endo/promise-kit';
 import type { WebSocketProvider } from 'ethers';
-import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
+import {
+  TxStatus,
+  TxType,
+} from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import type {
   PendingTx,
   TxId,
@@ -19,7 +22,12 @@ import {
   processPendingTxEvents,
   processInitialPendingTransactions,
 } from '../src/engine.ts';
-import { getIgnoredTx, getResolvedTx } from '../src/kv-store.ts';
+import {
+  getDerivedOutcome,
+  getIgnoredTx,
+  getResolvedTx,
+  setDerivedOutcome,
+} from '../src/kv-store.ts';
 import {
   createMockPendingTxOpts,
   createMockPendingTxEvent,
@@ -278,6 +286,45 @@ test('handlePendingTx prints error for unsupported transaction type', async t =>
       `🚨 [${unsupportedTx.txId}] No monitor registered for tx type: ${unsupportedTx.type}`,
     ],
   ]);
+});
+
+test('handlePendingTx fast-paths a cached derivedOutcome and skips the watcher', async t => {
+  const opts = createMockPendingTxOpts();
+  const submittedOffers: any[] = [];
+  const originalExecuteOffer = opts.signingSmartWalletKit.executeOffer;
+  // Capture every offer submitted via the resolver path.
+  (opts.signingSmartWalletKit as any).executeOffer = async (
+    offerSpec: any,
+    fee: any,
+  ) => {
+    submittedOffers.push(offerSpec);
+    return originalExecuteOffer(offerSpec, fee);
+  };
+
+  const txId = 'tx42' as TxId;
+  setDerivedOutcome(opts.kvStore, txId, {
+    status: TxStatus.SUCCESS,
+    txHash: '0xcafef00d',
+  });
+
+  // The fast path only reads tx.txId off this record; type is irrelevant
+  // because the monitor is skipped.
+  const fakeTx = {
+    txId,
+    type: TxType.CCTP_TO_EVM,
+    status: TxStatus.PENDING,
+    amount: 1n,
+    destinationAddress: 'eip155:1:0x0000000000000000000000000000000000000000',
+  } as unknown as PendingTx;
+
+  await handlePendingTx(fakeTx, opts);
+
+  t.is(submittedOffers.length, 1, 'submitted exactly one resolver offer');
+  t.is(submittedOffers[0].offerArgs.txId, txId);
+  t.is(submittedOffers[0].offerArgs.status, TxStatus.SUCCESS);
+  // After successful settlement the cache is promoted derivedOutcome→resolved.
+  t.is(getDerivedOutcome(opts.kvStore, txId), undefined);
+  t.is(getResolvedTx(opts.kvStore, txId), TxStatus.SUCCESS);
 });
 
 const immediateSetTimeout: typeof globalThis.setTimeout = ((

--- a/services/ymax-planner/test/resolved-tx.test.ts
+++ b/services/ymax-planner/test/resolved-tx.test.ts
@@ -8,10 +8,13 @@ import { makeKVStoreFromMap } from '@agoric/internal/src/kv-store.js';
 import { TxType } from '@agoric/portfolio-api/src/resolver.js';
 
 import {
+  deleteDerivedOutcome,
   deleteIgnoredTx,
   deleteResolvedTx,
+  getDerivedOutcome,
   getIgnoredTx,
   getResolvedTx,
+  setDerivedOutcome,
   setIgnoredTx,
   setResolvedTx,
 } from '../src/kv-store.ts';
@@ -78,4 +81,52 @@ test('resolved and ignored caches are keyed independently', t => {
   // Both helpers see their own value for the same txId.
   t.is(getResolvedTx(store, 'tx1'), 'success');
   t.is(getIgnoredTx(store, 'tx1'), TxType.IBC_FROM_AGORIC);
+});
+
+test('getDerivedOutcome returns undefined for an unknown txId', t => {
+  const store = makeKVStoreFromMap(new Map());
+  t.is(getDerivedOutcome(store, 'tx1'), undefined);
+});
+
+test('setDerivedOutcome then getDerivedOutcome roundtrips the record', t => {
+  const store = makeKVStoreFromMap(new Map());
+  setDerivedOutcome(store, 'tx1', { status: 'success', txHash: '0xabc' });
+  t.deepEqual(getDerivedOutcome(store, 'tx1'), {
+    status: 'success',
+    txHash: '0xabc',
+  });
+});
+
+test('setDerivedOutcome roundtrips a record without a txHash', t => {
+  const store = makeKVStoreFromMap(new Map());
+  setDerivedOutcome(store, 'tx1', { status: 'failed' });
+  t.deepEqual(getDerivedOutcome(store, 'tx1'), { status: 'failed' });
+});
+
+test('deleteDerivedOutcome removes the entry', t => {
+  const store = makeKVStoreFromMap(new Map());
+  setDerivedOutcome(store, 'tx1', { status: 'success' });
+  deleteDerivedOutcome(store, 'tx1');
+  t.is(getDerivedOutcome(store, 'tx1'), undefined);
+});
+
+test('derivedOutcome is keyed independently from resolved/ignored', t => {
+  const store = makeKVStoreFromMap(new Map());
+  setResolvedTx(store, 'tx1', 'success');
+  setIgnoredTx(store, 'tx1', TxType.IBC_FROM_AGORIC);
+  setDerivedOutcome(store, 'tx1', { status: 'failed', txHash: '0xdef' });
+  t.is(getResolvedTx(store, 'tx1'), 'success');
+  t.is(getIgnoredTx(store, 'tx1'), TxType.IBC_FROM_AGORIC);
+  t.deepEqual(getDerivedOutcome(store, 'tx1'), {
+    status: 'failed',
+    txHash: '0xdef',
+  });
+});
+
+test('getDerivedOutcome throws on a malformed value', t => {
+  const store = makeKVStoreFromMap(new Map());
+  store.set('tx1.derivedOutcome', '{not json');
+  t.throws(() => getDerivedOutcome(store, 'tx1'), {
+    message: /Invalid derivedOutcome for tx1/,
+  });
 });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://linear.app/agoric/issue/AGO-477/ymax-resolver-persist-resolved-tx-outcomes-to-skip-re-processing-on

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->




### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment.