### PR TITLE
fix(internal): XS-safe hex decoding table (bounded loop) + Bufferish codec validation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,8 @@ export default [
       // XXX outside the project service
       'packages/eslint-config',
       'packages/eslint-plugin',
+      // Standalone benchmark scripts, not part of the package's tsconfig project
+      'packages/internal/benchmark/',
       'services/ymax-planner/esbuild.config.mjs',
       '.github',
       '.yarn',

--- a/packages/internal/benchmark/README.md
+++ b/packages/internal/benchmark/README.md
@@ -1,0 +1,62 @@
+# hex decode benchmark: Map accelerator vs arithmetic
+
+This benchmark empirically tests whether the 484-entry `Map` "accelerator" that
+`packages/internal/src/hex.js` builds for `makePortableHexCodec().decodeHex` is
+actually faster than a table-free arithmetic decode, on **Node.js (V8, JIT)**
+and on **XS (xsnap, interpreted and metered)**. On the consensus engine the
+metered compute cost, not wall-clock, is what a contract pays, so the XS runner
+reports both.
+
+## The approaches
+
+- **`map`** — the Agoric-internal accelerator. A `Map` keyed by the 2-char hex
+  string, with all four lower/UPPER permutations of every byte pre-inserted
+  (484 distinct keys). Decode does `hex.slice(i, i+2)` then `decodings.get(...)`
+  per byte. Mirrors `makePortableHexCodec` at commit `47b701c`.
+- **`arith`** — `@endo/hex`'s `jsDecodeHex`: pure `charCodeAt` nibble arithmetic
+  in a bounded loop, no table.
+- **`lut`** — a third design the report weighs: a 256-entry `charCode -> nibble`
+  `Uint8Array` lookup table. No `Map`, no per-byte string slice, native
+  typed-array indexing.
+- **`buffer`** (Node only) — `Buffer.from(hex, 'hex')`, the path the internal
+  codec actually takes when `Buffer` is present (`makeBufferishHexCodec`).
+- **`native`** (Node only, when present) — the TC39 `Uint8Array.fromHex`
+  intrinsic `@endo/hex`'s `decodeHex` prefers. Absent on Node 22.23.
+
+## Files
+
+- `hex-decode-bench-core.js` — engine-agnostic core: both decoders, a
+  deterministic LCG corpus builder, a correctness check, and the timed loop. No
+  imports; the identical source runs on Node and XS. **No `flatMap` anywhere**:
+  every table and corpus is built with a bounded `for` loop, since `flatMap`
+  table construction is the XS metered-stack hazard PR #7 fixed.
+- `hex-decode-bench-node.mjs` — Node runner. Auto-calibrates iterations, warms
+  up, and reports ns/op and MB/s.
+- `hex-decode-bench-xs.mjs` — XS runner. Drives a prebuilt `xsnap-worker` over
+  its netstring protocol and reports both wall-clock per decode and metered
+  `compute` per decode (an `empty` baseline loop is subtracted out).
+
+## Running
+
+```sh
+node packages/internal/benchmark/hex-decode-bench-node.mjs
+
+# XS needs an exec-capable xsnap-worker (many sandboxes mount /tmp noexec, so
+# copy the cached prebuilt to an exec path first):
+XSNAP_WORKER=/path/to/xsnap-worker \
+  node packages/internal/benchmark/hex-decode-bench-xs.mjs
+```
+
+Both runners assert that `map`, `arith`, and `lut` decode byte-for-byte
+identically (including mixed case) before any timing.
+
+## Methodology
+
+- Inputs are deterministic (a seeded LCG), identical across approaches and
+  engines, at three sizes (8 B, 1 KiB, 16 KiB) and three case modes (lower,
+  UPPER, mixed) so the `Map`'s four-permutation reason-for-existing is actually
+  exercised.
+- The corpus and the `Map` are built **outside** the timed loop; the one-time
+  table build cost is reported separately (wall on Node, metered compute on XS).
+- Only the decode call is timed. A checksum of each result is accumulated so
+  neither engine can eliminate the loop as dead code.

--- a/packages/internal/benchmark/hex-decode-bench-core.js
+++ b/packages/internal/benchmark/hex-decode-bench-core.js
@@ -65,7 +65,9 @@
   // Verbatim algorithm from packages/hex/src/decode.js.
   const arithDecodeHex = string => {
     if (string.length % 2 !== 0) {
-      throw new Error(`Hex string must have an even length, got ${string.length}`);
+      throw new Error(
+        `Hex string must have an even length, got ${string.length}`,
+      );
     }
     const bytes = new Uint8Array(string.length / 2);
     for (let i = 0; i < bytes.length; i += 1) {
@@ -86,7 +88,9 @@
         if (x >= 97 && x <= 102) lo = x - 87;
       }
       if (hi < 0 || lo < 0) {
-        throw new Error(`Invalid hex character at offset ${hi < 0 ? i * 2 : i * 2 + 1}`);
+        throw new Error(
+          `Invalid hex character at offset ${hi < 0 ? i * 2 : i * 2 + 1}`,
+        );
       }
       bytes[i] = (hi << 4) | lo;
     }
@@ -114,7 +118,9 @@
       const hi = cHi < 256 ? nibbleLut[cHi] : 0xff;
       const lo = cLo < 256 ? nibbleLut[cLo] : 0xff;
       if (hi === 0xff || lo === 0xff) {
-        throw new Error(`invalid hex char at ${hi === 0xff ? i * 2 : i * 2 + 1}`);
+        throw new Error(
+          `invalid hex char at ${hi === 0xff ? i * 2 : i * 2 + 1}`,
+        );
       }
       bytes[i] = (hi << 4) | lo;
     }
@@ -182,13 +188,20 @@
       const a = mapDecodeHex(decodings, hex);
       const b = arithDecodeHex(hex);
       const c = lutDecodeHex(hex);
-      if (a.length !== expected.length || b.length !== expected.length || c.length !== expected.length) {
+      if (
+        a.length !== expected.length ||
+        b.length !== expected.length ||
+        c.length !== expected.length
+      ) {
         throw new Error(`length mismatch on ${key}`);
       }
       for (let i = 0; i < expected.length; i += 1) {
-        if (a[i] !== expected[i]) throw new Error(`map decode wrong at ${i} on ${key}`);
-        if (b[i] !== expected[i]) throw new Error(`arith decode wrong at ${i} on ${key}`);
-        if (c[i] !== expected[i]) throw new Error(`lut decode wrong at ${i} on ${key}`);
+        if (a[i] !== expected[i])
+          throw new Error(`map decode wrong at ${i} on ${key}`);
+        if (b[i] !== expected[i])
+          throw new Error(`arith decode wrong at ${i} on ${key}`);
+        if (c[i] !== expected[i])
+          throw new Error(`lut decode wrong at ${i} on ${key}`);
       }
       return 'OK';
     },

