### PR TITLE
feat(portfolio): add delegation concentration cap/limit

### DIFF
--- a/packages/portfolio-api/src/evm-wallet/eip712-messages.ts
+++ b/packages/portfolio-api/src/evm-wallet/eip712-messages.ts
@@ -117,7 +117,11 @@ const OperationSubTypes = {
   ],
   Asset: TokenPermissionsComponents,
   /** @see {@link PortfolioPermissions} */
-  PortfolioPermissions: [{ name: 'allocation', type: 'bool' }],
+  PortfolioPermissions: [
+    { name: 'mayAllocate', type: 'bool' },
+    { name: 'allocationCapPct', type: 'uint8' },
+    { name: 'mayRebalance', type: 'bool' },
+  ],
   /** @see {@link PortfolioAutoFeatures} */
   PortfolioAutoFeatures: [{ name: 'rebalance', type: 'bool' }],
 } as const satisfies TypedData;

--- a/packages/portfolio-api/src/evm-wallet/eip712-messages.ts
+++ b/packages/portfolio-api/src/evm-wallet/eip712-messages.ts
@@ -119,7 +119,7 @@ const OperationSubTypes = {
   /** @see {@link PortfolioPermissions} */
   PortfolioPermissions: [
     { name: 'mayAllocate', type: 'bool' },
-    { name: 'allocationCapPct', type: 'uint8' },
+    { name: 'allocationCapBps', type: 'uint16' },
     { name: 'mayRebalance', type: 'bool' },
   ],
   /** @see {@link PortfolioAutoFeatures} */

--- a/packages/portfolio-api/src/portfolio-permissions.ts
+++ b/packages/portfolio-api/src/portfolio-permissions.ts
@@ -6,6 +6,8 @@ import type {
   PortfolioPermissionsEIP712,
 } from './evm-wallet/eip712-messages.ts';
 
+const PercentShape = M.and(M.number(), M.gte(0), M.lte(100));
+
 /**
  * Portfolio permissions granted to an automation agent.
  */
@@ -14,7 +16,15 @@ export type PortfolioPermissions = {
    * whether the agent may change portions of instruments already in the
    * portfolio's `targetAllocation`, but may not add or remove keys.
    */
-  allocation?: boolean;
+  allocation?:
+    | boolean
+    | {
+        /**
+         * optional maximum integer percentage for any non-cash position in a
+         * delegated `setTargetAllocation` request.
+         */
+        capPct?: number;
+      };
   /** whether the agent may trigger a rebalance using the current policy. */
   rebalance?: boolean;
 };
@@ -24,22 +34,34 @@ export type PortfolioPermissions = {
  */
 export type PortfolioPermissionsExt = PortfolioPermissions & CopyRecord<any>;
 
+const permissionProperties = harden({
+  allocation: M.or(
+    M.boolean(),
+    M.splitRecord({}, { capPct: PercentShape }, {}),
+  ),
+  rebalance: M.boolean(),
+});
+
 /**
  * The currently implemented permissions. Granted permissions must match this shape.
  *
- * The empty bag `{}` is valid and represents no delegated authority. End-user
+ * The empty record `{}` is valid and represents no delegated authority. End-user
  * grant paths may still require specific permissions before creating a grant.
  */
 export const PortfolioPermissionsShape: TypedPattern<PortfolioPermissions> =
-  M.splitRecord({}, { allocation: M.boolean(), rebalance: M.boolean() }, {});
+  M.splitRecord({}, permissionProperties, {});
 
 export const PortfolioPermissionsEIP712Shape: TypedPattern<PortfolioPermissionsEIP712> =
-  M.splitRecord({ allocation: M.boolean() });
+  harden({
+    mayAllocate: M.boolean(),
+    allocationCapPct: PercentShape,
+    mayRebalance: M.boolean(),
+  });
 
 /**
  * Extensible app-level shape for portfolio permissions.
  *
- * Future versions may add more permission keys while preserving the
+ * Future versions may add new top-level permission keys while preserving the
  * broad `PortfolioPermissionsExt` type throughout the rest of the system.
  */
 export const PortfolioPermissionsExtShape: TypedPattern<PortfolioPermissionsExt> =

--- a/packages/portfolio-api/src/portfolio-permissions.ts
+++ b/packages/portfolio-api/src/portfolio-permissions.ts
@@ -6,7 +6,7 @@ import type {
   PortfolioPermissionsEIP712,
 } from './evm-wallet/eip712-messages.ts';
 
-const PercentShape = M.and(M.number(), M.gte(0), M.lte(100));
+const BasisPointsShape = M.and(M.number(), M.gte(0), M.lte(10_000));
 
 /**
  * Portfolio permissions granted to an automation agent.
@@ -20,10 +20,10 @@ export type PortfolioPermissions = {
     | boolean
     | {
         /**
-         * optional maximum integer percentage for any non-cash position in a
+         * optional maximum allocation in basis points for any non-cash position in a
          * delegated `setTargetAllocation` request.
          */
-        capPct?: number;
+        capBps?: number;
       };
   /** whether the agent may trigger a rebalance using the current policy. */
   rebalance?: boolean;
@@ -37,7 +37,7 @@ export type PortfolioPermissionsExt = PortfolioPermissions & CopyRecord<any>;
 const permissionProperties = harden({
   allocation: M.or(
     M.boolean(),
-    M.splitRecord({}, { capPct: PercentShape }, {}),
+    M.splitRecord({}, { capBps: BasisPointsShape }, {}),
   ),
   rebalance: M.boolean(),
 });
@@ -54,7 +54,7 @@ export const PortfolioPermissionsShape: TypedPattern<PortfolioPermissions> =
 export const PortfolioPermissionsEIP712Shape: TypedPattern<PortfolioPermissionsEIP712> =
   harden({
     mayAllocate: M.boolean(),
-    allocationCapPct: PercentShape,
+    allocationCapBps: BasisPointsShape,
     mayRebalance: M.boolean(),
   });
 

--- a/packages/portfolio-api/src/types.ts
+++ b/packages/portfolio-api/src/types.ts
@@ -23,6 +23,7 @@ import type { PublishedTx } from './resolver.js';
 import type { EVMWalletUpdate, PortfolioPath } from './evm/types.ts';
 import type {
   PortfolioAutoFeaturesExt,
+  PortfolioPermissions,
   PortfolioPermissionsExt,
 } from './portfolio-permissions.js';
 

--- a/packages/portfolio-api/test/eip712-messages.test.ts
+++ b/packages/portfolio-api/test/eip712-messages.test.ts
@@ -192,6 +192,42 @@ test('getYmaxStandaloneOperationData for SetTargetAllocation', t => {
   ]);
 });
 
