### PR TITLE
refactor(ymax-planner): Improve external request efficiency

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -375,8 +375,8 @@ export const processPortfolioEvents = async (
   ): Promise<StatusFor['flow']['state'] | undefined> => {
     const path = `${portfoliosPathPrefix}.${portfolioKey}.flows.${flowKey}`;
     const metaResponse = await readStorageMeta(vstorage, path, 'data', opts);
-    // If the flow's vstorage node exists only as an empty non-terminal (e.g.
-    // for a child such as `agent`), then it has no status.
+    // If the flow's vstorage node does not exist or exists only as an empty
+    // non-terminal (e.g. for a child such as `agent`), then it has no status.
     if (metaResponse.result.value === '') return undefined;
     const streamCell = parseStreamCell(metaResponse.result.value, path);
     const capdata = parseStreamCellValue(streamCell, -1, path);
@@ -610,14 +610,10 @@ export const processPortfolioEvents = async (
       { minBlockHeight: eventRecord.blockHeight, retries: 4 };
     await null;
     try {
-      const [statusCapdata, flowKeysResp] = await Promise.all([
-        readStreamCellValue(vstorage, path, readOpts),
-        readStorageMeta(vstorage, `${path}.flows`, 'children', readOpts),
-      ]);
+      const statusCapdata = await readStreamCellValue(vstorage, path, readOpts);
       const status = marshaller.fromCapData(statusCapdata) as StatusFor['portfolio'];
       mustMatch(status, PortfolioStatusShapeExt, path);
       portfolioRecordForKey.set(portfolioKey, { status, atBlockHeight: eventRecord.blockHeight });
-      const flowKeys = new Set(flowKeysResp.result.children);
       const fingerprint = fingerprintPortfolioState(status, { marshaller });
 
       // If status hasn't changed, there's no point in trying anything.
@@ -633,20 +629,24 @@ export const processPortfolioEvents = async (
       // Responding to later ones is pointless because acceptance of the first
       // submission would invalidate the others as stale, but we'll see them
       // again when such acceptance prompts changes to the portfolio status.
-      // TODO(https://github.com/Agoric/agoric-sdk/pull/12753): Use
-      // StatusFor['portfolio']['flowsRunning'][string]['planResolved'] rather
-      // than scanning vstorage child nodes.
       const flowsEntries = typedEntries(status.flowsRunning || {}).sort(
         ([a], [b]) => naturalCompare(a, b),
       );
       let txHash: string | undefined;
       for (const [flowKey, flowDetail] of flowsEntries) {
-        const flowStatus = flowKeys.has(flowKey)
-          ? await getFlowStatus(portfolioKey, flowKey, readOpts)
-          : undefined;
+        const { awaitingSteps } = flowDetail;
+        const flowStatus: StatusFor['flow']['state'] | 'INIT' =
+          { __proto__: null, true: 'INIT', false: 'run' }[`${awaitingSteps}`] ??
+          // TODO(https://github.com/Agoric/agoric-sdk/pull/12753): This
+          // fallback can be removed once we're certain that every entry in
+          // `flowsRunning` is guaranteed to have a boolean `awaitingSteps`.
+          (await getFlowStatus(portfolioKey, flowKey, readOpts)) ??
+          'INIT';
+
         // 'run' is the only non-terminal status.
         if (flowStatus === 'run') return;
-        if (flowStatus !== undefined) continue;
+        if (flowStatus !== 'INIT') continue;
+
         txHash = await startFlow(status, portfolioKey, flowKey, flowDetail);
         break;
       }

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -555,13 +555,17 @@ export const processPortfolioEvents = async (
         const cachedBalances = await getCachedBalances(portfolioKey);
         if (!cachedBalances) continue;
 
-        const candidateTargets = computeTargetBalances({
-          brand: depositBrand,
-          currentBalances: cachedBalances,
-          network,
-          targetAllocation,
-          instrumentBlocks,
-        });
+        // XXX We should refactor to avoid adding back unchanged balances.
+        const candidateTargets = {
+          ...cachedBalances,
+          ...computeTargetBalances({
+            brand: depositBrand,
+            currentBalances: cachedBalances,
+            network,
+            targetAllocation,
+            instrumentBlocks,
+          }),
+        };
         const shouldRebalance = checkAutoRebalance(
           targetAllocation,
           cachedBalances,

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -7,7 +7,6 @@ import { inspect } from 'node:util';
 import type { Coin } from '@cosmjs/stargate';
 
 import { Fail, annotateError, q } from '@endo/errors';
-import type { ERef } from '@endo/far';
 import { Nat } from '@endo/nat';
 import { reflectWalletStore, getInvocationUpdate } from '@agoric/client-utils';
 import type { SigningSmartWalletKit } from '@agoric/client-utils';
@@ -49,6 +48,7 @@ import {
 import {
   mustMatch,
   naturalCompare,
+  partialMap,
   provideLazyMap,
   stripPrefix,
   tryNow,
@@ -94,7 +94,8 @@ import {
   setResolvedTx,
 } from './kv-store.ts';
 import { UserInputError, type ReconnectingEvmProvider } from './support.ts';
-import { makeExpiringMap } from './utils.ts';
+import { makeExpiringMap, normalizeIsoTimestamp } from './utils.ts';
+import type { IsoTimestamp } from './utils.ts';
 import {
   encodedKeyToPath,
   pathToEncodedKey,
@@ -107,7 +108,8 @@ import {
   vstoragePathIsParentOf,
 } from './vstorage-utils.ts';
 import type { ReadStorageMetaOptions } from './vstorage-utils.ts';
-import type { PortfolioBalanceReader } from './yds-portfolio-balances.ts';
+import { normalizeYdsPortfolioBalances } from './yds-portfolio-balances.ts';
+import type { YdsPortfolioSummary } from './yds-portfolio-balances.ts';
 
 const compareBigints = (a: bigint, b: bigint) => (a > b ? 1 : a < b ? -1 : 0);
 
@@ -210,6 +212,9 @@ export type Powers = {
   evmTokenAddresses: Partial<Record<InstrumentId, EvmAddress>>;
   network: NetworkSpec;
   getInstrumentBlocks?: () => Promise<InstrumentBlocks | undefined>;
+  getPortfolioSummaries?: (
+    portfolioKeys: PortfolioKey[],
+  ) => Promise<YdsPortfolioSummary[] | undefined>;
   signingSmartWalletKit: SigningSmartWalletKit;
   /** Used to generate unique suffixes in agoric Smart Wallet OfferSpec ids. */
   makeNonce: () => string;
@@ -220,16 +225,17 @@ export type Powers = {
   ) => ReturnType<typeof getInvocationUpdate>;
   /** Prefer monotonicity (e.g., `performance.now` rather than `Date.now`). */
   now: () => number;
+  nowISO: () => string;
   gasEstimator: GasEstimator;
   usdcTokensByChain: Partial<Record<SupportedChain, string>>;
   chainNameToChainIdMap: Partial<Record<EvmChain, CaipChainId>>;
-  getYdsBalancesForPortfolio?: PortfolioBalanceReader;
   autoRebalance: AutoRebalanceConfig;
 };
 
 export type ProcessPortfolioPowers = Pick<
   Powers,
   | 'network'
+  | 'nowISO'
   | 'spectrumBlockchain'
   | 'spectrumChainIds'
   | 'evmTokenAddresses'
@@ -239,7 +245,6 @@ export type ProcessPortfolioPowers = Pick<
   | 'gasEstimator'
   | 'usdcTokensByChain'
   | 'chainNameToChainIdMap'
-  | 'getYdsBalancesForPortfolio'
   | 'autoRebalance'
 > & {
   console: Required<Powers>['console'];
@@ -258,7 +263,12 @@ export type PortfoliosMemory = {
   // TODO: Combine snapshots and portfolioRecordForKey.
   snapshots: Map<
     string,
-    { fingerprint: string; txHash?: null | string; repeats: number }
+    {
+      fingerprint: string;
+      repeats: number;
+      txHash?: null | string;
+      balancesTimestamp?: IsoTimestamp;
+    }
   >;
   portfolioRecordForKey: Map<
     PortfolioKey,
@@ -266,7 +276,10 @@ export type PortfoliosMemory = {
   >;
   balanceCache: Map<
     PortfolioKey,
-    ERef<Partial<Record<AssetPlaceRef, NatAmount>>>
+    {
+      isoTimestamp: IsoTimestamp;
+      balances: Partial<Record<AssetPlaceRef, NatAmount>>;
+    }
   >;
 };
 
@@ -309,6 +322,7 @@ export const processPortfolioEvents = async (
     feeBrand,
     gasEstimator,
     network,
+    nowISO,
     instrumentBlocks,
     signingSmartWalletKit,
     walletStore,
@@ -320,7 +334,6 @@ export const processPortfolioEvents = async (
     vstoragePathPrefixes,
     evmProviders,
     chainNameToChainIdMap,
-    getYdsBalancesForPortfolio,
     autoRebalance,
   }: ProcessPortfolioPowers,
 ) => {
@@ -345,26 +358,11 @@ export const processPortfolioEvents = async (
       depositBrand,
       balanceQueryPowers,
     );
-    balanceCache.set(portfolioKey, balances);
+    balanceCache.set(portfolioKey, {
+      isoTimestamp: normalizeIsoTimestamp(nowISO()),
+      balances,
+    });
     return balances;
-  };
-  const getCachedBalances = async (
-    portfolioKey: PortfolioKey,
-  ): Promise<Partial<Record<AssetPlaceRef, NatAmount>> | undefined> => {
-    const found = await balanceCache.get(portfolioKey);
-    if (found) return found;
-    const balancesP = getYdsBalancesForPortfolio?.(portfolioKey, depositBrand);
-    if (!balancesP) return undefined;
-    balanceCache.set(portfolioKey, balancesP);
-    try {
-      const balances = await balancesP;
-      balanceCache.set(portfolioKey, balances); // refreshes the TTL
-      return balances;
-    } catch (err) {
-      const refound = balanceCache.get(portfolioKey);
-      if (refound === balancesP) balanceCache.delete(portfolioKey);
-      throw err;
-    }
   };
   type ReadVstorageSimpleOpts = Pick<
     ReadStorageMetaOptions<'data'>,
@@ -552,15 +550,18 @@ export const processPortfolioEvents = async (
         }
 
         // Likewise if we don't have new balance information.
-        const cachedBalances = await getCachedBalances(portfolioKey);
-        if (!cachedBalances) continue;
+        const cachedBalanceData = await balanceCache.get(portfolioKey);
+        if (!cachedBalanceData) continue;
+        const { isoTimestamp, balances } = cachedBalanceData;
+        if (oldState.balancesTimestamp === isoTimestamp) continue;
+        oldState.balancesTimestamp = isoTimestamp;
 
         // XXX We should refactor to avoid adding back unchanged balances.
         const candidateTargets = {
-          ...cachedBalances,
+          ...balances,
           ...computeTargetBalances({
             brand: depositBrand,
-            currentBalances: cachedBalances,
+            currentBalances: balances,
             network,
             targetAllocation,
             instrumentBlocks,
@@ -568,13 +569,15 @@ export const processPortfolioEvents = async (
         };
         const shouldRebalance = checkAutoRebalance(
           targetAllocation,
-          cachedBalances,
+          balances,
           candidateTargets,
           autoRebalance,
         );
         if (!shouldRebalance) continue;
 
         const freshBalances = await getFreshBalances(portfolioKey, status);
+        const freshTimestamp = balanceCache.get(portfolioKey)!.isoTimestamp;
+        oldState.balancesTimestamp = freshTimestamp;
         const txHash = await maybeAutoRebalance(
           status,
           portfolioKey,
@@ -582,8 +585,12 @@ export const processPortfolioEvents = async (
           maybeAutoRebalancePowers,
         );
         if (txHash) {
-          const snapshot = { fingerprint, txHash, repeats: 0 };
-          memory.snapshots.set(portfolioKey, snapshot);
+          memory.snapshots.set(portfolioKey, {
+            fingerprint,
+            txHash,
+            repeats: 0,
+            balancesTimestamp: freshTimestamp,
+          });
         }
       } catch (err) {
         console.warn(
@@ -878,6 +885,7 @@ export const startEngine = async (
     signingSmartWalletKit,
     makeNonce,
     getInstrumentBlocks,
+    getPortfolioSummaries,
     now,
   } = powers;
   const { kvStore } = evmCtx;
@@ -905,12 +913,37 @@ export const startEngine = async (
   const depositAsset =
     vbankAssets.find(asset => asset.issuerName === depositBrandName) ||
     Fail`Could not find vbankAsset for ${q(depositBrandName)}`;
+  const depositBrand = depositAsset.brand as Brand<'nat'>;
   const feeAsset =
     vbankAssets.find(asset => asset.issuerName === feeBrandName) ||
     Fail`Could not find vbankAsset for ${q(feeBrandName)}`;
 
   const portfoliosMemory = makePortfoliosMemory({ balanceCacheTtlMs, now });
-  const { deferrals } = portfoliosMemory;
+  const { balanceCache, deferrals, portfolioRecordForKey } = portfoliosMemory;
+
+  const updatePortfolioBalances = async () => {
+    const autoRebalancers = partialMap(
+      [...portfolioRecordForKey],
+      ([portfolioKey, record]) =>
+        record.status.enabledAutoFeatures?.rebalance && portfolioKey,
+    );
+    const summaries = await getPortfolioSummaries?.(autoRebalancers);
+    if (!summaries) return;
+    for (const { portfolioId, latestSnapshot } of summaries) {
+      if (!latestSnapshot) continue;
+
+      // This data might be more stale than that of our own balance queries.
+      const isoTimestamp = normalizeIsoTimestamp(latestSnapshot.ts);
+      const found = balanceCache.get(portfolioId);
+      if (found && found.isoTimestamp >= isoTimestamp) continue;
+
+      const balances = normalizeYdsPortfolioBalances(
+        latestSnapshot,
+        depositBrand,
+      );
+      balanceCache.set(portfolioId, { isoTimestamp, balances });
+    }
+  };
 
   const blockHeightFromSubscriptionResponse = (resp: SubscriptionResponse) => {
     const { type: respType, value: respData } = resp;
@@ -968,7 +1001,7 @@ export const startEngine = async (
     ...powers,
     console,
     isDryRun,
-    depositBrand: depositAsset.brand as Brand<'nat'>,
+    depositBrand,
     feeBrand: feeAsset.brand as Brand<'nat'>,
     vstoragePathPrefixes,
     evmProviders: evmCtx.evmProviders,
@@ -1147,18 +1180,19 @@ export const startEngine = async (
     // Pending tx watchers must subscribe to EVM events ASAP to avoid missing
     // transactions, so process them concurrently with portfolio events.
     await Promise.all([
-      updateInstrumentBlocks()
-        .catch(err =>
+      Promise.all([
+        updateInstrumentBlocks().catch(err =>
           console.error('⚠️ Failed to update instrument blocks', err),
-        )
-        .then(() =>
-          processPortfolioEvents(
-            portfolioEvents,
-            respHeight,
-            portfoliosMemory,
-            { ...processPortfolioPowers, instrumentBlocks },
-          ),
         ),
+        updatePortfolioBalances().catch(err =>
+          console.error('⚠️ Failed to update portfolio balances', err),
+        ),
+      ]).then(() =>
+        processPortfolioEvents(portfolioEvents, respHeight, portfoliosMemory, {
+          ...processPortfolioPowers,
+          instrumentBlocks,
+        }),
+      ),
       processPendingTxEvents(pendingTxEvents, handlePendingTx, txPowers),
     ]);
 

--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -288,20 +288,14 @@ export const makePortfoliosMemory = (options?: {
 
 const fingerprintPortfolioState = (
   status: StatusFor['portfolio'],
-  activeFlowKeys: Set<string>,
   { marshaller }: { marshaller: SigningSmartWalletKit['marshaller'] },
 ): string => {
   // Ignore rebalanceCount, which can increment from one of our submissions even
   // if nothing actually changes.
   const { rebalanceCount: _rebalanceCount, ...statusFields } = status;
-  const sortedFlowKeys = [...activeFlowKeys].sort((a, b) =>
-    naturalCompare(a, b),
-  );
   // Rely on the determinism of @endo/marshal.
-  const fingerprint = marshaller.toCapData(
-    harden({ statusFields, activeFlowKeys: sortedFlowKeys }),
-  );
-  return fingerprint.body;
+  const fingerprint = marshaller.toCapData(harden(statusFields)).body;
+  return fingerprint;
 };
 
 export const processPortfolioEvents = async (
@@ -539,40 +533,28 @@ export const processPortfolioEvents = async (
   const scanAutoRebalances = async () => {
     await null;
     for (const [portfolioKey, portfolioRecord] of portfolioRecordForKey) {
-      const { atBlockHeight, status } = portfolioRecord;
+      const { status } = portfolioRecord;
       const { enabledAutoFeatures, targetAllocation } = status;
       if (!enabledAutoFeatures?.rebalance || !targetAllocation) continue;
       if (Object.keys(status.flowsRunning || {}).length > 0) continue;
 
-      const path = `${portfoliosPathPrefix}.${portfolioKey}`;
-      const readOpts: ReadVstorageSimpleOpts = {
-        minBlockHeight: atBlockHeight,
-        retries: 4,
-      };
       try {
-        // If this (portfolio, flows) data hasn't changed since our last
-        // successful submission, there's no point in trying again.
-        const flowKeysResp = await readStorageMeta(
-          vstorage,
-          `${path}.flows`,
-          'children',
-          readOpts,
-        );
-        const flowKeys = new Set(flowKeysResp.result.children as string[]);
-        const fingerprint = fingerprintPortfolioState(status, flowKeys, {
-          marshaller,
-        });
-        const oldState = memory.snapshots.get(portfolioKey);
-        if (oldState?.txHash && fingerprint === oldState.fingerprint) {
-          if (!oldState.repeats) {
-            console.warn(`⚠️  Ignoring unchanged auto-rebalance ${path}`);
-          }
-          oldState.repeats += 1;
+        // If status hasn't changed since our last successful submission,
+        // there's no point in checking.
+        const fingerprint = fingerprintPortfolioState(status, { marshaller });
+        const oldState = provideLazyMap(memory.snapshots, portfolioKey, () => ({
+          fingerprint,
+          repeats: 0,
+          txHash: null,
+        }));
+        if (oldState.txHash && fingerprint === oldState.fingerprint) {
           continue;
         }
 
+        // Likewise if we don't have new balance information.
         const cachedBalances = await getCachedBalances(portfolioKey);
         if (!cachedBalances) continue;
+
         const candidateTargets = computeTargetBalances({
           brand: depositBrand,
           currentBalances: cachedBalances,
@@ -625,10 +607,9 @@ export const processPortfolioEvents = async (
       mustMatch(status, PortfolioStatusShapeExt, path);
       portfolioRecordForKey.set(portfolioKey, { status, atBlockHeight: eventRecord.blockHeight });
       const flowKeys = new Set(flowKeysResp.result.children);
-      const fingerprint = fingerprintPortfolioState(status, flowKeys, { marshaller });
+      const fingerprint = fingerprintPortfolioState(status, { marshaller });
 
-      // If this (portfolio, flows) data hasn't changed since our last
-      // successful submission, there's no point in trying again.
+      // If status hasn't changed, there's no point in trying anything.
       const oldState = memory.snapshots.get(portfolioKey);
       if (oldState && fingerprint === oldState.fingerprint) {
         if (!oldState.repeats) console.warn(`⚠️  Ignoring unchanged ${path}`);
@@ -641,6 +622,9 @@ export const processPortfolioEvents = async (
       // Responding to later ones is pointless because acceptance of the first
       // submission would invalidate the others as stale, but we'll see them
       // again when such acceptance prompts changes to the portfolio status.
+      // TODO(https://github.com/Agoric/agoric-sdk/pull/12753): Use
+      // StatusFor['portfolio']['flowsRunning'][string]['planResolved'] rather
+      // than scanning vstorage child nodes.
       const flowsEntries = typedEntries(status.flowsRunning || {}).sort(
         ([a], [b]) => naturalCompare(a, b),
       );

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -61,6 +61,7 @@ import {
   type YdsPortfolioSummary,
 } from './yds-portfolio-balances.ts';
 import { getPoolTokenAddresses } from './evm-utils.ts';
+import { generateDiff } from './ses-utils.ts';
 import { makeNowISO } from './utils.ts';
 
 const { fromEntries, entries } = Object;
@@ -359,33 +360,19 @@ export const main = async (
             const elapsed = Number.isFinite(seconds)
               ? `overwriting after ${seconds} seconds`
               : 'initializing';
-            const diff: string[] = [];
-            const iters = [
-              JSON.parse(lastPortfolios.portfolioIdsString),
-              [...portfolioIds],
-            ].map(arr => arr.sort(naturalCompare)[Symbol.iterator]());
-            for (let pair = iters.map(iter => iter.next()); ; ) {
-              const [oldR, newR] = pair;
-              const forceCmp = oldR.done || newR.done ? NaN : undefined;
-              const cmp = forceCmp ?? naturalCompare(oldR.value, newR.value);
-              if (cmp === 0) {
-                diff.push(` ${oldR.value}`);
-                pair = iters.map(iter => iter.next());
-              } else if (!oldR.done && (newR.done || cmp < 0)) {
-                diff.push(`-${oldR.value}`);
-                pair[0] = iters[0].next();
-              } else if (!newR.done && (oldR.done || cmp > 0)) {
-                diff.push(`+${newR.value}`);
-                pair[1] = iters[1].next();
-              } else {
-                if (!Number.isNaN(cmp)) {
-                  const details = { oldR, newR, cmp };
-                  console.error(logPrefix, 'bad comparison', details);
-                }
-                break;
+            const idsDiff: string[] = [];
+            const sigilsByState = { common: ' ', removed: '-', added: '+' };
+            try {
+              const oldIdsString = lastPortfolios.portfolioIdsString;
+              const oldIds = JSON.parse(oldIdsString).sort(naturalCompare);
+              const diff = generateDiff(oldIds, portfolioIds, naturalCompare);
+              for (const { state, value } of diff) {
+                idsDiff.push(`${sigilsByState[state]}${value}`);
               }
+            } catch (err) {
+              console.error(logPrefix, err);
             }
-            const diffStr = diff.length ? `\n${diff.join('\n')}\n` : '';
+            const diffStr = idsDiff.length ? `\n${idsDiff.join('\n')}\n` : '';
             console.warn(logPrefix, elapsed, diffStr, summaries);
           }
 

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -24,9 +24,11 @@ import type { SigningSmartWalletKit } from '@agoric/client-utils';
 import type { CaipChainId } from '@agoric/orchestration';
 import {
   deeplyFulfilledObject,
+  naturalCompare,
   objectMap,
   withDeferredCleanup,
 } from '@agoric/internal';
+import type { PortfolioKey } from '@agoric/portfolio-api';
 import {
   CaipChainIds,
   UsdcTokenIds,
@@ -55,8 +57,8 @@ import { makeGasEstimator } from './gas-estimation.ts';
 import { makeSQLiteKeyValueStore } from './kv-store.ts';
 import { YdsNotifier } from './yds-notifier.ts';
 import {
-  makeYdsPortfolioBalanceReader,
   YDS_PORTFOLIO_BALANCE_CACHE_TTL_MS,
+  type YdsPortfolioSummary,
 } from './yds-portfolio-balances.ts';
 import { getPoolTokenAddresses } from './evm-utils.ts';
 import { makeNowISO } from './utils.ts';
@@ -91,8 +93,7 @@ export type SimplePowers = {
   makeAbortController: MakeAbortController;
 };
 
-/** `makeNonce` defaults to the wall clock for debugging sent transactions. */
-const defaultMakeNonce = makeNowISO(Date.now);
+const nowISO = makeNowISO(Date.now);
 
 export const main = async (
   cliArgs: string[],
@@ -100,7 +101,8 @@ export const main = async (
     env = process.env,
     fetch = globalThis.fetch,
     generateInterval = timersPromises.setInterval,
-    makeNonce = defaultMakeNonce,
+    /** `makeNonce` defaults to wall-clock timestamps for debugging sent transactions. */
+    makeNonce = nowISO,
     now = globalThis.performance.now.bind(globalThis.performance),
     setTimeout = globalThis.setTimeout,
     connectWithSigner = SigningStargateClient.connectWithSigner,
@@ -284,12 +286,16 @@ export const main = async (
     trace: () => {},
   });
 
+  const ydsApiKey = config.yds.apiKey;
   const ydsClient =
     config.yds.url &&
     ky.create({
       fetch,
-      headers: FETCH_HEADERS,
       prefixUrl: config.yds.url,
+      headers: {
+        ...FETCH_HEADERS,
+        ...(ydsApiKey ? { 'x-resolver-auth-key': ydsApiKey } : undefined),
+      },
       timeout: config.requestLimits.timeout,
       retry: config.requestLimits.maxRetries,
     });
@@ -317,6 +323,41 @@ export const main = async (
       }
     : undefined;
 
+  let lastPortfolios: {
+    timestamp: number;
+    portfolioIdsString: string;
+    summaries: YdsPortfolioSummary[];
+  } = { timestamp: -Infinity, portfolioIdsString: '[]', summaries: [] };
+  const getPortfolioSummaries =
+    ydsClient && ydsApiKey
+      ? async (
+          portfolioIds: PortfolioKey[],
+        ): Promise<YdsPortfolioSummary[] | undefined> => {
+          if (!portfolioIds.length) return [];
+
+          portfolioIds = portfolioIds.toSorted(naturalCompare);
+          const portfolioIdsString = JSON.stringify(portfolioIds);
+          const timestamp = now();
+          if (
+            portfolioIdsString === lastPortfolios.portfolioIdsString &&
+            timestamp <
+              lastPortfolios.timestamp + YDS_PORTFOLIO_BALANCE_CACHE_TTL_MS
+          ) {
+            return lastPortfolios.summaries;
+          }
+
+          const resp = await ydsClient
+            .post('portfolios:list', { json: { portfolioIds } })
+            .json();
+          const summaries = ((resp as any).data as YdsPortfolioSummary[]).sort(
+            (a, b) => naturalCompare(a.portfolioId, b.portfolioId),
+          );
+
+          lastPortfolios = { timestamp, portfolioIdsString, summaries };
+          return summaries;
+        }
+      : undefined;
+
   const ydsNotifier = config.yds.url
     ? new YdsNotifier(
         { fetch, log: console.log.bind(console) },
@@ -328,20 +369,6 @@ export const main = async (
         },
       )
     : undefined;
-  // TODO(https://github.com/Agoric/ymax-web/pull/782): make this more like
-  // getInstrumentBlocks
-  const getYdsBalancesForPortfolio =
-    config.yds.url && config.yds.apiKey
-      ? makeYdsPortfolioBalanceReader(
-          { fetch },
-          {
-            ydsUrl: config.yds.url,
-            ydsApiKey: config.yds.apiKey,
-            timeout: config.requestLimits.timeout,
-            retries: config.requestLimits.maxRetries,
-          },
-        )
-      : undefined;
 
   const retryProviders = fromEntries(
     entries(evmCtx.evmProviders).map(([caip, provider]) => [
@@ -370,6 +397,7 @@ export const main = async (
     spectrumBlockchain,
     network: PROD_NETWORK,
     getInstrumentBlocks,
+    getPortfolioSummaries,
     signingSmartWalletKit,
     makeNonce,
     walletStore,
@@ -379,10 +407,10 @@ export const main = async (
       return getInvocationUpdate(messageId, getLastUpdate, retryOpts);
     },
     now,
+    nowISO,
     gasEstimator,
     usdcTokensByChain,
     chainNameToChainIdMap: CaipChainIds[clusterName],
-    getYdsBalancesForPortfolio,
     autoRebalance: config.autoRebalance,
   };
 

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -353,6 +353,42 @@ export const main = async (
             (a, b) => naturalCompare(a.portfolioId, b.portfolioId),
           );
 
+          if (isVerbose) {
+            const logPrefix = '[getPortfolioSummaries]';
+            const seconds = (timestamp - lastPortfolios.timestamp) / 1000;
+            const elapsed = Number.isFinite(seconds)
+              ? `overwriting after ${seconds} seconds`
+              : 'initializing';
+            const diff: string[] = [];
+            const iters = [
+              JSON.parse(lastPortfolios.portfolioIdsString),
+              [...portfolioIds],
+            ].map(arr => arr.sort(naturalCompare)[Symbol.iterator]());
+            for (let pair = iters.map(iter => iter.next()); ; ) {
+              const [oldR, newR] = pair;
+              const forceCmp = oldR.done || newR.done ? NaN : undefined;
+              const cmp = forceCmp ?? naturalCompare(oldR.value, newR.value);
+              if (cmp === 0) {
+                diff.push(` ${oldR.value}`);
+                pair = iters.map(iter => iter.next());
+              } else if (!oldR.done && (newR.done || cmp < 0)) {
+                diff.push(`-${oldR.value}`);
+                pair[0] = iters[0].next();
+              } else if (!newR.done && (oldR.done || cmp > 0)) {
+                diff.push(`+${newR.value}`);
+                pair[1] = iters[1].next();
+              } else {
+                if (!Number.isNaN(cmp)) {
+                  const details = { oldR, newR, cmp };
+                  console.error(logPrefix, 'bad comparison', details);
+                }
+                break;
+              }
+            }
+            const diffStr = diff.length ? `\n${diff.join('\n')}\n` : '';
+            console.warn(logPrefix, elapsed, diffStr, summaries);
+          }
+
           lastPortfolios = { timestamp, portfolioIdsString, summaries };
           return summaries;
         }

--- a/services/ymax-planner/src/ses-utils.ts
+++ b/services/ymax-planner/src/ses-utils.ts
@@ -1,0 +1,42 @@
+/**
+ * @file Utility functions that are dependent upon a hardened environment.
+ */
+
+import { Fail, q } from '@endo/errors';
+
+const { freeze } = Object;
+
+function* generateDiffInternal<T = unknown>(
+  oldSource: Iterable<T>,
+  newSource: Iterable<T>,
+  compare: (a: T, b: T) => number = (a, b) => (a < b ? -1 : a > b ? 1 : 0),
+): Generator<{ state: 'common' | 'removed' | 'added'; value: T }> {
+  const iters = [oldSource, newSource].map(source => source[Symbol.iterator]());
+  for (let resultPair = iters.map(iter => iter.next()); ; ) {
+    const [oldResult, newResult] = resultPair;
+    const [oldDone, newDone] = [oldResult.done, newResult.done];
+    const [oldValue, newValue] = [oldResult.value, newResult.value];
+    const forceCmp = oldDone || newDone ? NaN : undefined;
+    const cmp = forceCmp ?? compare(oldValue, newValue);
+    if (cmp === 0) {
+      yield freeze({ state: 'common', value: oldValue });
+      resultPair = iters.map(iter => iter.next());
+    } else if (!oldDone && (newDone || cmp < 0)) {
+      yield freeze({ state: 'removed', value: oldValue });
+      resultPair[0] = iters[0].next();
+    } else if (!newDone && (oldDone || cmp > 0)) {
+      yield freeze({ state: 'added', value: newValue });
+      resultPair[1] = iters[1].next();
+    } else {
+      (oldDone && newDone) ||
+        Fail`bad comparison: ${q({ oldResult, newResult, cmp })}`;
+      break;
+    }
+  }
+}
+
+export const generateDiff = <T>(
+  ...args: Parameters<typeof generateDiffInternal<T>>
+): ReturnType<typeof generateDiffInternal<T>> =>
+  harden(generateDiffInternal(...args));
+harden(generateDiff);

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -13,6 +13,12 @@ import type { SupportedChain } from '@agoric/portfolio-api/src/constants.js';
 import type { EvmContext } from './pending-tx-manager.ts';
 import { lookupValueForKey } from './utils.ts';
 
+/**
+ * USDC value in floating-point major units (i.e., nominally corresponding with
+ * USD)
+ */
+export type UsdcNumber = number;
+
 export const UserInputError = class extends Error {} as ErrorConstructor;
 harden(UserInputError);
 

--- a/services/ymax-planner/src/utils.ts
+++ b/services/ymax-planner/src/utils.ts
@@ -88,6 +88,33 @@ export const makeNowISO = (now: typeof Date.now): (() => string) => {
 };
 
 /**
+ * An ECMAScript-compatible Z-offset ISO 8601 calendar date and time of day
+ * representation that uses a six-digit expanded year and three fractional
+ * seconds digits.
+ * https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date-time-string-format
+ */
+export type IsoTimestamp = `+${string}T${string}.${string}Z`;
+
+const isoTimestampPatt =
+  /^((?:[0-9]{4}|[+][0-9]{6})-(?:0[1-9]|1[012])-(?:0[1-9]|[12][0-9]|3[01]))T((?:[01][0-9]|2[0-3]):(?:[0-5][0-9]):(?:[0-5][0-9]))(?:[.]([0-9]+))?Z$/;
+
+/**
+ * Normalize a trivial Z-offset ISO 8601 string into an expanded form in which
+ * string comparison corresponds with temporal comparison.
+ */
+export const normalizeIsoTimestamp = (timestamp: string): IsoTimestamp => {
+  const parts = timestamp.match(isoTimestampPatt);
+  if (!parts) throw TypeError(`timestamp cannot be normalized: ${timestamp}`);
+
+  // eslint-disable-next-line prefer-const
+  let [, ymd, hms, frac = ''] = parts;
+  if (!ymd.startsWith('+')) ymd = `+00${ymd}`;
+  frac = frac.padEnd(3, '0');
+
+  return `${ymd as `+${string}`}T${hms}.${frac.substring(0, 3)}Z`;
+};
+
+/**
  * Parse the contents of a GRAPHQL_ENDPOINTS environment variable.
  * @see {@link ../README.md}
  */

--- a/services/ymax-planner/src/yds-portfolio-balances.ts
+++ b/services/ymax-planner/src/yds-portfolio-balances.ts
@@ -1,31 +1,51 @@
-import ky, { type KyInstance } from 'ky';
-
+import type { PoolKey } from '@aglocal/portfolio-contract/src/type-guards.ts';
 import type { AssetPlaceRef } from '@aglocal/portfolio-contract/src/type-guards-steps.js';
 import { AmountMath } from '@agoric/ertp';
 import type { Brand, NatAmount } from '@agoric/ertp/src/types.js';
+import type { EvmAddress } from '@agoric/fast-usdc';
+import type { Bech32Address, CaipChainId } from '@agoric/orchestration';
 import { SupportedChain } from '@agoric/portfolio-api/src/constants.js';
 import { PoolPlaces } from '@agoric/portfolio-api/src/places.js';
 import { Fail, bare, q } from '@endo/errors';
+import type { PortfolioKey } from '@agoric/portfolio-api';
 import { Nat } from '@endo/nat';
-import { FETCH_HEADERS } from './config.ts';
+import type { UsdcNumber } from './support.ts';
 
 export const YDS_PORTFOLIO_BALANCE_CACHE_TTL_MS = 60 * 60 * 1000;
 const USDC_DECIMALS = 6;
 
-export type PortfolioBalanceReader = (
-  portfolioKey: string,
-  brand: Brand<'nat'>,
-) => Promise<Partial<Record<AssetPlaceRef, NatAmount>>>;
+/** cf. https://github.com/Agoric/ymax-web/blob/main/yds/src/api-schemas.ts: PortfolioSummary */
+export type YdsPortfolioSummary = {
+  portfolioId: PortfolioKey;
+  targetAllocation: Record<string, number>;
+  positionStatus?: { pendingDelta: Partial<Record<AssetPlaceRef, UsdcNumber>> };
+  latestSnapshot: null | {
+    ts: `${string}Z`;
+    balances: {
+      positions: Partial<Record<PoolKey, null | UsdcNumber>>;
+      accounts: Partial<Record<SupportedChain, null | UsdcNumber>>;
+    };
+    totalValueUsdc: UsdcNumber;
+  };
+  reserved: UsdcNumber;
+  atBlockHeight: number;
 
-export type YdsPortfolioBalanceConfig = {
-  ydsUrl: string;
-  ydsApiKey: string;
-  timeout?: number;
-  retries?: number;
-};
-
-export type YdsPortfolioBalancePowers = {
-  fetch: typeof fetch;
+  walletAddress: null | string;
+  creationOfferId: null | string;
+  depositAddress: null | string;
+  accountStateByChain: Partial<
+    Record<
+      SupportedChain,
+      | { state: 'provisioning' | 'failed' | 'unknown' }
+      | {
+          state: 'active' | 'provisioning' | 'failed';
+          chainId: CaipChainId;
+          address: Bech32Address | EvmAddress;
+          routerFactory?: EvmAddress;
+        }
+    >
+  >;
+  vstorage: { structure: Record<string, unknown>; slots: string[] };
 };
 
 // TODO: Use something less open-coded, e.g. Zod or @endo/patterns.
@@ -64,21 +84,11 @@ const scaleToNat = (
   }
 };
 
-const getYdsBalances = (payload: unknown): Record<string, unknown> => {
-  const root = assertRecord(payload, 'portfolio response');
-  const data = assertRecord(root.data, 'portfolio response data');
-  const latestSnapshot = assertRecord(
-    data.latestSnapshot,
-    'portfolio latestSnapshot',
-  );
-  return assertRecord(latestSnapshot.balances, 'portfolio balances');
-};
-
 export const normalizeYdsPortfolioBalances = (
-  payload: unknown,
+  snapshot: NonNullable<YdsPortfolioSummary['latestSnapshot']>,
   brand: Brand<'nat'>,
 ): Partial<Record<AssetPlaceRef, NatAmount>> => {
-  const ydsBalances = getYdsBalances(payload);
+  const ydsBalances = assertRecord(snapshot.balances, 'portfolio balances');
   const positions = assertRecord(ydsBalances.positions, 'positions balances');
   const accounts = assertRecord(ydsBalances.accounts, 'accounts balances');
 
@@ -103,26 +113,4 @@ export const normalizeYdsPortfolioBalances = (
     balances[place] = AmountMath.make(brand, balance);
   }
   return harden(balances);
-};
-
-export const makeYdsPortfolioBalanceReader = (
-  { fetch }: YdsPortfolioBalancePowers,
-  config: YdsPortfolioBalanceConfig,
-): PortfolioBalanceReader => {
-  const http: KyInstance = ky.create({
-    fetch,
-    timeout: config.timeout,
-    retry: config.retries,
-    prefixUrl: config.ydsUrl,
-    headers: {
-      ...FETCH_HEADERS,
-      'x-resolver-auth-key': config.ydsApiKey,
-    },
-  });
-
-  const getYdsBalancesForPortfolio = async (portfolioKey, brand) => {
-    const payload = await http.get(`portfolios/${portfolioKey}`).json();
-    return normalizeYdsPortfolioBalances(payload, brand);
-  };
-  return getYdsBalancesForPortfolio;
 };

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -58,12 +58,15 @@ import type {
   ProcessPortfolioPowers,
   VstorageEventDetail,
 } from '../src/engine.ts';
+import { normalizeIsoTimestamp } from '../src/utils.ts';
 import {
   createMockEnginePowers,
   makeNotImplemented,
   mockEvmCtx,
   mockGasEstimator,
 } from './mocks.ts';
+
+const EPOCH_TIMESTAMP = normalizeIsoTimestamp(new Date(0).toISOString());
 
 // #region client-utils mocks
 // XXX these helpers belong somewhere else; maybe *in* packages/client-utils?
@@ -814,8 +817,11 @@ test('processPortfolioEvents starts auto rebalance when criteria fire', async t 
   const blockHeight = updateBlockHeight();
   const memory = makePortfoliosMemory();
   memory.balanceCache.set(`portfolio${portfolioId}`, {
-    '@noble': nobleBalance,
-    USDN: usdnBalance,
+    isoTimestamp: EPOCH_TIMESTAMP,
+    balances: {
+      '@noble': nobleBalance,
+      USDN: usdnBalance,
+    },
   });
   await processPortfolioEvents(
     [makeVstorageEventDetail(blockHeight, portfolioPath, portfolioStatus)],
@@ -881,9 +887,13 @@ test('processPortfolioEvents scans remembered portfolios when there are no event
     atBlockHeight: 0n,
     status: portfolioStatus,
   });
+  memory.snapshots.set(portfolioKey, { fingerprint: '', repeats: 0 });
   memory.balanceCache.set(portfolioKey, {
-    '@noble': nobleBalance,
-    USDN: usdnBalance,
+    isoTimestamp: EPOCH_TIMESTAMP,
+    balances: {
+      '@noble': nobleBalance,
+      USDN: usdnBalance,
+    },
   });
 
   await processPortfolioEvents([], blockHeight, memory, powers);
@@ -894,7 +904,7 @@ test('processPortfolioEvents scans remembered portfolios when there are no event
   ]);
 });
 
-test('processPortfolioEvents rechecks YDS candidates with fresh balances', async t => {
+test('processPortfolioEvents rebalances against latest balances', async t => {
   const kit = await fakePortfolioKit({
     accounts: { noble: makeDeposit(0n) },
     otherBalances: { usdn: makeDeposit(0n) },
@@ -908,13 +918,16 @@ test('processPortfolioEvents rechecks YDS candidates with fresh balances', async
     targetAllocation: { USDN: 1n },
     enabledAutoFeatures: { rebalance: true },
   });
-  powers.getYdsBalancesForPortfolio = async () => ({
-    '@noble': makeDeposit(25_000_000n),
-  });
   const memory = makePortfoliosMemory();
   memory.portfolioRecordForKey.set(portfolioKey, {
     atBlockHeight: 0n,
     status: portfolioStatus,
+  });
+  memory.balanceCache.set(portfolioKey, {
+    isoTimestamp: EPOCH_TIMESTAMP,
+    balances: {
+      '@noble': makeDeposit(25_000_000n),
+    },
   });
 
   await processPortfolioEvents([], blockHeight, memory, powers);
@@ -922,7 +935,6 @@ test('processPortfolioEvents rechecks YDS candidates with fresh balances', async
   t.deepEqual(
     getBridgeSends().map(invocation => invocation.action),
     [],
-    'stale YDS candidate is skipped after fresh direct balance recheck',
   );
 });
 
@@ -949,9 +961,6 @@ test('processPortfolioEvents continues auto scan after portfolio error', async t
     ...commonStatus,
     targetAllocation: { USDN: 1n },
   });
-  powers.getYdsBalancesForPortfolio = async () => ({
-    '@noble': makeDeposit(25_000_000n),
-  });
   const memory = makePortfoliosMemory();
   memory.portfolioRecordForKey.set(badPortfolioKey, {
     atBlockHeight: 0n,
@@ -961,6 +970,15 @@ test('processPortfolioEvents continues auto scan after portfolio error', async t
     atBlockHeight: 0n,
     status: goodPortfolioStatus,
   });
+  for (const portfolioKey of [badPortfolioKey, goodPortfolioKey]) {
+    memory.snapshots.set(portfolioKey, { fingerprint: '', repeats: 0 });
+    memory.balanceCache.set(portfolioKey, {
+      isoTimestamp: EPOCH_TIMESTAMP,
+      balances: {
+        '@noble': makeDeposit(25_000_000n),
+      },
+    });
+  }
 
   await processPortfolioEvents([], blockHeight, memory, powers);
 

--- a/services/ymax-planner/test/mocks.ts
+++ b/services/ymax-planner/test/mocks.ts
@@ -112,6 +112,7 @@ export const createMockEnginePowers = (): EnginePowers => ({
   walletStore: {} as any,
   getWalletInvocationUpdate: async () => undefined,
   now: () => NaN,
+  nowISO: () => '1970-01-01T00:00:00.000Z',
   setTimeout: globalThis.setTimeout,
   gasEstimator: {} as any,
   usdcTokensByChain: {},

--- a/services/ymax-planner/test/yds-portfolio-balances.test.ts
+++ b/services/ymax-planner/test/yds-portfolio-balances.test.ts
@@ -2,39 +2,29 @@ import test from 'ava';
 
 import { Far } from '@endo/pass-style';
 import type { Brand } from '@agoric/ertp/src/types.js';
-import {
-  makeYdsPortfolioBalanceReader,
-  normalizeYdsPortfolioBalances,
-} from '../src/yds-portfolio-balances.ts';
+import { normalizeYdsPortfolioBalances } from '../src/yds-portfolio-balances.ts';
+
+const EPOCH_TIMESTAMP = '1970-01-01T00:00:00Z';
 
 const brand = Far('mock USDC brand') as Brand<'nat'>;
-
-const makeYdsPayload = (
-  balances: unknown,
-  extras: Record<string, unknown> = {},
-) => ({
-  data: {
-    latestSnapshot: {
-      balances,
-      observedAt: '2026-06-18T00:00:00Z',
-    },
-    ...extras,
-  },
-});
 
 test('normalizeYdsPortfolioBalances accepts current endpoint balances', t => {
   t.deepEqual(
     normalizeYdsPortfolioBalances(
-      makeYdsPayload({
-        positions: {
-          USDN: 12.5,
-          Aave_Base: 2.000001,
+      {
+        ts: EPOCH_TIMESTAMP,
+        balances: {
+          positions: {
+            USDN: 12.5,
+            Aave_Base: 2.000001,
+          },
+          accounts: {
+            noble: 25,
+            Base: 1.25,
+          },
         },
-        accounts: {
-          noble: 25,
-          Base: 1.25,
-        },
-      }),
+        totalValueUsdc: 40.750001,
+      },
       brand,
     ),
     {
@@ -46,22 +36,13 @@ test('normalizeYdsPortfolioBalances accepts current endpoint balances', t => {
   );
 });
 
-test('normalizeYdsPortfolioBalances rejects legacy balance shapes', t => {
-  for (const payload of [
-    { balances: { '@noble': '3000000' } },
-    { data: { balances: { '@noble': '3000000' } } },
-    { data: { portfolio: { balances: [] } } },
-    makeYdsPayload([
-      { place: '@Base', amount: 1 },
-      { id: 'Aave_Base', balance: { value: '2' } },
-    ]),
-  ]) {
-    t.throws(() => normalizeYdsPortfolioBalances(payload, brand));
-  }
-});
-
 test('normalizeYdsPortfolioBalances rejects malformed places and balances', t => {
   for (const balances of [
+    { '@noble': 1000000 },
+    [{ place: '@Base', amount: 2000000 }],
+    [{ place: '@Base', amount: { value: 3000000 } }],
+    { positions: {}, accounts: { '@Base': 1 } },
+    { positions: {}, accounts: { Base: '1' } },
     { positions: { NotAnInstrument: 1 }, accounts: {} },
     { positions: {}, accounts: { NotAChain: 1 } },
     { positions: { USDN: '1' }, accounts: {} },
@@ -74,45 +55,8 @@ test('normalizeYdsPortfolioBalances rejects malformed places and balances', t =>
     { positions: {}, accounts: [] },
   ]) {
     t.throws(() =>
-      normalizeYdsPortfolioBalances(makeYdsPayload(balances), brand),
+      // @ts-expect-error intentionally malformed
+      normalizeYdsPortfolioBalances({ ts: EPOCH_TIMESTAMP, balances }, brand),
     );
   }
-});
-
-test('makeYdsPortfolioBalanceReader fetches portfolio endpoint with auth', async t => {
-  const calls: Array<{ url: string; headers: Headers }> = [];
-  const reader = makeYdsPortfolioBalanceReader(
-    {
-      fetch: async (input, init) => {
-        const url = input instanceof Request ? input.url : String(input);
-        const headers = new Headers(
-          input instanceof Request ? input.headers : init?.headers,
-        );
-        calls.push({ url, headers });
-        return new Response(
-          JSON.stringify(
-            makeYdsPayload({
-              positions: {},
-              accounts: { noble: 3 },
-            }),
-          ),
-          {
-            headers: { 'content-type': 'application/json' },
-          },
-        );
-      },
-    },
-    {
-      ydsUrl: 'https://yds.example.test/api',
-      ydsApiKey: 'secret',
-      retries: 0,
-    },
-  );
-
-  t.deepEqual(await reader('portfolio7', brand), {
-    '@noble': { brand, value: 3_000_000n },
-  });
-  t.is(calls.length, 1);
-  t.is(calls[0].url, 'https://yds.example.test/api/portfolios/portfolio7');
-  t.is(calls[0].headers.get('x-resolver-auth-key'), 'secret');
 });


### PR DESCRIPTION
Ref #12753
Ref PAK-523
Ref AGO-660

## Description
* Stop querying for portfolio flows vstorage child nodes (not necessary now that status is in the portfolio status data, cf. #12753)
* Fetch balance snapshots for multiple portfolios at once

### Security Considerations
None known

### Scaling Considerations
Multiple O(n) request patterns are being addressed (one eliminated, the rest replaced with O(1) analogs).

### Documentation Considerations
n/a

### Testing Considerations
Covered by unit tests and verified with a local ymax0 planner in dry-run mode.

### Upgrade Considerations
Depends upon contract changes from #12753.