### PR TITLE
fix(ymax-resolver): prevent one CCTP transfer from settling multiple pending txs

### DIFF
--- a/services/ymax-planner/src/kv-store.ts
+++ b/services/ymax-planner/src/kv-store.ts
@@ -187,3 +187,40 @@ export const deleteDerivedOutcome = (
 ): void => {
   store.delete(getDerivedOutcomeKey(txId));
 };
+
+const getConsumedTransferKey = (
+  chainId: string | undefined,
+  txHash: string,
+  logIndex: number | undefined,
+) => `consumedTransfer.${chainId}.${txHash}.${logIndex}`;
+
+/**
+ * Claim an on-chain transfer, identified by its unique `(chainId, txHash,
+ * logIndex)` fingerprint, for a single pending tx. This ensures that one
+ * physical transfer can never settle more than one pending tx: when several
+ * pending txs share the same `(destination, amount)` (e.g. two 5-USDC CCTP
+ * legs of one withdrawal), each must claim a distinct transfer before it may
+ * settle.
+ *
+ * Returns `true` if the caller now owns the transfer (it was unclaimed, or
+ * already claimed by the same `txId` — the re-watch-after-crash case), or
+ * `false` if a different `txId` already claimed it, in which case the caller
+ * must keep watching for the next matching transfer.
+ *
+ * Persisted so the "one transfer, one owner" guarantee survives planner
+ * restarts and lookback rescans; without persistence a restart would let a
+ * still-pending leg re-consume a transfer an already-settled leg had taken.
+ */
+export const claimTransferLog = (
+  store: KVStore,
+  chainId: string | undefined,
+  txHash: string,
+  logIndex: number | undefined,
+  txId: `tx${number}`,
+): boolean => {
+  const key = getConsumedTransferKey(chainId, txHash, logIndex);
+  const owner = store.get(key);
+  if (owner !== undefined && owner !== txId) return false;
+  store.set(key, txId);
+  return true;
+};

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -190,6 +190,7 @@ const cctpMonitor: PendingTxMonitor<CctpTx> = {
       toAddress: accountAddress as `0x${string}`,
       expectedAmount: amount,
       provider: rpc,
+      chainId: caipId,
       log: (msg, ...args) => log(logPrefix, msg, ...args),
     };
 