+test('getYmaxStandaloneOperationData for Grant', t => {
+  const data = {
+    accountHolder: 'agoric1delegate',
+    permissions: {
+      mayAllocate: true,
+      allocationCapPct: 30,
+      mayRebalance: false,
+    },
+    portfolio: 9n,
+    nonce: 2n,
+    deadline: 1700000000n,
+  };
+
+  const result = getYmaxStandaloneOperationData(
+    data,
+    'Grant',
+    42161n,
+    MOCK_CONTRACT_ADDRESS,
+  );
+
+  t.is(result.primaryType, 'Grant');
+  t.deepEqual(result.message, data);
+  t.deepEqual(result.types.Grant, [
+    { name: 'accountHolder', type: 'string' },
+    { name: 'permissions', type: 'PortfolioPermissions' },
+    { name: 'portfolio', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+  ]);
+  t.deepEqual(result.types.PortfolioPermissions, [
+    { name: 'mayAllocate', type: 'bool' },
+    { name: 'allocationCapPct', type: 'uint8' },
+    { name: 'mayRebalance', type: 'bool' },
+  ]);
+});
+
 test('getYmaxWitness for OpenPortfolio', t => {
   const allocations: TargetAllocation[] = [
     { instrument: 'Aave_Arbitrum', portion: 10000n },

--- a/packages/portfolio-api/test/eip712-messages.test.ts
+++ b/packages/portfolio-api/test/eip712-messages.test.ts
@@ -197,7 +197,7 @@ test('getYmaxStandaloneOperationData for Grant', t => {
     accountHolder: 'agoric1delegate',
     permissions: {
       mayAllocate: true,
-      allocationCapPct: 30,
+      allocationCapBps: 3000,
       mayRebalance: false,
     },
     portfolio: 9n,
@@ -223,7 +223,7 @@ test('getYmaxStandaloneOperationData for Grant', t => {
   ]);
   t.deepEqual(result.types.PortfolioPermissions, [
     { name: 'mayAllocate', type: 'bool' },
-    { name: 'allocationCapPct', type: 'uint8' },
+    { name: 'allocationCapBps', type: 'uint16' },
     { name: 'mayRebalance', type: 'bool' },
   ]);
 });

--- a/packages/portfolio-api/test/portfolio-permissions.test.ts
+++ b/packages/portfolio-api/test/portfolio-permissions.test.ts
@@ -1,0 +1,57 @@
+import test from 'ava';
+
+import { matches, mustMatch } from '@endo/patterns';
+import type { PortfolioPermissions } from '../src/main.js';
+import {
+  PortfolioPermissionsExtShape,
+  PortfolioPermissionsShape,
+} from '../src/portfolio-permissions.ts';
+
+test('PortfolioPermissionsShape', t => {
+  const passCases = harden({
+    empty: {},
+    allocateOnly: { allocation: true },
+    allocateObjectOnly: { allocation: {} },
+    allocateFalse: { allocation: false },
+    allocateZeroCap: { allocation: { capPct: 0 } },
+    allocateCap: { allocation: { capPct: 30 } },
+    allocateFullCap: { allocation: { capPct: 100 } },
+    rebalanceOnly: { rebalance: true },
+    rebalanceFalse: { rebalance: false },
+    both: { allocation: true, rebalance: true },
+  } satisfies Record<string, PortfolioPermissions>);
+  const failCases = harden({
+    allocationCapTooLow: { allocation: { capPct: -1 } },
+    allocationCapTooHigh: { allocation: { capPct: 101 } },
+    allocationCapExtraField: { allocation: { capPct: 30, future: true } },
+    futurePermission: { futurePermission: true },
+  }) satisfies Record<string, unknown>;
+
+  for (const [name, specimen] of Object.entries(passCases)) {
+    t.notThrows(
+      () => mustMatch(specimen, PortfolioPermissionsShape),
+      `${name}`,
+    );
+  }
+  for (const [name, specimen] of Object.entries(failCases)) {
+    t.false(matches(specimen, PortfolioPermissionsShape), `${name}`);
+  }
+});
+
+test('PortfolioPermissionsExtShape remains forward compatible', t => {
+  t.notThrows(() =>
+    mustMatch(
+      harden({
+        allocation: { capPct: 30, futureFlag: false },
+        futurePermission: false,
+      }),
+      PortfolioPermissionsExtShape,
+    ),
+  );
+  t.notThrows(() =>
+    mustMatch(
+      harden({ allocation: { future: { size: 1 } } }),
+      PortfolioPermissionsExtShape,
+    ),
+  );
+});

--- a/packages/portfolio-api/test/portfolio-permissions.test.ts
+++ b/packages/portfolio-api/test/portfolio-permissions.test.ts
@@ -13,17 +13,17 @@ test('PortfolioPermissionsShape', t => {
     allocateOnly: { allocation: true },
     allocateObjectOnly: { allocation: {} },
     allocateFalse: { allocation: false },
-    allocateZeroCap: { allocation: { capPct: 0 } },
-    allocateCap: { allocation: { capPct: 30 } },
-    allocateFullCap: { allocation: { capPct: 100 } },
+    allocateZeroCap: { allocation: { capBps: 0 } },
+    allocateCap: { allocation: { capBps: 3000 } },
+    allocateFullCap: { allocation: { capBps: 10_000 } },
     rebalanceOnly: { rebalance: true },
     rebalanceFalse: { rebalance: false },
     both: { allocation: true, rebalance: true },
   } satisfies Record<string, PortfolioPermissions>);
   const failCases = harden({
-    allocationCapTooLow: { allocation: { capPct: -1 } },
-    allocationCapTooHigh: { allocation: { capPct: 101 } },
-    allocationCapExtraField: { allocation: { capPct: 30, future: true } },
+    allocationCapTooLow: { allocation: { capBps: -1 } },
+    allocationCapTooHigh: { allocation: { capBps: 10_001 } },
+    allocationCapExtraField: { allocation: { capBps: 3000, future: true } },
     futurePermission: { futurePermission: true },
   }) satisfies Record<string, unknown>;
 
@@ -42,7 +42,7 @@ test('PortfolioPermissionsExtShape remains forward compatible', t => {
   t.notThrows(() =>
     mustMatch(
       harden({
-        allocation: { capPct: 30, futureFlag: false },
+        allocation: { capBps: 3000, futureFlag: false },
         futurePermission: false,
       }),
       PortfolioPermissionsExtShape,

--- a/packages/portfolio-contract/src/delegation.exo.ts
+++ b/packages/portfolio-contract/src/delegation.exo.ts
@@ -7,9 +7,13 @@
  * @see {@link preparePortfolioDelegationKit}
  */
 import type { TypedPattern } from '@agoric/internal';
+import { partialMap } from '@agoric/internal/src/js-utils.js';
 import {
   PortfolioAutoFeaturesExtShape,
+  PortfolioPermissionsExtShape,
+  isInstrumentId,
   type FlowKey,
+  type PortfolioPermissions,
   type PortfolioSyncState,
 } from '@agoric/portfolio-api';
 import type { ZCF } from '@agoric/zoe';
@@ -27,12 +31,14 @@ export const PortfolioSyncStateShape: TypedPattern<PortfolioSyncState> =
 
 type DelegationState = {
   agentId: number;
+  permissions: PortfolioPermissions;
   portfolioAccess: PortfolioKit['delegationHelper'];
 };
 
 // exoClassKit expects a plain state-shape record, not a TypedPattern wrapper.
 export const DelegationStateShape = {
   agentId: M.number(),
+  permissions: PortfolioPermissionsExtShape,
   portfolioAccess: M.remotable('PortfolioDelegationHelper'),
 };
 harden(DelegationStateShape);
@@ -48,6 +54,31 @@ const auditKeys = (
   const extra = actualKeys.filter(key => !expectedSet.has(key));
   const missing = expectedKeys.filter(key => !actualSet.has(key));
   return harden({ extra, missing });
+};
+
+const assertWithinAllocationCap = (
+  targetAllocation: TargetAllocation,
+  permissions: PortfolioPermissions,
+) => {
+  const { allocation } = permissions;
+  const capPct = typeof allocation === 'object' ? allocation.capPct : undefined;
+  if (capPct === undefined) {
+    return;
+  }
+  // `capPct` comes from the validated permission shape, so BigInt() is safe.
+  const scaledCap =
+    BigInt(capPct) *
+    Object.values(targetAllocation).reduce((sum, weight) => sum + weight, 0n);
+  if (scaledCap === 0n) {
+    return;
+  }
+  const overCap = partialMap(
+    Object.entries(targetAllocation),
+    ([key, weight]) =>
+      weight * 100n > scaledCap && isInstrumentId(key) ? key : undefined,
+  );
+  overCap.length === 0 ||
+    Fail`target allocation exceeds allocation cap for ${q(overCap)}`;
 };
 
 const DelegationReaderI = M.interface('PortfolioDelegationReader', {
@@ -112,13 +143,14 @@ export const preparePortfolioDelegationKit = (
           targetAllocation: TargetAllocation,
           syncState: PortfolioSyncState,
         ): FlowKey {
-          const { portfolioAccess, agentId } = this.state;
+          const { portfolioAccess, agentId, permissions } = this.state;
           const current =
             portfolioAccess.getTargetAllocation(this.facets.client, agentId) ||
             {};
           const { extra, missing } = auditKeys(current, targetAllocation);
           extra.length === 0 || Fail`unauthorized allocations for ${q(extra)}`;
           missing.length === 0 || Fail`missing allocations for ${q(missing)}`;
+          assertWithinAllocationCap(targetAllocation, permissions);
 
           return portfolioAccess.submitTargetAllocation(
             this.facets.client,

--- a/packages/portfolio-contract/src/delegation.exo.ts
+++ b/packages/portfolio-contract/src/delegation.exo.ts
@@ -58,13 +58,13 @@ const assertWithinAllocationCap = (
   permissions: PortfolioPermissions,
 ) => {
   const { allocation } = permissions;
-  const capPct = typeof allocation === 'object' ? allocation.capPct : undefined;
-  if (capPct === undefined) {
+  const capBps = typeof allocation === 'object' ? allocation.capBps : undefined;
+  if (capBps === undefined) {
     return;
   }
-  // `capPct` comes from the validated permission shape, so BigInt() is safe.
+  // `capBps` comes from the validated permission shape, so BigInt() is safe.
   const scaledCap =
-    BigInt(capPct) *
+    BigInt(capBps) *
     Object.values(targetAllocation).reduce((sum, weight) => sum + weight, 0n);
   if (scaledCap === 0n) {
     return;
@@ -72,7 +72,7 @@ const assertWithinAllocationCap = (
   const overCap = partialMap(
     Object.entries(targetAllocation),
     ([key, weight]) =>
-      weight * 100n > scaledCap && isInstrumentId(key) ? key : undefined,
+      weight * 10_000n > scaledCap && isInstrumentId(key) ? key : undefined,
   );
   overCap.length === 0 ||
     Fail`target allocation exceeds allocation cap for ${q(overCap)}`;

--- a/packages/portfolio-contract/src/delegation.exo.ts
+++ b/packages/portfolio-contract/src/delegation.exo.ts
@@ -10,7 +10,6 @@ import type { TypedPattern } from '@agoric/internal';
 import { partialMap } from '@agoric/internal/src/js-utils.js';
 import {
   PortfolioAutoFeaturesExtShape,
-  PortfolioPermissionsExtShape,
   isInstrumentId,
   type FlowKey,
   type PortfolioPermissions,
@@ -31,14 +30,12 @@ export const PortfolioSyncStateShape: TypedPattern<PortfolioSyncState> =
 
 type DelegationState = {
   agentId: number;
-  permissions: PortfolioPermissions;
   portfolioAccess: PortfolioKit['delegationHelper'];
 };
 
 // exoClassKit expects a plain state-shape record, not a TypedPattern wrapper.
 export const DelegationStateShape = {
   agentId: M.number(),
-  permissions: PortfolioPermissionsExtShape,
   portfolioAccess: M.remotable('PortfolioDelegationHelper'),
 };
 harden(DelegationStateShape);
@@ -143,13 +140,17 @@ export const preparePortfolioDelegationKit = (
           targetAllocation: TargetAllocation,
           syncState: PortfolioSyncState,
         ): FlowKey {
-          const { portfolioAccess, agentId, permissions } = this.state;
+          const { portfolioAccess, agentId } = this.state;
           const current =
             portfolioAccess.getTargetAllocation(this.facets.client, agentId) ||
             {};
           const { extra, missing } = auditKeys(current, targetAllocation);
           extra.length === 0 || Fail`unauthorized allocations for ${q(extra)}`;
           missing.length === 0 || Fail`missing allocations for ${q(missing)}`;
+          const permissions = portfolioAccess.getPermissions(
+            this.facets.client,
+            agentId,
+          );
           assertWithinAllocationCap(targetAllocation, permissions);
 
           return portfolioAccess.submitTargetAllocation(

--- a/packages/portfolio-contract/src/evm-wallet-handler.exo.ts
+++ b/packages/portfolio-contract/src/evm-wallet-handler.exo.ts
@@ -642,13 +642,13 @@ export type EVMWalletMessageHandler = ReturnType<
 export const fromPortfolioPermissionsEIP712 = (
   permissions: PortfolioPermissionsEIP712,
 ): PortfolioPermissions => {
-  const { mayAllocate, allocationCapPct, mayRebalance } = permissions;
+  const { mayAllocate, allocationCapBps, mayRebalance } = permissions;
 
   const appPermissions: PortfolioPermissions = harden({
     ...(mayAllocate
       ? {
           allocation:
-            allocationCapPct > 0 ? harden({ capPct: allocationCapPct }) : true,
+            allocationCapBps > 0 ? harden({ capBps: allocationCapBps }) : true,
         }
       : {}),
     ...(mayRebalance ? { rebalance: true } : {}),

--- a/packages/portfolio-contract/src/evm-wallet-handler.exo.ts
+++ b/packages/portfolio-contract/src/evm-wallet-handler.exo.ts
@@ -21,8 +21,9 @@ import {
   recoverTypedDataAddress,
   validateTypedData,
 } from '@agoric/orchestration/src/vendor/viem/viem-typedData.js';
-import type { StatusFor } from '@agoric/portfolio-api';
+import type { PortfolioPermissions, StatusFor } from '@agoric/portfolio-api';
 import type {
+  PortfolioPermissionsEIP712,
   YmaxFullDomain,
   YmaxPermitWitnessTransferFromData,
   YmaxStandaloneOperationData,
@@ -388,7 +389,7 @@ export const prepareEVMPortfolioOperationManager = (
               // we don't rely on it for correctness: the string will
               // be looked up in NamesByAddress.
               accountHolder as Bech32Address,
-              permissions,
+              fromPortfolioPermissionsEIP712(permissions),
             );
 
             return watch(result, BasicOutcomeWatcher);
@@ -638,3 +639,19 @@ export const prepareEVMWalletHandlerKit = (
 export type EVMWalletMessageHandler = ReturnType<
   ReturnType<typeof prepareEVMWalletHandlerKit>['makeEVMWalletMessageHandler']
 >;
+export const fromPortfolioPermissionsEIP712 = (
+  permissions: PortfolioPermissionsEIP712,
+): PortfolioPermissions => {
+  const { mayAllocate, allocationCapPct, mayRebalance } = permissions;
+
+  const appPermissions: PortfolioPermissions = harden({
+    ...(mayAllocate
+      ? {
+          allocation:
+            allocationCapPct > 0 ? harden({ capPct: allocationCapPct }) : true,
+        }
+      : {}),
+    ...(mayRebalance ? { rebalance: true } : {}),
+  });
+  return appPermissions;
+};

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -39,7 +39,7 @@ import type {
   FlowAgent,
   FlowConfig,
   PortfolioAgentGrantee,
-  PortfolioPermissionsExt,
+  PortfolioPermissions,
   PortfolioPublicInvitationMaker,
   TargetAllocation,
 } from '@agoric/portfolio-api';
@@ -631,7 +631,7 @@ export const contract = async (
     portfolioId: number,
     agentId: number,
     grantee: PortfolioAgentGrantee,
-    permissions: PortfolioPermissionsExt,
+    permissions: PortfolioPermissions,
   ): Promise<void> => {
     if (grantee === PortfolioPlannerAgent) {
       const planner = getPortfolio(portfolioId)!.planner;

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -643,6 +643,10 @@ export const preparePortfolioKit = (
           const { enabledAutoFeatures } = this.state;
           return enabledAutoFeatures;
         },
+        getPermissions(client: PortfolioDelegationClient, agentId: number) {
+          this.facets.delegationHelper.assertActive(client, agentId);
+          return this.state.delegations!.get(agentId).permissions;
+        },
         getTargetAllocation(
           client: PortfolioDelegationClient,
           agentId: number,
@@ -1030,7 +1034,6 @@ export const preparePortfolioKit = (
           const nextAgentId = delegations.getSize() + 1;
           const delegationKit = makeDelegationKit({
             agentId: nextAgentId,
-            permissions,
             portfolioAccess: this.facets.delegationHelper,
           });
           // Initialize the delegation record first to avoid any race claiming

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -24,7 +24,6 @@ import {
   sameEvmAddress,
 } from '@agoric/orchestration/src/utils/address.js';
 import {
-  PortfolioPermissionsShape,
   PortfolioAutoFeaturesShape,
   type FlowAgent,
   type FlowConfig,
@@ -34,11 +33,11 @@ import {
   type PortfolioAgentStatus,
   type PortfolioContinuingInvitationMaker,
   type PortfolioPermissions,
-  type PortfolioPermissionsExt,
   type PortfolioAutoFeatures,
   type PortfolioRemoteAccountState,
   type PortfolioAutoFeaturesExt,
   PortfolioAutoFeaturesExtShape,
+  PortfolioPermissionsShape,
 } from '@agoric/portfolio-api';
 import {
   AxelarChain,
@@ -424,7 +423,7 @@ export const preparePortfolioKit = (
       portfolioId: number,
       agentId: number,
       grantee: PortfolioAgentGrantee,
-      permissions: PortfolioPermissionsExt,
+      permissions: PortfolioPermissions,
     ) => Promise<void>;
   },
 ) => {
@@ -617,7 +616,7 @@ export const preparePortfolioKit = (
         assertActive(
           client: PortfolioDelegationClient,
           agentId: number,
-          required: Partial<PortfolioPermissions> = {},
+          required: string[] = [],
         ) {
           const { delegations, portfolioId } = this.state;
           if (!delegations) {
@@ -629,11 +628,9 @@ export const preparePortfolioKit = (
           status.state === 'active' ||
             Fail`delegation agent${agentId} is not active; current state is ${status.state}`;
 
-          for (const permission of Object.keys(
-            required,
-          ) as (keyof PortfolioPermissions)[]) {
-            status.permissions[permission] ||
-              Fail`delegation agent${agentId} does not have required permission ${permission}`;
+          for (const may of required) {
+            may in status.permissions ||
+              Fail`delegation agent${agentId} does not have required permission ${may}`;
           }
         },
         getPortfolioId(client: PortfolioDelegationClient, agentId: number) {
@@ -660,9 +657,9 @@ export const preparePortfolioKit = (
           targetAllocation: TargetAllocation,
           syncState: { policyVersion: number; rebalanceCount: number },
         ): FlowKey {
-          this.facets.delegationHelper.assertActive(client, agentId, {
-            allocation: true,
-          });
+          this.facets.delegationHelper.assertActive(client, agentId, [
+            'allocation',
+          ]);
           const { reader, reporter, simpleRebalanceHandler } = this.facets;
 
           const { policyVersion, rebalanceCount } = syncState;
@@ -681,9 +678,9 @@ export const preparePortfolioKit = (
           agentId: number,
           syncState: { policyVersion: number; rebalanceCount: number },
         ): FlowKey {
-          this.facets.delegationHelper.assertActive(client, agentId, {
-            rebalance: true,
-          });
+          this.facets.delegationHelper.assertActive(client, agentId, [
+            'rebalance',
+          ]);
           const { reader, reporter, manager } = this.facets;
 
           const { policyVersion, rebalanceCount } = syncState;
@@ -1018,7 +1015,7 @@ export const preparePortfolioKit = (
          */
         async grantDelegation(
           grantee: PortfolioAgentGrantee,
-          permissions: PortfolioPermissionsExt,
+          permissions: PortfolioPermissions,
         ) {
           const { portfolioId } = this.state;
           if (!('delegations' in this.state)) {
@@ -1033,6 +1030,7 @@ export const preparePortfolioKit = (
           const nextAgentId = delegations.getSize() + 1;
           const delegationKit = makeDelegationKit({
             agentId: nextAgentId,
+            permissions,
             portfolioAccess: this.facets.delegationHelper,
           });
           // Initialize the delegation record first to avoid any race claiming
@@ -1111,13 +1109,11 @@ export const preparePortfolioKit = (
             throw Fail`portfolio pre-dates auto features support`;
           }
 
-          const permissions: PortfolioPermissions = {
-            allocation: false,
-            rebalance: !!features.rebalance,
-          };
+          const permissions: PortfolioPermissions = features.rebalance
+            ? harden({ rebalance: true })
+            : harden({});
 
-          const hasAnyPermission =
-            permissions.allocation || permissions.rebalance;
+          const hasAnyPermission = Object.keys(permissions).length > 0;
 
           let plannerAgentId = this.state.plannerAgentId;
 
@@ -1484,15 +1480,13 @@ export const preparePortfolioKit = (
          * resolution is the authorization check; this method then enforces
          * its own input validation.
          */
-        grant(grantee: Bech32Address, permissions: PortfolioPermissionsExt) {
+        grant(grantee: Bech32Address, permissions: unknown) {
           return vowTools.asVow(async () => {
             mustMatch(permissions, PortfolioPermissionsShape);
             const { sourceAccountId } = this.state;
             if (!sourceAccountId) {
               throw Fail`grant requires sourceAccountId to be set (portfolio must be opened from EVM)`;
             }
-            permissions.allocation === true ||
-              Fail`grant requires allocation permission`;
             // Returns promise promptly resolved
             await this.facets.manager.grantDelegation(grantee, permissions);
           });

--- a/packages/portfolio-contract/src/portfolio.exo.ts
+++ b/packages/portfolio-contract/src/portfolio.exo.ts
@@ -1109,9 +1109,9 @@ export const preparePortfolioKit = (
             throw Fail`portfolio pre-dates auto features support`;
           }
 
-          const permissions: PortfolioPermissions = features.rebalance
-            ? harden({ rebalance: true })
-            : harden({});
+          const permissions: PortfolioPermissions = harden({
+            ...(features.rebalance ? { rebalance: true } : {}),
+          });
 
           const hasAnyPermission = Object.keys(permissions).length > 0;
 

--- a/packages/portfolio-contract/test/delegation.test.ts
+++ b/packages/portfolio-contract/test/delegation.test.ts
@@ -32,7 +32,7 @@ type ExpectedDelegationDetails = {
   portfolioId: number;
   agentId: `agent${number}`;
   permissions: {
-    allocation?: true | { capPct?: number };
+    allocation?: true | { capBps?: number };
     rebalance?: true;
   };
 };
@@ -302,7 +302,7 @@ test('delegated setTargetAllocation rejects a position above allocation cap', as
   const grantStatus = await peteArbitrum.grant(
     PETE_AGENT,
     harden({
-      allocation: { capPct: 30 },
+      allocation: { capBps: 3000 },
     }),
   );
   const { delegationClient } = await redeemAndCheckDelegation({
@@ -313,7 +313,7 @@ test('delegated setTargetAllocation rejects a position above allocation cap', as
     expectedDetails: {
       portfolioId: peteKit.evmTrader.getPortfolioId(),
       agentId: 'agent1',
-      permissions: { allocation: { capPct: 30 } },
+      permissions: { allocation: { capBps: 3000 } },
     },
   });
 
@@ -346,7 +346,7 @@ test('delegated setTargetAllocation ignores allocation cap for cash pseudo posit
   const grantStatus = await peteArbitrum.grant(
     PETE_AGENT,
     harden({
-      allocation: { capPct: 30 },
+      allocation: { capBps: 3000 },
     }),
   );
   const { delegationClient } = await redeemAndCheckDelegation({
@@ -357,7 +357,7 @@ test('delegated setTargetAllocation ignores allocation cap for cash pseudo posit
     expectedDetails: {
       portfolioId: peteKit.evmTrader.getPortfolioId(),
       agentId: 'agent1',
-      permissions: { allocation: { capPct: 30 } },
+      permissions: { allocation: { capBps: 3000 } },
     },
   });
 

--- a/packages/portfolio-contract/test/delegation.test.ts
+++ b/packages/portfolio-contract/test/delegation.test.ts
@@ -31,7 +31,10 @@ type Receiver<R> = ReturnType<typeof makeDepositFacetSpy<R>>;
 type ExpectedDelegationDetails = {
   portfolioId: number;
   agentId: `agent${number}`;
-  permissions: { allocation: true };
+  permissions: {
+    allocation?: true | { capPct?: number };
+    rebalance?: true;
+  };
 };
 
 const emptyProposal = harden({ give: {}, want: {} }) as Proposal;
@@ -97,7 +100,7 @@ const openPetePortfolio = async (
   allocations = [
     { instrument: 'Aave_Arbitrum', portion: 60n },
     { instrument: 'Compound_Arbitrum', portion: 40n },
-  ] as const,
+  ] as { instrument: string; portion: bigint }[],
   depositAmount = 10_000_000n,
 ) => {
   const receiver = await registerDepositFacet(
@@ -151,7 +154,9 @@ test('Pete may grant his own portfolio and grantee may rebalance through the red
     await openPetePortfolio(deployed);
   const grantStatus = await peteArbitrum.grant(
     PETE_AGENT,
-    harden({ allocation: true }),
+    harden({
+      allocation: true,
+    }),
   );
   const { delegationClient } = await redeemAndCheckDelegation({
     t,
@@ -210,7 +215,9 @@ test('Granted rebalance cannot introduce a new instrument', async t => {
   const { receiver, peteKit, peteArbitrum } = await openPetePortfolio(deployed);
   const grantStatus = await peteArbitrum.grant(
     PETE_AGENT,
-    harden({ allocation: true }),
+    harden({
+      allocation: true,
+    }),
   );
   const { delegationClient } = await redeemAndCheckDelegation({
     t,
@@ -252,7 +259,9 @@ test('Granted rebalance may retain an instrument key with zero portion', async t
   const { receiver, peteKit, peteArbitrum } = await openPetePortfolio(deployed);
   const grantStatus = await peteArbitrum.grant(
     PETE_AGENT,
-    harden({ allocation: true }),
+    harden({
+      allocation: true,
+    }),
   );
   const { delegationClient } = await redeemAndCheckDelegation({
     t,
@@ -286,13 +295,136 @@ test('Granted rebalance may retain an instrument key with zero portion', async t
   });
 });
 
+test('delegated setTargetAllocation rejects a position above allocation cap', async t => {
+  const deployed = await deploy(t);
+  const { zoe } = deployed;
+  const { receiver, peteKit, peteArbitrum } = await openPetePortfolio(deployed);
+  const grantStatus = await peteArbitrum.grant(
+    PETE_AGENT,
+    harden({
+      allocation: { capPct: 30 },
+    }),
+  );
+  const { delegationClient } = await redeemAndCheckDelegation({
+    t,
+    zoe,
+    grantStatus,
+    receiver,
+    expectedDetails: {
+      portfolioId: peteKit.evmTrader.getPortfolioId(),
+      agentId: 'agent1',
+      permissions: { allocation: { capPct: 30 } },
+    },
+  });
+
+  const before = await peteKit.evmTrader.getPortfolioStatus();
+  const { policyVersion, rebalanceCount } = before;
+  const rebalanceP = E(delegationClient).setTargetAllocation(
+    {
+      Aave_Arbitrum: 31n,
+      Compound_Arbitrum: 69n,
+    },
+    { policyVersion, rebalanceCount },
+  );
+
+  await t.throwsAsync(() => rebalanceP, {
+    message: /target allocation exceeds allocation cap/,
+  });
+});
+
+test('delegated setTargetAllocation ignores allocation cap for cash pseudo positions', async t => {
+  const deployed = await deploy(t);
+  const { zoe } = deployed;
+  const { receiver, peteKit, peteArbitrum } = await openPetePortfolio(
+    deployed,
+    PETE_AGENT,
+    [
+      { instrument: 'Aave_Arbitrum', portion: 60n },
+      { instrument: '@Base', portion: 40n },
+    ],
+  );
+  const grantStatus = await peteArbitrum.grant(
+    PETE_AGENT,
+    harden({
+      allocation: { capPct: 30 },
+    }),
+  );
+  const { delegationClient } = await redeemAndCheckDelegation({
+    t,
+    zoe,
+    grantStatus,
+    receiver,
+    expectedDetails: {
+      portfolioId: peteKit.evmTrader.getPortfolioId(),
+      agentId: 'agent1',
+      permissions: { allocation: { capPct: 30 } },
+    },
+  });
+
+  const before = await peteKit.evmTrader.getPortfolioStatus();
+  const { policyVersion, rebalanceCount } = before;
+  const rebalanceFlowId = await E(delegationClient).setTargetAllocation(
+    {
+      Aave_Arbitrum: 30n,
+      '@Base': 70n,
+    },
+    { policyVersion, rebalanceCount },
+  );
+
+  t.regex(String(rebalanceFlowId), /^flow\d+$/);
+
+  await eventLoopIteration();
+  const after = await peteKit.evmTrader.getPortfolioStatus();
+  t.deepEqual(after.targetAllocation, {
+    Aave_Arbitrum: 30n,
+    '@Base': 70n,
+  });
+});
+
+test('delegated setTargetAllocation remains uncapped when allocation cap is absent', async t => {
+  const deployed = await deploy(t);
+  const { zoe } = deployed;
+  const { receiver, peteKit, peteArbitrum } = await openPetePortfolio(deployed);
+  const grantStatus = await peteArbitrum.grant(
+    PETE_AGENT,
+    harden({
+      allocation: true,
+    }),
+  );
+  const { delegationClient } = await redeemAndCheckDelegation({
+    t,
+    zoe,
+    grantStatus,
+    receiver,
+    expectedDetails: {
+      portfolioId: peteKit.evmTrader.getPortfolioId(),
+      agentId: 'agent1',
+      permissions: { allocation: true },
+    },
+  });
+
+  const before = await peteKit.evmTrader.getPortfolioStatus();
+  const { policyVersion, rebalanceCount } = before;
+  const rebalanceFlowId = await E(delegationClient).setTargetAllocation(
+    {
+      Aave_Arbitrum: 100n,
+      Compound_Arbitrum: 0n,
+    },
+    { policyVersion, rebalanceCount },
+  );
+
+  t.regex(String(rebalanceFlowId), /^flow\d+$/);
+});
+
 test('Delegation is active only while registered on the portfolio', async t => {
   const deployed = await deploy(t);
   const { zoe } = deployed;
   const { receiver, peteKit, peteArbitrum } = await openPetePortfolio(deployed);
   const grantStatus = await peteArbitrum.grant(
     PETE_AGENT,
-    harden({ allocation: true }),
+    harden({
+      allocation: true,
+    }),
   );
   const { delegationClient } = await redeemAndCheckDelegation({
     t,
@@ -330,21 +462,24 @@ test('Delegation is active only while registered on the portfolio', async t => {
   t.regex(String(rebalanceFlowId), /^flow\d+$/);
 });
 
-test('Grant rejects allocation permission set to false', async t => {
+test('Grant allows empty permissions', async t => {
   const deployed = await deploy(t);
-  const { peteArbitrum } = await openPetePortfolio(deployed);
+  const { zoe } = deployed;
+  const { receiver, peteKit, peteArbitrum } = await openPetePortfolio(deployed);
 
-  const grantStatus = await peteArbitrum.grant(
-    PETE_AGENT,
-    harden({ allocation: false }),
-  );
+  const grantStatus = await peteArbitrum.grant(PETE_AGENT, harden({}));
 
-  t.is(grantStatus.status, 'error');
-  if (!('error' in grantStatus)) {
-    t.fail('expected error detail on failed grant');
-    return;
-  }
-  t.regex(grantStatus.error || '', /grant requires allocation permission/);
+  await redeemAndCheckDelegation({
+    t,
+    zoe,
+    grantStatus,
+    receiver,
+    expectedDetails: {
+      portfolioId: peteKit.evmTrader.getPortfolioId(),
+      agentId: 'agent1',
+      permissions: {},
+    },
+  });
 });
 
 test('Grant delivery failure is surfaced in wallet vstorage without publishing an unusable agent', async t => {
@@ -363,7 +498,9 @@ test('Grant delivery failure is surfaced in wallet vstorage without publishing a
 
   const grantStatus = await peteArbitrum.grant(
     PETE_AGENT,
-    harden({ allocation: true }),
+    harden({
+      allocation: true,
+    }),
   );
 
   t.is(grantStatus.status, 'error');

--- a/packages/portfolio-contract/test/offer-shapes.test.ts
+++ b/packages/portfolio-contract/test/offer-shapes.test.ts
@@ -211,16 +211,16 @@ test('PortfolioPermissionsShape', t => {
     allocateOnly: { allocation: true },
     allocateObjectOnly: { allocation: {} },
     allocateFalse: { allocation: false },
-    allocateZeroCap: { allocation: { capPct: 0 } },
-    allocateCap: { allocation: { capPct: 30 } },
-    allocateFullCap: { allocation: { capPct: 100 } },
+    allocateZeroCap: { allocation: { capBps: 0 } },
+    allocateCap: { allocation: { capBps: 3000 } },
+    allocateFullCap: { allocation: { capBps: 10_000 } },
     rebalanceOnly: { rebalance: true },
     rebalanceFalse: { rebalance: false },
   } satisfies Record<string, PortfolioPermissions>);
   const failCases = harden({
-    allocationCapTooLow: { allocation: { capPct: -1 } },
-    allocationCapTooHigh: { allocation: { capPct: 101 } },
-    allocationCapExtraField: { allocation: { capPct: 30, future: true } },
+    allocationCapTooLow: { allocation: { capBps: -1 } },
+    allocationCapTooHigh: { allocation: { capBps: 10_001 } },
+    allocationCapExtraField: { allocation: { capBps: 3000, future: true } },
     futurePermission: { futurePermission: true },
   }) satisfies Record<string, unknown>;
 
@@ -237,7 +237,7 @@ test('PortfolioPermissionsShape', t => {
 test('PortfolioPermissionsExtShape', t => {
   const passCases = harden({
     empty: {},
-    allocateCap: { allocation: { capPct: 30 } },
+    allocateCap: { allocation: { capBps: 3000 } },
     futurePermission: { allocation: true, futurePermission: false },
     badAllocation: { allocation: { future: { size: 1 } } },
   });

--- a/packages/portfolio-contract/test/offer-shapes.test.ts
+++ b/packages/portfolio-contract/test/offer-shapes.test.ts
@@ -5,7 +5,6 @@ import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 import {
   type PortfolioAgentStatus,
   type PortfolioPermissions,
-  type PortfolioPermissionsExt,
   PortfolioPermissionsExtShape,
   PortfolioPermissionsShape,
 } from '@agoric/portfolio-api';
@@ -209,22 +208,21 @@ test('PoolKeyExt shapes accept future pool keys', t => {
 test('PortfolioPermissionsShape', t => {
   const passCases = harden({
     empty: {},
-    allocationOnly: {
-      allocation: true,
-    },
-    rebalanceOnly: {
-      rebalance: true,
-    },
+    allocateOnly: { allocation: true },
+    allocateObjectOnly: { allocation: {} },
+    allocateFalse: { allocation: false },
+    allocateZeroCap: { allocation: { capPct: 0 } },
+    allocateCap: { allocation: { capPct: 30 } },
+    allocateFullCap: { allocation: { capPct: 100 } },
+    rebalanceOnly: { rebalance: true },
+    rebalanceFalse: { rebalance: false },
   } satisfies Record<string, PortfolioPermissions>);
   const failCases = harden({
-    futurePermission: {
-      allocation: true,
-      futurePermission: false,
-    },
-    futureObject: {
-      future: { size: 1 },
-    },
-  }) satisfies Record<string, PortfolioPermissionsExt>;
+    allocationCapTooLow: { allocation: { capPct: -1 } },
+    allocationCapTooHigh: { allocation: { capPct: 101 } },
+    allocationCapExtraField: { allocation: { capPct: 30, future: true } },
+    futurePermission: { futurePermission: true },
+  }) satisfies Record<string, unknown>;
 
   t.log('good:', Object.keys(passCases).join(', '));
   t.log('bad:', Object.keys(failCases).join(', '));
@@ -239,15 +237,11 @@ test('PortfolioPermissionsShape', t => {
 test('PortfolioPermissionsExtShape', t => {
   const passCases = harden({
     empty: {},
-    futurePermission: {
-      allocation: true,
-      futurePermission: false,
-    },
-    futureObject: {
-      future: { size: 1 },
-    },
-  }) satisfies Record<string, PortfolioPermissionsExt>;
-  const failCases = harden({});
+    allocateCap: { allocation: { capPct: 30 } },
+    futurePermission: { allocation: true, futurePermission: false },
+    badAllocation: { allocation: { future: { size: 1 } } },
+  });
+  const failCases = harden({}) satisfies Record<string, unknown>;
 
   t.log('good:', Object.keys(passCases).join(', '));
   t.log('bad:', Object.keys(failCases).join(', '));

--- a/packages/portfolio-contract/test/planner.exo.test.ts
+++ b/packages/portfolio-contract/test/planner.exo.test.ts
@@ -158,7 +158,7 @@ test('planner starts delegated rebalance and resolves its plan', async t => {
       permissions,
     ) {
       t.is(grantee, PortfolioPlannerAgent);
-      t.like(permissions, { rebalance: true });
+      t.deepEqual(permissions, { rebalance: true });
       plannerDelegations.set(aPortfolio.planner, client);
     },
     ...({} as any),

--- a/packages/portfolio-contract/test/portfolio.exo.test.ts
+++ b/packages/portfolio-contract/test/portfolio.exo.test.ts
@@ -1091,7 +1091,6 @@ test('delegation rebalance creates flow and calls executePlan', async t => {
   const { manager } = makePortfolioKit({ portfolioId: 20 });
 
   const agentId = await manager.grantDelegation('agoric1delegate', {
-    allocation: false,
     rebalance: true,
   });
 
@@ -1244,7 +1243,7 @@ test('setAutoFeatures grants, updates, and regrants planner delegation and publi
   t.like(await getPortfolioAgents!(22), {
     agent1: {
       grantee: PortfolioPlannerAgent,
-      permissions: { rebalance: false },
+      permissions: {},
       state: 'active',
     },
   });
@@ -1266,7 +1265,7 @@ test('setAutoFeatures grants, updates, and regrants planner delegation and publi
   t.like(await getPortfolioAgents!(22), {
     agent1: {
       grantee: PortfolioPlannerAgent,
-      permissions: { rebalance: false },
+      permissions: {},
       state: 'revoked',
     },
   });
@@ -1284,7 +1283,7 @@ test('setAutoFeatures grants, updates, and regrants planner delegation and publi
   t.like(await getPortfolioAgents!(22), {
     agent1: {
       grantee: PortfolioPlannerAgent,
-      permissions: { rebalance: false },
+      permissions: {},
       state: 'revoked',
     },
     agent2: {

--- a/packages/portfolio-contract/tools/portfolio-actors.ts
+++ b/packages/portfolio-contract/tools/portfolio-actors.ts
@@ -10,49 +10,51 @@
  *
  * @see type-guards.ts for the authoritative interface specification
  */
-import { AmountMath, type NatAmount } from '@agoric/ertp';
-import type { VstorageKit } from '@agoric/client-utils';
-import type { Bech32Address, ChainInfo } from '@agoric/orchestration';
-import { ROOT_STORAGE_PATH } from '@agoric/orchestration/tools/contract-tests.js';
-import {
-  getPermitWitnessTransferFromData,
-  type TokenPermissions,
-} from '@agoric/orchestration/src/utils/permit2.js';
-import type { VowTools } from '@agoric/vow';
-import type { InvitationSpec } from '@agoric/smart-wallet/src/invitations.js';
-import type { Instance } from '@agoric/zoe';
-import type { ExecutionContext } from 'ava';
 import { type start } from '@aglocal/portfolio-contract/src/portfolio.contract.js';
 import {
   makePositionPath,
   portfolioIdOfPath,
-  type OfferArgsFor,
-  type ProposalType,
-  type PortfolioPublishedPathTypes,
-  type StatusFor,
-  type PoolKey,
   type EVMContractAddressesMap,
+  type OfferArgsFor,
+  type PoolKey,
+  type PortfolioPublishedPathTypes,
+  type ProposalType,
+  type StatusFor,
 } from '@aglocal/portfolio-contract/src/type-guards.js';
 import type { WalletTool } from '@aglocal/portfolio-contract/tools/wallet-offer-tools.js';
-import type {
-  PortfolioAutoFeatures,
-  PortfolioPublicInvitationMaker,
-  PortfolioContinuingInvitationMaker,
-  AxelarChain,
-  PortfolioPermissions,
-} from '@agoric/portfolio-api';
+import type { VstorageKit } from '@agoric/client-utils';
+import { AmountMath, type NatAmount } from '@agoric/ertp';
+import { mustMatch, type ERemote } from '@agoric/internal';
+import type { Bech32Address, ChainInfo } from '@agoric/orchestration';
 import {
-  PortfolioAutoFeaturesEIP712Shape,
-  PortfolioPermissionsEIP712Shape,
-} from '@agoric/portfolio-api/src/portfolio-permissions.js';
+  getPermitWitnessTransferFromData,
+  type TokenPermissions,
+} from '@agoric/orchestration/src/utils/permit2.js';
+import { ROOT_STORAGE_PATH } from '@agoric/orchestration/tools/contract-tests.js';
+import type {
+  AxelarChain,
+  PortfolioAutoFeatures,
+  PortfolioContinuingInvitationMaker,
+  PortfolioPermissions,
+  PortfolioPublicInvitationMaker,
+} from '@agoric/portfolio-api';
 import {
   getYmaxStandaloneOperationData,
   getYmaxWitness,
+  type PortfolioAutoFeaturesEIP712,
+  type PortfolioPermissionsEIP712,
+  type TargetAllocation,
 } from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.js';
-import type { TargetAllocation } from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.js';
+import {
+  PortfolioAutoFeaturesEIP712Shape,
+  PortfolioPermissionsShape,
+} from '@agoric/portfolio-api/src/portfolio-permissions.js';
+import type { InvitationSpec } from '@agoric/smart-wallet/src/invitations.js';
 import type { TimerService } from '@agoric/time';
-import { mustMatch, type ERemote } from '@agoric/internal';
+import type { VowTools } from '@agoric/vow';
+import type { Instance } from '@agoric/zoe';
 import { E } from '@endo/far';
+import type { ExecutionContext } from 'ava';
 import type { TypedDataDefinition } from 'viem';
 import type { PrivateKeyAccount } from 'viem/accounts';
 import type { EVMWalletMessageHandler } from '../src/evm-wallet-handler.exo.ts';
@@ -522,9 +524,9 @@ export const makeEvmTrader = ({
          * entry for this trader's portfolio.
          *
          * Although the caller-facing type is {@link PortfolioPermissions},
-         * the current standalone EIP-712 `Grant` payload uses
-         * {@link PortfolioPermissionsEIP712Shape}. This helper validates that
-         * the requested permission bag fits the current wire shape before
+         * the standalone EIP-712 `Grant` payload uses a fixed permissions
+         * struct validated by {@link PortfolioPermissionsEIP712Shape}. This
+         * helper normalizes the TS permission bag into that wire shape before
          * signing, so unsupported permissions fail client-side.
          */
         async grant(
@@ -532,11 +534,11 @@ export const makeEvmTrader = ({
           permissions: PortfolioPermissions,
         ) {
           const deadline = await getDeadline();
-          mustMatch(permissions, PortfolioPermissionsEIP712Shape);
+          const wirePermissions = toPortfolioPermissionsEIP712(permissions);
           const message = getYmaxStandaloneOperationData(
             {
               accountHolder: granteeAddress,
-              permissions,
+              permissions: wirePermissions,
               portfolio: BigInt(self.getPortfolioId()),
               nonce: (nonce += 1n),
               deadline,
@@ -555,7 +557,9 @@ export const makeEvmTrader = ({
          */
         async setAutoFeatures(features: PortfolioAutoFeatures) {
           const deadline = await getDeadline();
-          const hardenedFeatures = harden({ ...features });
+          const hardenedFeatures: PortfolioAutoFeaturesEIP712 = harden({
+            rebalance: features.rebalance === true,
+          });
           mustMatch(hardenedFeatures, PortfolioAutoFeaturesEIP712Shape);
           const message = harden(
             getYmaxStandaloneOperationData(
@@ -586,4 +590,16 @@ export const makeEvmTrader = ({
   });
 
   return self;
+};
+export const toPortfolioPermissionsEIP712 = (
+  permissions: PortfolioPermissions,
+): PortfolioPermissionsEIP712 => {
+  mustMatch(permissions, PortfolioPermissionsShape);
+  const { allocation, rebalance } = permissions;
+  return harden({
+    mayAllocate: !!allocation,
+    allocationCapPct:
+      typeof allocation === 'object' ? (allocation.capPct ?? 0) : 0,
+    mayRebalance: !!rebalance,
+  });
 };

--- a/packages/portfolio-contract/tools/portfolio-actors.ts
+++ b/packages/portfolio-contract/tools/portfolio-actors.ts
@@ -598,8 +598,8 @@ export const toPortfolioPermissionsEIP712 = (
   const { allocation, rebalance } = permissions;
   return harden({
     mayAllocate: !!allocation,
-    allocationCapPct:
-      typeof allocation === 'object' ? (allocation.capPct ?? 0) : 0,
+    allocationCapBps:
+      typeof allocation === 'object' ? (allocation.capBps ?? 0) : 0,
     mayRebalance: !!rebalance,
   });
 };


### PR DESCRIPTION
refs: AGO-672

## Description
Add optional delegation permission `allocation: { capPct }` and enforce it only on delegated `setTargetAllocation()` calls.

- `capPct` is optional; absence means uncapped delegation
- valid range is integer percent `0..100`
- cap applies only to non-cash positions
  - cash pseudo-positions like `@Base` are exempt for now
- owner allocation changes are unchanged

### Security Considerations
lets porfolio owners further constrain mandate to agents

enforced in `setTargetAllocation()` in `delegation.exo.ts`; the contract doesn't check plans, flows, or anything like that.

### Scaling Considerations
N/A

### Documentation Considerations
Tests, types, and shapes provide docs as usual.

### Testing Considerations
Unit tests as usual.

Mainnet validation on `mainnet0` should include delegated `setTargetAllocation()` behavior for:
- uncapped delegation
- capped delegation under the limit
- capped delegation over the limit

### Upgrade Considerations
Existing delegations remain valid because absence of `capPct` means no cap.
