### PR TITLE
feat(ymax-planner): Log recoveries after external fetch errors

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -898,16 +898,19 @@ export const startEngine = async (
 
   let instrumentBlocks: InstrumentBlocks | undefined;
   const updateInstrumentBlocks = async () => {
-    instrumentBlocks = await getInstrumentBlocks?.();
+    await null;
+    try {
+      instrumentBlocks = await getInstrumentBlocks?.();
+    } catch (err) {
+      console.error('🚨 [updateInstrumentBlocks]', err);
+    }
   };
 
   const [vbankAssetCapData] = await Promise.all([
     readStreamCellValue(query.vstorage, 'published.agoricNames.vbankAsset', {
       retries: 4,
     }),
-    updateInstrumentBlocks().catch(err =>
-      console.error('🚨 Failed to initialize instrument blocks', err),
-    ),
+    updateInstrumentBlocks(),
   ]);
   const vbankAssets: AssetInfo[] = marshaller
     .fromCapData(vbankAssetCapData)
@@ -924,26 +927,31 @@ export const startEngine = async (
   const { balanceCache, deferrals, portfolioRecordForKey } = portfoliosMemory;
 
   const updatePortfolioBalances = async () => {
-    const autoRebalancers = partialMap(
-      [...portfolioRecordForKey],
-      ([portfolioKey, record]) =>
-        record.status.enabledAutoFeatures?.rebalance && portfolioKey,
-    );
-    const summaries = await getPortfolioSummaries?.(autoRebalancers);
-    if (!summaries) return;
-    for (const { portfolioId, latestSnapshot } of summaries) {
-      if (!latestSnapshot) continue;
-
-      // This data might be more stale than that of our own balance queries.
-      const isoTimestamp = normalizeIsoTimestamp(latestSnapshot.ts);
-      const found = balanceCache.get(portfolioId);
-      if (found && found.isoTimestamp >= isoTimestamp) continue;
-
-      const balances = normalizeYdsPortfolioBalances(
-        latestSnapshot,
-        depositBrand,
+    await null;
+    try {
+      const autoRebalancers = partialMap(
+        [...portfolioRecordForKey],
+        ([portfolioKey, record]) =>
+          record.status.enabledAutoFeatures?.rebalance && portfolioKey,
       );
-      balanceCache.set(portfolioId, { isoTimestamp, balances });
+      const summaries = await getPortfolioSummaries?.(autoRebalancers);
+      if (!summaries) return;
+      for (const { portfolioId, latestSnapshot } of summaries) {
+        if (!latestSnapshot) continue;
+
+        // This data might be more stale than that of our own balance queries.
+        const isoTimestamp = normalizeIsoTimestamp(latestSnapshot.ts);
+        const found = balanceCache.get(portfolioId);
+        if (found && found.isoTimestamp >= isoTimestamp) continue;
+
+        const balances = normalizeYdsPortfolioBalances(
+          latestSnapshot,
+          depositBrand,
+        );
+        balanceCache.set(portfolioId, { isoTimestamp, balances });
+      }
+    } catch (err) {
+      console.error('🚨 [updatePortfolioBalances]', err);
     }
   };
 
@@ -1182,18 +1190,17 @@ export const startEngine = async (
     // Pending tx watchers must subscribe to EVM events ASAP to avoid missing
     // transactions, so process them concurrently with portfolio events.
     await Promise.all([
-      Promise.all([
-        updateInstrumentBlocks().catch(err =>
-          console.error('⚠️ Failed to update instrument blocks', err),
-        ),
-        updatePortfolioBalances().catch(err =>
-          console.error('⚠️ Failed to update portfolio balances', err),
-        ),
-      ]).then(() =>
-        processPortfolioEvents(portfolioEvents, respHeight, portfoliosMemory, {
-          ...processPortfolioPowers,
-          instrumentBlocks,
-        }),
+      Promise.all([updateInstrumentBlocks(), updatePortfolioBalances()]).then(
+        () =>
+          processPortfolioEvents(
+            portfolioEvents,
+            respHeight,
+            portfoliosMemory,
+            {
+              ...processPortfolioPowers,
+              instrumentBlocks,
+            },
+          ),
       ),
       processPendingTxEvents(pendingTxEvents, handlePendingTx, txPowers),
     ]);

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -66,6 +66,41 @@ import { makeNowISO } from './utils.ts';
 
 const { fromEntries, entries } = Object;
 
+// exported for testing
+export const makeHealthLogger = (console: Pick<Console, 'warn' | 'error'>) => {
+  const health = new Map<string, 'ok' | 'failed'>();
+  const withHealthLogging = async <T>(
+    key: string,
+    promise: Promise<T>,
+    logContext?: unknown,
+  ): Promise<T | undefined> => {
+    await null;
+    try {
+      const result = await promise;
+      if (health.get(key) === 'failed') console.warn(`Recovered ${key}`);
+      health.set(key, 'ok');
+      return result;
+    } catch (err) {
+      const { name, message } = err ?? {};
+      let alertMessage = health.has(key)
+        ? `⚠️ Failed to update ${key}`
+        : `🚨 Failed to initialize ${key}`;
+      // Include sufficient detail for line-oriented log propagation.
+      if (name && message) {
+        alertMessage = `${alertMessage}: [${name}] ${message}`;
+      }
+      if (logContext) {
+        console.error(alertMessage, logContext, err);
+      } else {
+        console.error(alertMessage, err);
+      }
+      health.set(key, 'failed');
+      return undefined;
+    }
+  };
+  return withHealthLogging;
+};
+
 const assertChainId = async (
   rpc: CosmosRPCClient,
   chainId: string,
@@ -99,6 +134,7 @@ const nowISO = makeNowISO(Date.now);
 export const main = async (
   cliArgs: string[],
   {
+    console = globalThis.console,
     env = process.env,
     fetch = globalThis.fetch,
     generateInterval = timersPromises.setInterval,
@@ -118,6 +154,7 @@ export const main = async (
   }).values;
   const makeMaybeLogger = (prefix: string): ((...args: unknown[]) => void) =>
     isVerbose ? (...args) => console.log(prefix, ...args) : () => {};
+  const withHealthLogging = makeHealthLogger(console);
 
   const makeAbortController = prepareAbortController({
     setTimeout,
@@ -288,18 +325,18 @@ export const main = async (
   });
 
   const ydsApiKey = config.yds.apiKey;
-  const ydsClient =
-    config.yds.url &&
-    ky.create({
-      fetch,
-      prefixUrl: config.yds.url,
-      headers: {
-        ...FETCH_HEADERS,
-        ...(ydsApiKey ? { 'x-resolver-auth-key': ydsApiKey } : undefined),
-      },
-      timeout: config.requestLimits.timeout,
-      retry: config.requestLimits.maxRetries,
-    });
+  const ydsClient = config.yds.url
+    ? ky.create({
+        fetch,
+        prefixUrl: config.yds.url,
+        headers: {
+          ...FETCH_HEADERS,
+          ...(ydsApiKey ? { 'x-resolver-auth-key': ydsApiKey } : undefined),
+        },
+        timeout: config.requestLimits.timeout,
+        retry: config.requestLimits.maxRetries,
+      })
+    : undefined;
 
   let lastInstrumentBlocksString = '';
   const stringifyInstrumentBlocks = (instrumentBlocks: InstrumentBlocks) => {
@@ -309,7 +346,12 @@ export const main = async (
   };
   const getInstrumentBlocks = ydsClient
     ? async (): Promise<InstrumentBlocks | undefined> => {
-        const resp = await ydsClient.get('instruments?includeAll=true').json();
+        const resp = await withHealthLogging(
+          'instruments',
+          ydsClient.get('instruments?includeAll=true').json(),
+          config.requestLimits,
+        );
+        if (!resp) return undefined;
         const instruments = (resp as any).data as YdsInstrument[];
         const instrumentBlocks = calculateInstrumentBlocks(instruments);
 
@@ -347,9 +389,13 @@ export const main = async (
             return lastPortfolios.summaries;
           }
 
-          const resp = await ydsClient
-            .post('portfolios:list', { json: { portfolioIds } })
-            .json();
+          const reqBody = { portfolioIds };
+          const resp = await withHealthLogging(
+            'portfolios',
+            ydsClient.post('portfolios:list', { json: reqBody }).json(),
+            config.requestLimits,
+          );
+          if (!resp) return undefined;
           const summaries = ((resp as any).data as YdsPortfolioSummary[]).sort(
             (a, b) => naturalCompare(a.portfolioId, b.portfolioId),
           );

--- a/services/ymax-planner/test/with-health-logging.test.ts
+++ b/services/ymax-planner/test/with-health-logging.test.ts
@@ -1,0 +1,171 @@
+import test from 'ava';
+import type { ExecutionContext } from 'ava';
+
+import { arrayIsLike } from '@agoric/internal/tools/ava-assertions.js';
+import { makeHealthLogger } from '../src/main.ts';
+
+type LogEntry = { level: 'log' | 'warn' | 'error'; args: unknown[] };
+const makeHealthLoggingKit = () => {
+  const output: LogEntry[] = [];
+  const withHealthLogging = makeHealthLogger({
+    warn: (...args) => {
+      output.push({ level: 'warn', args });
+    },
+    error: (...args) => {
+      output.push({ level: 'error', args });
+    },
+  });
+  return { withHealthLogging, output };
+};
+
+const assertResultAndLogs = async (
+  t: ExecutionContext,
+  message: string,
+  promise: Promise<unknown>,
+  expected: unknown,
+  getLogs: () => LogEntry[],
+  expectedLogs: LogEntry[],
+) => {
+  t.is(await promise, expected, `${message} result`);
+  const logs = getLogs();
+  arrayIsLike(t, logs, expectedLogs, `${message} logs`);
+};
+
+test('withHealthLogging logs status by key', async t => {
+  const { withHealthLogging, output } = makeHealthLoggingKit();
+
+  const result = 'result';
+  const goodP = Promise.resolve(result);
+  const err = Error('description');
+  const badP = Promise.reject(err);
+
+  await assertResultAndLogs(
+    t,
+    'good initialization',
+    withHealthLogging('foo', goodP),
+    result,
+    () => output.splice(0),
+    [],
+  );
+
+  await assertResultAndLogs(
+    t,
+    'bad initialization',
+    withHealthLogging('bar', badP),
+    undefined,
+    () => output.splice(0),
+    [
+      {
+        level: 'error',
+        args: ['🚨 Failed to initialize bar: [Error] description', err],
+      },
+    ],
+  );
+
+  await assertResultAndLogs(
+    t,
+    'bad initialization recovery',
+    withHealthLogging('bar', goodP),
+    result,
+    () => output.splice(0),
+    [
+      {
+        level: 'warn',
+        args: ['Recovered bar'],
+      },
+    ],
+  );
+
+  await assertResultAndLogs(
+    t,
+    'update failure',
+    withHealthLogging('foo', badP),
+    undefined,
+    () => output.splice(0),
+    [
+      {
+        level: 'error',
+        args: ['⚠️ Failed to update foo: [Error] description', err],
+      },
+    ],
+  );
+
+  await assertResultAndLogs(
+    t,
+    'interleaved success',
+    withHealthLogging('bar', goodP),
+    result,
+    () => output.splice(0),
+    [],
+  );
+
+  await assertResultAndLogs(
+    t,
+    'bad update recovery',
+    withHealthLogging('foo', goodP),
+    result,
+    () => output.splice(0),
+    [{ level: 'warn', args: ['Recovered foo'] }],
+  );
+
+  t.is(await withHealthLogging('foo', goodP), result);
+  t.is(await withHealthLogging('bar', goodP), result);
+  t.is(await withHealthLogging('bar', goodP), result);
+  t.is(await withHealthLogging('foo', goodP), result);
+  arrayIsLike(t, output, [], 'steady-state is quiet');
+});
+
+test('withHealthLogging failure logs include context', async t => {
+  const { withHealthLogging, output } = makeHealthLoggingKit();
+
+  const result = 'result';
+  const goodP = Promise.resolve(result);
+  const err = Error('description');
+  const badP = Promise.reject(err);
+  const logContext = {};
+
+  await assertResultAndLogs(
+    t,
+    'bad initialization',
+    withHealthLogging('foo', badP, logContext),
+    undefined,
+    () => output.splice(0),
+    [
+      {
+        level: 'error',
+        args: [
+          '🚨 Failed to initialize foo: [Error] description',
+          logContext,
+          err,
+        ],
+      },
+    ],
+  );
+
+  await withHealthLogging('bar', goodP, logContext);
+  await assertResultAndLogs(
+    t,
+    'bad update',
+    withHealthLogging('bar', badP, logContext),
+    undefined,
+    () => output.splice(0),
+    [
+      {
+        level: 'error',
+        args: ['⚠️ Failed to update bar: [Error] description', logContext, err],
+      },
+    ],
+  );
+
+  await withHealthLogging('foo', goodP, logContext);
+  await withHealthLogging('bar', goodP, logContext);
+  arrayIsLike(
+    t,
+    output,
+    [
+      { level: 'warn', args: ['Recovered foo'] },
+      { level: 'warn', args: ['Recovered bar'] },
+    ],
+    'recovery messages do not include context',
+  );
+});


### PR DESCRIPTION
## Description
Keep track of when external requests fail so we can log their subsequent recovery to suppress associated alerts.

### Security Considerations
None known.

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Will be tested by local execution.

### Upgrade Considerations
Safe for immediate deployment after testing.