### PR TITLE
ci(after-merge): Fix OIDC trusted publishing for `@agoric/cosmos` and `@agoric/wallet-backend` packages

### DIFF
--- a/golang/cosmos/package.json
+++ b/golang/cosmos/package.json
@@ -2,6 +2,10 @@
   "name": "@agoric/cosmos",
   "version": "0.34.1",
   "description": "Connect JS to the Cosmos blockchain SDK",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Agoric/agoric-sdk.git"
+  },
   "parsers": {
     "js": "mjs"
   },

--- a/packages/wallet/api/package.json
+++ b/packages/wallet/api/package.json
@@ -42,7 +42,7 @@
   "keywords": [],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Agoric/agoric"
+    "url": "git+https://github.com/Agoric/agoric-sdk.git"
   },
   "author": "Agoric",
   "license": "Apache-2.0",


### PR DESCRIPTION
refs: #12683

## Description
The two packages `@agoric/cosmos` and `@agoric/wallet-backend` had incorrect repository URLs configured which is why OIDC trusted publishing was failing

### Security Considerations
N/A

### Scaling Considerations
N/A

### Documentation Considerations
N/A

### Testing Considerations
N/A

### Upgrade Considerations
N/A