--- a/packages/internal/benchmark/hex-decode-bench-core.js
+++ b/packages/internal/benchmark/hex-decode-bench-core.js
@@ -1,0 +1,228 @@
+/* eslint-disable no-bitwise */
+/**
+ * Engine-agnostic core for the hex-decode benchmark. Defines the two decoders
+ * under test, a deterministic input-corpus builder, and a timed decode loop,
+ * all attached to `globalThis.hexbench`.
+ *
+ * This file has NO imports and uses only ES features that both V8 (Node) and
+ * XS (xsnap) accept, so the identical source runs on both engines: the Node
+ * runner evaluates it in-process, and the XS runner feeds the same text to a
+ * prebuilt xsnap-worker over the netstring protocol.
+ *
+ * IMPORTANT: no `flatMap` anywhere. PR #7 exists because building the decoder
+ * table with `encodings.flatMap(...) -> new Map(...)` materializes ~1024 live
+ * pair-arrays and overflows the XS metered value stack. Every table and corpus
+ * here is built with a bounded `for` loop so the benchmark cannot reintroduce
+ * the very hazard it measures.
+ */
+
+/* global globalThis */
+
+(() => {
+  // --- The two approaches under test -------------------------------------
+
+  // Agoric-internal "accelerator": a Map keyed by the 2-char hex string, with
+  // all four lower/UPPER permutations of every byte pre-inserted. Mirrors
+  // packages/internal/src/hex.js makePortableHexCodec at commit 47b701c.
+  const buildMapDecoder = () => {
+    const encodings = [];
+    for (let b = 0; b < 256; b += 1) {
+      let s = b.toString(16);
+      if (s.length < 2) s = `0${s}`;
+      encodings.push(s);
+    }
+    const decodings = new Map();
+    for (let b = 0; b < 256; b += 1) {
+      const hexdigits = encodings[b];
+      const lo = hexdigits.toLowerCase();
+      const UP = hexdigits.toUpperCase();
+      decodings.set(lo, b);
+      decodings.set(`${lo[0]}${UP[1]}`, b);
+      decodings.set(`${UP[0]}${lo[1]}`, b);
+      decodings.set(UP, b);
+    }
+    return { encodings, decodings };
+  };
+
+  // Map lookup by 2-char hex slice (the accelerator decode path).
+  const mapDecodeHex = (decodings, hex) => {
+    const inputLen = hex.length;
+    if (inputLen % 2 !== 0) {
+      throw new Error(`Invalid hex string: ${hex}`);
+    }
+    const buf = new Uint8Array(inputLen / 2);
+    for (let i = 0; i < inputLen; i += 2) {
+      const b = decodings.get(hex.slice(i, i + 2));
+      if (b === undefined) {
+        throw new Error(`Invalid hex string: ${hex}`);
+      }
+      buf[i >> 1] = b;
+    }
+    return buf;
+  };
+
+  // Endo @endo/hex jsDecodeHex: pure charCodeAt nibble arithmetic, no table.
+  // Verbatim algorithm from packages/hex/src/decode.js.
+  const arithDecodeHex = string => {
+    if (string.length % 2 !== 0) {
+      throw new Error(`Hex string must have an even length, got ${string.length}`);
+    }
+    const bytes = new Uint8Array(string.length / 2);
+    for (let i = 0; i < bytes.length; i += 1) {
+      const cHi = string.charCodeAt(i * 2);
+      const cLo = string.charCodeAt(i * 2 + 1);
+      let hi = -1;
+      if (cHi >= 48 && cHi <= 57) {
+        hi = cHi - 48;
+      } else {
+        const x = cHi | 0x20;
+        if (x >= 97 && x <= 102) hi = x - 87;
+      }
+      let lo = -1;
+      if (cLo >= 48 && cLo <= 57) {
+        lo = cLo - 48;
+      } else {
+        const x = cLo | 0x20;
+        if (x >= 97 && x <= 102) lo = x - 87;
+      }
+      if (hi < 0 || lo < 0) {
+        throw new Error(`Invalid hex character at offset ${hi < 0 ? i * 2 : i * 2 + 1}`);
+      }
+      bytes[i] = (hi << 4) | lo;
+    }
+    return bytes;
+  };
+
+  // A third design the report weighs: a 256-entry charCode -> nibble lookup
+  // table held in a Uint8Array (0xff marks invalid). No Map, no per-byte
+  // string slice/hash, and indexing a small typed array is a cheap native op
+  // on both V8 and XS. Built with a bounded loop (no flatMap).
+  const nibbleLut = new Uint8Array(256);
+  for (let i = 0; i < 256; i += 1) nibbleLut[i] = 0xff;
+  for (let c = 48; c <= 57; c += 1) nibbleLut[c] = c - 48; // '0'-'9'
+  for (let c = 97; c <= 102; c += 1) nibbleLut[c] = c - 87; // 'a'-'f'
+  for (let c = 65; c <= 70; c += 1) nibbleLut[c] = c - 55; // 'A'-'F'
+
+  const lutDecodeHex = string => {
+    if (string.length % 2 !== 0) {
+      throw new Error(`odd length ${string.length}`);
+    }
+    const bytes = new Uint8Array(string.length / 2);
+    for (let i = 0; i < bytes.length; i += 1) {
+      const cHi = string.charCodeAt(i * 2);
+      const cLo = string.charCodeAt(i * 2 + 1);
+      const hi = cHi < 256 ? nibbleLut[cHi] : 0xff;
+      const lo = cLo < 256 ? nibbleLut[cLo] : 0xff;
+      if (hi === 0xff || lo === 0xff) {
+        throw new Error(`invalid hex char at ${hi === 0xff ? i * 2 : i * 2 + 1}`);
+      }
+      bytes[i] = (hi << 4) | lo;
+    }
+    return bytes;
+  };
+
+  // --- Deterministic corpus (no Math.random, no flatMap) -----------------
+
+  // A small LCG so both engines and every run see byte-for-byte identical
+  // inputs. Seed in, pseudo-random bytes out.
+  const makeBytes = (n, seed) => {
+    const out = new Uint8Array(n);
+    let s = seed >>> 0;
+    for (let i = 0; i < n; i += 1) {
+      s = (Math.imul(s, 1103515245) + 12345) >>> 0;
+      out[i] = (s >>> 16) & 0xff;
+    }
+    return out;
+  };
+
+  const toHexLower = (bytes, encodings) => {
+    let acc = '';
+    for (let i = 0; i < bytes.length; i += 1) {
+      acc += encodings[bytes[i]];
+    }
+    return acc;
+  };
+
+  // lower | upper | mixed. "mixed" alternates case per character so every
+  // decode exercises a different one of the Map's four permutations and the
+  // arithmetic decoder's `| 0x20` case fold.
+  const caseVariant = (hexLower, mode) => {
+    if (mode === 'lower') return hexLower;
+    if (mode === 'upper') return hexLower.toUpperCase();
+    let out = '';
+    for (let i = 0; i < hexLower.length; i += 1) {
+      const c = hexLower[i];
+      out += i % 2 === 0 ? c.toUpperCase() : c.toLowerCase();
+    }
+    return out;
+  };
+
+  // --- State + entry points ----------------------------------------------
+
+  const { encodings, decodings } = buildMapDecoder();
+  const corpus = Object.create(null);
+
+  const api = {
+    tableSize: decodings.size,
+
+    // Build and store one corpus string under `key`, outside any timed loop.
+    makeCorpus: (key, nbytes, mode, seed) => {
+      const bytes = makeBytes(nbytes, seed);
+      const hex = caseVariant(toHexLower(bytes, encodings), mode);
+      corpus[key] = hex;
+      return hex.length;
+    },
+
+    // Confirm both decoders agree with each other (and that they actually
+    // decode the bytes the corpus was built from) before any timing. Returns
+    // 'OK' or throws.
+    checkCorrectness: (key, nbytes, seed) => {
+      const expected = makeBytes(nbytes, seed);
+      const hex = corpus[key];
+      const a = mapDecodeHex(decodings, hex);
+      const b = arithDecodeHex(hex);
+      const c = lutDecodeHex(hex);
+      if (a.length !== expected.length || b.length !== expected.length || c.length !== expected.length) {
+        throw new Error(`length mismatch on ${key}`);
+      }
+      for (let i = 0; i < expected.length; i += 1) {
+        if (a[i] !== expected[i]) throw new Error(`map decode wrong at ${i} on ${key}`);
+        if (b[i] !== expected[i]) throw new Error(`arith decode wrong at ${i} on ${key}`);
+        if (c[i] !== expected[i]) throw new Error(`lut decode wrong at ${i} on ${key}`);
+      }
+      return 'OK';
+    },
+
+    // The timed kernel. `approach` is 'map' | 'arith' | 'empty'. 'empty' is a
+    // loop that touches the corpus but does not decode, to measure call/loop
+    // overhead that is subtracted out of the XS metered numbers. Returns a
+    // checksum so neither engine can eliminate the loop as dead code.
+    decodeLoop: (approach, key, iters) => {
+      const hex = corpus[key];
+      let sink = 0;
+      if (approach === 'map') {
+        for (let k = 0; k < iters; k += 1) {
+          const out = mapDecodeHex(decodings, hex);
+          sink = (sink + out[0] + out[out.length - 1]) & 0xffff;
+        }
+      } else if (approach === 'arith') {
+        for (let k = 0; k < iters; k += 1) {
+          const out = arithDecodeHex(hex);
+          sink = (sink + out[0] + out[out.length - 1]) & 0xffff;
+        }
+      } else if (approach === 'lut') {
+        for (let k = 0; k < iters; k += 1) {
+          const out = lutDecodeHex(hex);
+          sink = (sink + out[0] + out[out.length - 1]) & 0xffff;
+        }
+      } else {
+        for (let k = 0; k < iters; k += 1) {
+          sink = (sink + hex.length + hex.charCodeAt(0)) & 0xffff;
+        }
+      }
+      return sink;
+    },
+  };
+
+  globalThis.hexbench = api;
+})();

