### PR TITLE
fix(ymax-planner): detect WebSocket errors in CCTP watcher

### DIFF
--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -208,21 +208,28 @@ const cctpMonitor: PendingTxMonitor<CctpTx> = {
         opts.signal ? [opts.signal] : undefined,
       );
 
-      const liveResultP = watchCctpTransfer({
-        ...watchArgs,
-        timeoutMs: opts.timeoutMs,
-        signal: abortController.signal,
-        kvStore: ctx.kvStore,
-        txId,
+      const liveResultP = liveWatchWithRetry(
+        () =>
+          watchCctpTransfer({
+            ...watchArgs,
+            timeoutMs: opts.timeoutMs,
+            signal: abortController.signal,
+            kvStore: ctx.kvStore,
+            txId,
+          }),
+        {
+          makeAbortController: ctx.makeAbortController,
+          signal: abortController.signal,
+          log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
+        },
+        e => log(`${logPrefix} Live watcher failed:`, e),
+      );
+      void liveResultP.then(result => {
+        if (result.settled) {
+          log(`${logPrefix} Live mode completed`);
+          abortController.abort();
+        }
       });
-      void liveResultP
-        .then(result => {
-          if (result.settled) {
-            log(`${logPrefix} Live mode completed`);
-            abortController.abort();
-          }
-        })
-        .catch(e => log(`${logPrefix} Live watcher failed:`, e));
 
       await null;
       // Wait for at least one block to ensure overlap between lookback and live mode

--- a/services/ymax-planner/src/watchers/cctp-watcher.ts
+++ b/services/ymax-planner/src/watchers/cctp-watcher.ts
@@ -1,8 +1,10 @@
 import type { Filter, Log } from 'ethers';
 import { id, zeroPadValue, getAddress, ethers } from 'ethers';
+import type { WebSocket } from 'ws';
 import type { CaipChainId } from '@agoric/orchestration';
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
 import { PendingTxCode, TX_TIMEOUT_MS } from '../pending-tx-manager.ts';
+import { WatcherTransportError } from './watcher-utils.ts';
 import {
   getBlockNumberBeforeRealTime,
   scanEvmLogsInChunks,
@@ -80,7 +82,7 @@ export const watchCctpTransfer = ({
   setTimeout = globalThis.setTimeout,
   signal,
 }: CctpWatch & WatcherTimeoutOptions): Promise<WatcherResult> => {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     if (signal?.aborted) {
       resolve({ settled: false });
       return;
@@ -95,20 +97,72 @@ export const watchCctpTransfer = ({
       `Watching for ERC-20 transfers to: ${toAddress} with amount: ${expectedAmount}`,
     );
 
+    const ws = provider.websocket as WebSocket;
+    let done = false;
     let transferFound = false;
-    let timeoutId: NodeJS.Timeout;
-    let listeners: Array<{ event: any; listener: any }> = [];
-
-    const finish = (result: WatcherResult) => {
-      resolve(result);
-      if (timeoutId) clearTimeout(timeoutId);
-      for (const { event, listener } of listeners) {
-        void provider.off(event, listener);
+    const cleanups: (() => unknown)[] = [];
+    const doCleanup = () => {
+      for (const cleanup of cleanups) {
+        try {
+          cleanup();
+        } catch (err) {
+          log('Error during cleanup:', err);
+        }
       }
-      listeners = [];
     };
 
-    signal?.addEventListener('abort', () => finish({ settled: false }));
+    const finish = (result: WatcherResult) => {
+      if (done) return;
+      done = true;
+      resolve(result);
+      doCleanup();
+    };
+
+    /**
+     * Cleanup and reject with a transport error. Used for fatal WebSocket
+     * failures where we cannot continue watching. This signals that the WATCH
+     * failed, not that the transaction failed, so the caller can safely
+     * re-subscribe (via `watchWithRetry`).
+     */
+    const fail = (err: unknown) => {
+      if (done) return;
+      done = true;
+      reject(err);
+      doCleanup();
+    };
+
+    const onWsError = (e: any) => {
+      const errorMsg = e?.message || String(e);
+      log(`WebSocket error during CCTP watch: ${errorMsg}`);
+      fail(
+        new WatcherTransportError(`WebSocket connection error: ${errorMsg}`, {
+          cause: e,
+        }),
+      );
+    };
+
+    const onWsClose = (code?: number, reason?: any) => {
+      log(
+        `WebSocket closed during CCTP watch (code=${code}, reason=${reason})`,
+      );
+      fail(
+        new WatcherTransportError(
+          `WebSocket closed unexpectedly: ${reason} (code=${code})`,
+        ),
+      );
+    };
+
+    ws.on('error', onWsError);
+    cleanups.unshift(() => ws.off('error', onWsError));
+
+    ws.on('close', onWsClose);
+    cleanups.unshift(() => ws.off('close', onWsClose));
+
+    if (signal) {
+      const onAbort = () => finish({ settled: false });
+      signal.addEventListener('abort', onAbort);
+      cleanups.unshift(() => signal.removeEventListener('abort', onAbort));
+    }
 
     const listenForTransfer = async (eventLog: Log) => {
       let transferData;
@@ -143,15 +197,18 @@ export const watchCctpTransfer = ({
     };
 
     void provider.on(filter, listenForTransfer);
-    listeners.push({ event: filter, listener: listenForTransfer });
+    cleanups.unshift(() => {
+      void provider.off(filter, listenForTransfer);
+    });
 
-    timeoutId = setTimeout(() => {
-      if (!transferFound) {
-        log(
-          `[${PendingTxCode.CCTP_TX_NOT_FOUND}] ✗ No matching transfer found within ${timeoutMs / 60000} minutes`,
-        );
-      }
+    // Intentional: does not resolve/reject; only logs on timeout.
+    const timeoutId = setTimeout(() => {
+      if (done || transferFound) return;
+      log(
+        `[${PendingTxCode.CCTP_TX_NOT_FOUND}] ✗ No matching transfer found within ${timeoutMs / 60000} minutes`,
+      );
     }, timeoutMs);
+    cleanups.unshift(() => clearTimeout(timeoutId));
   });
 };
 

--- a/services/ymax-planner/test/cctp-watcher.test.ts
+++ b/services/ymax-planner/test/cctp-watcher.test.ts
@@ -11,6 +11,7 @@ import {
 } from './mocks.ts';
 import { handlePendingTx } from '../src/pending-tx-manager.ts';
 import { getResolvedTx } from '../src/kv-store.ts';
+import { WatcherTransportError } from '../src/watchers/watcher-utils.ts';
 
 const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const toAddress = '0x742d35Cc6635C0532925a3b8D9dEB1C9e5eb2b64';
@@ -279,4 +280,46 @@ test('watchCctpTransfer returns txHash when transfer is found', async t => {
     expectedTxHash,
     'Should return the correct transaction hash',
   );
+});
+
+test('watchCctpTransfer rejects with WatcherTransportError on WebSocket error', async t => {
+  const provider = createMockProvider();
+  const kvStore = makeKVStoreFromMap(new Map());
+
+  const watchPromise = watchCctpTransfer({
+    usdcAddress,
+    provider,
+    toAddress,
+    expectedAmount: 1_000_000n,
+    timeoutMs: 5000,
+    kvStore,
+    txId: 'tx0',
+  });
+
+  setTimeout(() => {
+    (provider.websocket as any).emit('error', new Error('socket boom'));
+  }, 20);
+
+  await t.throwsAsync(watchPromise, { instanceOf: WatcherTransportError });
+});
+
+test('watchCctpTransfer rejects with WatcherTransportError on WebSocket close', async t => {
+  const provider = createMockProvider();
+  const kvStore = makeKVStoreFromMap(new Map());
+
+  const watchPromise = watchCctpTransfer({
+    usdcAddress,
+    provider,
+    toAddress,
+    expectedAmount: 1_000_000n,
+    timeoutMs: 5000,
+    kvStore,
+    txId: 'tx0',
+  });
+
+  setTimeout(() => {
+    (provider.websocket as any).emit('close', 1006, 'abnormal');
+  }, 20);
+
+  await t.throwsAsync(watchPromise, { instanceOf: WatcherTransportError });
 });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://linear.app/agoric/issue/PAK-479/ymax-resolver-cctp-watcher-missed-settling-live-transactions

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

Bring the CCTP watcher in line with the others:
- attach ws `'error'/'close'` handlers that reject with `WatcherTransportError`, which feeds the existing `watchWithRetry` re-subscribe path
- wrap the lookback mode's concurrent live arm in `liveWatchWithRetry`


### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
- The change is unit tested.

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment on `main0` and `main1`.