@@ -243,7 +244,6 @@ const cctpMonitor: PendingTxMonitor<CctpTx> = {
       transferResult = await lookBackCctp({
         ...watchArgs,
         publishTimeMs: opts.publishTimeMs,
-        chainId: caipId,
         setTimeout: ctx.setTimeout,
         signal: abortController.signal,
         kvStore: ctx.kvStore,

--- a/services/ymax-planner/src/watchers/cctp-watcher.ts
+++ b/services/ymax-planner/src/watchers/cctp-watcher.ts
@@ -12,6 +12,7 @@ import {
   type WatcherTimeoutOptions,
 } from '../evm-scanner.ts';
 import {
+  claimTransferLog,
   deleteTxBlockLowerBound,
   getTxBlockLowerBound,
   setTxBlockLowerBound,
@@ -48,6 +49,7 @@ type CctpWatch = {
   log?: (...args: unknown[]) => void;
   kvStore: KVStore;
   txId: `tx${number}`;
+  chainId?: CaipChainId;
 };
 
 const parseTransferLog = log => {
@@ -81,6 +83,9 @@ export const watchCctpTransfer = ({
   log = () => {},
   setTimeout = globalThis.setTimeout,
   signal,
+  kvStore,
+  txId,
+  chainId,
 }: CctpWatch & WatcherTimeoutOptions): Promise<WatcherResult> => {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
@@ -181,6 +186,22 @@ export const watchCctpTransfer = ({
       );
 
       if (amount === expectedAmount && usdcAddress === tokenAddr) {
+        // Claim this specific transfer so a single physical transfer cannot
+        // settle more than one pending tx sharing the same (destination,
+        // amount). If another leg already claimed it, keep watching.
+        const claimed = claimTransferLog(
+          kvStore,
+          chainId,
+          eventLog.transactionHash,
+          eventLog.index,
+          txId,
+        );
+        if (!claimed) {
+          log(
+            `Transfer ${eventLog.transactionHash}:${eventLog.index} already claimed by another pending tx; continuing to watch`,
+          );
+          return;
+        }
         log(
           `✓ Amount matches! Expected: ${expectedAmount}, Received: ${amount}`,
         );
@@ -268,7 +289,24 @@ export const lookBackCctp = async ({
         try {
           const t = parseTransferLog(ev);
           log(`Check: amount=${t.amount}`);
-          return t.amount === expectedAmount;
+          if (t.amount !== expectedAmount) return false;
+          // Claim this specific transfer so a single physical transfer cannot
+          // settle more than one pending tx sharing the same (destination,
+          // amount). If another leg already claimed it, skip to the next match.
+          const claimed = claimTransferLog(
+            kvStore,
+            chainId,
+            ev.transactionHash,
+            ev.index,
+            txId,
+          );
+          if (!claimed) {
+            log(
+              `Transfer ${ev.transactionHash}:${ev.index} already claimed by another pending tx; skipping`,
+            );
+            return false;
+          }
+          return true;
         } catch (e) {
           log(`Parse error:`, e);
           return false;

--- a/services/ymax-planner/test/cctp-watcher.test.ts
+++ b/services/ymax-planner/test/cctp-watcher.test.ts
@@ -10,7 +10,7 @@ import {
   mockFetch,
 } from './mocks.ts';
 import { handlePendingTx } from '../src/pending-tx-manager.ts';
-import { getResolvedTx } from '../src/kv-store.ts';
+import { claimTransferLog, getResolvedTx } from '../src/kv-store.ts';
 import { WatcherTransportError } from '../src/watchers/watcher-utils.ts';
 
 const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
@@ -279,6 +279,110 @@ test('watchCctpTransfer returns txHash when transfer is found', async t => {
     result.txHash,
     expectedTxHash,
     'Should return the correct transaction hash',
+  );
+});
+
+// Regression test for PAK-574: withdrawing 10 USDC from two 5-USDC positions
+// registers two CCTP_TO_EVM pending txs with identical destinationAddress and
+// identical amount. A single on-chain 5-USDC Transfer must never settle both
+// legs — each leg must claim a distinct physical transfer.
+test('claimTransferLog: one transfer settles at most one pending tx', t => {
+  const kvStore = makeKVStoreFromMap(new Map());
+  const chainId = 'eip155:1';
+  const txHash = '0xdeadbeef';
+  const logIndex = 3;
+
+  // tx1 claims the transfer first.
+  t.true(
+    claimTransferLog(kvStore, chainId, txHash, logIndex, 'tx1'),
+    'first claimant owns the transfer',
+  );
+  // The same tx re-claiming (e.g. after a planner restart) is idempotent.
+  t.true(
+    claimTransferLog(kvStore, chainId, txHash, logIndex, 'tx1'),
+    're-claim by the same txId succeeds',
+  );
+  // A different pending tx cannot claim the already-owned transfer.
+  t.false(
+    claimTransferLog(kvStore, chainId, txHash, logIndex, 'tx2'),
+    'a different txId cannot steal an owned transfer',
+  );
+  // The same (txHash) at a different logIndex is a distinct physical transfer.
+  t.true(
+    claimTransferLog(kvStore, chainId, txHash, logIndex + 1, 'tx2'),
+    'a distinct (txHash, logIndex) is a separate transfer',
+  );
+});
+
+test('watchCctpTransfer: a transfer claimed by another tx cannot settle a second tx', async t => {
+  const provider = createMockProvider();
+  const expectedAmount = 5_000_000n; // 5 USDC — identical for both legs
+  const kvStore = makeKVStoreFromMap(new Map());
+  const chainId = 'eip155:1';
+
+  const filter = {
+    topics: [
+      id('Transfer(address,address,uint256)'),
+      null,
+      zeroPadValue(toAddress.toLowerCase(), 32),
+    ],
+  };
+  const emitTransfer = (transactionHash: string, index: number) => {
+    (provider as any).emit(filter, {
+      address: usdcAddress,
+      topics: [
+        id('Transfer(address,address,uint256)'),
+        '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+        zeroPadValue(toAddress.toLowerCase(), 32),
+      ],
+      data: encodeAmount(expectedAmount),
+      transactionHash,
+      index,
+      blockNumber: 18500000,
+    });
+  };
+
+  const transferA = '0xaaa111';
+  const transferB = '0xbbb222';
+
+  // Leg 1 (tx1) observes and claims transfer A.
+  const tx1Promise = watchCctpTransfer({
+    usdcAddress,
+    provider,
+    toAddress,
+    expectedAmount,
+    timeoutMs: 5000,
+    kvStore,
+    txId: 'tx1',
+    chainId,
+  });
+  setTimeout(() => emitTransfer(transferA, 0), 20);
+  const tx1Result = await tx1Promise;
+  t.true(tx1Result.settled);
+  t.is(tx1Result.txHash, transferA, 'tx1 settles on transfer A');
+
+  // Leg 2 (tx2) then observes the SAME transfer A (e.g. restart / lookback
+  // overlap). It must reject the already-claimed transfer and keep watching,
+  // settling only when a distinct transfer B arrives.
+  const tx2Promise = watchCctpTransfer({
+    usdcAddress,
+    provider,
+    toAddress,
+    expectedAmount,
+    timeoutMs: 5000,
+    kvStore,
+    txId: 'tx2',
+    chainId,
+  });
+  setTimeout(() => emitTransfer(transferA, 0), 20); // already claimed by tx1
+  setTimeout(() => emitTransfer(transferB, 0), 40); // fresh transfer
+  const tx2Result = await tx2Promise;
+
+  t.true(tx2Result.settled);
+  t.is(
+    tx2Result.txHash,
+    transferB,
+    'tx2 must not reuse transfer A; it settles on the distinct transfer B',
   );
 });
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Integration testing generally doesn't run until a PR is labeled for merge, but can be opted into for every push by adding label 'force:integration', and can be customized to use non-default external targets by including lines here that **start** with leading-`#` directives:
* (https://github.com/Agoric/documentation) #documentation-branch: $BRANCH_NAME
* (https://github.com/endojs/endo) #endo-branch: $BRANCH_NAME
* (https://github.com/Agoric/dapp-offer-up) #getting-started-branch: $BRANCH_NAME
* (https://github.com/Agoric/testnet-load-generator) #loadgen-branch: $BRANCH_NAME

These directives should be removed before adding a merge label, so final integration tests run against default targets.
-->

<!-- Most PRs should close a specific issue. All PRs should at least reference one or more issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes:https://linear.app/agoric/issue/PAK-574/investigate-portfolio81flow5-duplicate-cctp-settlement-resolved-both-5

## Description
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review. -->

Withdrawing from two positions of equal size registers two CCTP_TO_EVM pending txs with identical destinationAddress and amount, so a single on-chain Transfer could settle both legs. Claim each physical transfer by its `(chainId, txHash, logIndex)` fingerprint for exactly one txId, in both the live and lookback paths. The claim is persisted so the guarantee holds across planner restarts and lookback rescans.


### Testing Considerations
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? -->
The fix is unit tested. 

### Upgrade Considerations
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? What steps should be followed to verify that its changes have been included in a release (ollinet/emerynet/mainnet/etc.) and work successfully there? If the process is elaborate, consider adding a script to scripts/verification/. -->
- New planner deployment.