### PR TITLE
fix(ymax-planner): Better handle a suppressed sink position on a net sink chain

### DIFF
--- a/packages/portfolio-api/src/target-balances.ts
+++ b/packages/portfolio-api/src/target-balances.ts
@@ -334,6 +334,12 @@ export const computeTargetBalances = <
   );
   let remainder = liquidTotal;
   const pending = new Set<DraftRecord>(Object.values(draft));
+  const claim = (chainName: SupportedChain, value: NatValue) => {
+    const chainPlace = `@${chainName}` as C | T;
+    draft[chainPlace] ??= makeDraftRecord(chainPlace);
+    draft[chainPlace].resolvedDelta += value;
+    if (!pending.has(draft[chainPlace])) remainder -= value;
+  };
   for (const draftRecord of pending) {
     pending.delete(draftRecord);
     const { place, current, delta, resolvedDelta } = draftRecord;
@@ -347,30 +353,26 @@ export const computeTargetBalances = <
 
     // This sink cannot receive its inbound funds. If its chain is a net source
     // or neutral, we leave them at the local hub. Otherwise, we reduce the net
-    // outflow from one or more donor-chain hubs.
+    // outflow from one or more donor-chain hubs before adjusting the local hub.
     remainder -= current;
     const local = getPlaceData(place, network).chain;
-    const localNetOut = donorChainsDesc.find(([n]) => n === local.name)![1];
+    const localDonorEntry = donorChainsDesc.find(([n]) => n === local.name)!;
+    const localNetOut = localDonorEntry[1];
     if (localNetOut >= 0n) {
-      const chainPlace = `@${local.name}` as C | T;
-      draft[chainPlace] ??= makeDraftRecord(chainPlace);
-      draft[chainPlace].resolvedDelta += delta;
-      if (!pending.has(draft[chainPlace])) remainder -= delta;
+      claim(local.name, delta);
     } else {
       let excess = delta;
       for (const donorEntry of donorChainsDesc) {
         const [chainName, netOut] = donorEntry;
         if (excess === 0n || netOut <= 0n) break;
-        const chainPlace = `@${chainName}` as C | T;
-        draft[chainPlace] ??= makeDraftRecord(chainPlace);
         const d = bigintMin(excess, netOut);
-        if (!pending.has(draft[chainPlace])) remainder -= d;
-        draft[chainPlace].resolvedDelta += d;
+        claim(chainName, d);
         donorEntry[1] -= d;
         excess -= d;
       }
       if (excess !== 0n) {
-        failInternal(`internal: Unable to suppress ${place}`);
+        claim(local.name, excess);
+        localDonorEntry[1] -= excess;
       }
       sortEntriesDesc(donorChainsDesc);
     }

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -56,6 +56,7 @@ import {
 } from './mocks.ts';
 import type { Sdk as SpectrumBlockchainSdk } from '../src/graphql/api-spectrum-blockchain/__generated/sdk.ts';
 import PROD_NETWORK_202604 from '../tools/network-snapshots/prod-network-2026-04.ts';
+import PROD_NETWORK_202606 from '../tools/network-snapshots/prod-network-2026-06.ts';
 
 const depositBrand = Far('mock brand') as Brand<'nat'>;
 const makeDeposit = value => AmountMath.make(depositBrand, value);
@@ -859,6 +860,38 @@ test('solver regressions', async t => {
     makeMovementDesc('@Optimism', 'Compound_Optimism', scale6(495)),
     makeMovementDesc('@Base', 'Compound_Base', scale6(495)),
   ]);
+
+  // 2026-06-15 (simulated)
+  const portfolio145Rebalance202606 = await planRebalanceToAllocations({
+    ...plannerContext,
+    network: PROD_NETWORK_202606,
+    targetAllocation: {
+      ERC4626_morphoAlphaUsdcCore_Ethereum: 1515152n,
+      ERC4626_morphoClearstarHighYieldUsdc_Ethereum: 2525253n,
+      ERC4626_morphoGauntletUsdcCore_Arbitrum: 1515152n,
+      ERC4626_morphoGauntletUsdcRwa_Ethereum: 1414141n,
+      ERC4626_morphoSeamlessUsdcVault_Base: 1515152n,
+      ERC4626_morphoSteakhousePrimeUsdc_Base: 1515152n,
+    },
+    currentBalances: {
+      Compound_Arbitrum: makeDeposit(37n),
+      ERC4626_morphoAlphaUsdcCore_Ethereum: makeDeposit(15465311n),
+      ERC4626_morphoClearstarHighYieldUsdc_Ethereum: makeDeposit(69299093n),
+      ERC4626_morphoGauntletUsdcCore_Arbitrum: makeDeposit(15372933n),
+      ERC4626_morphoGauntletUsdcRwa_Ethereum: makeDeposit(14394083n),
+      ERC4626_morphoSeamlessUsdcVault_Base: makeDeposit(13870033n),
+      ERC4626_morphoSteakhousePrimeUsdc_Base: makeDeposit(15387391n),
+      '@Base': makeDeposit(1402522n),
+      '@Arbitrum': makeDeposit(0n),
+      '@Ethereum': makeDeposit(4633698n),
+    },
+  });
+  await assertPlanFlow(
+    t,
+    'portfolio145 simulated rebalance',
+    portfolio145Rebalance202606.flow,
+    [],
+  );
 });
 
 test('planRebalanceToAllocations regression - multiple sources', async t => {

--- a/services/ymax-planner/test/deposit-tools.test.ts
+++ b/services/ymax-planner/test/deposit-tools.test.ts
@@ -1,6 +1,6 @@
 /** @file test for deposit tools */
 import test from 'ava';
-import type { Assertions } from 'ava';
+import type { ExecutionContext } from 'ava';
 
 import type { PartialDeep } from 'type-fest';
 
@@ -93,13 +93,17 @@ const makeMovementDesc = (
 };
 
 /** A helper to support prettier-friendly plan flow assertions. */
-const assertPlanFlow = (
-  t: Assertions,
+const assertPlanFlow = async (
+  t: ExecutionContext,
   label: string,
   flow: MovementDesc[],
   expectedFlow: PartialDeep<MovementDesc>[],
 ) => {
-  arrayIsLike(t, flow, expectedFlow, label);
+  const result = await t.try(tt => arrayIsLike(tt, flow, expectedFlow, label));
+  if (!result.passed) {
+    t.log(`${label} actual flow`, readableSteps(flow, depositBrand));
+  }
+  result.commit();
 };
 
 /**
@@ -740,7 +744,7 @@ test('solver regressions', async t => {
     },
     amount: makeDeposit(223560027n),
   });
-  assertPlanFlow(t, 'portfolio90 flow9', portfolio90Flow9.flow, [
+  await assertPlanFlow(t, 'portfolio90 flow9', portfolio90Flow9.flow, [
     makeMovementDesc('Aave_Ethereum', '@Ethereum', 108975753n),
     makeMovementDesc('Compound_Ethereum', '@Ethereum', 114584274n),
     makeMovementDesc('@Ethereum', '@agoric', 223560027n),
@@ -758,11 +762,16 @@ test('solver regressions', async t => {
     amount: makeDeposit(999999n),
     toChain: 'Avalanche',
   });
-  assertPlanFlow(t, 'portfolio176 flow{2,3,4,8}', portfolio176FlowX.flow, [
-    makeMovementDesc('Aave_Base', '@Base', 999999n),
-    makeMovementDesc('@Base', '@Avalanche', 999999n),
-    makeMovementDesc('@Avalanche', '-Avalanche', 999999n),
-  ]);
+  await assertPlanFlow(
+    t,
+    'portfolio176 flow{2,3,4,8}',
+    portfolio176FlowX.flow,
+    [
+      makeMovementDesc('Aave_Base', '@Base', 999999n),
+      makeMovementDesc('@Base', '@Avalanche', 999999n),
+      makeMovementDesc('@Avalanche', '-Avalanche', 999999n),
+    ],
+  );
 
   // 2026-04-21T16:31Z
   const portfolio81Flow23 = await planDepositToAllocations({
@@ -778,7 +787,7 @@ test('solver regressions', async t => {
     amount: makeDeposit(1000000000n),
     fromChain: 'Ethereum',
   });
-  assertPlanFlow(t, 'portfolio81 flow23', portfolio81Flow23.flow, [
+  await assertPlanFlow(t, 'portfolio81 flow23', portfolio81Flow23.flow, [
     makeMovementDesc('+Ethereum', '@Ethereum', 1000000000n),
     makeMovementDesc('@Ethereum', 'Aave_Ethereum', 499989607n),
     makeMovementDesc('@Ethereum', 'Compound_Ethereum', 500010393n),
@@ -796,7 +805,7 @@ test('solver regressions', async t => {
     amount: makeDeposit(scale6(25_000)),
     fromChain: 'Ethereum',
   });
-  assertPlanFlow(t, 'portfolio177 flow1', portfolio177Flow1.flow, [
+  await assertPlanFlow(t, 'portfolio177 flow1', portfolio177Flow1.flow, [
     makeMovementDesc('+Ethereum', '@Ethereum', scale6(25_000)),
     makeMovementDesc('@Ethereum', 'Aave_Ethereum', scale6(8500)),
     makeMovementDesc('@Ethereum', 'Compound_Ethereum', scale6(8250)),
@@ -820,9 +829,12 @@ test('solver regressions', async t => {
     },
     currentBalances: { '@Avalanche': makeDeposit(3900011n) },
   });
-  assertPlanFlow(t, 'ymax0 portfolio35 flow76', ymax0Portfolio35Flow76.flow, [
-    makeMovementDesc('@Avalanche', 'Aave_Avalanche', 3900011n),
-  ]);
+  await assertPlanFlow(
+    t,
+    'ymax0 portfolio35 flow76',
+    ymax0Portfolio35Flow76.flow,
+    [makeMovementDesc('@Avalanche', 'Aave_Avalanche', 3900011n)],
+  );
 
   // 2026-05-13T17:42Z
   const portfolio195Flow2 = await planDepositToAllocations({
@@ -836,7 +848,7 @@ test('solver regressions', async t => {
     amount: makeDeposit(1500000000n),
     fromChain: 'Ethereum',
   });
-  assertPlanFlow(t, 'portfolio195 flow2', portfolio195Flow2.flow, [
+  await assertPlanFlow(t, 'portfolio195 flow2', portfolio195Flow2.flow, [
     makeMovementDesc('+Ethereum', '@Ethereum', scale6(1500)),
     makeMovementDesc('@Ethereum', '@agoric', scale6(1500)),
     makeMovementDesc('@agoric', '@noble', scale6(1500)),
@@ -1055,7 +1067,7 @@ test('@<ChainName> USDC target allocations', async t => {
     targetAllocation: objectMap(currentBalances, amt => amt.value),
     amount: makeDeposit(scale6(10)),
   });
-  assertPlanFlow(t, 'withdraw from mixed targets', withdrawPlan.flow, [
+  await assertPlanFlow(t, 'withdraw from mixed targets', withdrawPlan.flow, [
     makeMovementDesc('Aave_Base', '@Base', scale6(5)),
     makeMovementDesc('@Base', '@agoric', scale6(10)),
     makeMovementDesc('@agoric', '<Cash>', scale6(10)),
@@ -1067,7 +1079,7 @@ test('@<ChainName> USDC target allocations', async t => {
     targetAllocation: objectMap(currentBalances, amt => amt.value),
     amount: makeDeposit(scale6(10)),
   });
-  assertPlanFlow(t, 'deposit to mixed targets', depositPlan.flow, [
+  await assertPlanFlow(t, 'deposit to mixed targets', depositPlan.flow, [
     makeMovementDesc('<Deposit>', '@agoric', scale6(10)),
     makeMovementDesc('@agoric', '@noble', scale6(10)),
     makeMovementDesc('@noble', '@Base', scale6(10)),
@@ -1080,19 +1092,24 @@ test('@<ChainName> USDC target allocations', async t => {
     targetAllocation: { '@Base': 100n },
     amount: makeDeposit(scale6(10)),
   });
-  assertPlanFlow(t, 'deposit and consolidate', depositAndRebalancePlan.flow, [
-    makeMovementDesc('Aave_Base', '@Base', scale6(10)),
-    makeMovementDesc('<Deposit>', '@agoric', scale6(10)),
-    makeMovementDesc('@agoric', '@noble', scale6(10)),
-    makeMovementDesc('@noble', '@Base', scale6(10)),
-  ]);
+  await assertPlanFlow(
+    t,
+    'deposit and consolidate',
+    depositAndRebalancePlan.flow,
+    [
+      makeMovementDesc('Aave_Base', '@Base', scale6(10)),
+      makeMovementDesc('<Deposit>', '@agoric', scale6(10)),
+      makeMovementDesc('@agoric', '@noble', scale6(10)),
+      makeMovementDesc('@noble', '@Base', scale6(10)),
+    ],
+  );
 
   const rebalancePlan = await planRebalanceToAllocations({
     ...plannerContext,
     currentBalances,
     targetAllocation: { '@Base': 100n },
   });
-  assertPlanFlow(t, 'rebalance into chain', rebalancePlan.flow, [
+  await assertPlanFlow(t, 'rebalance into chain', rebalancePlan.flow, [
     makeMovementDesc('Aave_Base', '@Base', scale6(10)),
   ]);
 
@@ -1101,7 +1118,7 @@ test('@<ChainName> USDC target allocations', async t => {
     currentBalances,
     targetAllocation: { '@Base': 50n, '@Optimism': 50n },
   });
-  assertPlanFlow(t, 'rebalance into chains', rerebalancePlan.flow, [
+  await assertPlanFlow(t, 'rebalance into chains', rerebalancePlan.flow, [
     makeMovementDesc('Aave_Base', '@Base', scale6(10)),
     makeMovementDesc('@Base', '@agoric', scale6(10)),
     makeMovementDesc('@agoric', '@noble', scale6(10)),

--- a/services/ymax-planner/tools/network-snapshots/prod-network-2026-06.ts
+++ b/services/ymax-planner/tools/network-snapshots/prod-network-2026-06.ts
@@ -1,0 +1,399 @@
+import type { NetworkSpec } from '@agoric/portfolio-api/src/network/network-spec.js';
+
+const isPrimitive = (value: unknown): boolean => Object(value) !== value;
+
+const deepFreeze = <T>(value: T): T => {
+  if (isPrimitive(value)) return value;
+  const obj = value as Record<PropertyKey, unknown>;
+  Object.freeze(obj);
+  for (const key of Reflect.ownKeys(obj)) {
+    deepFreeze(obj[key]);
+  }
+  return value;
+};
+
+// Initial production network in NetworkSpec format
+export const PROD_NETWORK: NetworkSpec = deepFreeze({
+  // Enable debug diagnostics to aid troubleshooting in tests
+  debug: true,
+  environment: 'prod',
+  chains: [
+    { name: 'agoric', control: 'local' },
+    { name: 'noble', control: 'ibc' },
+    { name: 'Arbitrum', control: 'axelar' },
+    { name: 'Avalanche', control: 'axelar' },
+    { name: 'Base', control: 'axelar' },
+    { name: 'Ethereum', control: 'axelar' },
+    { name: 'Optimism', control: 'axelar' },
+  ],
+  pools: [
+    { pool: 'Aave_Arbitrum', chain: 'Arbitrum', protocol: 'Aave' },
+    { pool: 'Aave_Avalanche', chain: 'Avalanche', protocol: 'Aave' },
+    { pool: 'Aave_Base', chain: 'Base', protocol: 'Aave' },
+    { pool: 'Aave_Ethereum', chain: 'Ethereum', protocol: 'Aave' },
+    { pool: 'Aave_Optimism', chain: 'Optimism', protocol: 'Aave' },
+    { pool: 'Beefy_re7_Avalanche', chain: 'Avalanche', protocol: 'Beefy' },
+    {
+      pool: 'Beefy_morphoGauntletUsdc_Ethereum',
+      chain: 'Ethereum',
+      protocol: 'Beefy',
+    },
+    {
+      pool: 'Beefy_morphoSmokehouseUsdc_Ethereum',
+      chain: 'Ethereum',
+      protocol: 'Beefy',
+    },
+    { pool: 'Beefy_morphoSeamlessUsdc_Base', chain: 'Base', protocol: 'Beefy' },
+    {
+      pool: 'Beefy_compoundUsdc_Optimism',
+      chain: 'Optimism',
+      protocol: 'Beefy',
+    },
+    {
+      pool: 'Beefy_compoundUsdc_Arbitrum',
+      chain: 'Arbitrum',
+      protocol: 'Beefy',
+    },
+    {
+      pool: 'ERC4626_morphoClearstarHighYieldUsdc_Ethereum',
+      chain: 'Ethereum',
+      protocol: 'ERC4626',
+      blockDepositReason: 'AT_CAPACITY',
+      blockWithdrawReason: 'LOW_LIQUIDITY',
+    },
+    {
+      pool: 'ERC4626_morphoSeamlessUsdcVault_Base',
+      chain: 'Base',
+      protocol: 'ERC4626',
+      blockDepositReason: 'AT_CAPACITY',
+    },
+    { pool: 'Compound_Arbitrum', chain: 'Arbitrum', protocol: 'Compound' },
+    { pool: 'Compound_Base', chain: 'Base', protocol: 'Compound' },
+    { pool: 'Compound_Ethereum', chain: 'Ethereum', protocol: 'Compound' },
+    { pool: 'Compound_Optimism', chain: 'Optimism', protocol: 'Compound' },
+    { pool: 'USDN', chain: 'noble', protocol: 'USDN' },
+    { pool: 'USDNVault', chain: 'noble', protocol: 'USDN' },
+  ],
+  localPlaces: [
+    { id: '<Deposit>', chain: 'agoric' },
+    { id: '<Cash>', chain: 'agoric' },
+    { id: '+agoric', chain: 'agoric' },
+  ],
+  links: [
+    // USDN costs a fee to get into
+    {
+      src: '@noble',
+      dest: 'USDN',
+      transfer: 'local',
+      variableFeeBps: 10,
+      timeSec: 0,
+      feeMode: 'toUSDN',
+    },
+    {
+      src: '@noble',
+      dest: 'USDNVault',
+      transfer: 'local',
+      variableFeeBps: 10,
+      timeSec: 0,
+      feeMode: 'toUSDN',
+    },
+
+    // CCTP slow (inbound auto-forward compressed: EVM -> @agoric)
+    // Latency kept at 1080s (assuming IBC forward overlaps); adjust if sequential.
+    {
+      src: '@Arbitrum',
+      dest: '@agoric',
+      transfer: 'cctpToNoble',
+      variableFeeBps: 0,
+      timeSec: 1080,
+      feeMode: 'evmToNoble',
+    },
+    {
+      src: '@Avalanche',
+      dest: '@agoric',
+      transfer: 'cctpToNoble',
+      variableFeeBps: 0,
+      timeSec: 30, // Avalanche has instant finality (~7 seconds observed)
+      feeMode: 'evmToNoble',
+    },
+    {
+      src: '@Ethereum',
+      dest: '@agoric',
+      transfer: 'cctpToNoble',
+      variableFeeBps: 0,
+      timeSec: 1080,
+      feeMode: 'evmToNoble',
+    },
+    {
+      src: '@Optimism',
+      dest: '@agoric',
+      transfer: 'cctpToNoble',
+      variableFeeBps: 0,
+      timeSec: 1080,
+      feeMode: 'evmToNoble',
+    },
+    {
+      src: '@Base',
+      dest: '@agoric',
+      transfer: 'cctpToNoble',
+      variableFeeBps: 0,
+      timeSec: 1080,
+      feeMode: 'evmToNoble',
+    },
+    // CCTP return (fast on return path); 1 USDC minimum
+    {
+      src: '@noble',
+      dest: '@Arbitrum',
+      transfer: 'cctpFromNoble',
+      variableFeeBps: 0,
+      timeSec: 20,
+      min: 1_000_000n,
+      feeMode: 'makeEvmAccount',
+    },
+    {
+      src: '@noble',
+      dest: '@Avalanche',
+      transfer: 'cctpFromNoble',
+      variableFeeBps: 0,
+      timeSec: 20,
+      min: 1_000_000n,
+      feeMode: 'makeEvmAccount',
+    },
+    {
+      src: '@noble',
+      dest: '@Ethereum',
+      transfer: 'cctpFromNoble',
+      variableFeeBps: 0,
+      timeSec: 20,
+      min: 1_000_000n,
+      feeMode: 'makeEvmAccount',
+    },
+    {
+      src: '@noble',
+      dest: '@Optimism',
+      transfer: 'cctpFromNoble',
+      variableFeeBps: 0,
+      timeSec: 20,
+      min: 1_000_000n,
+      feeMode: 'makeEvmAccount',
+    },
+    {
+      src: '@noble',
+      dest: '@Base',
+      transfer: 'cctpFromNoble',
+      variableFeeBps: 0,
+      timeSec: 20,
+      min: 1_000_000n,
+      feeMode: 'makeEvmAccount',
+    },
+    // IBC connectivity (explicit both directions required for USDN and other noble-origin flows)
+    {
+      src: '@agoric',
+      dest: '@noble',
+      transfer: 'ibc',
+      variableFeeBps: 0,
+      timeSec: 10,
+    },
+    {
+      src: '@noble',
+      dest: '@agoric',
+      transfer: 'ibc',
+      variableFeeBps: 0,
+      timeSec: 10,
+    },
+
+    // CCTPv2 direct EVM-to-EVM routes (full mesh connectivity)
+    // Estimated time: ~13-60 seconds depending on finality threshold
+    // Note: CCTPv2 contracts must be deployed on both source and destination chains
+
+    // Arbitrum ↔ other EVM chains
+    {
+      src: '@Arbitrum',
+      dest: '@Ethereum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Ethereum',
+      dest: '@Arbitrum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Arbitrum',
+      dest: '@Base',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Base',
+      dest: '@Arbitrum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Arbitrum',
+      dest: '@Avalanche',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 30, // Avalanche has instant finality
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Avalanche',
+      dest: '@Arbitrum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Arbitrum',
+      dest: '@Optimism',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Optimism',
+      dest: '@Arbitrum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+
+    // Base ↔ other EVM chains (excluding Arbitrum, already defined)
+    {
+      src: '@Base',
+      dest: '@Ethereum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Ethereum',
+      dest: '@Base',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Base',
+      dest: '@Avalanche',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 30, // Avalanche has instant finality
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Avalanche',
+      dest: '@Base',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Base',
+      dest: '@Optimism',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Optimism',
+      dest: '@Base',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+
+    // Ethereum ↔ other EVM chains (excluding Arbitrum, Base already defined)
+    {
+      src: '@Ethereum',
+      dest: '@Avalanche',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 30, // Avalanche has instant finality
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Avalanche',
+      dest: '@Ethereum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Ethereum',
+      dest: '@Optimism',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Optimism',
+      dest: '@Ethereum',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+
+    // Avalanche ↔ Optimism (remaining pair)
+    {
+      src: '@Avalanche',
+      dest: '@Optimism',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 60,
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+    {
+      src: '@Optimism',
+      dest: '@Avalanche',
+      transfer: 'cctpV2',
+      variableFeeBps: 0,
+      timeSec: 30, // Avalanche has instant finality
+      min: 100_000n,
+      feeMode: 'evmToEvm',
+    },
+  ],
+});
+
+export default PROD_NETWORK;


### PR DESCRIPTION
Fixes AGO-698

## Description
When there is no net source whose outflow can be reduced, just adjust the local hub in anticipation that things will balance out. If they actually don't, an error will be thrown from later validation.

### Security Considerations
None known.

### Scaling Considerations
None.

### Documentation Considerations
Just inline comments.

### Testing Considerations
I used the specific reported scenario, which can also be validated live after release.

### Upgrade Considerations
Safe for immediate deployment.