### PR TITLE
feat(client-utils)!: Introduce reflectWalletStore target method modifier `once`

### DIFF
--- a/a3p-integration/proposals/f:ymax0-restart/test/delegate.test.js
+++ b/a3p-integration/proposals/f:ymax0-restart/test/delegate.test.js
@@ -81,9 +81,15 @@ test.serial('invoke ymaxControl showing no instance', async t => {
   // TODO test this invokation id?
   // const id = 'getCreatorFacet.1';
 
-  await t.throwsAsync(ymaxControl.overwrite('creatorFacet').getCreatorFacet(), {
-    message: /no StartedInstanceKit/,
-  });
+  await t.throwsAsync(
+    ymaxControl.getCreatorFacet.once({
+      saveAs: 'creatorFacet',
+      overwrite: true,
+    })(),
+    {
+      message: /no StartedInstanceKit/,
+    },
+  );
 });
 
 test.serial('start using ymaxControl', async t => {
@@ -137,7 +143,10 @@ test.serial('start using ymaxControl', async t => {
 });
 
 test.serial('invoke ymaxControl to getCreatorFacet', async t => {
-  const cf = await ymaxControl.overwrite('creatorFacet').getCreatorFacet();
+  const cf = await ymaxControl.getCreatorFacet.once({
+    saveAs: 'creatorFacet',
+    overwrite: true,
+  })();
 
   t.truthy(cf, 'Creator facet saved to wallet store');
 });

--- a/a3p-integration/proposals/g:ymax1/test/ymax1.test.js
+++ b/a3p-integration/proposals/g:ymax1/test/ymax1.test.js
@@ -92,9 +92,9 @@ test.serial('no instance currently deployed', async t => {
 });
 
 test.serial('invoke ymaxControl showing no instance', async t => {
-  const yc = ymaxControl.saveAs('creatorFacet');
+  const yc = ymaxControl;
 
-  await t.throwsAsync(yc.getCreatorFacet(), {
+  await t.throwsAsync(yc.getCreatorFacet.once({ saveAs: 'creatorFacet' })(), {
     message: /no StartedInstanceKit/,
   });
 });
@@ -136,7 +136,9 @@ test.serial('installAndStart using ymaxControl', async t => {
 });
 
 test.serial('invoke ymaxControl to getCreatorFacet', async t => {
-  const { result } = await ymaxControl.saveAs('creatorFacet').getCreatorFacet();
+  const { result } = await ymaxControl.getCreatorFacet.once({
+    saveAs: 'creatorFacet',
+  })();
 
   t.truthy(result, 'Creator facet saved to wallet store');
 });

--- a/packages/client-utils/src/wallet-store.ts
+++ b/packages/client-utils/src/wallet-store.ts
@@ -1,3 +1,4 @@
+import { defineName } from '@agoric/internal/src/js-utils.js';
 import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
 import type { ECallable } from '@agoric/vow/src/E.js';
 import type { EUnwrap } from '@agoric/vow/src/types.js';
@@ -11,23 +12,13 @@ import type { RetryOptionsAndPowers } from './sync-tools.js';
 /**
  * A type-aware representation of an object saved in the wallet store, with
  * methods that return information about their implementing "invokeEntry"
- * submissions. If Recursive is true, then each method has an initial
- * { name?: string, overwrite?: boolean } parameter for specifying how (or if)
- * to save results back into the wallet store and responses for such saved
- * results also include a WalletStoreEntryProxy `result` representing those
- * results.
+ * submissions. Each method is also extended with a `once` method of its own for
+ * binding options to a single invocation, and when those options include
+ * `saveAs`, the response from the bound method includes a corresponding
+ * `result` WalletStoreEntryProxy.
  *
- * XXX We should replace special treatment of "saveAs" and "overwrite"
- * pseudo-methods with a generic pattern for invocation-with-options, such as
- * the parameter-prepending `getForSavingResults` that was removed by
- * https://github.com/Agoric/agoric-sdk/pull/12413 and if re-introduced would
- * look something like
- * ```
- * walletStore.getForInvocationWithOptions(savedName).method(
- *   { name: resultName, memo },
- *   ...args,
- * );
- * ```
+ * XXX We should remove special treatment of "saveAs" and "overwrite"
+ * pseudo-methods in favor of `once`.
  */
 export type WalletStoreEntryProxy<T> = {
   readonly [M in keyof T]: T[M] extends (...args: infer P) => infer R
@@ -35,19 +26,37 @@ export type WalletStoreEntryProxy<T> = {
         (...args: P) => {
           id?: string;
           tx: DeliverTxResponse;
-          result?: WalletStoreEntryProxy<EUnwrap<R>>;
         }
-      >
+      > & {
+        once: (options: SingleTxOptions) => ECallable<
+          (...args: P) => {
+            id?: string;
+            tx: DeliverTxResponse;
+            /** Only present with a non-empty `saveAs`. */
+            result?: WalletStoreEntryProxy<EUnwrap<R>>;
+          }
+        >;
+      }
     : never;
 } & {
   [SAVE_AS]: (name: string) => WalletStoreEntryProxy<T>;
   [OVERWRITE]: (name: string) => WalletStoreEntryProxy<T>;
 };
 
+/**
+ * Options specific to a single invocation (i.e., not to be remembered/reused).
+ */
+type SingleTxOptions = Partial<{
+  fee: StdFee;
+  memo: string;
+  signerData: SignerData;
+  saveAs: string;
+  overwrite: boolean;
+}>;
+
+/** Options for use across one or more invocations. */
 type TxOptions = RetryOptionsAndPowers & {
   fee?: StdFee;
-  memo?: string;
-  signerData?: SignerData;
   sendOnly?: boolean;
   makeNonce?: () => string;
 };
@@ -81,14 +90,13 @@ export const reflectWalletStore = (
 
   const makeEntryProxy = (
     targetName: string,
-    overrides?: Partial<TxOptions>,
-    saveTo?: { name: string; overwrite: boolean },
+    options?: Partial<TxOptions>,
+    deprecatedSaveTo?: Pick<Required<SingleTxOptions>, 'saveAs' | 'overwrite'>,
   ) => {
-    const combinedOpts = { ...baseTxOpts, ...overrides } as TxOptions;
+    const combinedOpts = { ...baseTxOpts, ...options } as TxOptions;
     combinedOpts.setTimeout || Fail`missing setTimeout`;
-    const { fee, memo, signerData, sendOnly, makeNonce, ...retryOpts } =
-      combinedOpts;
-    if (saveTo && !makeNonce && !sendOnly) {
+    const { fee: sharedFee, sendOnly, makeNonce, ...retryOpts } = combinedOpts;
+    if (!makeNonce && !sendOnly) {
       throw Fail`makeNonce is required without sendOnly: true (to create an awaitable message id)`;
     }
     const { log = () => {} } = combinedOpts;
@@ -100,46 +108,68 @@ export const reflectWalletStore = (
       get(_t, method, _rx) {
         assert.typeof(method, 'string');
         method !== 'then' || Fail`unsupported method name "then"`;
+
+        // deprecated pseudo-methods
         if (method === SAVE_AS) {
-          return harden((name: string) =>
-            makeEntryProxy(targetName, overrides, { name, overwrite: false }),
+          return harden((saveAs: string) =>
+            makeEntryProxy(targetName, options, { saveAs, overwrite: false }),
           );
         }
         if (method === OVERWRITE) {
-          return harden((name: string) =>
-            makeEntryProxy(targetName, overrides, { name, overwrite: true }),
+          return harden((saveAs: string) =>
+            makeEntryProxy(targetName, options, { saveAs, overwrite: true }),
           );
         }
-        const boundMethod = async (...args) => {
-          const id = makeNonce ? `${method}.${makeNonce()}` : undefined;
-          const message = logged('invoke', {
-            id,
-            targetName,
-            method,
-            args,
-            ...(saveTo ? { saveResult: saveTo } : undefined),
+
+        const makeBoundMethod = (onceOpts?: SingleTxOptions) => {
+          let invoked = false;
+          return defineName(method, async (...args) => {
+            !invoked || !onceOpts || Fail`single-tx options cannot be reused`;
+            invoked = true;
+            const boundOpts = onceOpts || {};
+            const {
+              memo,
+              signerData,
+              saveAs,
+              overwrite = false,
+            } = { ...deprecatedSaveTo, ...boundOpts };
+            const fee = boundOpts.fee || sharedFee;
+            const saveResult = saveAs ? { name: saveAs, overwrite } : undefined;
+            const id = makeNonce ? `${method}.${makeNonce()}` : undefined;
+            const message = logged('invoke', {
+              id,
+              targetName,
+              method,
+              args,
+              ...(saveResult ? { saveResult } : undefined),
+            });
+            const tx = await sswk.sendBridgeAction(
+              { method: 'invokeEntry', message },
+              fee,
+              memo,
+              signerData,
+            );
+            if (tx.code !== 0) {
+              throw Error(tx.rawLog);
+            }
+            if (!sendOnly && id) {
+              await getInvocationUpdate(
+                id,
+                sswk.query.getLastUpdate,
+                retryOpts,
+              );
+            }
+            const ret = { id, tx };
+            const result = saveAs ? makeEntryProxy(saveAs, options) : undefined;
+            return saveAs !== undefined ? { ...ret, result } : ret;
           });
-          const tx = await sswk.sendBridgeAction(
-            { method: 'invokeEntry', message },
-            fee,
-            memo,
-            signerData,
-          );
-          if (tx.code !== 0) {
-            throw Error(tx.rawLog);
-          }
-          if (!sendOnly && id) {
-            await getInvocationUpdate(id, sswk.query.getLastUpdate, retryOpts);
-          }
-          const ret = { id, tx };
-          if (saveTo) {
-            const result = saveTo.name
-              ? makeEntryProxy(saveTo.name, overrides)
-              : undefined;
-            return { ...ret, result };
-          }
-          return ret;
         };
+        const boundMethod = makeBoundMethod();
+        const makeOverridden = defineName('once', onceOpts => {
+          onceOpts || Fail`missing single-tx options`;
+          return harden(makeBoundMethod(onceOpts));
+        });
+        Object.defineProperty(boundMethod, 'once', { value: makeOverridden });
         return harden(boundMethod);
       },
     });
@@ -148,11 +178,10 @@ export const reflectWalletStore = (
   const saveOfferResult = async (
     { instance, description }: { instance: Instance; description: string },
     name: string = description,
-    options?: Partial<TxOptions & { overwrite: boolean }>,
+    options?: Partial<TxOptions & Omit<SingleTxOptions, 'saveAs'>>,
   ) => {
-    const combinedOpts = { ...baseTxOpts, ...options } as TxOptions & {
-      overwrite?: boolean;
-    };
+    const combinedOpts = { ...baseTxOpts, ...options } as TxOptions &
+      Omit<SingleTxOptions, 'saveAs'>;
     const {
       fee,
       memo,
@@ -192,14 +221,21 @@ export const reflectWalletStore = (
      * confirmation in vstorage when sent with an `id` (e.g., derived from a
      * `makeNonce` option) unless overridden by a `sendOnly: true` option.
      *
-     * Use `.saveAs(name)` or `.overwrite(name)` to persist a method result
-     * without changing the method's argument signature (but see
-     * {@link WalletStoreEntryProxy} about changing that.
+     * Each method supports a `.once(singleUseOptions)` method of its own for
+     * binding options to a single invocation, and when those options include
+     * `saveAs`, the response from the bound method includes a corresponding
+     * `result` proxy.
+     *
+     * There is also deprecated support for `.saveAs(name)` and
+     * `.overwrite(name)` pseudo-methods that return a modified proxy for
+     * persisting the result of any method call *without* the only-once
+     * constraint.
      *
      * @param name The wallet store name of the saved entry to retrieve.
      */
     get: <T>(name: string, options?: Partial<TxOptions>) =>
       makeEntryProxy(name, options) as WalletStoreEntryProxy<T>,
+
     /**
      * Execute the offer specified by { instance, description } and save the
      * result in the wallet store with the specified name (default to match the

--- a/packages/client-utils/test/wallet-store.test.ts
+++ b/packages/client-utils/test/wallet-store.test.ts
@@ -54,7 +54,100 @@ const makeImmediateSetTimeout = () => {
   return immediateSetTimeout;
 };
 
-test('reflectWalletStore save/overwrite chains without changing args', async t => {
+test('reflectWalletStore', async t => {
+  const { sends, signer } = makeMockSigner();
+  const walletStore = reflectWalletStore(signer, {
+    setTimeout: makeImmediateSetTimeout(),
+    makeNonce: () => '123',
+  });
+
+  const fee: StdFee = { amount: [], gas: '0denom' };
+  const target = walletStore.get<any>('foo', { fee });
+
+  await target.bar('baz');
+  await target.qux.once({})(1);
+  await target.qux.once({ memo: 'quux' })(2);
+
+  arrayIsLike(t, sends, [
+    {
+      action: {
+        method: 'invokeEntry',
+        message: {
+          targetName: 'foo',
+          method: 'bar',
+          args: ['baz'],
+          id: 'bar.123',
+        },
+      },
+      fee,
+    },
+    {
+      action: {
+        method: 'invokeEntry',
+        message: {
+          targetName: 'foo',
+          method: 'qux',
+          args: [1],
+          id: 'qux.123',
+        },
+      },
+      fee,
+      memo: undefined,
+    },
+    {
+      action: {
+        method: 'invokeEntry',
+        message: {
+          targetName: 'foo',
+          method: 'qux',
+          args: [2],
+          id: 'qux.123',
+        },
+      },
+      fee,
+      memo: 'quux',
+    },
+  ]);
+});
+
+test('reflectWalletStore save/overwrite', async t => {
+  const { sends, signer } = makeMockSigner();
+  const walletStore = reflectWalletStore(signer, {
+    setTimeout: makeImmediateSetTimeout(),
+    makeNonce: () => '123',
+  });
+
+  const target = walletStore.get<any>('ymaxControl');
+
+  await target.getCreatorFacet('arg1', 2);
+  t.is(sends.length, 1);
+  const message1 = (sends[0].action as InvokeStoreEntryAction).message;
+  t.deepEqual(message1.args, ['arg1', 2]);
+  t.falsy(message1.saveResult);
+
+  await target.getCreatorFacet.once({ saveAs: 'creatorFacet' })('arg2');
+  t.is(sends.length, 2);
+  const message2 = (sends[1].action as InvokeStoreEntryAction).message;
+  t.deepEqual(message2.args, ['arg2']);
+  t.deepEqual(message2.saveResult, {
+    name: 'creatorFacet',
+    overwrite: false,
+  });
+
+  await target.getCreatorFacet.once({
+    saveAs: 'creatorFacet',
+    overwrite: true,
+  })('arg3');
+  t.is(sends.length, 3);
+  const message3 = (sends[2].action as InvokeStoreEntryAction).message;
+  t.deepEqual(message3.args, ['arg3']);
+  t.deepEqual(message3.saveResult, {
+    name: 'creatorFacet',
+    overwrite: true,
+  });
+});
+
+test('deprecated reflectWalletStore pseudo-methods', async t => {
   const { sends, signer } = makeMockSigner();
   const walletStore = reflectWalletStore(signer, {
     setTimeout: makeImmediateSetTimeout(),
@@ -102,9 +195,10 @@ test('reflectWalletStore supports fee/memo/signerData', async t => {
     sequence: 456,
     chainId: 'test-chain',
   };
-  const target = walletStore.get<any>('foo', { fee, memo, signerData });
 
-  await target.bar('baz');
+  const target = walletStore.get<any>('foo', { fee });
+  await target.bar.once({ memo, signerData })('baz');
+
   arrayIsLike(t, sends, [
     {
       action: {
@@ -121,4 +215,23 @@ test('reflectWalletStore supports fee/memo/signerData', async t => {
       signerData,
     },
   ]);
+});
+
+test('reflectWalletStore target.method.once', async t => {
+  const { signer } = makeMockSigner();
+  const walletStore = reflectWalletStore(signer, {
+    setTimeout: makeImmediateSetTimeout(),
+    makeNonce: () => '123',
+  });
+
+  const target = walletStore.get<any>('foo');
+  t.throws(
+    // @ts-expect-error intentional misuse
+    () => target.bar.once(),
+    { message: 'missing single-tx options' },
+    'target.method.once requires options',
+  );
+  const bound = target.bar.once({});
+  await bound();
+  await t.throwsAsync(bound, { message: 'single-tx options cannot be reused' });
 });

--- a/packages/portfolio-deploy/src/ymax-get-creator-facet.ts
+++ b/packages/portfolio-deploy/src/ymax-get-creator-facet.ts
@@ -11,7 +11,7 @@ const getCreatorFacet = async ({ scriptArgs, makeAccount }: RunTools) => {
   const { contract } = parseArgs({ args: scriptArgs, options }).values;
   const { ymaxControl } = await getYmaxControlKit(makeAccount, contract);
   const creatorFacetKey = getCreatorFacetKey(contract);
-  await ymaxControl.saveAs(creatorFacetKey).getCreatorFacet();
+  await ymaxControl.getCreatorFacet.once({ saveAs: creatorFacetKey })();
 };
 
 export default getCreatorFacet;


### PR DESCRIPTION
Ref #12413
Ref #12755

## Description
For use like e.g.
```ts
const { tx, id } = walletStore
  .get<PortfolioPlanner>('planner')
  .rebalance.once({ memo, saveAs })(...args);
```

or alternatively, we could eliminate the second set of parentheses and the call-only-once guard by instead prepending the options, e.g.
```ts
const { tx, id } = walletStore
  .get<PortfolioPlanner>('planner')
  .rebalance.withOptions({ memo, saveAs }, ...args);
```

`saveAs` and `overwrite` pseudo-methods from #12413 are deprecated.

Reusable `memo`/`signerData` options from #12755 are removed.

### Security Considerations
As indicated by the name, the bound method returned from `once` may only be called a single time.

### Scaling Considerations
n/a

### Documentation Considerations
Via JSDoc.

### Testing Considerations
Covered by unit tests.

### Upgrade Considerations
This is technically a backwards-incompatible change to the `reflectWalletStore` interface, but as a fast-follow to #12755 (which has not yet been released) per the request at https://github.com/Agoric/agoric-sdk/pull/12755#discussion_r3469931050 . A future backwards-incompatible change is expected to remove the `saveAs` and `overwrite` pseudo-methods (theirselves added by silently-backwards-incompatible changes in #12413) after the replacements here have been confirmed.