### PR TITLE
chore(planner): treat empty .flowN as missing

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -319,7 +319,14 @@ export const processPortfolioEvents = async (
     opts?: ReadVstorageSimpleOpts,
   ) => {
     const path = `${portfoliosPathPrefix}.${portfolioKey}.flows.${flowKey}`;
-    const capdata = await readStreamCellValue(vstorage, path, opts);
+    const metaResponse = await readStorageMeta(vstorage, path, 'data', opts);
+    if (metaResponse.result.value === '') {
+      // A flow key may exist only as a parent of children such as `.agent`,
+      // with no published flow-status payload at the flow node itself yet.
+      return undefined;
+    }
+    const streamCell = parseStreamCell(metaResponse.result.value, path);
+    const capdata = parseStreamCellValue(streamCell, -1, path);
     const flowStatus = marshaller.fromCapData(capdata);
     mustMatch(flowStatus, FlowStatusShape, path);
     return flowStatus.state === 'run';
@@ -499,7 +506,14 @@ export const processPortfolioEvents = async (
       for (const [flowKey, flowDetail] of typedEntries(status.flowsRunning || {})) {
         // If vstorage has a node for this flow then we've already responded.
         if (flowKeys.has(flowKey)) {
-          if (await isActiveFlow(portfolioKey, flowKey, readOpts)) return;
+          const isActive = await isActiveFlow(portfolioKey, flowKey, readOpts);
+          if (isActive === undefined) {
+            // Treat empty flow nodes like missing status nodes: tolerate the
+            // goofy publish shape and submit the flow instead of deferring.
+            await startFlow(status, portfolioKey, flowKey, flowDetail);
+            break;
+          }
+          if (isActive) return;
           continue;
         }
         await startFlow(status, portfolioKey, flowKey, flowDetail);

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -721,6 +721,71 @@ test('processPortfolioEvents runs flows in sequence', async t => {
   }
 });
 
+test('processPortfolioEvents does not defer when a flow key exists only via flow.agent', async t => {
+  const kit = await fakePortfolioKit({
+    accounts: { noble: makeDeposit(0n) },
+    otherBalances: { usdn: makeDeposit(0n) },
+  });
+  const { portfolioId, portfolioPath, initialPortfolioStatus, powers } = kit;
+  const { consoleWrites, getBridgeSends, updateBlockHeight, updateVstorage } =
+    kit.testPowers;
+
+  const flowId = 2;
+  const flowKey = `flow${flowId}`;
+  const portfolioStatus = {
+    ...initialPortfolioStatus,
+    rebalanceCount: 0,
+    positionKeys: ['USDN'],
+    targetAllocation: { USDN: 1n },
+    flowCount: 2,
+    flowsRunning: {
+      [flowKey]: {
+        type: 'rebalance',
+      },
+    },
+  };
+  updateVstorage(portfolioPath, 'set', {
+    object: { ...portfolioStatus },
+    wrap: true,
+  });
+  updateVstorage(`${portfolioPath}.flows.${flowKey}`, 'set', { string: '' });
+  updateVstorage(`${portfolioPath}.flows.${flowKey}.agent`, 'set', {
+    object: { id: 'agent1' },
+    wrap: true,
+  });
+
+  const blockHeight = updateBlockHeight();
+  const vstorageEventDetail = makeVstorageEventDetail(
+    blockHeight,
+    portfolioPath,
+    harden({ ...portfolioStatus }),
+  );
+  const memory: PortfoliosMemory = { deferrals: [] };
+  await processPortfolioEvents(
+    [vstorageEventDetail],
+    blockHeight,
+    memory,
+    powers,
+  );
+
+  t.deepEqual(memory.deferrals, []);
+  t.false(consoleWrites.some(({ level }) => level === 'error'));
+  const bridgeActions = getBridgeSends().map(invocation => invocation.action);
+  arrayIsLike(t, bridgeActions, [bridgeActions[0]]);
+  const action = bridgeActions[0] as InvokeStoreEntryAction;
+  t.like(action, {
+    method: 'invokeEntry',
+    message: { targetName: 'planner' },
+  });
+  arrayIsLike(t, action.message.args, [
+    portfolioId,
+    flowId,
+    action.message.args[2],
+    portfolioStatus.policyVersion,
+    portfolioStatus.rebalanceCount,
+  ]);
+});
+
 test('startFlow logs include traceId prefix', async t => {
   const kit = await fakePortfolioKit({
     accounts: { noble: AmountMath.make(depositBrand, 1_000_000n) },


### PR DESCRIPTION
refs:
 - #12688

## Description

the contract published a `.flow2.agent` node, and I didn't intend to put a signal at `.flow2`. But the planner seemed to get an empty string at `.flow2`, and hence:

```
🚨 Deferring published.ymax0.portfolios.portfolio75 of age 437 block(s) for error: non-JSON value at vstorage path "published.ymax0.portfolios.portfolio75.flows.flow2": Unexpected end of JSON input for input ""
```


### Security / Scaling Considerations

n/a

### Documentation Considerations

There are comments noting that this is a work-around.

### Testing Considerations

1 unit test

### Upgrade Considerations

normal SOP