--- a/packages/internal/benchmark/hex-decode-bench-node.mjs
+++ b/packages/internal/benchmark/hex-decode-bench-node.mjs
@@ -72,7 +72,8 @@ const localCorpus = Object.create(null);
     if (mode === 'lower') return s;
     if (mode === 'upper') return s.toUpperCase();
     let out = '';
-    for (let i = 0; i < s.length; i += 1) out += i % 2 === 0 ? s[i].toUpperCase() : s[i];
+    for (let i = 0; i < s.length; i += 1)
+      out += i % 2 === 0 ? s[i].toUpperCase() : s[i];
     return out;
   };
   for (const { name, bytes } of SIZES) {
@@ -127,10 +128,26 @@ const timeOp = run => {
 };
 
 const APPROACHES = [
-  { key: 'map', label: 'Map accelerator (internal)', run: (key, n) => hexbench.decodeLoop('map', key, n) },
-  { key: 'arith', label: 'Arithmetic (@endo/hex jsDecodeHex)', run: (key, n) => hexbench.decodeLoop('arith', key, n) },
-  { key: 'lut', label: 'charCode Uint8Array LUT', run: (key, n) => hexbench.decodeLoop('lut', key, n) },
-  { key: 'buffer', label: 'Buffer.from (internal on Node)', run: (key, n) => localLoop(bufferDecodeHex, key, n) },
+  {
+    key: 'map',
+    label: 'Map accelerator (internal)',
+    run: (key, n) => hexbench.decodeLoop('map', key, n),
+  },
+  {
+    key: 'arith',
+    label: 'Arithmetic (@endo/hex jsDecodeHex)',
+    run: (key, n) => hexbench.decodeLoop('arith', key, n),
+  },
+  {
+    key: 'lut',
+    label: 'charCode Uint8Array LUT',
+    run: (key, n) => hexbench.decodeLoop('lut', key, n),
+  },
+  {
+    key: 'buffer',
+    label: 'Buffer.from (internal on Node)',
+    run: (key, n) => localLoop(bufferDecodeHex, key, n),
+  },
 ];
 if (nativeFromHex) {
   APPROACHES.push({
@@ -154,12 +171,17 @@ const buildReps = 200;
   // Restore the canonical hexbench after the rebuild loop.
   (0, eval)(coreSrc);
   for (const { name, bytes } of SIZES) {
-    for (const mode of MODES) globalThis.hexbench.makeCorpus(`${name}-${mode}`, bytes, mode, SEED);
+    for (const mode of MODES)
+      globalThis.hexbench.makeCorpus(`${name}-${mode}`, bytes, mode, SEED);
   }
   // eslint-disable-next-line no-console
-  console.log(`\n# Table build cost (Map accelerator, ${globalThis.hexbench.tableSize}-entry Map)`);
+  console.log(
+    `\n# Table build cost (Map accelerator, ${globalThis.hexbench.tableSize}-entry Map)`,
+  );
   // eslint-disable-next-line no-console
-  console.log(`  core-eval incl. 484-entry table build: ~${(best / 1000).toFixed(1)} us per realm init\n`);
+  console.log(
+    `  core-eval incl. 484-entry table build: ~${(best / 1000).toFixed(1)} us per realm init\n`,
+  );
 }
 
 // --- Run ---------------------------------------------------------------------
@@ -172,7 +194,16 @@ for (const { name, bytes } of SIZES) {
       const { nsPerOp, iters } = timeOp(n => a.run(key, n));
       const nsPerByte = nsPerOp / bytes;
       const mbPerSec = 1e3 / nsPerByte; // bytes/ns -> MB/s
-      results.push({ size: name, bytes, mode, approach: a.key, nsPerOp, nsPerByte, mbPerSec, iters });
+      results.push({
+        size: name,
+        bytes,
+        mode,
+        approach: a.key,
+        nsPerOp,
+        nsPerByte,
+        mbPerSec,
+        iters,
+      });
     }
   }
 }
@@ -182,7 +213,9 @@ for (const { name, bytes } of SIZES) {
 const fmt = (n, w) => String(n).padStart(w);
 const pad = (s, w) => String(s).padEnd(w);
 // eslint-disable-next-line no-console
-console.log('# Node.js hex decode (ns/op, lower is better; MB/s, higher is better)\n');
+console.log(
+  '# Node.js hex decode (ns/op, lower is better; MB/s, higher is better)\n',
+);
 // eslint-disable-next-line no-console
 console.log(`node ${process.version}, V8 ${process.versions.v8}\n`);
 let header = `${pad('size', 8)}${pad('mode', 7)}`;
@@ -193,7 +226,9 @@ for (const { name } of SIZES) {
   for (const mode of MODES) {
     let row = `${pad(name, 8)}${pad(mode, 7)}`;
     for (const a of APPROACHES) {
-      const r = results.find(x => x.size === name && x.mode === mode && x.approach === a.key);
+      const r = results.find(
+        x => x.size === name && x.mode === mode && x.approach === a.key,
+      );
       row += pad(`${r.nsPerOp.toFixed(0)}`, 12);
     }
     // eslint-disable-next-line no-console
@@ -208,7 +243,9 @@ for (const { name } of SIZES) {
   for (const mode of MODES) {
     let row = `${pad(name, 8)}${pad(mode, 7)}`;
     for (const a of APPROACHES) {
-      const r = results.find(x => x.size === name && x.mode === mode && x.approach === a.key);
+      const r = results.find(
+        x => x.size === name && x.mode === mode && x.approach === a.key,
+      );
       row += pad(`${r.mbPerSec.toFixed(1)}`, 12);
     }
     // eslint-disable-next-line no-console
@@ -218,5 +255,7 @@ for (const { name } of SIZES) {
 
 // Machine-readable for the report.
 // eslint-disable-next-line no-console
-console.log(`\n#JSON ${JSON.stringify({ engine: 'node', version: process.version, tableSize: globalThis.hexbench.tableSize, results })}`);
+console.log(
+  `\n#JSON ${JSON.stringify({ engine: 'node', version: process.version, tableSize: globalThis.hexbench.tableSize, results })}`,
+);
 void fmt;

--- a/packages/internal/benchmark/hex-decode-bench-node.mjs
+++ b/packages/internal/benchmark/hex-decode-bench-node.mjs
@@ -1,0 +1,222 @@
+/* eslint-disable no-bitwise */
+/**
+ * Node.js (V8, JIT) runner for the hex-decode benchmark.
+ *
+ * Loads the engine-agnostic core (the Map accelerator decode and the Endo
+ * arithmetic decode), asserts both decode identically across lower/UPPER/mixed
+ * case, then times each approach across several input sizes with warmup and
+ * auto-calibrated iteration counts. Also measures two Node-only data points:
+ * the Node `Buffer.from(hex,'hex')` path that the internal codec actually uses
+ * when `Buffer` is present, and the native `Uint8Array.fromHex` intrinsic that
+ * @endo/hex prefers when the platform ships it.
+ *
+ * Run: node packages/internal/benchmark/hex-decode-bench-node.mjs
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const coreSrc = readFileSync(`${here}hex-decode-bench-core.js`, 'utf8');
+// Evaluate the core in this realm; it installs globalThis.hexbench.
+// eslint-disable-next-line no-eval
+(0, eval)(coreSrc);
+const { hexbench } = globalThis;
+
+const SIZES = [
+  { name: 'short', bytes: 8 },
+  { name: 'medium', bytes: 1024 },
+  { name: 'large', bytes: 16384 },
+];
+const MODES = ['lower', 'upper', 'mixed'];
+const SEED = 0x1234abcd;
+
+// Build the corpus and check correctness BEFORE any timing.
+for (const { name, bytes } of SIZES) {
+  for (const mode of MODES) {
+    const key = `${name}-${mode}`;
+    hexbench.makeCorpus(key, bytes, mode, SEED);
+    hexbench.checkCorrectness(key, bytes, SEED);
+  }
+}
+
+// --- Node-only decoders, timed with the same harness -------------------------
+
+const bufferDecodeHex = hex => {
+  if (hex.length % 2 !== 0) throw new Error('odd length');
+  const b = Buffer.from(hex, 'hex');
+  if (b.byteLength !== hex.length / 2) throw new Error('invalid hex');
+  return new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
+};
+const nativeFromHex =
+  typeof (/** @type {any} */ (Uint8Array).fromHex) === 'function'
+    ? hex => Uint8Array.fromHex(hex)
+    : undefined;
+
+// Corpus mirror in this realm for the Node-only loops (the core keeps its own
+// private copy; we rebuild identical strings here).
+const localCorpus = Object.create(null);
+{
+  const makeBytes = (n, seed) => {
+    const out = new Uint8Array(n);
+    let s = seed >>> 0;
+    for (let i = 0; i < n; i += 1) {
+      s = (Math.imul(s, 1103515245) + 12345) >>> 0;
+      out[i] = (s >>> 16) & 0xff;
+    }
+    return out;
+  };
+  const enc = [];
+  for (let b = 0; b < 256; b += 1) enc.push(b.toString(16).padStart(2, '0'));
+  const caseVariant = (s, mode) => {
+    if (mode === 'lower') return s;
+    if (mode === 'upper') return s.toUpperCase();
+    let out = '';
+    for (let i = 0; i < s.length; i += 1) out += i % 2 === 0 ? s[i].toUpperCase() : s[i];
+    return out;
+  };
+  for (const { name, bytes } of SIZES) {
+    for (const mode of MODES) {
+      const by = makeBytes(bytes, SEED);
+      let hex = '';
+      for (let i = 0; i < by.length; i += 1) hex += enc[by[i]];
+      localCorpus[`${name}-${mode}`] = caseVariant(hex, mode);
+    }
+  }
+}
+
+const localLoop = (fn, key, iters) => {
+  const hex = localCorpus[key];
+  let sink = 0;
+  for (let k = 0; k < iters; k += 1) {
+    const out = fn(hex);
+    sink = (sink + out[0] + out[out.length - 1]) & 0xffff;
+  }
+  return sink;
+};
+
+// --- Timing harness ----------------------------------------------------------
+
+const now = () => Number(process.hrtime.bigint());
+const TARGET_NS = 350e6; // grow iterations until a measured run exceeds this
+
+// Auto-calibrate iters so the timed region runs ~TARGET_NS, then take the best
+// (minimum ns/op) of several measured reps to reject scheduler noise.
+const timeOp = run => {
+  // Warmup + calibrate.
+  let iters = 64;
+  for (;;) {
+    const t0 = now();
+    run(iters);
+    const dt = now() - t0;
+    if (dt >= TARGET_NS || iters >= 1 << 30) break;
+    const scale = Math.max(2, Math.min(16, TARGET_NS / Math.max(dt, 1)));
+    iters = Math.ceil(iters * scale);
+  }
+  // A couple more warmup passes at the chosen size.
+  run(iters);
+  run(iters);
+  let best = Infinity;
+  for (let rep = 0; rep < 5; rep += 1) {
+    const t0 = now();
+    run(iters);
+    const dt = now() - t0;
+    best = Math.min(best, dt / iters);
+  }
+  return { nsPerOp: best, iters };
+};
+
+const APPROACHES = [
+  { key: 'map', label: 'Map accelerator (internal)', run: (key, n) => hexbench.decodeLoop('map', key, n) },
+  { key: 'arith', label: 'Arithmetic (@endo/hex jsDecodeHex)', run: (key, n) => hexbench.decodeLoop('arith', key, n) },
+  { key: 'lut', label: 'charCode Uint8Array LUT', run: (key, n) => hexbench.decodeLoop('lut', key, n) },
+  { key: 'buffer', label: 'Buffer.from (internal on Node)', run: (key, n) => localLoop(bufferDecodeHex, key, n) },
+];
+if (nativeFromHex) {
+  APPROACHES.push({
+    key: 'native',
+    label: 'Uint8Array.fromHex (native)',
+    run: (key, n) => localLoop(nativeFromHex, key, n),
+  });
+}
+
+// One-time table build cost (the accelerator's fixed overhead).
+const buildReps = 200;
+{
+  // Warmup
+  for (let i = 0; i < 20; i += 1) (0, eval)(coreSrc);
+  let best = Infinity;
+  for (let rep = 0; rep < 5; rep += 1) {
+    const t0 = now();
+    for (let i = 0; i < buildReps; i += 1) (0, eval)(coreSrc);
+    best = Math.min(best, (now() - t0) / buildReps);
+  }
+  // Restore the canonical hexbench after the rebuild loop.
+  (0, eval)(coreSrc);
+  for (const { name, bytes } of SIZES) {
+    for (const mode of MODES) globalThis.hexbench.makeCorpus(`${name}-${mode}`, bytes, mode, SEED);
+  }
+  // eslint-disable-next-line no-console
+  console.log(`\n# Table build cost (Map accelerator, ${globalThis.hexbench.tableSize}-entry Map)`);
+  // eslint-disable-next-line no-console
+  console.log(`  core-eval incl. 484-entry table build: ~${(best / 1000).toFixed(1)} us per realm init\n`);
+}
+
+// --- Run ---------------------------------------------------------------------
+
+const results = [];
+for (const { name, bytes } of SIZES) {
+  for (const mode of MODES) {
+    const key = `${name}-${mode}`;
+    for (const a of APPROACHES) {
+      const { nsPerOp, iters } = timeOp(n => a.run(key, n));
+      const nsPerByte = nsPerOp / bytes;
+      const mbPerSec = 1e3 / nsPerByte; // bytes/ns -> MB/s
+      results.push({ size: name, bytes, mode, approach: a.key, nsPerOp, nsPerByte, mbPerSec, iters });
+    }
+  }
+}
+
+// --- Report ------------------------------------------------------------------
+
+const fmt = (n, w) => String(n).padStart(w);
+const pad = (s, w) => String(s).padEnd(w);
+// eslint-disable-next-line no-console
+console.log('# Node.js hex decode (ns/op, lower is better; MB/s, higher is better)\n');
+// eslint-disable-next-line no-console
+console.log(`node ${process.version}, V8 ${process.versions.v8}\n`);
+let header = `${pad('size', 8)}${pad('mode', 7)}`;
+for (const a of APPROACHES) header += pad(a.key, 12);
+// eslint-disable-next-line no-console
+console.log(header);
+for (const { name } of SIZES) {
+  for (const mode of MODES) {
+    let row = `${pad(name, 8)}${pad(mode, 7)}`;
+    for (const a of APPROACHES) {
+      const r = results.find(x => x.size === name && x.mode === mode && x.approach === a.key);
+      row += pad(`${r.nsPerOp.toFixed(0)}`, 12);
+    }
+    // eslint-disable-next-line no-console
+    console.log(row);
+  }
+}
+// eslint-disable-next-line no-console
+console.log('\n# Throughput MB/s\n');
+// eslint-disable-next-line no-console
+console.log(header);
+for (const { name } of SIZES) {
+  for (const mode of MODES) {
+    let row = `${pad(name, 8)}${pad(mode, 7)}`;
+    for (const a of APPROACHES) {
+      const r = results.find(x => x.size === name && x.mode === mode && x.approach === a.key);
+      row += pad(`${r.mbPerSec.toFixed(1)}`, 12);
+    }
+    // eslint-disable-next-line no-console
+    console.log(row);
+  }
+}
+
+// Machine-readable for the report.
+// eslint-disable-next-line no-console
+console.log(`\n#JSON ${JSON.stringify({ engine: 'node', version: process.version, tableSize: globalThis.hexbench.tableSize, results })}`);
+void fmt;

--- a/packages/internal/benchmark/hex-decode-bench-xs.mjs
+++ b/packages/internal/benchmark/hex-decode-bench-xs.mjs
@@ -10,21 +10,48 @@
  * a contract pays, so it is the number that decides whether the 484-entry Map
  * accelerator earns its keep.
  *
- * The worker path defaults to the cached agoric prebuilt; override with
- * XSNAP_WORKER. NOTE: many sandboxes mount /tmp noexec, so copy the worker to
- * an exec-capable path (for example under ~/.cache) before pointing this here.
+ * The worker path is resolved portably through `@agoric/xsnap`: we resolve the
+ * package via `import.meta.resolve` and then point at the prebuilt
+ * `xsnap-worker` in its dist layout (the same location `install-prebuilt`
+ * populates), so the benchmark finds the worker wherever `@agoric/xsnap` is
+ * installed in the workspace. Set XSNAP_WORKER to override with an explicit
+ * path. NOTE: many sandboxes mount /tmp noexec, so an overriding XSNAP_WORKER
+ * should point at an exec-capable location (for example under ~/.cache).
  *
- * Run: XSNAP_WORKER=/path/to/xsnap-worker \
+ * We resolve only the package's path (not its module graph) to avoid pulling
+ * the SES-dependent @agoric/xsnap runtime into this plain benchmark process.
+ *
+ * Run: node packages/internal/benchmark/hex-decode-bench-xs.mjs
+ *   or: XSNAP_WORKER=/path/to/xsnap-worker \
  *        node packages/internal/benchmark/hex-decode-bench-xs.mjs
  */
 
 import { spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { type as osType } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
-const WORKER =
-  process.env.XSNAP_WORKER ||
-  '/home/kris/.cache/agoric-sdk/xsnap/prebuilt/0.14.2/bundle/dist/linux-x64/release/xsnap-worker';
+// Platform directory under @agoric/xsnap's dist layout (matches the package's
+// own resolveXsnapWorkerPath mapping).
+const XSNAP_PLATFORM = { Linux: 'lin', Darwin: 'mac' }[osType()];
+if (XSNAP_PLATFORM === undefined) {
+  throw Error(`xsnap does not support platform ${osType()}`);
+}
+
+const resolveWorkerPath = () => {
+  if (process.env.XSNAP_WORKER) return process.env.XSNAP_WORKER;
+  // import.meta.resolve gives the URL of @agoric/xsnap's package.json; the
+  // prebuilt worker lives at xsnap-native/.../xsnap-worker beside it.
+  const pkgJsonUrl = import.meta.resolve('@agoric/xsnap/package.json');
+  return fileURLToPath(
+    new URL(
+      `./xsnap-native/xsnap/build/bin/${XSNAP_PLATFORM}/release/xsnap-worker`,
+      pkgJsonUrl,
+    ),
+  );
+};
+
+const WORKER = resolveWorkerPath();
 
 const here = fileURLToPath(new URL('.', import.meta.url));
 const coreSrc = readFileSync(`${here}hex-decode-bench-core.js`, 'utf8');

--- a/packages/internal/benchmark/hex-decode-bench-xs.mjs
+++ b/packages/internal/benchmark/hex-decode-bench-xs.mjs
@@ -66,7 +66,17 @@ const makeWorker = ({ meteringLimit }) => {
   const args = ['hexbench'];
   if (meteringLimit) args.push('-l', `${meteringLimit}`);
   const child = spawn(WORKER, args, {
-    stdio: ['ignore', 'inherit', 'inherit', 'pipe', 'pipe', 'ignore', 'ignore', 'ignore', 'ignore'],
+    stdio: [
+      'ignore',
+      'inherit',
+      'inherit',
+      'pipe',
+      'pipe',
+      'ignore',
+      'ignore',
+      'ignore',
+      'ignore',
+    ],
   });
   let pending = null;
   const reader = makeReader(msg => {
@@ -129,7 +139,11 @@ const buildRes = must(await w.evaluate(coreSrc));
 const tableBuildCompute = buildRes.meter ? buildRes.meter.compute : null;
 // xsnap's `e` reply carries the meter but not the completion value, so confirm
 // the table size by asserting inside XS (throws -> non-ok if it is not 484).
-must(await w.evaluate('if (hexbench.tableSize !== 484) throw Error("table size " + hexbench.tableSize)'));
+must(
+  await w.evaluate(
+    'if (hexbench.tableSize !== 484) throw Error("table size " + hexbench.tableSize)',
+  ),
+);
 const tableSize = 484;
 
 // Build + correctness-check every corpus before timing. checkCorrectness
@@ -137,8 +151,16 @@ const tableSize = 484;
 for (const { name, bytes } of SIZES) {
   for (const mode of MODES) {
     const key = `${name}-${mode}`;
-    must(await w.evaluate(`hexbench.makeCorpus(${JSON.stringify(key)}, ${bytes}, ${JSON.stringify(mode)}, ${SEED})`));
-    must(await w.evaluate(`hexbench.checkCorrectness(${JSON.stringify(key)}, ${bytes}, ${SEED})`));
+    must(
+      await w.evaluate(
+        `hexbench.makeCorpus(${JSON.stringify(key)}, ${bytes}, ${JSON.stringify(mode)}, ${SEED})`,
+      ),
+    );
+    must(
+      await w.evaluate(
+        `hexbench.checkCorrectness(${JSON.stringify(key)}, ${bytes}, ${SEED})`,
+      ),
+    );
   }
 }
 
@@ -170,7 +192,9 @@ for (const { name, bytes, iters } of SIZES) {
       const m = await measure(approach, key, iters);
       const wallPerOp = (m.wall - base.wall) / iters;
       const computePerOp =
-        m.compute != null && base.compute != null ? (m.compute - base.compute) / iters : null;
+        m.compute != null && base.compute != null
+          ? (m.compute - base.compute) / iters
+          : null;
       results.push({
         size: name,
         bytes,
@@ -191,14 +215,20 @@ w.close();
 
 const pad = (s, n) => String(s).padEnd(n);
 const find = (size, mode, approach) =>
-  results.find(r => r.size === size && r.mode === mode && r.approach === approach);
+  results.find(
+    r => r.size === size && r.mode === mode && r.approach === approach,
+  );
 
 // eslint-disable-next-line no-console
-console.log(`# XS (xsnap) hex decode\nworker: ${WORKER}\ntable: ${tableSize}-entry Map\n`);
+console.log(
+  `# XS (xsnap) hex decode\nworker: ${WORKER}\ntable: ${tableSize}-entry Map\n`,
+);
 // eslint-disable-next-line no-console
 console.log(`# Table build cost (one-time, at module instantiation)`);
 // eslint-disable-next-line no-console
-console.log(`  metered compute to build the 484-entry Map accelerator: ${tableBuildCompute}\n`);
+console.log(
+  `  metered compute to build the 484-entry Map accelerator: ${tableBuildCompute}\n`,
+);
 
 const APPROACHES = ['map', 'arith', 'lut'];
 const head = `${pad('size', 8)}${pad('mode', 7)}${APPROACHES.map(a => pad(a, 12)).join('')}${pad('map/arith', 10)}`;
@@ -209,10 +239,16 @@ console.log('# XS metered compute per decode (lower is better)\n');
 console.log(head);
 for (const { name } of SIZES) {
   for (const mode of MODES) {
-    const cells = APPROACHES.map(a => pad(find(name, mode, a).computePerOp.toFixed(0), 12)).join('');
-    const ratio = find(name, mode, 'map').computePerOp / find(name, mode, 'arith').computePerOp;
+    const cells = APPROACHES.map(a =>
+      pad(find(name, mode, a).computePerOp.toFixed(0), 12),
+    ).join('');
+    const ratio =
+      find(name, mode, 'map').computePerOp /
+      find(name, mode, 'arith').computePerOp;
     // eslint-disable-next-line no-console
-    console.log(`${pad(name, 8)}${pad(mode, 7)}${cells}${pad(`${ratio.toFixed(2)}x`, 10)}`);
+    console.log(
+      `${pad(name, 8)}${pad(mode, 7)}${cells}${pad(`${ratio.toFixed(2)}x`, 10)}`,
+    );
   }
 }
 
@@ -222,10 +258,16 @@ console.log('\n# XS wall-clock per decode, ns (lower is better)\n');
 console.log(head);
 for (const { name } of SIZES) {
   for (const mode of MODES) {
-    const cells = APPROACHES.map(a => pad(find(name, mode, a).wallPerOpNs.toFixed(0), 12)).join('');
-    const ratio = find(name, mode, 'map').wallPerOpNs / find(name, mode, 'arith').wallPerOpNs;
+    const cells = APPROACHES.map(a =>
+      pad(find(name, mode, a).wallPerOpNs.toFixed(0), 12),
+    ).join('');
+    const ratio =
+      find(name, mode, 'map').wallPerOpNs /
+      find(name, mode, 'arith').wallPerOpNs;
     // eslint-disable-next-line no-console
-    console.log(`${pad(name, 8)}${pad(mode, 7)}${cells}${pad(`${ratio.toFixed(2)}x`, 10)}`);
+    console.log(
+      `${pad(name, 8)}${pad(mode, 7)}${cells}${pad(`${ratio.toFixed(2)}x`, 10)}`,
+    );
   }
 }
 

--- a/packages/internal/benchmark/hex-decode-bench-xs.mjs
+++ b/packages/internal/benchmark/hex-decode-bench-xs.mjs
@@ -1,0 +1,235 @@
+/* eslint-disable no-bitwise */
+/**
+ * XS (xsnap) runner for the hex-decode benchmark.
+ *
+ * Drives a prebuilt agoric `xsnap-worker` over its fd-3/fd-4 netstring
+ * protocol (the same protocol @agoric/xsnap speaks), feeds it the identical
+ * engine-agnostic core used by the Node runner, then for each approach and
+ * input reports BOTH the XS wall-clock per decode AND the XS metered `compute`
+ * per decode. On the consensus engine the metered cost, not wall-clock, is what
+ * a contract pays, so it is the number that decides whether the 484-entry Map
+ * accelerator earns its keep.
+ *
+ * The worker path defaults to the cached agoric prebuilt; override with
+ * XSNAP_WORKER. NOTE: many sandboxes mount /tmp noexec, so copy the worker to
+ * an exec-capable path (for example under ~/.cache) before pointing this here.
+ *
+ * Run: XSNAP_WORKER=/path/to/xsnap-worker \
+ *        node packages/internal/benchmark/hex-decode-bench-xs.mjs
+ */
+
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const WORKER =
+  process.env.XSNAP_WORKER ||
+  '/home/kris/.cache/agoric-sdk/xsnap/prebuilt/0.14.2/bundle/dist/linux-x64/release/xsnap-worker';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const coreSrc = readFileSync(`${here}hex-decode-bench-core.js`, 'utf8');
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+const OK = '.'.charCodeAt(0);
+const ERROR = '!'.charCodeAt(0);
+const OK_SEPARATOR = 1;
+
+const frame = bytes => {
+  const head = enc.encode(`${bytes.length}:`);
+  const out = new Uint8Array(head.length + bytes.length + 1);
+  out.set(head, 0);
+  out.set(bytes, head.length);
+  out[out.length - 1] = ','.charCodeAt(0);
+  return out;
+};
+
+const makeReader = onMessage => {
+  let buf = Buffer.alloc(0);
+  return chunk => {
+    buf = Buffer.concat([buf, chunk]);
+    for (;;) {
+      const colon = buf.indexOf(0x3a);
+      if (colon < 0) return;
+      const len = Number(buf.subarray(0, colon).toString('ascii'));
+      const start = colon + 1;
+      const end = start + len;
+      if (buf.length < end + 1) return;
+      const payload = buf.subarray(start, end);
+      buf = buf.subarray(end + 1);
+      onMessage(Uint8Array.from(payload));
+    }
+  };
+};
+
+const makeWorker = ({ meteringLimit }) => {
+  const args = ['hexbench'];
+  if (meteringLimit) args.push('-l', `${meteringLimit}`);
+  const child = spawn(WORKER, args, {
+    stdio: ['ignore', 'inherit', 'inherit', 'pipe', 'pipe', 'ignore', 'ignore', 'ignore', 'ignore'],
+  });
+  let pending = null;
+  const reader = makeReader(msg => {
+    if (!pending) return;
+    const p = pending;
+    pending = null;
+    if (msg[0] === OK) {
+      const sep = msg.indexOf(OK_SEPARATOR, 1);
+      let meter = null;
+      if (sep > 1) {
+        try {
+          meter = JSON.parse(dec.decode(msg.subarray(1, sep)));
+        } catch {
+          meter = null;
+        }
+      }
+      const reply = sep < 0 ? msg.subarray(1) : msg.subarray(sep + 1);
+      p.resolve({ ok: true, meter, reply: dec.decode(reply) });
+    } else if (msg[0] === ERROR) {
+      p.resolve({ ok: false, error: dec.decode(msg.subarray(1)) });
+    } else {
+      p.resolve({ ok: false, error: `unknown reply ${dec.decode(msg)}` });
+    }
+  });
+  child.stdio[4].on('data', reader);
+  const toX = child.stdio[3];
+  const evaluate = code =>
+    new Promise(resolve => {
+      pending = { resolve };
+      toX.write(Buffer.from(frame(enc.encode(`e${code}`))));
+    });
+  const close = () => {
+    try {
+      child.kill();
+    } catch {
+      // ignore
+    }
+  };
+  return { evaluate, close };
+};
+
+const must = res => {
+  if (!res.ok) throw new Error(`XS eval failed: ${res.error}`);
+  return res;
+};
+
+const SIZES = [
+  { name: 'short', bytes: 8, iters: 4000 },
+  { name: 'medium', bytes: 1024, iters: 400 },
+  { name: 'large', bytes: 16384, iters: 40 },
+];
+const MODES = ['lower', 'upper', 'mixed'];
+const SEED = 0x1234abcd;
+
+const w = makeWorker({ meteringLimit: 2_000_000_000 });
+
+// Table build cost: the metered compute of evaluating the core (which builds
+// the 484-entry Map accelerator at module scope).
+const buildRes = must(await w.evaluate(coreSrc));
+const tableBuildCompute = buildRes.meter ? buildRes.meter.compute : null;
+// xsnap's `e` reply carries the meter but not the completion value, so confirm
+// the table size by asserting inside XS (throws -> non-ok if it is not 484).
+must(await w.evaluate('if (hexbench.tableSize !== 484) throw Error("table size " + hexbench.tableSize)'));
+const tableSize = 484;
+
+// Build + correctness-check every corpus before timing. checkCorrectness
+// throws inside XS on any mismatch, so an ok reply IS the pass signal.
+for (const { name, bytes } of SIZES) {
+  for (const mode of MODES) {
+    const key = `${name}-${mode}`;
+    must(await w.evaluate(`hexbench.makeCorpus(${JSON.stringify(key)}, ${bytes}, ${JSON.stringify(mode)}, ${SEED})`));
+    must(await w.evaluate(`hexbench.checkCorrectness(${JSON.stringify(key)}, ${bytes}, ${SEED})`));
+  }
+}
+
+// Measure one (approach,key) cell: median-ish wall over a few reps plus the
+// deterministic metered compute, both for the requested approach and the
+// 'empty' loop baseline so loop/call overhead is subtracted out.
+const measure = async (approach, key, iters) => {
+  const call = `hexbench.decodeLoop(${JSON.stringify(approach)}, ${JSON.stringify(key)}, ${iters})`;
+  // warmup
+  must(await w.evaluate(call));
+  let bestWall = Infinity;
+  let compute = null;
+  for (let rep = 0; rep < 4; rep += 1) {
+    const t0 = process.hrtime.bigint();
+    const r = must(await w.evaluate(call));
+    const dt = Number(process.hrtime.bigint() - t0);
+    bestWall = Math.min(bestWall, dt);
+    if (r.meter) compute = r.meter.compute;
+  }
+  return { wall: bestWall, compute };
+};
+
+const results = [];
+for (const { name, bytes, iters } of SIZES) {
+  for (const mode of MODES) {
+    const key = `${name}-${mode}`;
+    const base = await measure('empty', key, iters);
+    for (const approach of ['map', 'arith', 'lut']) {
+      const m = await measure(approach, key, iters);
+      const wallPerOp = (m.wall - base.wall) / iters;
+      const computePerOp =
+        m.compute != null && base.compute != null ? (m.compute - base.compute) / iters : null;
+      results.push({
+        size: name,
+        bytes,
+        mode,
+        approach,
+        iters,
+        wallPerOpNs: wallPerOp,
+        computePerOp,
+        computeTotal: m.compute,
+      });
+    }
+  }
+}
+
+w.close();
+
+// --- Report ------------------------------------------------------------------
+
+const pad = (s, n) => String(s).padEnd(n);
+const find = (size, mode, approach) =>
+  results.find(r => r.size === size && r.mode === mode && r.approach === approach);
+
+// eslint-disable-next-line no-console
+console.log(`# XS (xsnap) hex decode\nworker: ${WORKER}\ntable: ${tableSize}-entry Map\n`);
+// eslint-disable-next-line no-console
+console.log(`# Table build cost (one-time, at module instantiation)`);
+// eslint-disable-next-line no-console
+console.log(`  metered compute to build the 484-entry Map accelerator: ${tableBuildCompute}\n`);
+
+const APPROACHES = ['map', 'arith', 'lut'];
+const head = `${pad('size', 8)}${pad('mode', 7)}${APPROACHES.map(a => pad(a, 12)).join('')}${pad('map/arith', 10)}`;
+
+// eslint-disable-next-line no-console
+console.log('# XS metered compute per decode (lower is better)\n');
+// eslint-disable-next-line no-console
+console.log(head);
+for (const { name } of SIZES) {
+  for (const mode of MODES) {
+    const cells = APPROACHES.map(a => pad(find(name, mode, a).computePerOp.toFixed(0), 12)).join('');
+    const ratio = find(name, mode, 'map').computePerOp / find(name, mode, 'arith').computePerOp;
+    // eslint-disable-next-line no-console
+    console.log(`${pad(name, 8)}${pad(mode, 7)}${cells}${pad(`${ratio.toFixed(2)}x`, 10)}`);
+  }
+}
+
+// eslint-disable-next-line no-console
+console.log('\n# XS wall-clock per decode, ns (lower is better)\n');
+// eslint-disable-next-line no-console
+console.log(head);
+for (const { name } of SIZES) {
+  for (const mode of MODES) {
+    const cells = APPROACHES.map(a => pad(find(name, mode, a).wallPerOpNs.toFixed(0), 12)).join('');
+    const ratio = find(name, mode, 'map').wallPerOpNs / find(name, mode, 'arith').wallPerOpNs;
+    // eslint-disable-next-line no-console
+    console.log(`${pad(name, 8)}${pad(mode, 7)}${cells}${pad(`${ratio.toFixed(2)}x`, 10)}`);
+  }
+}
+
+// eslint-disable-next-line no-console
+console.log(
+  `\n#JSON ${JSON.stringify({ engine: 'xs', worker: WORKER, tableSize, tableBuildCompute, results })}`,
+);

--- a/packages/internal/src/hex.js
+++ b/packages/internal/src/hex.js
@@ -81,7 +81,21 @@ export const makeBufferishHexCodec = Bufferish => {
     encodeHex: buf =>
       (Bufferish.isBuffer?.(buf) ? buf : Bufferish.from(buf)).toString('hex'),
     decodeHex: hex => {
+      // `Bufferish.from(hex, 'hex')` silently drops invalid input rather than
+      // throwing: it ignores an odd-length trailing nibble and stops at the
+      // first non-hex character, returning the bytes parsed so far. Validate
+      // up front so this codec rejects the same inputs as the portable codec,
+      // throwing the identical `Invalid hex string: ${hex}` error.
+      if (hex.length % 2 !== 0) {
+        throw new Error(`Invalid hex string: ${hex}`);
+      }
       const buf = Bufferish.from(hex, 'hex');
+      // A complete parse consumes the whole string, yielding one byte per two
+      // input characters. A shorter result means a non-hex character was
+      // encountered and the tail was silently dropped.
+      if (buf.byteLength !== hex.length / 2) {
+        throw new Error(`Invalid hex string: ${hex}`);
+      }
 
       // Coerce to Uint8Array to avoid leaking the abstraction.
       const u8a = new Uint8Array(

--- a/packages/internal/src/hex.js
+++ b/packages/internal/src/hex.js
@@ -11,25 +11,28 @@ const encodings = Array.from({ length: 256 }, (_, b) =>
 );
 
 /**
- * Create map entries for all four permutations of lowercase and uppercase
- * transformations of the two hex digits per byte. The map is keyed by the hex
- * string and the value is the byte value. This allows for fast lookups when
- * decoding hex strings.
+ * Map every hex string to its byte value, keyed by all four permutations of
+ * lowercase and uppercase transformations of the two hex digits per byte. This
+ * allows for fast lookups when decoding hex strings.
+ *
+ * Built with a bounded `for` loop that inserts entries incrementally, rather
+ * than `encodings.flatMap(...)` feeding a 1024-element pair array into
+ * `new Map(...)`. On XS, constructing and spreading large intermediate arrays
+ * this way is a metered-stack hazard; incremental `set` keeps stack depth O(1)
+ * in the table size.
  *
  * @type {Map<string, number>}
  */
-const decodings = new Map(
-  encodings.flatMap((hexdigits, b) => {
-    const lo = hexdigits.toLowerCase();
-    const UP = hexdigits.toUpperCase();
-    return [
-      [lo, b],
-      [`${lo[0]}${UP[1]}`, b],
-      [`${UP[0]}${lo[1]}`, b],
-      [UP, b],
-    ];
-  }),
-);
+const decodings = new Map();
+for (let b = 0; b < encodings.length; b += 1) {
+  const hexdigits = encodings[b];
+  const lo = hexdigits.toLowerCase();
+  const UP = hexdigits.toUpperCase();
+  decodings.set(lo, b);
+  decodings.set(`${lo[0]}${UP[1]}`, b);
+  decodings.set(`${UP[0]}${lo[1]}`, b);
+  decodings.set(UP, b);
+}
 
 /**
  * Create a hex codec that is portable across standard JS environments.

--- a/packages/internal/test/hex.test.js
+++ b/packages/internal/test/hex.test.js
@@ -1,0 +1,92 @@
+// @ts-check
+import test from 'ava';
+
+import { makePortableHexCodec, makeBufferishHexCodec } from '../src/hex.js';
+
+/**
+ * The two codecs must be observationally equivalent: whichever one a platform
+ * selects, `encodeHex`/`decodeHex` must accept and reject the same inputs and
+ * produce the same bytes. The portable codec is the reference; the Bufferish
+ * codec is exercised through Node's real `Buffer`.
+ */
+/** @type {Array<[string, import('../src/hex.js').HexCodec]>} */
+const codecs = [
+  ['portable', makePortableHexCodec()],
+  ['bufferish', makeBufferishHexCodec(Buffer)],
+];
+
+/** @type {Array<[string, number[]]>} valid input -> expected bytes */
+const validCases = [
+  ['', []],
+  ['00', [0x00]],
+  ['41', [0x41]],
+  ['ff', [0xff]],
+  ['deadbeef', [0xde, 0xad, 0xbe, 0xef]],
+  ['DEADBEEF', [0xde, 0xad, 0xbe, 0xef]],
+  ['DeAdBeEf', [0xde, 0xad, 0xbe, 0xef]],
+  ['0a0B', [0x0a, 0x0b]],
+];
+
+/** Inputs both codecs must reject by throwing `Invalid hex string: ...`. */
+const invalidCases = [
+  'f', // odd length, single nibble
+  'abc', // odd length with a valid prefix
+  '012', // odd length
+  'zz', // non-hex characters
+  'GG', // non-hex uppercase
+  'gg', // non-hex lowercase
+  'xy', // non-hex characters
+  'abxc', // non-hex character mid-string
+  'abcx', // non-hex character at the tail of an even-length string
+  '12 34', // embedded whitespace
+  '0x41', // hex literal prefix is not valid hex
+];
+
+for (const [name, codec] of codecs) {
+  for (const [hex, bytes] of validCases) {
+    test(`${name} decodeHex accepts valid input ${JSON.stringify(hex)}`, t => {
+      t.deepEqual([...codec.decodeHex(hex)], bytes);
+    });
+  }
+
+  for (const hex of invalidCases) {
+    test(`${name} decodeHex rejects invalid input ${JSON.stringify(hex)}`, t => {
+      t.throws(() => codec.decodeHex(hex), {
+        message: `Invalid hex string: ${hex}`,
+      });
+    });
+  }
+
+  test(`${name} encodeHex round-trips and normalizes to lowercase`, t => {
+    for (const [hex] of validCases) {
+      const round = codec.encodeHex(codec.decodeHex(hex));
+      t.is(round, hex.toLowerCase());
+    }
+  });
+
+  test(`${name} decodeHex round-trips arbitrary bytes`, t => {
+    const all = Uint8Array.from({ length: 256 }, (_, b) => b);
+    t.deepEqual([...codec.decodeHex(codec.encodeHex(all))], [...all]);
+  });
+}
+
+test('both codecs agree on every accept/reject decision', t => {
+  const [, portable] = codecs[0];
+  const [, bufferish] = codecs[1];
+  for (const [hex] of validCases) {
+    t.deepEqual(
+      [...bufferish.decodeHex(hex)],
+      [...portable.decodeHex(hex)],
+      `accepted bytes disagree for ${JSON.stringify(hex)}`,
+    );
+  }
+  for (const hex of invalidCases) {
+    const portableThrew = t.throws(() => portable.decodeHex(hex));
+    const bufferishThrew = t.throws(() => bufferish.decodeHex(hex));
+    t.is(
+      bufferishThrew?.message,
+      portableThrew?.message,
+      `rejection message disagrees for ${JSON.stringify(hex)}`,
+    );
+  }
+});

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -27,7 +27,10 @@
         "**/dist",
         "**/docs",
         "**/vendor",
-        "**/*.umd.js"
+        "**/*.umd.js",
+        // Standalone benchmark scripts (engine-agnostic, intentionally untyped;
+        // run by hand, not part of the package's tsconfig project).
+        "packages/internal/benchmark"
     ],
     "include": [
         // .ts/.mts anywhere in the repo


### PR DESCRIPTION
## Summary

Two related fixes to the hex codec in `packages/internal/src/hex.js`, plus engine-comparison benchmarks.

## 1. XS stack safety — bounded-loop decoding table (headline)

The portable codec's `decodings` map was built by feeding a 1024-element pair array from `encodings.flatMap(...)` into `new Map(...)`. On XS, constructing and spreading large intermediate arrays this way is a metered-stack-overflow hazard. Replaced with a bounded `for` loop that inserts the four case permutations per byte incrementally, so stack depth is O(1) in the table size.

The resulting map is **byte-identical** to the old one — verified across all 256 byte values × all four lower/upper case permutations (1024 lookups; 484 unique entries). Decode/encode behavior is unchanged.

## 2. Bufferish codec validation consistency

`makeBufferishHexCodec().decodeHex` previously delegated to `Bufferish.from(hex, 'hex')`, which silently drops invalid input — it ignores an odd-length trailing nibble and stops at the first non-hex character, returning the bytes parsed so far. It now rejects odd-length and non-hex input by throwing the same `Invalid hex string: ${hex}` error as `makePortableHexCodec().decodeHex` (an up-front length check plus a complete-parse length check after decoding).

`packages/internal/test/hex.test.js` pins both codecs to identical accept/reject behavior, which is also what keeps the bounded-loop refactor honest.

## 3. Benchmarks (`packages/internal/benchmark/`)

Standalone, run-by-hand benchmark scripts comparing the Map-accelerator decode against an arithmetic decode on Node and XS. They are engine-agnostic and intentionally untyped, so `packages/internal/benchmark` is excluded from the repo-wide typecheck (`tsconfig.check.json`) and lint, matching how `packages/benchmark` is already handled.

The XS benchmark resolves the prebuilt xsnap-worker portably via `import.meta.resolve('@agoric/xsnap')` (pointing at the package's dist layout wherever `@agoric/xsnap` is installed in the workspace) rather than a hard-coded per-user path; `XSNAP_WORKER` remains as an explicit override.

## Testing

The hex codec change is import-free pure JS. Verified directly: the new bounded-loop table decodes byte-identically to the previous `flatMap`-built table across all 1024 case permutations, both codecs agree on round-trips, and both now reject the same invalid inputs (odd-length, non-hex) while accepting valid mixed-case.
