### PR TITLE
fix(ymax-resolver): self-heal dead EVM WebSockets to keep resolving pending txs

### DIFF
--- a/services/ymax-planner/scripts/process-tx-lib.ts
+++ b/services/ymax-planner/scripts/process-tx-lib.ts
@@ -113,10 +113,13 @@ export const processTx = async (
   const failedEvmChains = [] as Array<keyof typeof evmCtx.evmProviders>;
   const evmHeights = await deeplyFulfilledObject(
     objectMap(evmCtx.evmProviders, (provider, chainId) =>
-      provider.getBlockNumber().catch(err => {
-        failedEvmChains.push(chainId);
-        return { error: err.message };
-      }),
+      provider
+        .getProvider()
+        .getBlockNumber()
+        .catch(err => {
+          failedEvmChains.push(chainId);
+          return { error: err.message };
+        }),
     ),
   );
   if (isVerbose) {

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -93,7 +93,7 @@ import {
   setIgnoredTx,
   setResolvedTx,
 } from './kv-store.ts';
-import { UserInputError, type ReconnectingProvider } from './support.ts';
+import { UserInputError, type ReconnectingEvmProvider } from './support.ts';
 import { makeExpiringMap } from './utils.ts';
 import {
   encodedKeyToPath,
@@ -250,7 +250,7 @@ export type ProcessPortfolioPowers = Pick<
   vstoragePathPrefixes: {
     portfoliosPathPrefix: string;
   };
-  evmProviders: Record<CaipChainId, ReconnectingProvider>;
+  evmProviders: Record<CaipChainId, ReconnectingEvmProvider>;
 };
 
 export type PortfoliosMemory = {

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -64,7 +64,6 @@ import type {
 } from '@agoric/portfolio-api';
 
 import type { EvmAddress } from '@agoric/fast-usdc';
-import type { WebSocketProvider } from 'ethers';
 import {
   checkAutoRebalance,
   maybeAutoRebalance,
@@ -94,7 +93,7 @@ import {
   setIgnoredTx,
   setResolvedTx,
 } from './kv-store.ts';
-import { UserInputError } from './support.ts';
+import { UserInputError, type ReconnectingProvider } from './support.ts';
 import { makeExpiringMap } from './utils.ts';
 import {
   encodedKeyToPath,
@@ -251,7 +250,7 @@ export type ProcessPortfolioPowers = Pick<
   vstoragePathPrefixes: {
     portfoliosPathPrefix: string;
   };
-  evmProviders: Record<CaipChainId, WebSocketProvider>;
+  evmProviders: Record<CaipChainId, ReconnectingProvider>;
 };
 
 export type PortfoliosMemory = {

--- a/services/ymax-planner/src/errors.ts
+++ b/services/ymax-planner/src/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * Signals that a watcher's underlying transport (WebSocket) failed.
+ * Distinct from a transaction-level failure: the watch could not continue,
+ * so the caller may safely restart it (see `watchWithRetry`).
+ *
+ * Defined in its own leaf module so both the RPC layer (`makeEvmRpc`, which
+ * throws it on a bounded-call timeout) and the watchers can import it without
+ * an import cycle.
+ */
+export const WatcherTransportError = class WatcherTransportError extends Error {};
+WatcherTransportError.prototype.name = WatcherTransportError.name;

--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -2,7 +2,12 @@ import { WebSocketProvider, Log, toQuantity, isError } from 'ethers';
 import type { Filter, TransactionReceipt, TransactionResponse } from 'ethers';
 import type { Address as EvmAddress } from 'viem';
 import type { CaipChainId } from '@agoric/orchestration';
-import { getBlockTimeMs, prepareAbortController } from './support.ts';
+import {
+  getBlockTimeMs,
+  prepareAbortController,
+  type ReconnectingProvider,
+} from './support.ts';
+import { WatcherTransportError } from './errors.ts';
 
 export const DEFAULT_CONFIRMATION_POLL_INTERVAL_MS = 5_000;
 
@@ -55,35 +60,84 @@ type BinarySearch = {
 };
 
 /**
- * A provider facade whose methods automatically retry on Alchemy 429
- * rate-limit errors using exponential backoff with jitter.
+ * Per-call timeout. A zombie socket (open but neither responding nor faulting)
+ * makes a request/response call hang indefinitely; bounding it turns that
+ * silent stall into a fast, retryable {@link WatcherTransportError} and reports
+ * the socket as unhealthy so it gets reconnected (see PAK-517).
+ */
+export const RPC_CALL_TIMEOUT_MS = 20_000;
+
+/**
+ * A provider facade whose methods retry on Alchemy 429 rate-limit errors
+ * (exponential backoff with jitter) and are bounded by a per-call timeout.
+ *
+ * It delegates to the {@link ReconnectingProvider}'s *current* provider on every
+ * call, so after a reconnect the facade (held by long-lived watchers) keeps
+ * working against the fresh socket.
  */
 export const makeEvmRpc = (
-  provider: WebSocketProvider,
+  reconnecting: ReconnectingProvider,
   setTimeout: typeof globalThis.setTimeout,
-) => ({
-  // RPC calls with retry
-  getBlock: (n: number) =>
-    withRateLimitRetry(() => provider.getBlock(n), setTimeout),
-  getBlockNumber: () =>
-    withRateLimitRetry(() => provider.getBlockNumber(), setTimeout),
-  getLogs: (filter: Filter) =>
-    withRateLimitRetry(() => provider.getLogs(filter), setTimeout),
-  getNetwork: () => withRateLimitRetry(() => provider.getNetwork(), setTimeout),
-  getTransactionReceipt: (txHash: string) =>
-    withRateLimitRetry(
-      () => provider.getTransactionReceipt(txHash),
-      setTimeout,
-    ),
-  send: (...args: Parameters<WebSocketProvider['send']>) =>
-    withRateLimitRetry(() => provider.send(...args), setTimeout),
-  // Subscription pass-throughs (no retry needed)
-  on: provider.on.bind(provider) as WebSocketProvider['on'],
-  off: provider.off.bind(provider) as WebSocketProvider['off'],
-  get websocket() {
-    return (provider as any).websocket;
-  },
-});
+  {
+    timeoutMs = RPC_CALL_TIMEOUT_MS,
+    log = (..._args: unknown[]) => {},
+  }: { timeoutMs?: number; log?: (...args: unknown[]) => void } = {},
+) => {
+  const withTimeout = <T>(label: string, op: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        log(`RPC ${label} timed out after ${timeoutMs}ms; cycling socket`);
+        reconnecting.reportUnhealthy(`${label} timeout`);
+        reject(
+          new WatcherTransportError(
+            `RPC ${label} timed out after ${timeoutMs}ms`,
+          ),
+        );
+      }, timeoutMs);
+      op().then(
+        value => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          resolve(value);
+        },
+        err => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          reject(err);
+        },
+      );
+    });
+
+  const call = <T>(label: string, op: () => Promise<T>): Promise<T> =>
+    withRateLimitRetry(() => withTimeout(label, op), setTimeout);
+
+  const p = () => reconnecting.getProvider();
+
+  return {
+    // RPC calls with rate-limit retry and per-call timeout
+    getBlock: (n: number) => call('getBlock', () => p().getBlock(n)),
+    getBlockNumber: () => call('getBlockNumber', () => p().getBlockNumber()),
+    getLogs: (filter: Filter) => call('getLogs', () => p().getLogs(filter)),
+    getNetwork: () => call('getNetwork', () => p().getNetwork()),
+    getTransactionReceipt: (txHash: string) =>
+      call('getTransactionReceipt', () => p().getTransactionReceipt(txHash)),
+    send: (...args: Parameters<WebSocketProvider['send']>) =>
+      call('send', () => p().send(...args)),
+    // Subscription pass-throughs (delegate to the current provider; no retry)
+    on: ((...args: Parameters<WebSocketProvider['on']>) =>
+      p().on(...args)) as WebSocketProvider['on'],
+    off: ((...args: Parameters<WebSocketProvider['off']>) =>
+      p().off(...args)) as WebSocketProvider['off'],
+    get websocket() {
+      return reconnecting.websocket;
+    },
+  };
+};
 
 export type EvmRpc = ReturnType<typeof makeEvmRpc>;
 

