### PR TITLE
feat(client-utils): Add memo/signerData support to `reflectWalletStore`

### DIFF
--- a/packages/client-utils/src/sync-tools.js
+++ b/packages/client-utils/src/sync-tools.js
@@ -15,6 +15,7 @@
 
 /**
  * @import {RemotableObject} from '@endo/marshal';
+ * @import {OfferStatus} from '@agoric/smart-wallet/src/offers.js';
  * @import {VstorageKit} from './types.js';
  */
 
@@ -224,7 +225,7 @@ const makeQueryWallet = follow => async (/** @type {string} */ addr) => {
 
 /**
  *
- * @param {Record<string, any>} offerStatus
+ * @param {{ updated?: string, status?: OfferStatus }} offerStatus
  * @param {boolean} waitForPayouts
  * @param {string} offerId
  */
@@ -271,8 +272,12 @@ export const waitUntilOfferResult = (
 /// ////////// Making sure a core-eval successfully sent zoe invitations to committee members for governance /////////////
 
 /**
+ * Check if a capabilities-as-pure-data representation (specifically replacing
+ * each Remotable with a string containing its alleged interface name) of a
+ * smart-wallet UpdateRecord indicates that it is a balance update whose
+ * `currentAmount` `brand` looks like a Zoe Invitation.
  *
- * @param {{ updated: string, currentAmount: any }} update
+ * @param {{ updated?: string, currentAmount?: { brand?: string } }} update
  * @returns {boolean}
  */
 const checkForInvitation = update => {
@@ -285,6 +290,10 @@ const checkForInvitation = update => {
 };
 
 /**
+ * Wait for the specified address's wallet to publish a balance update with a
+ * `currentAmount` whose `brand` looks like a Zoe Invitation.
+ * @deprecated because it requires io.follow to map Amount `brand` references
+ * into strings
  *
  * @param {string} addr
  * @param {{ follow: () => object, log: typeof console.log, setTimeout: typeof globalThis.setTimeout}} io
@@ -309,12 +318,12 @@ const makeQueryWalletCurrent = follow => (/** @type {string} */ addr) =>
   follow('-lF', `:published.wallet.${addr}.current`);
 
 /**
- * @param {Record<string, any>} update
+ * @param {Record<string, unknown>} update
  * @param {string} offerId
  * @returns {boolean}
  */
 const checkLiveOffers = (update, offerId) => {
-  const liveOffers = update.liveOffers;
+  const liveOffers = /** @type {string[][] | undefined} */ (update.liveOffers);
   if (!liveOffers) {
     return false;
   }

--- a/packages/client-utils/src/sync-tools.js
+++ b/packages/client-utils/src/sync-tools.js
@@ -26,7 +26,7 @@
  * @property {(value: unknown) => unknown} [renderResult]
  *
  * @typedef {object} RetryPowers
- * @property {typeof globalThis.setTimeout} setTimeout
+ * @property {<T extends (...args: unknown[]) => unknown>(fn: T, timeout?: number, ...args: Parameters<T>) => unknown} setTimeout
  * @property {(...args: unknown[]) => void} [log]
  *
  * @typedef {RetryOptions & RetryPowers} RetryOptionsAndPowers mixes ocaps with configuration
@@ -47,7 +47,7 @@
 export const sleep = (ms, { log = () => {}, setTimeout }) =>
   new Promise(resolve => {
     log(`Sleeping for ${ms}ms...`);
-    setTimeout(resolve, ms);
+    setTimeout(() => resolve(undefined), ms);
   });
 
 /**

--- a/packages/client-utils/src/wallet-store.ts
+++ b/packages/client-utils/src/wallet-store.ts
@@ -16,6 +16,18 @@ import type { RetryOptionsAndPowers } from './sync-tools.js';
  * to save results back into the wallet store and responses for such saved
  * results also include a WalletStoreEntryProxy `result` representing those
  * results.
+ *
+ * XXX We should replace special treatment of "saveAs" and "overwrite"
+ * pseudo-methods with a generic pattern for invocation-with-options, such as
+ * the parameter-prepending `getForSavingResults` that was removed by
+ * https://github.com/Agoric/agoric-sdk/pull/12413 and if re-introduced would
+ * look something like
+ * ```
+ * walletStore.getForInvocationWithOptions(savedName).method(
+ *   { name: resultName, memo },
+ *   ...args,
+ * );
+ * ```
  */
 export type WalletStoreEntryProxy<T> = {
   readonly [M in keyof T]: T[M] extends (...args: infer P) => infer R
@@ -180,8 +192,9 @@ export const reflectWalletStore = (
      * confirmation in vstorage when sent with an `id` (e.g., derived from a
      * `makeNonce` option) unless overridden by a `sendOnly: true` option.
      *
-     * Use `.save(name)` or `.overwrite(name)` to persist a method result
-     * without changing the method's argument signature.
+     * Use `.saveAs(name)` or `.overwrite(name)` to persist a method result
+     * without changing the method's argument signature (but see
+     * {@link WalletStoreEntryProxy} about changing that.
      *
      * @param name The wallet store name of the saved entry to retrieve.
      */

--- a/packages/client-utils/src/wallet-store.ts
+++ b/packages/client-utils/src/wallet-store.ts
@@ -2,7 +2,7 @@ import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
 import type { ECallable } from '@agoric/vow/src/E.js';
 import type { EUnwrap } from '@agoric/vow/src/types.js';
 import type { Instance } from '@agoric/zoe';
-import type { DeliverTxResponse, StdFee } from '@cosmjs/stargate';
+import type { DeliverTxResponse, SignerData, StdFee } from '@cosmjs/stargate';
 import { Fail } from '@endo/errors';
 import type { SigningSmartWalletKit } from './signing-smart-wallet-kit.ts';
 import { getInvocationUpdate, getOfferResult } from './smart-wallet-utils.js';
@@ -34,6 +34,8 @@ export type WalletStoreEntryProxy<T> = {
 
 type TxOptions = RetryOptionsAndPowers & {
   fee?: StdFee;
+  memo?: string;
+  signerData?: SignerData;
   sendOnly?: boolean;
   makeNonce?: () => string;
 };
@@ -72,7 +74,8 @@ export const reflectWalletStore = (
   ) => {
     const combinedOpts = { ...baseTxOpts, ...overrides } as TxOptions;
     combinedOpts.setTimeout || Fail`missing setTimeout`;
-    const { fee, sendOnly, makeNonce, ...retryOpts } = combinedOpts;
+    const { fee, memo, signerData, sendOnly, makeNonce, ...retryOpts } =
+      combinedOpts;
     if (saveTo && !makeNonce && !sendOnly) {
       throw Fail`makeNonce is required without sendOnly: true (to create an awaitable message id)`;
     }
@@ -107,6 +110,8 @@ export const reflectWalletStore = (
           const tx = await sswk.sendBridgeAction(
             { method: 'invokeEntry', message },
             fee,
+            memo,
+            signerData,
           );
           if (tx.code !== 0) {
             throw Error(tx.rawLog);
@@ -138,6 +143,8 @@ export const reflectWalletStore = (
     };
     const {
       fee,
+      memo,
+      signerData,
       sendOnly: _sendOnly,
       makeNonce,
       overwrite = true,
@@ -154,6 +161,8 @@ export const reflectWalletStore = (
     const tx = await sswk.sendBridgeAction(
       { method: 'executeOffer', offer },
       fee,
+      memo,
+      signerData,
     );
     const status = await getOfferResult(
       id,

--- a/packages/client-utils/test/wallet-store.test.ts
+++ b/packages/client-utils/test/wallet-store.test.ts
@@ -1,51 +1,124 @@
 import test from 'ava';
 
-import { reflectWalletStore } from '../src/wallet-store.js';
+import type { SignerData, StdFee } from '@cosmjs/stargate';
 
-test('reflectWalletStore save/overwrite chains without changing args', async t => {
-  const actions: any[] = [];
+import { arrayIsLike } from '@agoric/internal/tools/ava-assertions.js';
+import type {
+  InvokeStoreEntryAction,
+  BridgeAction,
+} from '@agoric/smart-wallet/src/smartWallet.js';
+
+import {
+  reflectWalletStore,
+  type WalletStoreSigner,
+} from '../src/wallet-store.js';
+
+type BridgeSend<T extends BridgeAction = BridgeAction> = {
+  action: T;
+  fee?: StdFee;
+  memo?: string;
+  signerData?: SignerData;
+};
+
+const makeMockSigner = () => {
+  const sends: BridgeSend[] = [];
   let lastId = '';
-  const signer = {
-    sendBridgeAction: async action => {
-      lastId = action.message?.id || '';
-      actions.push(action);
-      return { code: 0 };
+  const signer: WalletStoreSigner = {
+    sendBridgeAction: async (action, fee, memo, signerData) => {
+      lastId = (action as any).message?.id || '';
+      sends.push({ action, fee, memo, signerData });
+      return {
+        height: -1,
+        txIndex: 0,
+        code: 0,
+        transactionHash: '',
+        events: [],
+        msgResponses: [],
+        gasUsed: 0n,
+        gasWanted: 0n,
+      };
     },
     query: {
       getLastUpdate: async () => ({
         updated: 'invocation',
         id: lastId,
-        result: 'ok',
+        result: { passStyle: 'undefined' },
       }),
     },
   };
+  return { sends, signer };
+};
 
-  const walletStore = reflectWalletStore(
-    // @ts-expect-error minimal signer for test
-    signer,
-    { setTimeout: globalThis.setTimeout, makeNonce: () => '123' },
-  );
+const makeImmediateSetTimeout = () => {
+  const immediateSetTimeout = (fn, _ms, ..._args) => setTimeout(fn, 0);
+  return immediateSetTimeout;
+};
+
+test('reflectWalletStore save/overwrite chains without changing args', async t => {
+  const { sends, signer } = makeMockSigner();
+  const walletStore = reflectWalletStore(signer, {
+    setTimeout: makeImmediateSetTimeout(),
+    makeNonce: () => '123',
+  });
 
   const target = walletStore.get<any>('ymaxControl');
 
   await target.getCreatorFacet('arg1', 2);
-  t.is(actions.length, 1);
-  t.deepEqual(actions[0].message.args, ['arg1', 2]);
-  t.falsy(actions[0].message.saveResult);
+  t.is(sends.length, 1);
+  const message1 = (sends[0].action as InvokeStoreEntryAction).message;
+  t.deepEqual(message1.args, ['arg1', 2]);
+  t.falsy(message1.saveResult);
 
   await target.saveAs('creatorFacet').getCreatorFacet('arg2');
-  t.is(actions.length, 2);
-  t.deepEqual(actions[1].message.args, ['arg2']);
-  t.deepEqual(actions[1].message.saveResult, {
+  t.is(sends.length, 2);
+  const message2 = (sends[1].action as InvokeStoreEntryAction).message;
+  t.deepEqual(message2.args, ['arg2']);
+  t.deepEqual(message2.saveResult, {
     name: 'creatorFacet',
     overwrite: false,
   });
 
   await target.overwrite('creatorFacet').getCreatorFacet('arg3');
-  t.is(actions.length, 3);
-  t.deepEqual(actions[2].message.args, ['arg3']);
-  t.deepEqual(actions[2].message.saveResult, {
+  t.is(sends.length, 3);
+  const message3 = (sends[2].action as InvokeStoreEntryAction).message;
+  t.deepEqual(message3.args, ['arg3']);
+  t.deepEqual(message3.saveResult, {
     name: 'creatorFacet',
     overwrite: true,
   });
+});
+
+test('reflectWalletStore supports fee/memo/signerData', async t => {
+  const { sends, signer } = makeMockSigner();
+  const walletStore = reflectWalletStore(signer, {
+    setTimeout: makeImmediateSetTimeout(),
+    makeNonce: () => '123',
+  });
+
+  const fee: StdFee = { amount: [], gas: '0denom' };
+  const memo = 'Kilroy was here';
+  const signerData: SignerData = {
+    accountNumber: 123,
+    sequence: 456,
+    chainId: 'test-chain',
+  };
+  const target = walletStore.get<any>('foo', { fee, memo, signerData });
+
+  await target.bar('baz');
+  arrayIsLike(t, sends, [
+    {
+      action: {
+        method: 'invokeEntry',
+        message: {
+          targetName: 'foo',
+          method: 'bar',
+          args: ['baz'],
+          id: 'bar.123',
+        },
+      },
+      fee,
+      memo,
+      signerData,
+    },
+  ]);
 });


### PR DESCRIPTION
Ref AGO-690

## Description
Add `memo` and `signerData` fields to the `reflectWalletStore` options bag, for use like e.g. `walletStore.get(name, { memo: 'Hello, world!' })`.

### Security Considerations
None known.

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Just unit tests.

### Upgrade Considerations
None known.