### PR TITLE
feat(ymax-planner): Auto-rebalance portfolios in parallel

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -535,77 +535,48 @@ export const processPortfolioEvents = async (
     postYdsTransaction,
     walletStore,
   };
-  const scanAutoRebalances = async () => {
-    await null;
-    for (const [portfolioKey, portfolioRecord] of portfolioRecordForKey) {
-      const { status } = portfolioRecord;
-      const { enabledAutoFeatures, targetAllocation } = status;
-      if (!enabledAutoFeatures?.rebalance || !targetAllocation) continue;
-      if (Object.keys(status.flowsRunning || {}).length > 0) continue;
+  const shouldRebalance = (
+    portfolioKey: PortfolioKey,
+    status: StatusFor['portfolio'],
+  ): boolean => {
+    const { enabledAutoFeatures, targetAllocation } = status;
+    if (!enabledAutoFeatures?.rebalance || !targetAllocation) return false;
 
-      try {
-        // If status hasn't changed since our last successful submission,
-        // there's no point in checking.
-        const fingerprint = fingerprintPortfolioState(status, { marshaller });
-        const oldState = provideLazyMap(memory.snapshots, portfolioKey, () => ({
-          fingerprint,
-          repeats: 0,
-          txHash: null,
-        }));
-        if (oldState.txHash && fingerprint === oldState.fingerprint) {
-          continue;
-        }
+    // If status hasn't changed since our last successful submission,
+    // there's no point in checking.
+    const fingerprint = fingerprintPortfolioState(status, { marshaller });
+    const oldState = provideLazyMap(memory.snapshots, portfolioKey, () => ({
+      fingerprint,
+      repeats: 0,
+      txHash: null,
+    }));
+    if (oldState.txHash && fingerprint === oldState.fingerprint) return false;
 
-        // Likewise if we don't have new balance information.
-        const cachedBalanceData = await balanceCache.get(portfolioKey);
-        if (!cachedBalanceData) continue;
-        const { isoTimestamp, balances } = cachedBalanceData;
-        if (oldState.balancesTimestamp === isoTimestamp) continue;
-        oldState.balancesTimestamp = isoTimestamp;
+    // Likewise if we don't have new balance information.
+    const cachedBalanceData = balanceCache.get(portfolioKey);
+    if (!cachedBalanceData) return false;
+    const { isoTimestamp, balances } = cachedBalanceData;
+    if (oldState.balancesTimestamp === isoTimestamp) return false;
+    oldState.balancesTimestamp = isoTimestamp;
 
-        // XXX We should refactor to avoid adding back unchanged balances.
-        const candidateTargets = {
-          ...balances,
-          ...computeTargetBalances({
-            brand: depositBrand,
-            currentBalances: balances,
-            network,
-            targetAllocation,
-            instrumentBlocks,
-          }),
-        };
-        const shouldRebalance = checkAutoRebalance(
-          targetAllocation,
-          balances,
-          candidateTargets,
-          autoRebalance,
-        );
-        if (!shouldRebalance) continue;
-
-        const freshBalances = await getFreshBalances(portfolioKey, status);
-        const freshTimestamp = balanceCache.get(portfolioKey)!.isoTimestamp;
-        oldState.balancesTimestamp = freshTimestamp;
-        const txHash = await maybeAutoRebalance(
-          status,
-          portfolioKey,
-          freshBalances,
-          maybeAutoRebalancePowers,
-        );
-        if (txHash) {
-          memory.snapshots.set(portfolioKey, {
-            fingerprint,
-            txHash,
-            repeats: 0,
-            balancesTimestamp: freshTimestamp,
-          });
-        }
-      } catch (err) {
-        console.warn(
-          `[${portfolioKey}.autoRebalance] ⚠️ Skipping auto rebalance scan`,
-          err,
-        );
-      }
-    }
+    // XXX We should refactor to avoid adding back unchanged balances.
+    const candidateTargets = {
+      ...balances,
+      ...computeTargetBalances({
+        brand: depositBrand,
+        currentBalances: balances,
+        network,
+        targetAllocation,
+        instrumentBlocks,
+      }),
+    };
+    const rebalanceDetail = checkAutoRebalance(
+      targetAllocation,
+      balances,
+      candidateTargets,
+      autoRebalance,
+    );
+    return !!rebalanceDetail;
   };
   const handledPortfolioKeys = new Set<string>();
   // prettier-ignore
@@ -651,7 +622,7 @@ export const processPortfolioEvents = async (
           'INIT';
 
         // 'run' is the only non-terminal status.
-        if (flowStatus === 'run') return;
+        if (flowStatus === 'run') break;
         if (flowStatus !== 'INIT') continue;
 
         txHash = await startFlow(status, portfolioKey, flowKey, flowDetail);
@@ -708,7 +679,36 @@ export const processPortfolioEvents = async (
       await handlePortfolio(portfolioKey, eventRecord);
     }
   }
-  await scanAutoRebalances();
+  await makeWorkPool(portfolioRecordForKey, undefined, async entry => {
+    const [portfolioKey, portfolioRecord] = entry;
+    const { status } = portfolioRecord;
+    if (Object.keys(status.flowsRunning || {}).length > 0) return;
+
+    await null;
+    try {
+      if (!shouldRebalance(portfolioKey, status)) return;
+      const freshBalances = await getFreshBalances(portfolioKey, status);
+      const freshTimestamp = balanceCache.get(portfolioKey)!.isoTimestamp;
+      const oldState = memory.snapshots.get(portfolioKey)!;
+      oldState.balancesTimestamp = freshTimestamp;
+      const txHash = await maybeAutoRebalance(
+        status,
+        portfolioKey,
+        freshBalances,
+        maybeAutoRebalancePowers,
+      );
+      if (!txHash) return;
+      memory.snapshots.set(portfolioKey, {
+        fingerprint: fingerprintPortfolioState(status, { marshaller }),
+        txHash,
+        repeats: 0,
+        balancesTimestamp: freshTimestamp,
+      });
+    } catch (err) {
+      const msg = `[${portfolioKey}.autoRebalance] ⚠️ Failure ${err?.name}: ${err?.message}`;
+      console.warn(msg, err);
+    }
+  }).done;
 };
 
 export const processPendingTxEvents = async (

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -146,6 +146,22 @@ export type SimplePowers = {
 
 const nowISO = makeNowISO(Date.now);
 
+/**
+ * For debugging transactions sent at the same time, `makeNonce` defaults to
+ * wall-clock timestamps plus a counter.
+ */
+const lastNonce = { timestamp: '', counter: 0 };
+const defaultMakeNonce = () => {
+  const timestamp = nowISO();
+  if (timestamp !== lastNonce.timestamp) {
+    lastNonce.timestamp = timestamp;
+    lastNonce.counter = 1;
+  } else {
+    lastNonce.counter += 1;
+  }
+  return `${timestamp}.${lastNonce.counter}`;
+};
+
 export const main = async (
   cliArgs: string[],
   {
@@ -153,8 +169,7 @@ export const main = async (
     env = process.env,
     fetch = globalThis.fetch,
     generateInterval = timersPromises.setInterval,
-    /** `makeNonce` defaults to wall-clock timestamps for debugging sent transactions. */
-    makeNonce = nowISO,
+    makeNonce = defaultMakeNonce,
     now = globalThis.performance.now.bind(globalThis.performance),
     setTimeout = globalThis.setTimeout,
     connectWithSigner = SigningStargateClient.connectWithSigner,

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -987,8 +987,8 @@ test('processPortfolioEvents continues auto scan after portfolio error', async t
     consoleWrites.some(
       ({ level, args }) =>
         level === 'warn' &&
-        args[0] ===
-          `[${badPortfolioKey}.autoRebalance] ⚠️ Skipping auto rebalance scan`,
+        typeof args[0] === 'string' &&
+        args[0].startsWith(`[${badPortfolioKey}.autoRebalance] ⚠️ `),
     ),
     'bad portfolio scan error is logged',
   );


### PR DESCRIPTION
## Description
...using `makeWorkPool`.

### Security Considerations
This runs the risk of sequence number mismatches, but ymax-planner already uses `makeSequencingSmartWallet`.

### Scaling Considerations
Performance should improve, but we may need to reduce concurrency to avoid excessive external requests.

### Documentation Considerations
n/a

### Testing Considerations
Covered by existing tests.

### Upgrade Considerations
Safe for immediate deployment to ymax0, but is coupled to auto-rebalance for ymax1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Auto-rebalance scanning logic optimized for concurrent execution with enhanced error handling during rebalance attempts.
  * Nonce generation improved to handle multiple calls within the same timestamp consistently.

* **Tests**
  * Updated test assertions for auto-rebalance error logging validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->