### PR TITLE
ci: Name the post-merge GitHub Actions workflow

### DIFF
--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -1,3 +1,5 @@
+name: Post-merge publishes/checks
+
 # Run after merge to trunk
 # Note that this relies on branch protection having:
 #  Require branches to be up to date before merging


### PR DESCRIPTION
So it shows up as something better than a path name at https://github.com/Agoric/agoric-sdk/actions .