--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -5,7 +5,7 @@ import type { CaipChainId } from '@agoric/orchestration';
 import {
   getBlockTimeMs,
   prepareAbortController,
-  type ReconnectingProvider,
+  type ReconnectingEvmProvider,
 } from './support.ts';
 import { WatcherTransportError } from './errors.ts';
 
@@ -71,12 +71,12 @@ export const RPC_CALL_TIMEOUT_MS = 20_000;
  * A provider facade whose methods retry on Alchemy 429 rate-limit errors
  * (exponential backoff with jitter) and are bounded by a per-call timeout.
  *
- * It delegates to the {@link ReconnectingProvider}'s *current* provider on every
+ * It delegates to the {@link ReconnectingEvmProvider}'s *current* provider on every
  * call, so after a reconnect the facade (held by long-lived watchers) keeps
  * working against the fresh socket.
  */
 export const makeEvmRpc = (
-  reconnecting: ReconnectingProvider,
+  reconnectingProvider: ReconnectingEvmProvider,
   setTimeout: typeof globalThis.setTimeout,
   {
     timeoutMs = RPC_CALL_TIMEOUT_MS,
@@ -90,7 +90,7 @@ export const makeEvmRpc = (
         if (settled) return;
         settled = true;
         log(`RPC ${label} timed out after ${timeoutMs}ms; cycling socket`);
-        reconnecting.reportUnhealthy(`${label} timeout`);
+        reconnectingProvider.reportUnhealthy(`${label} timeout`);
         reject(
           new WatcherTransportError(
             `RPC ${label} timed out after ${timeoutMs}ms`,
@@ -116,7 +116,7 @@ export const makeEvmRpc = (
   const call = <T>(label: string, op: () => Promise<T>): Promise<T> =>
     withRateLimitRetry(() => withTimeout(label, op), setTimeout);
 
-  const p = () => reconnecting.getProvider();
+  const p = () => reconnectingProvider.getProvider();
 
   return {
     // RPC calls with rate-limit retry and per-call timeout
@@ -134,7 +134,7 @@ export const makeEvmRpc = (
     off: ((...args: Parameters<WebSocketProvider['off']>) =>
       p().off(...args)) as WebSocketProvider['off'],
     get websocket() {
-      return reconnecting.websocket;
+      return reconnectingProvider.websocket;
     },
   };
 };

--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -82,7 +82,19 @@ export const makeEvmRpc = (
     timeoutMs = RPC_CALL_TIMEOUT_MS,
     log = (..._args: unknown[]) => {},
   }: { timeoutMs?: number; log?: (...args: unknown[]) => void } = {},
-) => {
+): Pick<
+  WebSocketProvider,
+  | 'getBlockNumber'
+  | 'getNetwork'
+  | 'getTransactionReceipt'
+  | 'send'
+  | 'on'
+  | 'off'
+  | 'websocket'
+> & {
+  getBlock: (n: number) => ReturnType<WebSocketProvider['getBlock']>;
+  getLogs: (filter: Filter) => ReturnType<WebSocketProvider['getLogs']>;
+} => {
   const withTimeout = <T>(label: string, op: () => Promise<T>): Promise<T> =>
     new Promise<T>((resolve, reject) => {
       let settled = false;

--- a/services/ymax-planner/src/evm-utils.ts
+++ b/services/ymax-planner/src/evm-utils.ts
@@ -16,6 +16,7 @@ import { fromUniqueEntries, partialMap, typedEntries } from '@agoric/internal';
 import type { axelarConfig } from '@aglocal/portfolio-deploy/src/axelar-configs.js';
 import type { EVMContractAddresses } from '@aglocal/portfolio-contract/src/portfolio.contract.ts';
 import type { EvmChain } from './pending-tx-manager.ts';
+import type { ReconnectingProvider } from './support.ts';
 
 /**
  * Build a unified map of pool/instrument IDs to their on-chain token contract
@@ -210,7 +211,7 @@ export type EvmBalancePowers = {
     Record<InterChainAccountRef | PoolKey, EvmAddress>
   >;
   chainNameToChainIdMap: Partial<Record<EvmChain, CaipChainId>>;
-  evmProviders: Record<CaipChainId, WebSocketProvider>;
+  evmProviders: Record<CaipChainId, ReconnectingProvider>;
 };
 
 /**
@@ -236,10 +237,11 @@ export const getErc20Balances = async (
           Fail`No token address configured for instrument ${q(place)}`;
 
         const chainId: CaipChainId = chainNameToChainIdMap[chainName];
-        const provider = evmProviders[chainId];
-        if (!provider) {
+        const reconnecting = evmProviders[chainId];
+        if (!reconnecting) {
           throw Error(`No provider found for chain: ${chainId}`);
         }
+        const provider = reconnecting.getProvider();
 
         let balance: bigint;
         if (isBeefyInstrumentId(place)) {

--- a/services/ymax-planner/src/evm-utils.ts
+++ b/services/ymax-planner/src/evm-utils.ts
@@ -237,11 +237,10 @@ export const getErc20Balances = async (
           Fail`No token address configured for instrument ${q(place)}`;
 
         const chainId: CaipChainId = chainNameToChainIdMap[chainName];
-        const reconnecting = evmProviders[chainId];
-        if (!reconnecting) {
+        const provider = evmProviders[chainId]?.getProvider();
+        if (!provider) {
           throw Error(`No provider found for chain: ${chainId}`);
         }
-        const provider = reconnecting.getProvider();
 
         let balance: bigint;
         if (isBeefyInstrumentId(place)) {

--- a/services/ymax-planner/src/evm-utils.ts
+++ b/services/ymax-planner/src/evm-utils.ts
@@ -16,7 +16,7 @@ import { fromUniqueEntries, partialMap, typedEntries } from '@agoric/internal';
 import type { axelarConfig } from '@aglocal/portfolio-deploy/src/axelar-configs.js';
 import type { EVMContractAddresses } from '@aglocal/portfolio-contract/src/portfolio.contract.ts';
 import type { EvmChain } from './pending-tx-manager.ts';
-import type { ReconnectingProvider } from './support.ts';
+import type { ReconnectingEvmProvider } from './support.ts';
 
 /**
  * Build a unified map of pool/instrument IDs to their on-chain token contract
@@ -211,7 +211,7 @@ export type EvmBalancePowers = {
     Record<InterChainAccountRef | PoolKey, EvmAddress>
   >;
   chainNameToChainIdMap: Partial<Record<EvmChain, CaipChainId>>;
-  evmProviders: Record<CaipChainId, ReconnectingProvider>;
+  evmProviders: Record<CaipChainId, ReconnectingEvmProvider>;
 };
 
 /**

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -47,6 +47,7 @@ import {
   createEVMContext,
   prepareAbortController,
   spectrumChainIdsByCluster,
+  WS_HEARTBEAT_INTERVAL_MS,
 } from './support.ts';
 import type { MakeAbortController } from './support.ts';
 import { makeEvmRpc, type EvmRpc } from './evm-scanner.ts';
@@ -252,16 +253,21 @@ export const main = async (
   const evmCtx = await createEVMContext({
     clusterName,
     alchemyApiKey: config.alchemyApiKey,
+    makeHeartbeat: () => generateInterval(WS_HEARTBEAT_INTERVAL_MS),
+    log: (...args) => console.warn('EVM provider:', ...args),
   });
 
   // Verify Alchemy chain availability.
   const failedEvmChains = [] as Array<keyof typeof evmCtx.evmProviders>;
   const evmHeights = await deeplyFulfilledObject(
     objectMap(evmCtx.evmProviders, (provider, chainId) =>
-      provider.getBlockNumber().catch(err => {
-        failedEvmChains.push(chainId);
-        return { error: err.message };
-      }),
+      provider
+        .getProvider()
+        .getBlockNumber()
+        .catch(err => {
+          failedEvmChains.push(chainId);
+          return { error: err.message };
+        }),
     ),
   );
   console.warn('EVM chain heights:', evmHeights);
@@ -340,7 +346,9 @@ export const main = async (
   const retryProviders = fromEntries(
     entries(evmCtx.evmProviders).map(([caip, provider]) => [
       caip,
-      makeEvmRpc(provider, setTimeout),
+      makeEvmRpc(provider, setTimeout, {
+        log: (...args) => console.warn(`EVM RPC [${caip}]:`, ...args),
+      }),
     ]),
   ) as Record<CaipChainId, EvmRpc>;
 

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -16,7 +16,6 @@ import type {
 } from '@aglocal/portfolio-contract/src/resolver/types.ts';
 import type { KVStore } from '@agoric/internal/src/kv-store.js';
 
-import type { WebSocketProvider } from 'ethers';
 import {
   deleteDerivedOutcome,
   getDerivedOutcome,
@@ -26,7 +25,11 @@ import {
 import { resolvePendingTx } from './resolver.ts';
 import { withRetriesForAlerting } from './retries.ts';
 import { waitForBlock, type EvmRpc } from './evm-scanner.ts';
-import type { MakeAbortController, UsdcAddresses } from './support.ts';
+import type {
+  MakeAbortController,
+  ReconnectingProvider,
+  UsdcAddresses,
+} from './support.ts';
 import { lookBackCctp, watchCctpTransfer } from './watchers/cctp-watcher.ts';
 import { lookBackGmp, watchGmp } from './watchers/gmp-watcher.ts';
 import {
@@ -59,7 +62,7 @@ export type EvmContext = {
   usdcAddresses: UsdcAddresses['mainnet' | 'testnet'];
   // XXX eliminate evmProviders from EvmContext and use retryProviders for the
   // balance-checking path too.
-  evmProviders: Record<CaipChainId, WebSocketProvider>;
+  evmProviders: Record<CaipChainId, ReconnectingProvider>;
   retryProviders: Record<CaipChainId, EvmRpc>;
   signingSmartWalletKit: SigningSmartWalletKit;
   /** Used to generate unique suffixes in agoric Smart Wallet OfferSpec ids. */

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -27,7 +27,7 @@ import { withRetriesForAlerting } from './retries.ts';
 import { waitForBlock, type EvmRpc } from './evm-scanner.ts';
 import type {
   MakeAbortController,
-  ReconnectingProvider,
+  ReconnectingEvmProvider,
   UsdcAddresses,
 } from './support.ts';
 import { lookBackCctp, watchCctpTransfer } from './watchers/cctp-watcher.ts';
@@ -62,7 +62,7 @@ export type EvmContext = {
   usdcAddresses: UsdcAddresses['mainnet' | 'testnet'];
   // XXX eliminate evmProviders from EvmContext and use retryProviders for the
   // balance-checking path too.
-  evmProviders: Record<CaipChainId, ReconnectingProvider>;
+  evmProviders: Record<CaipChainId, ReconnectingEvmProvider>;
   retryProviders: Record<CaipChainId, EvmRpc>;
   signingSmartWalletKit: SigningSmartWalletKit;
   /** Used to generate unique suffixes in agoric Smart Wallet OfferSpec ids. */

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -25,8 +25,8 @@ import type {
 import { ACCOUNT_DUST_EPSILON } from '@agoric/portfolio-api';
 
 import type { EvmAddress } from '@agoric/fast-usdc';
-import type { WebSocketProvider } from 'ethers';
 import { getErc20Balances } from './evm-utils.ts';
+import type { ReconnectingProvider } from './support.ts';
 import type {
   ChainAddressTokenBalance as SpectrumGetAddressBalanceResult,
   ChainAddressTokenInput as SpectrumGetAddressBalanceInput,
@@ -55,7 +55,7 @@ export type BalanceQueryPowers = {
     Record<InterChainAccountRef | PoolKey, EvmAddress>
   >;
   usdcTokensByChain: Partial<Record<SupportedChain, string>>;
-  evmProviders: Record<CaipChainId, WebSocketProvider>;
+  evmProviders: Record<CaipChainId, ReconnectingProvider>;
   chainNameToChainIdMap: Partial<Record<EvmChain, CaipChainId>>;
 };
 

--- a/services/ymax-planner/src/plan-deposit.ts
+++ b/services/ymax-planner/src/plan-deposit.ts
@@ -26,7 +26,7 @@ import { ACCOUNT_DUST_EPSILON } from '@agoric/portfolio-api';
 
 import type { EvmAddress } from '@agoric/fast-usdc';
 import { getErc20Balances } from './evm-utils.ts';
-import type { ReconnectingProvider } from './support.ts';
+import type { ReconnectingEvmProvider } from './support.ts';
 import type {
   ChainAddressTokenBalance as SpectrumGetAddressBalanceResult,
   ChainAddressTokenInput as SpectrumGetAddressBalanceInput,
@@ -55,7 +55,7 @@ export type BalanceQueryPowers = {
     Record<InterChainAccountRef | PoolKey, EvmAddress>
   >;
   usdcTokensByChain: Partial<Record<SupportedChain, string>>;
-  evmProviders: Record<CaipChainId, ReconnectingProvider>;
+  evmProviders: Record<CaipChainId, ReconnectingEvmProvider>;
   chainNameToChainIdMap: Partial<Record<EvmChain, CaipChainId>>;
 };
 

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -285,7 +285,7 @@ export type ReconnectingEvmProvider = {
   getProvider: () => WebSocketProvider;
   /** The current underlying socket. */
   readonly websocket: WebSocketProvider['websocket'];
-  /** Force an immediate reconnect (e.g. an RPC call timed out). */
+  /** Force an immediate reconnect (e.g. because an RPC call timed out). */
   reportUnhealthy: (reason?: string) => void;
   /** Permanently close: stop heartbeats and reconnection. */
   close: () => void;
@@ -299,11 +299,14 @@ export const makeReconnectingEvmProvider = ({
 }: {
   wsUrl: string;
   makeProvider?: (url: string) => WebSocketProvider;
-  /** Yields once per heartbeat interval; a fresh one is taken per socket. */
+  /**
+   * Must yield once per heartbeat interval; a fresh iterator is created for
+   * each successive provider.
+   */
   makeHeartbeat?: () => AsyncIterable<unknown>;
   log?: (...args: unknown[]) => void;
 }): ReconnectingEvmProvider => {
-  let current: WebSocketProvider;
+  let currentProvider: WebSocketProvider;
   // Monotonic id of the live socket. Stale listeners (from a prior socket)
   // compare against it to avoid cycling a provider that is no longer current.
   let generation = 0;
@@ -312,14 +315,12 @@ export const makeReconnectingEvmProvider = ({
   const attach = (provider: WebSocketProvider, gen: number) => {
     const ws = provider.websocket as unknown as WsWebSocket;
 
-    ws.on('close', (code?: number, reason?: unknown) => {
-      if (gen !== generation || closed) return;
-      cycle(gen, `socket close (code=${code}, reason=${reason})`);
-    });
-    ws.on('error', (err: unknown) => {
-      if (gen !== generation || closed) return;
-      cycle(gen, `socket error: ${(err as Error)?.message ?? err}`);
-    });
+    ws.on('close', (code?: number, reason?: unknown) =>
+      cycle(gen, `socket close (code=${code}, reason=${reason})`),
+    );
+    ws.on('error', (err: unknown) =>
+      cycle(gen, `socket error: ${(err as Error)?.message ?? err}`),
+    );
 
     if (!makeHeartbeat) return;
     let gotPong = true;
@@ -328,7 +329,7 @@ export const makeReconnectingEvmProvider = ({
     });
     void (async () => {
       for await (const _ of makeHeartbeat()) {
-        if (gen !== generation || closed) break;
+        if (closed || gen !== generation) break;
         if (ws.readyState !== 1 /* OPEN */) continue;
         if (!gotPong) {
           cycle(gen, 'pong timeout');
@@ -348,10 +349,10 @@ export const makeReconnectingEvmProvider = ({
     // Ignore stale triggers: only the current generation may cycle.
     if (closed || fromGen !== generation) return;
     generation += 1;
-    const old = current;
+    const old = currentProvider;
     log(`cycling WebSocket (gen ${fromGen}→${generation}): ${reason}`);
-    current = makeProvider(wsUrl);
-    attach(current, generation);
+    currentProvider = makeProvider(wsUrl);
+    attach(currentProvider, generation);
     // `terminate` (vs a graceful close) dislodges a zombie/half-open socket and
     // emits `close`, prompting active watchers to re-subscribe on the new one.
     try {
@@ -362,19 +363,19 @@ export const makeReconnectingEvmProvider = ({
     void old.destroy().catch(err => log('error destroying old provider', err));
   };
 
-  current = makeProvider(wsUrl);
-  attach(current, generation);
+  currentProvider = makeProvider(wsUrl);
+  attach(currentProvider, generation);
 
   return {
-    getProvider: () => current,
+    getProvider: () => currentProvider,
     get websocket() {
-      return current.websocket;
+      return currentProvider.websocket;
     },
     reportUnhealthy: (reason = 'reported unhealthy') =>
       cycle(generation, reason),
     close: () => {
       closed = true;
-      void current
+      void currentProvider
         .destroy()
         .catch(err => log('error destroying provider', err));
     },
@@ -384,7 +385,10 @@ export const makeReconnectingEvmProvider = ({
 type CreateContextParams = {
   clusterName: ClusterName;
   alchemyApiKey: string;
-  /** Yields once per heartbeat interval; a fresh one is taken per socket. */
+  /**
+   * Must yield once per heartbeat interval; a fresh iterator is created for
+   * each EVM provider (including providers created by automatic reconnections).
+   */
   makeHeartbeat?: () => AsyncIterable<unknown>;
   log?: (...args: unknown[]) => void;
 };

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -1,4 +1,5 @@
 import { WebSocketProvider } from 'ethers';
+import type { WebSocket as WsWebSocket } from 'ws';
 import type { Address as EvmAddress } from 'viem';
 import type { CaipChainId } from '@agoric/orchestration';
 import type { ClusterName } from '@agoric/internal';
@@ -262,14 +263,137 @@ export const getEvmRpcMap = (
       throw Error(`Unsupported cluster name ${clusterName}`);
   }
 };
+/** Interval between WebSocket liveness pings. */
+export const WS_HEARTBEAT_INTERVAL_MS = 30_000;
+
+/**
+ * A reconnecting wrapper around an ethers {@link WebSocketProvider}. ethers v6
+ * does not reconnect on its own, so a dropped or zombie (open-but-dead) socket
+ * otherwise stays broken for the whole process lifetime, leaving watchers
+ * silently stalled until a manual restart (see PAK-517).
+ *
+ * Liveness is detected two ways: ping/pong heartbeats catch an idle socket that
+ * has gone dead, and {@link reportUnhealthy} lets the RPC layer report a call
+ * that timed out (an in-use zombie). On either, the underlying provider is
+ * recreated. The previous socket is `terminate`d, which surfaces a `close`
+ * event to any active watchers; their existing
+ * `onWsClose → WatcherTransportError → watchWithRetry` path then re-subscribes
+ * on the fresh socket.
+ */
+export type ReconnectingProvider = {
+  /** The current live provider; never a destroyed one. */
+  getProvider: () => WebSocketProvider;
+  /** The current underlying socket. */
+  readonly websocket: WebSocketProvider['websocket'];
+  /** Force an immediate reconnect (e.g. an RPC call timed out). */
+  reportUnhealthy: (reason?: string) => void;
+  /** Permanently close: stop heartbeats and reconnection. */
+  close: () => void;
+};
+
+export const makeReconnectingProvider = ({
+  wsUrl,
+  makeProvider = url => new WebSocketProvider(url),
+  makeHeartbeat,
+  log = () => {},
+}: {
+  wsUrl: string;
+  makeProvider?: (url: string) => WebSocketProvider;
+  /** Yields once per heartbeat interval; a fresh one is taken per socket. */
+  makeHeartbeat?: () => AsyncIterable<unknown>;
+  log?: (...args: unknown[]) => void;
+}): ReconnectingProvider => {
+  let current: WebSocketProvider;
+  // Monotonic id of the live socket. Stale listeners (from a prior socket)
+  // compare against it to avoid cycling a provider that is no longer current.
+  let generation = 0;
+  let closed = false;
+
+  const attach = (provider: WebSocketProvider, gen: number) => {
+    const ws = provider.websocket as unknown as WsWebSocket;
+
+    ws.on('close', (code?: number, reason?: unknown) => {
+      if (gen !== generation || closed) return;
+      cycle(gen, `socket close (code=${code}, reason=${reason})`);
+    });
+    ws.on('error', (err: unknown) => {
+      if (gen !== generation || closed) return;
+      cycle(gen, `socket error: ${(err as Error)?.message ?? err}`);
+    });
+
+    if (!makeHeartbeat) return;
+    let gotPong = true;
+    ws.on('pong', () => {
+      gotPong = true;
+    });
+    void (async () => {
+      for await (const _ of makeHeartbeat()) {
+        if (gen !== generation || closed) break;
+        if (ws.readyState !== 1 /* OPEN */) continue;
+        if (!gotPong) {
+          cycle(gen, 'pong timeout');
+          break;
+        }
+        gotPong = false;
+        try {
+          ws.ping();
+        } catch (err) {
+          log('error sending ping', err);
+        }
+      }
+    })();
+  };
+
+  const cycle = (fromGen: number, reason: string) => {
+    // Ignore stale triggers: only the current generation may cycle.
+    if (closed || fromGen !== generation) return;
+    generation += 1;
+    const old = current;
+    log(`cycling WebSocket (gen ${fromGen}→${generation}): ${reason}`);
+    current = makeProvider(wsUrl);
+    attach(current, generation);
+    // `terminate` (vs a graceful close) dislodges a zombie/half-open socket and
+    // emits `close`, prompting active watchers to re-subscribe on the new one.
+    try {
+      (old.websocket as unknown as WsWebSocket).terminate();
+    } catch (err) {
+      log('error terminating old socket', err);
+    }
+    void old.destroy().catch(err => log('error destroying old provider', err));
+  };
+
+  current = makeProvider(wsUrl);
+  attach(current, generation);
+
+  return {
+    getProvider: () => current,
+    get websocket() {
+      return current.websocket;
+    },
+    reportUnhealthy: (reason = 'reported unhealthy') =>
+      cycle(generation, reason),
+    close: () => {
+      closed = true;
+      void current
+        .destroy()
+        .catch(err => log('error destroying provider', err));
+    },
+  };
+};
+
 type CreateContextParams = {
   clusterName: ClusterName;
   alchemyApiKey: string;
+  /** Yields once per heartbeat interval; a fresh one is taken per socket. */
+  makeHeartbeat?: () => AsyncIterable<unknown>;
+  log?: (...args: unknown[]) => void;
 };
 
 export const createEVMContext = async ({
   clusterName,
   alchemyApiKey,
+  makeHeartbeat,
+  log = () => {},
 }: CreateContextParams): Promise<
   Pick<EvmContext, 'evmProviders' | 'usdcAddresses'>
 > => {
@@ -280,9 +404,13 @@ export const createEVMContext = async ({
   const evmProviders = Object.fromEntries(
     Object.entries(wssUrls).map(([caip, wsUrl]) => [
       caip,
-      new WebSocketProvider(wsUrl),
+      makeReconnectingProvider({
+        wsUrl,
+        makeHeartbeat,
+        log: (...args) => log(`[${caip}]`, ...args),
+      }),
     ]),
-  ) as Record<CaipChainId, WebSocketProvider>;
+  ) as Record<CaipChainId, ReconnectingProvider>;
 
   return {
     evmProviders,

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -280,7 +280,7 @@ export const WS_HEARTBEAT_INTERVAL_MS = 30_000;
  * `onWsClose → WatcherTransportError → watchWithRetry` path then re-subscribes
  * on the fresh socket.
  */
-export type ReconnectingProvider = {
+export type ReconnectingEvmProvider = {
   /** The current live provider; never a destroyed one. */
   getProvider: () => WebSocketProvider;
   /** The current underlying socket. */
@@ -291,7 +291,7 @@ export type ReconnectingProvider = {
   close: () => void;
 };
 
-export const makeReconnectingProvider = ({
+export const makeReconnectingEvmProvider = ({
   wsUrl,
   makeProvider = url => new WebSocketProvider(url),
   makeHeartbeat,
@@ -302,7 +302,7 @@ export const makeReconnectingProvider = ({
   /** Yields once per heartbeat interval; a fresh one is taken per socket. */
   makeHeartbeat?: () => AsyncIterable<unknown>;
   log?: (...args: unknown[]) => void;
-}): ReconnectingProvider => {
+}): ReconnectingEvmProvider => {
   let current: WebSocketProvider;
   // Monotonic id of the live socket. Stale listeners (from a prior socket)
   // compare against it to avoid cycling a provider that is no longer current.
@@ -404,13 +404,13 @@ export const createEVMContext = async ({
   const evmProviders = Object.fromEntries(
     Object.entries(wssUrls).map(([caip, wsUrl]) => [
       caip,
-      makeReconnectingProvider({
+      makeReconnectingEvmProvider({
         wsUrl,
         makeHeartbeat,
         log: (...args) => log(`[${caip}]`, ...args),
       }),
     ]),
-  ) as Record<CaipChainId, ReconnectingProvider>;
+  ) as Record<CaipChainId, ReconnectingEvmProvider>;
 
   return {
     evmProviders,

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -28,13 +28,9 @@ export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
 /** Scope tag for failed-transaction lookback searches. */
 export const FAILED_TX_SCOPE = 'failedTx';
 
-/**
- * Signals that a watcher's underlying transport (WebSocket) failed.
- * Distinct from a transaction-level failure: the watch could not continue,
- * so the caller may safely restart it.
- */
-export const WatcherTransportError = class WatcherTransportError extends Error {};
-WatcherTransportError.prototype.name = WatcherTransportError.name;
+// Re-exported from its canonical leaf module (avoids an import cycle with the
+// RPC layer, which also throws it).
+export { WatcherTransportError } from '../errors.ts';
 
 /**
  * Sleep for `ms` milliseconds or until `signal` aborts (whichever comes first).

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -24,7 +24,10 @@ import type { EvmAddress } from '@agoric/fast-usdc/src/types.ts';
 import type { Powers as EnginePowers } from '../src/engine.ts';
 import { makeGasEstimator } from '../src/gas-estimation.ts';
 import type { HandlePendingTxOpts } from '../src/pending-tx-manager.ts';
-import { prepareAbortController } from '../src/support.ts';
+import {
+  prepareAbortController,
+  type ReconnectingProvider,
+} from '../src/support.ts';
 import type { YdsNotifier } from '../src/yds-notifier.ts';
 import type { Sdk as SpectrumBlockchainSdk } from '../src/graphql/api-spectrum-blockchain/__generated/sdk.ts';
 import { ERC20_BALANCE_ABI } from '../src/evm-utils.ts';
@@ -372,11 +375,19 @@ export const createMockProviderSets = ({
     'eip155:11155111',
     'eip155:43113',
   ];
-  const evmProviders = {} as Record<CaipChainId, WebSocketProvider>;
+  const evmProviders = {} as Record<CaipChainId, ReconnectingProvider>;
   const retryProviders = {} as Record<CaipChainId, EvmRpc>;
   for (const chainId of chainIds) {
     const provider = createMockProvider(latestBlock, events, balances);
-    evmProviders[chainId] = provider;
+    // Augment the mock provider in place with a no-op reconnecting surface
+    // (the mock socket never dies in tests), so it satisfies both
+    // ReconnectingProvider and the raw-provider shape some tests poke at.
+    const reconnecting = Object.assign(provider, {
+      getProvider: () => provider,
+      reportUnhealthy: () => {},
+      close: () => {},
+    });
+    evmProviders[chainId] = reconnecting as unknown as ReconnectingProvider;
     // Mock providers already satisfy the EvmRpc shape.
     retryProviders[chainId] = provider as unknown as ReturnType<
       typeof makeEvmRpc

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -26,7 +26,7 @@ import { makeGasEstimator } from '../src/gas-estimation.ts';
 import type { HandlePendingTxOpts } from '../src/pending-tx-manager.ts';
 import {
   prepareAbortController,
-  type ReconnectingProvider,
+  type ReconnectingEvmProvider,
 } from '../src/support.ts';
 import type { YdsNotifier } from '../src/yds-notifier.ts';
 import type { Sdk as SpectrumBlockchainSdk } from '../src/graphql/api-spectrum-blockchain/__generated/sdk.ts';
@@ -375,19 +375,19 @@ export const createMockProviderSets = ({
     'eip155:11155111',
     'eip155:43113',
   ];
-  const evmProviders = {} as Record<CaipChainId, ReconnectingProvider>;
+  const evmProviders = {} as Record<CaipChainId, ReconnectingEvmProvider>;
   const retryProviders = {} as Record<CaipChainId, EvmRpc>;
   for (const chainId of chainIds) {
     const provider = createMockProvider(latestBlock, events, balances);
     // Augment the mock provider in place with a no-op reconnecting surface
     // (the mock socket never dies in tests), so it satisfies both
-    // ReconnectingProvider and the raw-provider shape some tests poke at.
+    // ReconnectingEvmProvider and the raw-provider shape some tests poke at.
     const reconnecting = Object.assign(provider, {
       getProvider: () => provider,
       reportUnhealthy: () => {},
       close: () => {},
     });
-    evmProviders[chainId] = reconnecting as unknown as ReconnectingProvider;
+    evmProviders[chainId] = reconnecting as unknown as ReconnectingEvmProvider;
     // Mock providers already satisfy the EvmRpc shape.
     retryProviders[chainId] = provider as unknown as ReturnType<
       typeof makeEvmRpc

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -17,7 +17,7 @@ import { handlePendingTx, watchWithRetry } from '../src/pending-tx-manager.ts';
 import { WatcherTransportError } from '../src/watchers/watcher-utils.ts';
 import {
   prepareAbortController,
-  type ReconnectingProvider,
+  type ReconnectingEvmProvider,
 } from '../src/support.ts';
 import type { EvmRpc } from '../src/evm-scanner.ts';
 import {
@@ -1106,7 +1106,7 @@ const makeFailedTxTestContext = ({
           transactionHash: failedTxHash,
         }),
         ...extra,
-      }) as unknown as ReconnectingProvider,
+      }) as unknown as ReconnectingEvmProvider,
   );
 
   const ctxWithFetch = harden({

--- a/services/ymax-planner/test/pending-tx.test.ts
+++ b/services/ymax-planner/test/pending-tx.test.ts
@@ -3,7 +3,6 @@ import { ethers } from 'ethers';
 import { boardSlottingMarshaller } from '@agoric/client-utils';
 import { objectMap } from '@endo/patterns';
 import { makePromiseKit } from '@endo/promise-kit';
-import type { WebSocketProvider } from 'ethers';
 import {
   TxStatus,
   TxType,
@@ -16,7 +15,10 @@ import { createMockPendingTxData } from '@aglocal/portfolio-contract/tools/mocks
 import type { CaipChainId } from '@agoric/orchestration';
 import { handlePendingTx, watchWithRetry } from '../src/pending-tx-manager.ts';
 import { WatcherTransportError } from '../src/watchers/watcher-utils.ts';
-import { prepareAbortController } from '../src/support.ts';
+import {
+  prepareAbortController,
+  type ReconnectingProvider,
+} from '../src/support.ts';
 import type { EvmRpc } from '../src/evm-scanner.ts';
 import {
   processPendingTxEvents,
@@ -1104,7 +1106,7 @@ const makeFailedTxTestContext = ({
           transactionHash: failedTxHash,
         }),
         ...extra,
-      }) as unknown as WebSocketProvider,
+      }) as unknown as ReconnectingProvider,
   );
 
   const ctxWithFetch = harden({

--- a/services/ymax-planner/test/reconnecting-provider.test.ts
+++ b/services/ymax-planner/test/reconnecting-provider.test.ts
@@ -11,35 +11,40 @@ import { makeEvmRpc } from '../src/evm-scanner.ts';
 /** Flush pending microtasks/timers so heartbeat loop bodies run. */
 const flush = () => new Promise(resolve => setTimeout(resolve, 0));
 
-class FakeSocket extends EventEmitter {
-  readyState = 1; // OPEN
-  pings = 0;
-  terminated = false;
+const makeFakeSocket = () => {
+  const socket = Object.assign(new EventEmitter(), {
+    readyState: 1, // OPEN
+    pings: 0,
+    terminated: false,
+    ping: () => {
+      socket.pings += 1;
+    },
+    terminate: () => {
+      socket.terminated = true;
+      socket.readyState = 3; // CLOSED
+      socket.emit('close', 1006, 'terminated');
+    },
+  });
+  return socket;
+};
 
-  ping() {
-    this.pings += 1;
-  }
+const makeFakeProvider = () => {
+  const provider = {
+    websocket: makeFakeSocket(),
+    destroyed: false,
+    destroy: async () => {
+      provider.destroyed = true;
+    },
+  };
+  return provider;
+};
 
-  terminate() {
-    this.terminated = true;
-    this.readyState = 3; // CLOSED
-    this.emit('close', 1006, 'terminated');
-  }
-}
-
-class FakeProvider {
-  websocket = new FakeSocket();
-  destroyed = false;
-
-  async destroy() {
-    this.destroyed = true;
-  }
-}
+type FakeProvider = ReturnType<typeof makeFakeProvider>;
 
 const makeFakeProviders = () => {
   const created: FakeProvider[] = [];
   const makeProvider = () => {
-    const provider = new FakeProvider();
+    const provider = makeFakeProvider();
     created.push(provider);
     return provider as unknown as WebSocketProvider;
   };

--- a/services/ymax-planner/test/reconnecting-provider.test.ts
+++ b/services/ymax-planner/test/reconnecting-provider.test.ts
@@ -2,8 +2,8 @@ import test from 'ava';
 import { EventEmitter } from 'node:events';
 import type { WebSocketProvider } from 'ethers';
 import {
-  makeReconnectingProvider,
-  type ReconnectingProvider,
+  makeReconnectingEvmProvider,
+  type ReconnectingEvmProvider,
 } from '../src/support.ts';
 import { WatcherTransportError } from '../src/errors.ts';
 import { makeEvmRpc } from '../src/evm-scanner.ts';
@@ -88,7 +88,7 @@ const makeManualHeartbeats = () => {
 
 test('reportUnhealthy recreates the provider and terminates the old socket', t => {
   const { created, makeProvider } = makeFakeProviders();
-  const sh = makeReconnectingProvider({ wsUrl: 'ws://x', makeProvider });
+  const sh = makeReconnectingEvmProvider({ wsUrl: 'ws://x', makeProvider });
 
   t.is(sh.getProvider(), created[0] as unknown as WebSocketProvider);
 
@@ -102,7 +102,7 @@ test('reportUnhealthy recreates the provider and terminates the old socket', t =
 
 test('a socket close triggers a reconnect', t => {
   const { created, makeProvider } = makeFakeProviders();
-  const sh = makeReconnectingProvider({ wsUrl: 'ws://x', makeProvider });
+  const sh = makeReconnectingEvmProvider({ wsUrl: 'ws://x', makeProvider });
 
   created[0].websocket.emit('close', 1006, 'boom');
 
@@ -112,7 +112,7 @@ test('a socket close triggers a reconnect', t => {
 
 test('a stale socket close does not cycle the current provider', t => {
   const { created, makeProvider } = makeFakeProviders();
-  const sh = makeReconnectingProvider({ wsUrl: 'ws://x', makeProvider });
+  const sh = makeReconnectingEvmProvider({ wsUrl: 'ws://x', makeProvider });
 
   sh.reportUnhealthy('first'); // gen 0 → 1
   t.is(created.length, 2);
@@ -125,7 +125,7 @@ test('a stale socket close does not cycle the current provider', t => {
 test('heartbeat reconnects on a missed pong but not while ponging', async t => {
   const { created, makeProvider } = makeFakeProviders();
   const { makeHeartbeat, tick } = makeManualHeartbeats();
-  makeReconnectingProvider({ wsUrl: 'ws://x', makeProvider, makeHeartbeat });
+  makeReconnectingEvmProvider({ wsUrl: 'ws://x', makeProvider, makeHeartbeat });
 
   // Tick once: pings, awaits pong.
   tick();
@@ -158,7 +158,7 @@ test('makeEvmRpc bounds a hanging call and reports the socket unhealthy', async 
       unhealthyReason = reason;
     },
     close: () => {},
-  } as unknown as ReconnectingProvider;
+  } as unknown as ReconnectingEvmProvider;
 
   const rpc = makeEvmRpc(sh, globalThis.setTimeout, { timeoutMs: 50 });
   const err = await t.throwsAsync(() => rpc.getBlockNumber());
@@ -173,7 +173,7 @@ test('makeEvmRpc passes a fast call through and clears the timeout', async t => 
     websocket: {},
     reportUnhealthy: () => t.fail('should not cycle on a fast call'),
     close: () => {},
-  } as unknown as ReconnectingProvider;
+  } as unknown as ReconnectingEvmProvider;
 
   const rpc = makeEvmRpc(sh, globalThis.setTimeout, { timeoutMs: 1000 });
   t.is(await rpc.getBlockNumber(), 123);

--- a/services/ymax-planner/test/reconnecting-provider.test.ts
+++ b/services/ymax-planner/test/reconnecting-provider.test.ts
@@ -1,0 +1,175 @@
+import test from 'ava';
+import { EventEmitter } from 'node:events';
+import type { WebSocketProvider } from 'ethers';
+import {
+  makeReconnectingProvider,
+  type ReconnectingProvider,
+} from '../src/support.ts';
+import { WatcherTransportError } from '../src/errors.ts';
+import { makeEvmRpc } from '../src/evm-scanner.ts';
+
+/** Flush pending microtasks/timers so heartbeat loop bodies run. */
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+class FakeSocket extends EventEmitter {
+  readyState = 1; // OPEN
+  pings = 0;
+  terminated = false;
+
+  ping() {
+    this.pings += 1;
+  }
+
+  terminate() {
+    this.terminated = true;
+    this.readyState = 3; // CLOSED
+    this.emit('close', 1006, 'terminated');
+  }
+}
+
+class FakeProvider {
+  websocket = new FakeSocket();
+  destroyed = false;
+
+  async destroy() {
+    this.destroyed = true;
+  }
+}
+
+const makeFakeProviders = () => {
+  const created: FakeProvider[] = [];
+  const makeProvider = () => {
+    const provider = new FakeProvider();
+    created.push(provider);
+    return provider as unknown as WebSocketProvider;
+  };
+  return { created, makeProvider };
+};
+
+/** A heartbeat whose ticks are driven manually; exposes the latest ticker. */
+const makeManualHeartbeats = () => {
+  let current: { tick: () => void };
+  const makeHeartbeat = () => {
+    const pending: true[] = [];
+    let waiting: ((r: IteratorResult<unknown>) => void) | null = null;
+    current = {
+      tick: () => {
+        if (waiting) {
+          const resolve = waiting;
+          waiting = null;
+          resolve({ value: undefined, done: false });
+        } else {
+          pending.push(true);
+        }
+      },
+    };
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: () => {
+          if (pending.length) {
+            pending.shift();
+            return Promise.resolve({ value: undefined, done: false });
+          }
+          return new Promise<IteratorResult<unknown>>(resolve => {
+            waiting = resolve;
+          });
+        },
+        return: () => Promise.resolve({ value: undefined, done: true }),
+      }),
+    };
+  };
+  return { makeHeartbeat, tick: () => current.tick() };
+};
+
+test('reportUnhealthy recreates the provider and terminates the old socket', t => {
+  const { created, makeProvider } = makeFakeProviders();
+  const sh = makeReconnectingProvider({ wsUrl: 'ws://x', makeProvider });
+
+  t.is(sh.getProvider(), created[0] as unknown as WebSocketProvider);
+
+  sh.reportUnhealthy('test');
+
+  t.is(created.length, 2, 'a new provider is created');
+  t.is(sh.getProvider(), created[1] as unknown as WebSocketProvider);
+  t.true(created[0].websocket.terminated, 'old socket is terminated');
+  t.true(created[0].destroyed, 'old provider is destroyed');
+});
+
+test('a socket close triggers a reconnect', t => {
+  const { created, makeProvider } = makeFakeProviders();
+  const sh = makeReconnectingProvider({ wsUrl: 'ws://x', makeProvider });
+
+  created[0].websocket.emit('close', 1006, 'boom');
+
+  t.is(created.length, 2);
+  t.is(sh.getProvider(), created[1] as unknown as WebSocketProvider);
+});
+
+test('a stale socket close does not cycle the current provider', t => {
+  const { created, makeProvider } = makeFakeProviders();
+  const sh = makeReconnectingProvider({ wsUrl: 'ws://x', makeProvider });
+
+  sh.reportUnhealthy('first'); // gen 0 → 1
+  t.is(created.length, 2);
+
+  // A late close from the already-replaced socket must be ignored.
+  created[0].websocket.emit('close', 1006, 'late');
+  t.is(created.length, 2, 'no extra reconnect from the stale socket');
+});
+
+test('heartbeat reconnects on a missed pong but not while ponging', async t => {
+  const { created, makeProvider } = makeFakeProviders();
+  const { makeHeartbeat, tick } = makeManualHeartbeats();
+  makeReconnectingProvider({ wsUrl: 'ws://x', makeProvider, makeHeartbeat });
+
+  // Tick once: pings, awaits pong.
+  tick();
+  await flush();
+  t.is(created[0].websocket.pings, 1);
+
+  // Pong arrives → still alive on the next tick.
+  created[0].websocket.emit('pong');
+  tick();
+  await flush();
+  t.is(created.length, 1, 'no reconnect while ponging');
+  t.is(created[0].websocket.pings, 2);
+
+  // No pong before the next tick → declared dead and reconnected.
+  tick();
+  await flush();
+  t.is(created.length, 2, 'reconnected after a missed pong');
+  t.true(created[0].websocket.terminated);
+});
+
+test('makeEvmRpc bounds a hanging call and reports the socket unhealthy', async t => {
+  let unhealthyReason: string | undefined;
+  const hanging = {
+    getBlockNumber: () => new Promise<number>(() => {}), // never resolves
+  };
+  const sh = {
+    getProvider: () => hanging,
+    websocket: {},
+    reportUnhealthy: (reason?: string) => {
+      unhealthyReason = reason;
+    },
+    close: () => {},
+  } as unknown as ReconnectingProvider;
+
+  const rpc = makeEvmRpc(sh, globalThis.setTimeout, { timeoutMs: 50 });
+  const err = await t.throwsAsync(() => rpc.getBlockNumber());
+
+  t.true(err instanceof WatcherTransportError);
+  t.is(unhealthyReason, 'getBlockNumber timeout');
+});
+
+test('makeEvmRpc passes a fast call through and clears the timeout', async t => {
+  const sh = {
+    getProvider: () => ({ getBlockNumber: async () => 123 }),
+    websocket: {},
+    reportUnhealthy: () => t.fail('should not cycle on a fast call'),
+    close: () => {},
+  } as unknown as ReconnectingProvider;
+
+  const rpc = makeEvmRpc(sh, globalThis.setTimeout, { timeoutMs: 1000 });
+  t.is(await rpc.getBlockNumber(), 123);
+});

--- a/services/ymax-planner/test/tx-block-lower-bound.test.ts
+++ b/services/ymax-planner/test/tx-block-lower-bound.test.ts
@@ -43,7 +43,7 @@ const setupEnvironment = ({
 
   const event = createMockGmpStatusEvent(txId, blockWithEvent);
   const opts = createMockPendingTxOpts(latestBlock, [event]);
-  const mockProvider = opts.evmProviders[chainId];
+  const mockProvider = opts.evmProviders[chainId] as any;
 
   const currentTimeMs = 1700000000; // 2023-11-14T22:13:20Z
   const txTimestampMs = currentTimeMs - 10 * 1000; // 10 seconds ago

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -1,11 +1,11 @@
 import test from 'ava';
 import { zeroPadValue, AbiCoder, Interface, ethers } from 'ethers';
 import { objectMap } from '@endo/patterns';
-import type { WebSocketProvider } from 'ethers';
 import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import type { PendingTx } from '@aglocal/portfolio-contract/src/resolver/types.ts';
 import type { CaipChainId } from '@agoric/orchestration';
 import { createMockPendingTxOpts } from './mocks.ts';
+import type { ReconnectingProvider } from '../src/support.ts';
 import { handlePendingTx } from '../src/pending-tx-manager.ts';
 import type { EvmRpc } from '../src/evm-scanner.ts';
 import {
@@ -350,13 +350,13 @@ test('find a failed tx in MAKE_ACCOUNT lookback mode via trace_filter', async t 
           blockNumber: latestBlock,
           transactionHash: failedTxHash,
         }),
-      }) as unknown as WebSocketProvider,
+      }) as unknown as ReconnectingProvider,
   );
 
   const ctxWithFetch = harden({
     ...opts,
     evmProviders: newEvmProviders,
-    retryProviders: newEvmProviders as Record<CaipChainId, EvmRpc>,
+    retryProviders: newEvmProviders as unknown as Record<CaipChainId, EvmRpc>,
     fetch: async () => ({}) as Response,
   });
 

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -5,7 +5,7 @@ import { TxType } from '@aglocal/portfolio-contract/src/resolver/constants.js';
 import type { PendingTx } from '@aglocal/portfolio-contract/src/resolver/types.ts';
 import type { CaipChainId } from '@agoric/orchestration';
 import { createMockPendingTxOpts } from './mocks.ts';
-import type { ReconnectingProvider } from '../src/support.ts';
+import type { ReconnectingEvmProvider } from '../src/support.ts';
 import { handlePendingTx } from '../src/pending-tx-manager.ts';
 import type { EvmRpc } from '../src/evm-scanner.ts';
 import {
@@ -350,7 +350,7 @@ test('find a failed tx in MAKE_ACCOUNT lookback mode via trace_filter', async t 
           blockNumber: latestBlock,
           transactionHash: failedTxHash,
         }),
-      }) as unknown as ReconnectingProvider,
+      }) as unknown as ReconnectingEvmProvider,
   );
 
   const ctxWithFetch = harden({


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: https://linear.app/agoric/issue/PAK-517/ymax-resolver-dead-evm-websocket-leaves-pending-txs-unresolved-until
refs: https://linear.app/agoric/issue/PAK-516/ymax-resolver-investigate-routed-gmp-transactions-resolution-only#comment-f29571b3

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->
Make the planner's EVM WebSocket layer self-healing so a dead socket no longer leaves cross-chain pending txs unresolved until a manual restart.


### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
- Currently, the changes are unit tested. 

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment.