### PR TITLE
feat(ymax-planner): Query YDS for dynamic instrument status 

### DIFF
--- a/packages/portfolio-api/package.json
+++ b/packages/portfolio-api/package.json
@@ -53,6 +53,7 @@
     "@endo/patterns": "^1.7.0"
   },
   "devDependencies": {
+    "@endo/far": "^1.1.14",
     "@types/js-yaml": "^4",
     "ajv": "^6.12.6",
     "ava": "^7.0.0",

--- a/packages/portfolio-api/src/network/network-spec.ts
+++ b/packages/portfolio-api/src/network/network-spec.ts
@@ -48,8 +48,8 @@ export interface ChainSpec {
 
 // Any reason to block withdrawal is by extension also a reason to block
 // deposit.
-type BlockWithdrawReason = null | 'LOW_LIQUIDITY';
-type BlockDepositReason = BlockWithdrawReason | 'AT_CAPACITY';
+export type BlockWithdrawReason = null | 'LOW_LIQUIDITY';
+export type BlockDepositReason = BlockWithdrawReason | 'AT_CAPACITY';
 
 export type PoolKey = InstrumentId;
 

--- a/packages/portfolio-api/src/network/network-spec.ts
+++ b/packages/portfolio-api/src/network/network-spec.ts
@@ -48,7 +48,7 @@ export interface ChainSpec {
 
 // Any reason to block withdrawal is by extension also a reason to block
 // deposit.
-type BlockWithdrawReason = 'LOW_LIQUIDITY';
+type BlockWithdrawReason = null | 'LOW_LIQUIDITY';
 type BlockDepositReason = BlockWithdrawReason | 'AT_CAPACITY';
 
 export type PoolKey = InstrumentId;

--- a/packages/portfolio-api/src/target-balances.ts
+++ b/packages/portfolio-api/src/target-balances.ts
@@ -47,6 +47,10 @@ export type ComputeTargetBalancesOptions<
    * target sink is unavailable or suppressed.
    */
   depositFromChain?: SupportedChain;
+  instrumentBlocks?: {
+    noDepositInstruments: Set<AssetPlaceRef>;
+    noWithdrawInstruments: Set<AssetPlaceRef>;
+  };
 };
 
 type PlaceRecord = {
@@ -156,7 +160,10 @@ export const computeTargetBalances = <
   targetAllocation = {},
   network,
   depositFromChain,
+  instrumentBlocks,
 }: ComputeTargetBalancesOptions<C, T>): Partial<Record<C | T, NatAmount>> => {
+  const { noDepositInstruments, noWithdrawInstruments } =
+    instrumentBlocks ?? {};
   const currentValues = objectMap(
     currentBalances as Record<C, NatAmount>,
     amount => amount.value,
@@ -204,14 +211,23 @@ export const computeTargetBalances = <
     weight: NatValue = 0n,
   ): DraftRecord => {
     const placeData = getPlaceData(place, network);
+    const { blockDepositReason, blockWithdrawReason } = placeData.pool ?? {};
     return {
       place,
       chain: placeData.chain,
       weight,
       current: getOwn(currentValues, place) ?? 0n,
-      blockDeposit: !!placeData.pool?.blockDepositReason,
-      blockWithdraw: !!placeData.pool?.blockWithdrawReason,
       deltaSoftMin: placeData.chain.deltaSoftMin ?? DEFAULT_DELTA_SOFT_MIN,
+      // `network` can force an instrument to be blocked or unblocked, but
+      // otherwise it's based upon dynamic status.
+      blockDeposit:
+        blockDepositReason !== undefined
+          ? !!blockDepositReason
+          : !!noDepositInstruments?.has(place),
+      blockWithdraw:
+        blockWithdrawReason !== undefined
+          ? !!blockWithdrawReason
+          : !!noWithdrawInstruments?.has(place),
 
       target: 0n,
       delta: 0n,

--- a/packages/portfolio-api/test/target-balances.test.ts
+++ b/packages/portfolio-api/test/target-balances.test.ts
@@ -1,0 +1,80 @@
+import test from 'ava';
+
+import { Far } from '@endo/far';
+
+import type { Brand } from '@agoric/ertp/src/types.js';
+
+import { computeTargetBalances } from '../src/target-balances.js';
+import type { NetworkSpec } from '../src/network/network-spec.js';
+
+const brand = Far('mock brand') as Brand<'nat'>;
+const makeAmount = (value: bigint) => harden({ brand, value });
+const scale6 = (x: number) => BigInt(Math.round(x * 1e6));
+
+const tinyNetwork: NetworkSpec = harden({
+  localPlaces: [],
+  chains: [{ name: 'Ethereum', control: 'axelar' }],
+  pools: [
+    { pool: 'Aave_Ethereum', chain: 'Ethereum', protocol: 'Aave' },
+    { pool: 'Compound_Ethereum', chain: 'Ethereum', protocol: 'Compound' },
+  ],
+  links: [],
+});
+const amount = makeAmount(scale6(100));
+const half = makeAmount(scale6(50));
+
+test('computeTargetBalances honors dynamic no-deposit instruments', t => {
+  const target = computeTargetBalances({
+    brand,
+    currentBalances: {},
+    balanceDelta: amount.value,
+    targetAllocation: { Aave_Ethereum: 50n, Compound_Ethereum: 50n },
+    depositFromChain: 'Ethereum',
+    network: tinyNetwork,
+    instrumentBlocks: {
+      noDepositInstruments: new Set(['Aave_Ethereum']),
+      noWithdrawInstruments: new Set(),
+    },
+  });
+  t.deepEqual(target, { '@Ethereum': half, Compound_Ethereum: half });
+});
+
+test('computeTargetBalances honors dynamic no-withdraw instruments', t => {
+  const target = computeTargetBalances({
+    brand,
+    currentBalances: { Aave_Ethereum: amount, Compound_Ethereum: amount },
+    balanceDelta: -half.value,
+    targetAllocation: { Aave_Ethereum: 50n, Compound_Ethereum: 50n },
+    network: tinyNetwork,
+    instrumentBlocks: {
+      noDepositInstruments: new Set(),
+      noWithdrawInstruments: new Set(['Aave_Ethereum']),
+    },
+  });
+  t.deepEqual(target, { Compound_Ethereum: half });
+});
+
+test('computeTargetBalances network can statically unblock instruments', t => {
+  const network = {
+    ...tinyNetwork,
+    pools: tinyNetwork.pools.map(poolSpec => {
+      const blockDepositReason =
+        poolSpec.pool === 'Compound_Ethereum' ? null : undefined;
+      const blockWithdrawReason =
+        poolSpec.pool === 'Aave_Ethereum' ? null : undefined;
+      return { ...poolSpec, blockDepositReason, blockWithdrawReason };
+    }),
+  };
+  const target = computeTargetBalances({
+    brand,
+    currentBalances: { Aave_Ethereum: amount },
+    balanceDelta: 0n,
+    targetAllocation: { Aave_Ethereum: 50n, Compound_Ethereum: 50n },
+    network,
+    instrumentBlocks: {
+      noDepositInstruments: new Set(['Aave_Ethereum', 'Compound_Ethereum']),
+      noWithdrawInstruments: new Set(['Aave_Ethereum', 'Compound_Ethereum']),
+    },
+  });
+  t.deepEqual(target, { Aave_Ethereum: half, Compound_Ethereum: half });
+});

--- a/services/ymax-planner/README.md
+++ b/services/ymax-planner/README.md
@@ -175,7 +175,7 @@ Environment variables:
 - `GRAPHQL_ENDPOINTS`: JSON text for a Record\<dirname, url[]> object describing endpoints associated with each api-\* GraphQL API directory under [graphql](./src/graphql) (optional)
 - `SQLITE_DB_PATH`: The path where the SQLiteDB used by the resolver should be created. While a relative path can be provided (relative to the cwd),
 an absolute path is recommended
-- `YDS_URL`: Base URL of the YMax Data Service API, for sending transaction settlement notifications (optional)
+- `YDS_URL`: Base URL of the YMax Data Service API, for fetching dynamic instrument status and sending transaction settlement notifications (optional)
 - `YDS_API_KEY`: API key for authenticating with YDS (required with `YDS_URL`)
 - `DOTENV`: Path to environment file containing defaults of above (default ".env")
 

--- a/services/ymax-planner/src/config.ts
+++ b/services/ymax-planner/src/config.ts
@@ -25,6 +25,10 @@ export type RequestLimits = {
   maxBackoff: number;
 };
 
+export const FETCH_HEADERS = harden({
+  'User-Agent': 'Agoric-YMax-Planner/1.0.0',
+});
+
 export interface YmaxPlannerConfig {
   readonly clusterName: ClusterName;
   readonly contractInstance: string;

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -62,6 +62,7 @@ import type { EvmAddress } from '@agoric/fast-usdc';
 import type { WebSocketProvider } from 'ethers';
 import type { CosmosRPCClient, SubscriptionResponse } from './cosmos-rpc.ts';
 import type { Sdk as SpectrumBlockchainSdk } from './graphql/api-spectrum-blockchain/__generated/sdk.ts';
+import type { InstrumentBlocks } from './instrument-status.ts';
 import type {
   EvmChain,
   EvmContext,
@@ -199,6 +200,7 @@ export type Powers = {
   spectrumChainIds: Partial<Record<SupportedChain, string>>;
   evmTokenAddresses: Partial<Record<InstrumentId, EvmAddress>>;
   network: NetworkSpec;
+  getInstrumentBlocks?: () => Promise<InstrumentBlocks>;
   signingSmartWalletKit: SigningSmartWalletKit;
   /** Used to generate unique suffixes in agoric Smart Wallet OfferSpec ids. */
   makeNonce: () => string;
@@ -231,6 +233,7 @@ export type ProcessPortfolioPowers = Pick<
   isDryRun?: boolean;
   depositBrand: Brand<'nat'>;
   feeBrand: Brand<'nat'>;
+  instrumentBlocks?: InstrumentBlocks;
   portfolioKeyForDepositAddr: Map<Bech32Address, string>;
   vstoragePathPrefixes: {
     portfoliosPathPrefix: string;
@@ -272,6 +275,7 @@ export const processPortfolioEvents = async (
     feeBrand,
     gasEstimator,
     network,
+    instrumentBlocks,
     signingSmartWalletKit,
     walletStore,
     getWalletInvocationUpdate,
@@ -393,6 +397,7 @@ export const processPortfolioEvents = async (
       // "deposit" and "withdraw" and it's harmless otherwise.
       amount: flowDetail.amount,
       network,
+      instrumentBlocks,
       brand: depositBrand,
       feeBrand,
       gasEstimator,
@@ -750,6 +755,7 @@ export const startEngine = async (
     rpc,
     signingSmartWalletKit,
     makeNonce,
+    getInstrumentBlocks,
   } = powers;
   const { kvStore } = evmCtx;
   const vstoragePathPrefixes = makeVstoragePathPrefixes(contractInstance);
@@ -757,11 +763,19 @@ export const startEngine = async (
   await null;
   const { query, marshaller } = signingSmartWalletKit;
 
-  const vbankAssetCapData = await readStreamCellValue(
-    query.vstorage,
-    'published.agoricNames.vbankAsset',
-    { retries: 4 },
-  );
+  let instrumentBlocks: InstrumentBlocks | undefined;
+  const updateInstrumentBlocks = async () => {
+    instrumentBlocks = await getInstrumentBlocks?.();
+  };
+
+  const [vbankAssetCapData] = await Promise.all([
+    readStreamCellValue(query.vstorage, 'published.agoricNames.vbankAsset', {
+      retries: 4,
+    }),
+    updateInstrumentBlocks().catch(err =>
+      console.error('🚨 Failed to initialize instrument blocks', err),
+    ),
+  ]);
   const vbankAssets: AssetInfo[] = marshaller
     .fromCapData(vbankAssetCapData)
     .map(([_ibcDenom, asset]) => asset);
@@ -837,6 +851,7 @@ export const startEngine = async (
     vstoragePathPrefixes,
     portfolioKeyForDepositAddr,
     evmProviders: evmCtx.evmProviders,
+    instrumentBlocks,
   });
   await makeWorkPool(portfolioKeys, undefined, async portfolioKey => {
     const { streamCellJson, event } = makeVstorageEvent(
@@ -1012,12 +1027,21 @@ export const startEngine = async (
     // ASAP to avoid missing transactions that settle while portfolio
     // processing (balance queries, planning, tx submission) is in progress.
     await Promise.all([
-      processPortfolioEvents(
-        portfolioEvents,
-        respHeight,
-        portfoliosMemory,
-        processPortfolioPowers,
-      ),
+      portfolioEvents.length &&
+        // Update blocked-instrument sets at most once per chain block, and only
+        // when there are portfolio events to process.
+        updateInstrumentBlocks()
+          .catch(err =>
+            console.error('⚠️ Failed to update instrument blocks', err),
+          )
+          .then(() =>
+            processPortfolioEvents(
+              portfolioEvents,
+              respHeight,
+              portfoliosMemory,
+              { ...processPortfolioPowers, instrumentBlocks },
+            ),
+          ),
       processPendingTxEvents(pendingTxEvents, handlePendingTx, txPowers),
     ]);
 

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -200,7 +200,7 @@ export type Powers = {
   spectrumChainIds: Partial<Record<SupportedChain, string>>;
   evmTokenAddresses: Partial<Record<InstrumentId, EvmAddress>>;
   network: NetworkSpec;
-  getInstrumentBlocks?: () => Promise<InstrumentBlocks>;
+  getInstrumentBlocks?: () => Promise<InstrumentBlocks | undefined>;
   signingSmartWalletKit: SigningSmartWalletKit;
   /** Used to generate unique suffixes in agoric Smart Wallet OfferSpec ids. */
   makeNonce: () => string;

--- a/services/ymax-planner/src/instrument-status.ts
+++ b/services/ymax-planner/src/instrument-status.ts
@@ -1,0 +1,39 @@
+import type { AssetPlaceRef } from '@aglocal/portfolio-contract/src/type-guards-steps.js';
+import type { CaipChainId } from '@agoric/orchestration';
+import type { ComputeTargetBalancesOptions } from '@agoric/portfolio-api/src/target-balances.js';
+
+/** cf. https://github.com/Agoric/ymax-web/blob/main/yds/src/api-schemas.ts: Instrument */
+export type YdsInstrument = {
+  id: AssetPlaceRef;
+  caipChainId: CaipChainId;
+  tvl?: number;
+  totalSupplyUsd?: number;
+  supplyUtilizationRatio?: number;
+  liquidityUsd?: number;
+};
+
+export type InstrumentBlocks = Required<
+  ComputeTargetBalancesOptions<any, any>
+>['instrumentBlocks'];
+
+export const calculateInstrumentBlocks = (
+  instruments: YdsInstrument[],
+): InstrumentBlocks => {
+  const noDepositInstruments = new Set<AssetPlaceRef>();
+  const noWithdrawInstruments = new Set<AssetPlaceRef>();
+  for (const instrument of instruments) {
+    const { id, totalSupplyUsd, liquidityUsd } = instrument;
+    if (totalSupplyUsd === undefined || liquidityUsd === undefined) continue;
+
+    // Block deposits if liquidity < $10k or liquidity < 10% of total supply.
+    if (liquidityUsd < 10_000 || liquidityUsd < 0.1 * totalSupplyUsd) {
+      noDepositInstruments.add(id);
+    }
+
+    // Block withdrawals if liquidity < $1k and liquidity < 5% of total supply.
+    if (liquidityUsd < 1000 && liquidityUsd < 0.05 * totalSupplyUsd) {
+      noWithdrawInstruments.add(id);
+    }
+  }
+  return { noDepositInstruments, noWithdrawInstruments };
+};

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -274,11 +274,9 @@ export const main = async (
     trace: () => {},
   });
 
-  const ydsFetchConfig = {
-    fetch,
-    prefixUrl: config.yds.url,
-    headers: FETCH_HEADERS,
-  };
+  const ydsClient =
+    config.yds.url &&
+    ky.create({ fetch, headers: FETCH_HEADERS, prefixUrl: config.yds.url });
 
   let lastInstrumentBlocksString = '';
   const stringifyInstrumentBlocks = (instrumentBlocks: InstrumentBlocks) => {
@@ -286,19 +284,18 @@ export const main = async (
     const sets = { noDepositInstruments, noWithdrawInstruments };
     return JSON.stringify(objectMap(sets, s => [...s].sort()));
   };
-  const getInstrumentBlocks = config.yds.url
+  const getInstrumentBlocks = ydsClient
     ? async (): Promise<InstrumentBlocks> => {
-        const resp = await ky
-          .get('instruments', ydsFetchConfig)
-          .json<{ data: YdsInstrument[] }>();
-        const instrumentBlocks = calculateInstrumentBlocks(resp.data);
-        {
-          const newBlocksString = stringifyInstrumentBlocks(instrumentBlocks);
-          if (newBlocksString !== lastInstrumentBlocksString) {
-            console.warn('New instrument blocks:', instrumentBlocks, resp.data);
-          }
-          lastInstrumentBlocksString = newBlocksString;
+        const resp = await ydsClient.get('instruments').json();
+        const instruments = (resp as any).data as YdsInstrument[];
+        const instrumentBlocks = calculateInstrumentBlocks(instruments);
+
+        const newBlocksString = stringifyInstrumentBlocks(instrumentBlocks);
+        if (newBlocksString !== lastInstrumentBlocksString) {
+          console.warn('New instrument blocks:', instrumentBlocks, instruments);
         }
+        lastInstrumentBlocksString = newBlocksString;
+
         return instrumentBlocks;
       }
     : undefined;

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -5,6 +5,7 @@ import { inspect } from 'node:util';
 
 import { SigningStargateClient, StargateClient } from '@cosmjs/stargate';
 import type { GraphQLClient } from 'graphql-request';
+import ky from 'ky';
 import * as ws from 'ws';
 
 import { Fail, q } from '@endo/errors';
@@ -35,11 +36,13 @@ import {
   axelarConfigTestnet,
 } from '@aglocal/portfolio-deploy/src/axelar-configs.js';
 
-import { loadConfig } from './config.ts';
+import { FETCH_HEADERS, loadConfig } from './config.ts';
 import { CosmosRPCClient } from './cosmos-rpc.ts';
 import { makeGraphqlMultiClient } from './graphql-client.ts';
 import { getSdk as getSpectrumBlockchainSdk } from './graphql/api-spectrum-blockchain/__generated/sdk.ts';
 import { startEngine } from './engine.ts';
+import { calculateInstrumentBlocks } from './instrument-status.ts';
+import type { InstrumentBlocks, YdsInstrument } from './instrument-status.ts';
 import {
   createEVMContext,
   prepareAbortController,
@@ -271,6 +274,21 @@ export const main = async (
     trace: () => {},
   });
 
+  const ydsFetchConfig = {
+    fetch,
+    prefixUrl: config.yds.url,
+    headers: FETCH_HEADERS,
+  };
+
+  const getInstrumentBlocks = config.yds.url
+    ? async (): Promise<InstrumentBlocks> => {
+        const resp = await ky
+          .get('instruments', ydsFetchConfig)
+          .json<{ data: YdsInstrument[] }>();
+        return calculateInstrumentBlocks(resp.data);
+      }
+    : undefined;
+
   const ydsNotifier = config.yds.url
     ? new YdsNotifier(
         { fetch, log: console.log.bind(console) },
@@ -305,6 +323,7 @@ export const main = async (
     evmTokenAddresses,
     spectrumBlockchain,
     network: PROD_NETWORK,
+    getInstrumentBlocks,
     signingSmartWalletKit,
     makeNonce,
     walletStore,

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -285,7 +285,7 @@ export const main = async (
     return JSON.stringify(objectMap(sets, s => [...s].sort()));
   };
   const getInstrumentBlocks = ydsClient
-    ? async (): Promise<InstrumentBlocks> => {
+    ? async (): Promise<InstrumentBlocks | undefined> => {
         const resp = await ydsClient.get('instruments?includeAll=true').json();
         const instruments = (resp as any).data as YdsInstrument[];
         const instrumentBlocks = calculateInstrumentBlocks(instruments);
@@ -296,7 +296,8 @@ export const main = async (
         }
         lastInstrumentBlocksString = newBlocksString;
 
-        return instrumentBlocks;
+        // TODO(AGO-550): return instrumentBlocks;
+        return undefined;
       }
     : undefined;
 

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -280,12 +280,26 @@ export const main = async (
     headers: FETCH_HEADERS,
   };
 
+  let lastInstrumentBlocksString = '';
+  const stringifyInstrumentBlocks = (instrumentBlocks: InstrumentBlocks) => {
+    const { noDepositInstruments, noWithdrawInstruments } = instrumentBlocks;
+    const sets = { noDepositInstruments, noWithdrawInstruments };
+    return JSON.stringify(objectMap(sets, s => [...s].sort()));
+  };
   const getInstrumentBlocks = config.yds.url
     ? async (): Promise<InstrumentBlocks> => {
         const resp = await ky
           .get('instruments', ydsFetchConfig)
           .json<{ data: YdsInstrument[] }>();
-        return calculateInstrumentBlocks(resp.data);
+        const instrumentBlocks = calculateInstrumentBlocks(resp.data);
+        {
+          const newBlocksString = stringifyInstrumentBlocks(instrumentBlocks);
+          if (newBlocksString !== lastInstrumentBlocksString) {
+            console.warn('New instrument blocks:', instrumentBlocks, resp.data);
+          }
+          lastInstrumentBlocksString = newBlocksString;
+        }
+        return instrumentBlocks;
       }
     : undefined;
 

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -286,7 +286,7 @@ export const main = async (
   };
   const getInstrumentBlocks = ydsClient
     ? async (): Promise<InstrumentBlocks> => {
-        const resp = await ydsClient.get('instruments').json();
+        const resp = await ydsClient.get('instruments?includeAll=true').json();
         const instruments = (resp as any).data as YdsInstrument[];
         const instrumentBlocks = calculateInstrumentBlocks(instruments);
 

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -255,6 +255,7 @@ export type PlannerContext<
   | 'currentBalances'
   | 'targetAllocation'
   | 'network'
+  | 'instrumentBlocks'
 > & {
   feeBrand: Brand<'nat'>;
   gasEstimator: GasEstimator;
@@ -288,6 +289,7 @@ export const planDepositToAllocations: PlanMaker<{
     network,
     targetAllocation,
     depositFromChain: fromChain,
+    instrumentBlocks: details.instrumentBlocks,
   });
   if (Object.keys(target).length === 0) return { flow: [], order: undefined };
 
@@ -318,6 +320,7 @@ export const planRebalanceToAllocations: PlanMaker = async details => {
     currentBalances,
     network,
     targetAllocation,
+    instrumentBlocks: details.instrumentBlocks,
   });
   if (Object.keys(target).length === 0) return { flow: [], order: undefined };
 
@@ -345,6 +348,7 @@ export const planWithdrawFromAllocations: PlanMaker<{
     network,
     balanceDelta: -amount.value,
     targetAllocation,
+    instrumentBlocks: details.instrumentBlocks,
   });
 
   const { feeBrand, gasEstimator, toChain = 'agoric' } = details;

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -10,7 +10,7 @@ import type {
 import { PoolPlaces } from '@aglocal/portfolio-contract/src/type-guards.js';
 import { planRebalanceFlow } from '@aglocal/portfolio-contract/tools/plan-solve.js';
 import { computeTargetBalances } from '@agoric/portfolio-api/src/target-balances.js';
-import type { NetworkSpec } from '@agoric/portfolio-api/src/network/network-spec.js';
+import type { ComputeTargetBalancesOptions } from '@agoric/portfolio-api/src/target-balances.js';
 import type { GasEstimator } from '@aglocal/portfolio-contract/tools/plan-solve.ts';
 import { AmountMath } from '@agoric/ertp/src/amountMath.js';
 import type { Brand, NatAmount } from '@agoric/ertp/src/types.js';
@@ -248,12 +248,14 @@ export const getNonDustBalances = async <C extends AssetPlaceRef>(
 
 export type PlannerContext<
   C extends AssetPlaceRef,
-  T extends keyof TargetAllocation,
-> = {
-  currentBalances: Record<C, NatAmount>;
-  targetAllocation?: Partial<Pick<TargetAllocation, T>>;
-  network: NetworkSpec;
-  brand: Brand<'nat'>;
+  T extends string & keyof TargetAllocation,
+> = Pick<
+  ComputeTargetBalancesOptions<C, T>,
+  | 'brand'
+  | 'currentBalances'
+  | 'targetAllocation'
+  | 'network'
+> & {
   feeBrand: Brand<'nat'>;
   gasEstimator: GasEstimator;
 };

--- a/services/ymax-planner/src/yds-notifier.ts
+++ b/services/ymax-planner/src/yds-notifier.ts
@@ -1,4 +1,5 @@
 import ky, { type KyInstance } from 'ky';
+import { FETCH_HEADERS } from './config.ts';
 
 export type YdsNotificationData = {
   txNum: `tx${number}`;
@@ -47,8 +48,7 @@ export class YdsNotifier {
       timeout: this.#config.timeout,
       retry: this.#config.retries,
       headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': 'Agoric-YMax-Planner/1.0.0',
+        ...FETCH_HEADERS,
         'x-resolver-auth-key': this.#config.ydsApiKey,
       },
     });
@@ -76,9 +76,7 @@ export class YdsNotifier {
     );
 
     try {
-      await this.#http.post(endpoint, {
-        json: payload,
-      });
+      await this.#http.post(endpoint, { json: payload });
       this.#log(`[YdsNotifier] Successfully sent notification for ${txNum}`);
       return true;
     } catch (err) {

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -23,8 +23,10 @@ import {
 } from '@aglocal/portfolio-contract/test/supports.js';
 import { TEST_NETWORK } from '@aglocal/portfolio-contract/tools/network/test-network.js';
 import type {
+  BlockWithdrawReason,
   NetworkSpec,
   PoolKey,
+  PoolSpec,
 } from '@agoric/portfolio-api/src/network/network-spec.js';
 import type { GasEstimator } from '@aglocal/portfolio-contract/tools/plan-solve.ts';
 import { makePortfolioQuery } from '@aglocal/portfolio-contract/tools/portfolio-actors.js';
@@ -38,6 +40,7 @@ import { Far } from '@endo/pass-style';
 import PROD_NETWORK from '@agoric/portfolio-api/src/network/prod-network.js';
 import type { EvmAddress } from '@agoric/fast-usdc';
 import { assetList as nobleAssetList } from 'chain-registry/mainnet/noble/index.js';
+import type { InstrumentBlocks } from '../src/instrument-status.ts';
 import {
   getNonDustBalances,
   planDepositToAllocations,
@@ -1361,9 +1364,12 @@ test('@<ChainName> USDC target allocations', async t => {
 // |       A is no-withdraw | *$20* |  $16  |  $16  |  $16  |  $16  |  $16  |
 // |       D is no-withdraw |  $20  |  $15  |  $15  | *$20* |  $15  |  $15  |
 // |  chain min delta is $6 |  $20  |  $14  | *$18* |  $20  |  $14  |  $14  |
-test('computeTargetBalances cascades blocked/suppressed sources', async t => {
-  const blockWithdrawReason = 'LOW_LIQUIDITY';
-  const blockDepositReason = 'AT_CAPACITY';
+//
+// We run this scenario over multiple tests to cover both static and dynamic
+// instrument blocking (cf. `cases` below).
+{
+  const blockWithdrawReason = 'LOW_LIQUIDITY' as const;
+  const blockDepositReason = 'AT_CAPACITY' as const;
   const chain = 'Ethereum';
   const atChain = `@${chain}` as AssetPlaceRef;
   const fromChain = `+${chain}` as AssetPlaceRef;
@@ -1374,124 +1380,169 @@ test('computeTargetBalances cascades blocked/suppressed sources', async t => {
   const E = `E_${chain}` as AssetPlaceRef;
   const F = `F_${chain}` as AssetPlaceRef;
   const X = `X_${chain}` as AssetPlaceRef;
-  const network: NetworkSpec = harden({
-    ...plannerContext.network,
-    chains: [
-      ...plannerContext.network.chains.map(c =>
-        c.name === chain ? { ...c, deltaSoftMin: 6_000_000n } : c,
-      ),
-    ] as NetworkSpec['chains'],
-    pools: [
-      ...plannerContext.network.pools,
-      { pool: A, chain, protocol: 'A', blockWithdrawReason },
-      { pool: B, chain, protocol: 'B' },
-      { pool: C, chain, protocol: 'C' },
-      { pool: D, chain, protocol: 'D', blockWithdrawReason },
-      { pool: E, chain, protocol: 'E' },
-      { pool: F, chain, protocol: 'F' },
-      { pool: X, chain, protocol: 'X', blockDepositReason },
-    ] as NetworkSpec['pools'],
-  });
-  const currentBalances = {
-    [A]: makeDeposit(scale6(20)),
-    [B]: makeDeposit(scale6(20)),
-    [C]: makeDeposit(scale6(18)),
-    [D]: makeDeposit(scale6(20)),
-    [E]: makeDeposit(scale6(8)),
-    [F]: makeDeposit(scale6(2)),
-  } as any;
-  const targetAllocation: TargetAllocation = {
-    [A]: 0n,
-    [B]: 20n,
-    [C]: 20n,
-    [D]: 20n,
-    [E]: 20n,
-    [F]: 20n,
-  };
-  {
-    const plan = await planDepositToAllocations({
-      ...plannerContext,
-      network,
-      currentBalances,
-      targetAllocation,
-      amount: makeDeposit(scale6(12)),
-      fromChain: chain,
-    });
-    // t.log(readableSteps(plan.flow, depositBrand));
-    arrayIsLike(t, plan?.flow, [
-      makeMovementDesc(B, atChain, scale6(6)),
-      makeMovementDesc(atChain, E, scale6(6)),
-      makeMovementDesc(fromChain, atChain, scale6(12)),
-      makeMovementDesc(atChain, F, scale6(12)),
-    ]);
-  }
+  const chains = [
+    ...plannerContext.network.chains.map(c =>
+      c.name === chain ? { ...c, deltaSoftMin: 6_000_000n } : c,
+    ),
+  ] as NetworkSpec['chains'];
 
-  // Now replace F with the deposit-blocked X.
-  currentBalances[X] = currentBalances[F];
-  delete currentBalances[F];
-  targetAllocation[X] = targetAllocation[F];
-  delete targetAllocation[F];
-  {
-    const plan = await planDepositToAllocations({
-      ...plannerContext,
-      network,
-      currentBalances,
-      targetAllocation,
-      amount: makeDeposit(scale6(12)),
-      fromChain: chain,
+  const staticBlocks = [
+    { pool: A, chain, protocol: 'A' as any, blockWithdrawReason },
+    { pool: B, chain, protocol: 'B' as any },
+    { pool: C, chain, protocol: 'C' as any },
+    { pool: D, chain, protocol: 'D' as any, blockWithdrawReason },
+    { pool: E, chain, protocol: 'E' as any },
+    { pool: F, chain, protocol: 'F' as any },
+    { pool: X, chain, protocol: 'X' as any, blockDepositReason },
+  ] as PoolSpec[];
+  // Dynamic equivalent of `staticBlocks`:
+  // * D remains statically no-withdraw
+  // * X is dynamically no-deposit and A is dynamically no-withdraw
+  // * dynamic blocks of B and E are statically overridden
+  const dynamicBlocks = {
+    noDepositInstruments: new Set([B, E, X]),
+    noWithdrawInstruments: new Set([B, E, A]),
+  } as InstrumentBlocks;
+  const overrides = { [B]: null, [E]: null };
+  const blockDepositOverrides = { ...overrides };
+  const blockWithdrawOverrides = { ...overrides, [D]: blockWithdrawReason };
+
+  const cases: [string, PoolSpec[], InstrumentBlocks?][] = [
+    ['static', staticBlocks, undefined],
+    [
+      'dynamic',
+      staticBlocks.map<PoolSpec>(poolSpec => ({
+        ...poolSpec,
+        blockDepositReason: blockDepositOverrides[poolSpec.pool],
+        blockWithdrawReason: blockWithdrawOverrides[poolSpec.pool],
+      })),
+      dynamicBlocks,
+    ],
+  ];
+  for (const [kind, extraPools, instrumentBlocks] of cases) {
+    test(`computeTargetBalances cascades blocked/suppressed sources, ${kind}`, async t => {
+      const network: NetworkSpec = harden({
+        ...plannerContext.network,
+        chains,
+        pools: [...plannerContext.network.pools, ...extraPools],
+      });
+      const currentBalances = {
+        [A]: makeDeposit(scale6(20)),
+        [B]: makeDeposit(scale6(20)),
+        [C]: makeDeposit(scale6(18)),
+        [D]: makeDeposit(scale6(20)),
+        [E]: makeDeposit(scale6(8)),
+        [F]: makeDeposit(scale6(2)),
+      } as any;
+      const targetAllocation: TargetAllocation = {
+        [A]: 0n,
+        [B]: 20n,
+        [C]: 20n,
+        [D]: 20n,
+        [E]: 20n,
+        [F]: 20n,
+      };
+      {
+        const plan = await planDepositToAllocations({
+          ...plannerContext,
+          network,
+          currentBalances,
+          targetAllocation,
+          amount: makeDeposit(scale6(12)),
+          fromChain: chain,
+          instrumentBlocks,
+        });
+        // t.log(readableSteps(plan.flow, depositBrand));
+        arrayIsLike(t, plan?.flow, [
+          makeMovementDesc(B, atChain, scale6(6)),
+          makeMovementDesc(atChain, E, scale6(6)),
+          makeMovementDesc(fromChain, atChain, scale6(12)),
+          makeMovementDesc(atChain, F, scale6(12)),
+        ]);
+      }
+
+      // Now replace F with the deposit-blocked X.
+      currentBalances[X] = currentBalances[F];
+      delete currentBalances[F];
+      targetAllocation[X] = targetAllocation[F];
+      delete targetAllocation[F];
+      {
+        const plan = await planDepositToAllocations({
+          ...plannerContext,
+          network,
+          currentBalances,
+          targetAllocation,
+          amount: makeDeposit(scale6(12)),
+          fromChain: chain,
+          instrumentBlocks,
+        });
+        // t.log(readableSteps(plan.flow, depositBrand));
+        arrayIsLike(t, plan?.flow, [
+          makeMovementDesc(B, atChain, scale6(6)),
+          makeMovementDesc(atChain, E, scale6(6)),
+          makeMovementDesc(fromChain, atChain, scale6(12)),
+        ]);
+      }
     });
-    // t.log(readableSteps(plan.flow, depositBrand));
-    arrayIsLike(t, plan?.flow, [
-      makeMovementDesc(B, atChain, scale6(6)),
-      makeMovementDesc(atChain, E, scale6(6)),
-      makeMovementDesc(fromChain, atChain, scale6(12)),
-    ]);
   }
-});
+}
 
 for (const [title, usdcOverdraft] of Object.entries({
   'planWithdrawFromAllocations works around withdraw-blocked pools': 0,
   'planWithdrawFromAllocations clamps to withdrawable amounts': 10,
 })) {
-  // TODO(AGO-535): Both of these scenarios should withdraw 50 USDC.
-  const testFn = usdcOverdraft === 0 ? test : test.failing;
-  testFn(title, async t => {
-    const network: NetworkSpec = harden({
-      ...plannerContext.network,
-      pools: [
-        ...plannerContext.network.pools.filter(p => p.pool !== 'Aave_Base'),
-        {
-          pool: 'Aave_Base',
-          chain: 'Base',
-          protocol: 'Aave',
-          blockWithdrawReason: 'LOW_LIQUIDITY',
-        },
-      ] as NetworkSpec['pools'],
-    });
-    const currentBalances = {
-      Aave_Base: makeDeposit(scale6(50)),
-      Aave_Ethereum: makeDeposit(scale6(25)),
-      Compound_Ethereum: makeDeposit(scale6(25)),
-    };
-    const targetAllocation: TargetAllocation = {
-      Aave_Base: 50n,
-      Aave_Ethereum: 25n,
-      Compound_Ethereum: 25n,
-    };
+  // Each of these scenarios is also covered by equivalent testing against both
+  // static and dynamic instrument blocking.
+  const dynamicBlocks = {
+    noDepositInstruments: new Set([]),
+    noWithdrawInstruments: new Set(['Aave_Base']),
+  } as InstrumentBlocks;
+  const cases: [string, BlockWithdrawReason?, InstrumentBlocks?][] = [
+    ['static', 'LOW_LIQUIDITY', undefined],
+    ['dynamic', undefined, dynamicBlocks],
+  ];
+  for (const [kind, staticBlockWithdrawReason, instrumentBlocks] of cases) {
+    // TODO(AGO-535): Both of these scenarios should withdraw 50 USDC.
+    const testFn = usdcOverdraft === 0 ? test : test.failing;
+    testFn(`${title}, ${kind}`, async t => {
+      const network: NetworkSpec = harden({
+        ...plannerContext.network,
+        pools: [
+          ...plannerContext.network.pools.filter(p => p.pool !== 'Aave_Base'),
+          {
+            pool: 'Aave_Base',
+            chain: 'Base',
+            protocol: 'Aave',
+            blockWithdrawReason: staticBlockWithdrawReason,
+          },
+        ] as NetworkSpec['pools'],
+      });
+      const currentBalances = {
+        Aave_Base: makeDeposit(scale6(50)),
+        Aave_Ethereum: makeDeposit(scale6(25)),
+        Compound_Ethereum: makeDeposit(scale6(25)),
+      };
+      const targetAllocation: TargetAllocation = {
+        Aave_Base: 50n,
+        Aave_Ethereum: 25n,
+        Compound_Ethereum: 25n,
+      };
 
-    const plan = await planWithdrawFromAllocations({
-      ...plannerContext,
-      network,
-      currentBalances,
-      targetAllocation,
-      amount: makeDeposit(scale6(50 + usdcOverdraft)),
-      toChain: 'Ethereum',
+      const plan = await planWithdrawFromAllocations({
+        ...plannerContext,
+        network,
+        currentBalances,
+        targetAllocation,
+        amount: makeDeposit(scale6(50 + usdcOverdraft)),
+        toChain: 'Ethereum',
+        instrumentBlocks,
+      });
+      // t.log(readableSteps(plan.flow, depositBrand));
+      arrayIsLike(t, plan?.flow, [
+        makeMovementDesc('Aave_Ethereum', '@Ethereum', scale6(25)),
+        makeMovementDesc('Compound_Ethereum', '@Ethereum', scale6(25)),
+        makeMovementDesc('@Ethereum', '-Ethereum', scale6(50)),
+      ]);
     });
-    // t.log(readableSteps(plan.flow, depositBrand));
-    arrayIsLike(t, plan?.flow, [
-      makeMovementDesc('Aave_Ethereum', '@Ethereum', scale6(25)),
-      makeMovementDesc('Compound_Ethereum', '@Ethereum', scale6(25)),
-      makeMovementDesc('@Ethereum', '-Ethereum', scale6(50)),
-    ]);
-  });
+  }
 }

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -1442,7 +1442,10 @@ test('@<ChainName> USDC target allocations', async t => {
         [E]: 20n,
         [F]: 20n,
       };
-      {
+      const assertPlan = async (
+        label: string,
+        expectSteps: ReturnType<typeof makeMovementDesc>[],
+      ) => {
         const plan = await planDepositToAllocations({
           ...plannerContext,
           network,
@@ -1453,36 +1456,25 @@ test('@<ChainName> USDC target allocations', async t => {
           instrumentBlocks,
         });
         // t.log(readableSteps(plan.flow, depositBrand));
-        arrayIsLike(t, plan?.flow, [
-          makeMovementDesc(B, atChain, scale6(6)),
-          makeMovementDesc(atChain, E, scale6(6)),
-          makeMovementDesc(fromChain, atChain, scale6(12)),
-          makeMovementDesc(atChain, F, scale6(12)),
-        ]);
-      }
+        arrayIsLike(t, plan?.flow, expectSteps, label);
+      };
+      await assertPlan('without deposit blocking', [
+        makeMovementDesc(B, atChain, scale6(6)),
+        makeMovementDesc(atChain, E, scale6(6)),
+        makeMovementDesc(fromChain, atChain, scale6(12)),
+        makeMovementDesc(atChain, F, scale6(12)),
+      ]);
 
       // Now replace F with the deposit-blocked X.
       currentBalances[X] = currentBalances[F];
       delete currentBalances[F];
       targetAllocation[X] = targetAllocation[F];
       delete targetAllocation[F];
-      {
-        const plan = await planDepositToAllocations({
-          ...plannerContext,
-          network,
-          currentBalances,
-          targetAllocation,
-          amount: makeDeposit(scale6(12)),
-          fromChain: chain,
-          instrumentBlocks,
-        });
-        // t.log(readableSteps(plan.flow, depositBrand));
-        arrayIsLike(t, plan?.flow, [
-          makeMovementDesc(B, atChain, scale6(6)),
-          makeMovementDesc(atChain, E, scale6(6)),
-          makeMovementDesc(fromChain, atChain, scale6(12)),
-        ]);
-      }
+      await assertPlan('with deposit blocking', [
+        makeMovementDesc(B, atChain, scale6(6)),
+        makeMovementDesc(atChain, E, scale6(6)),
+        makeMovementDesc(fromChain, atChain, scale6(12)),
+      ]);
     });
   }
 }

--- a/services/ymax-planner/test/instrument-status.test.ts
+++ b/services/ymax-planner/test/instrument-status.test.ts
@@ -1,0 +1,68 @@
+import test from 'ava';
+
+import {
+  calculateInstrumentBlocks,
+  type YdsInstrument,
+} from '../src/instrument-status.ts';
+
+const caipChainId = 'eip155:1' as const;
+
+const instrument = (
+  id: string,
+  liquidityUsd: number,
+  totalSupplyUsd: number,
+): YdsInstrument => ({
+  id: id as YdsInstrument['id'],
+  caipChainId,
+  liquidityUsd,
+  totalSupplyUsd,
+});
+
+const missingDataInstrument: YdsInstrument = { id: '@Ethereum', caipChainId };
+
+test('calculateInstrumentBlocks ignores instruments without supply/liquidity data', t => {
+  const { noDepositInstruments, noWithdrawInstruments } =
+    calculateInstrumentBlocks([missingDataInstrument]);
+
+  t.deepEqual([...noDepositInstruments].sort(), []);
+  t.deepEqual([...noWithdrawInstruments].sort(), []);
+});
+
+test('calculateInstrumentBlocks blocks deposits if liquidity < $10k or < 10% of total supply', t => {
+  const instruments = [
+    missingDataInstrument,
+    instrument('liquidity < $10k but = 10%', 9999.99, 9999.99 * 10),
+    instrument('liquidity = $10k but < 10%', 10_000, 10_000 * 10 + 0.01),
+    instrument('liquidity < $10k and < 10%', 9999.99, 9999.99 * 10 + 0.01),
+    instrument('liquidity = $10k and = 10%', 10_000, 10_000 * 10),
+  ];
+  const { noDepositInstruments, noWithdrawInstruments } =
+    calculateInstrumentBlocks(instruments);
+
+  t.deepEqual(
+    [...noDepositInstruments].sort(),
+    [
+      'liquidity < $10k but = 10%',
+      'liquidity = $10k but < 10%',
+      'liquidity < $10k and < 10%',
+    ].sort(),
+  );
+  t.deepEqual([...noWithdrawInstruments].sort(), []);
+});
+
+test('calculateInstrumentBlocks blocks withdrawals if liquidity < $1k and < 5% of total supply', t => {
+  const instruments = [
+    instrument('liquidity < $1k but = 5%', 999.99, 999.99 * 20),
+    instrument('liquidity = $1k but < 5%', 1000, 1000 * 20 + 0.01),
+    instrument('liquidity < $1k and < 5%', 999.99, 999.99 * 20 + 0.01),
+    instrument('liquidity = $1k and = 5%', 1000, 1000 * 20),
+  ];
+  const { noDepositInstruments, noWithdrawInstruments } =
+    calculateInstrumentBlocks(instruments);
+
+  t.deepEqual(
+    [...noDepositInstruments].sort(),
+    instruments.map(({ id }) => id).sort(),
+  );
+  t.deepEqual([...noWithdrawInstruments].sort(), ['liquidity < $1k and < 5%']);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,6 +989,7 @@ __metadata:
     "@agoric/orchestration": "workspace:*"
     "@endo/common": "npm:^1.2.13"
     "@endo/errors": "npm:^1.2.13"
+    "@endo/far": "npm:^1.1.14"
     "@endo/patterns": "npm:^1.7.0"
     "@types/js-yaml": "npm:^4"
     ajv: "npm:^6.12.6"


### PR DESCRIPTION
Ref AGO-550
Blocked on https://github.com/Agoric/ymax-web/pull/722

I'm tagging many reviewers as a heads-up, and because I don't know who is best positioned to provide a meaningful approval.

## Description
Update `computeTargetBalances` to accept [dynamic] instrument deposit/withdraw blocks, and update the ymax-planner engine to calculate those before each `processPortfolioEvents` by querying [YDS /instruments](https://ymax.app/docs#operations-Instruments-get_instruments) ~~and applying the logic specified in AGO-550~~. When the YDS query fails, a warning is emitted and previous status is reüsed.

**EDIT**: This is currently disabled because the logic called for blocking Aave_Ethereum.

### Security Considerations
None known.

### Scaling Considerations
This approach queries YDS up to once per block. It could in principle retain status for even longer, but this feels to me like a good level of responsiveness.

### Documentation Considerations
None known. The YMax UI currently doesn't account for this, but will acquire the behavior as part of planner simulation improvements.

### Testing Considerations
New tests cover the new behavior, and it will be explicitly verified in ymax0 against a YDS that incorporates https://github.com/Agoric/ymax-web/pull/722 .

### Upgrade Considerations
As noted, blocked on https://github.com/Agoric/ymax-web/pull/722 .