### PR TITLE
fix(ci): flaky jobs handle more than 30 results

### DIFF
--- a/.github/workflows/detect-flaky-jobs.yml
+++ b/.github/workflows/detect-flaky-jobs.yml
@@ -54,12 +54,16 @@ jobs:
                   failedWorkflowAttempts.push(attemptNum);
 
                   // Get failed jobs for this attempt
-                  const jobs = await github.rest.actions.listJobsForWorkflowRunAttempt({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    run_id: runId,
-                    attempt_number: attemptNum
-                  });
+                  const jobs = await github.paginate(
+                    github.rest.actions.listJobsForWorkflowRunAttempt,
+                    {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      run_id: runId,
+                      attempt_number: attemptNum,
+                      per_page: 100
+                    }
+                  );
 
                   const failedJobsInAttempt = [];
                   for (const job of jobs.data.jobs) {


### PR DESCRIPTION
Incidental

## Description
By default GH Rest API only returns 30 entries. Our Test all packages workflow currently has 57 jobs. Increase default page size and auto paginate the query.

### Testing Considerations
Not tested, we'll see outcome on future runs.
