### PR TITLE
refactor(ymax-planner): Simplify tx watching

### DIFF
--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -663,10 +663,6 @@ export const waitForConfirmations = async ({
       return null;
     }
 
-    await new Promise(resolve => {
-      const { signal: timeoutSignal } = makeAbortController(sleepMs, [signal]);
-      if (timeoutSignal.aborted) return resolve(undefined);
-      timeoutSignal.addEventListener('abort', () => resolve(undefined));
-    });
+    await makeAbortController(sleepMs, [signal]).abortedP;
   }
 };

--- a/services/ymax-planner/src/evm-scanner.ts
+++ b/services/ymax-planner/src/evm-scanner.ts
@@ -664,10 +664,7 @@ export const waitForConfirmations = async ({
     }
 
     await new Promise(resolve => {
-      const { signal: timeoutSignal } = makeAbortController(
-        sleepMs,
-        signal ? [signal] : undefined,
-      );
+      const { signal: timeoutSignal } = makeAbortController(sleepMs, [signal]);
       if (timeoutSignal.aborted) return resolve(undefined);
       timeoutSignal.addEventListener('abort', () => resolve(undefined));
     });

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -40,10 +40,7 @@ import {
   watchOperationResult,
   lookBackOperationResult,
 } from './watchers/operation-watcher.ts';
-import {
-  abortableSleep,
-  WatcherTransportError,
-} from './watchers/watcher-utils.ts';
+import { WatcherTransportError } from './watchers/watcher-utils.ts';
 import type { YdsNotifier } from './yds-notifier.ts';
 
 export type EvmChain = keyof typeof AxelarChain;
@@ -705,7 +702,7 @@ export const watchWithRetry = async <T>(
         `⚠️  Watcher transport failure (attempt ${attempt}/${limit}), retrying in ${delay}ms`,
         err,
       );
-      await abortableSleep(makeAbortController, delay, signal);
+      await makeAbortController(delay, [signal]).abortedP;
       if (signal?.aborted) return undefined;
     }
   }

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -208,10 +208,7 @@ const cctpMonitor: PendingTxMonitor<CctpTx> = {
       transferResult = await getLiveResult(opts.signal);
     } else {
       // Lookback mode with concurrent live watching
-      const abortController = ctx.makeAbortController(
-        undefined,
-        opts.signal ? [opts.signal] : undefined,
-      );
+      const abortController = ctx.makeAbortController(undefined, [opts.signal]);
       const finish = (reason: string) => {
         log(reason);
         abortController.abort(reason);
@@ -321,10 +318,7 @@ const gmpMonitor: PendingTxMonitor<GmpTx> = {
       transferResult = await getLiveResult(opts.signal);
     } else {
       // Lookback mode with concurrent live watching
-      const abortController = ctx.makeAbortController(
-        undefined,
-        opts.signal ? [opts.signal] : undefined,
-      );
+      const abortController = ctx.makeAbortController(undefined, [opts.signal]);
       const finish = (reason: string) => {
         log(reason);
         abortController.abort(reason);
@@ -453,10 +447,7 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx> = {
       walletResult = await getLiveResult(opts.signal);
     } else {
       // Lookback mode with concurrent live watching
-      const abortController = ctx.makeAbortController(
-        undefined,
-        opts.signal ? [opts.signal] : undefined,
-      );
+      const abortController = ctx.makeAbortController(undefined, [opts.signal]);
       const finish = (reason: string) => {
         log(reason);
         abortController.abort(reason);
@@ -570,10 +561,7 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx> = {
       transferResult = await getLiveResult(opts.signal);
     } else {
       // Lookback mode with concurrent live watching
-      const abortController = ctx.makeAbortController(
-        undefined,
-        opts.signal ? [opts.signal] : undefined,
-      );
+      const abortController = ctx.makeAbortController(undefined, [opts.signal]);
       const finish = (reason: string) => {
         log(reason);
         abortController.abort(reason);

--- a/services/ymax-planner/src/pending-tx-manager.ts
+++ b/services/ymax-planner/src/pending-tx-manager.ts
@@ -195,52 +195,47 @@ const cctpMonitor: PendingTxMonitor<CctpTx> = {
     };
 
     let transferResult: WatcherResult | undefined;
-
-    if (opts.mode === 'live') {
-      transferResult = await watchCctpTransfer({
+    const getLiveResult = (signal?: AbortSignal) =>
+      watchCctpTransfer({
         ...watchArgs,
         timeoutMs: opts.timeoutMs,
-        signal: opts.signal,
+        signal,
         kvStore: ctx.kvStore,
         txId,
       });
+
+    if (opts.mode === 'live') {
+      transferResult = await getLiveResult(opts.signal);
     } else {
       // Lookback mode with concurrent live watching
-      // Start live mode now in case the txId has not yet appeared
       const abortController = ctx.makeAbortController(
         undefined,
         opts.signal ? [opts.signal] : undefined,
       );
+      const finish = (reason: string) => {
+        log(reason);
+        abortController.abort(reason);
+      };
 
+      // Start live mode now in case the txId has not yet appeared
       const liveResultP = liveWatchWithRetry(
-        () =>
-          watchCctpTransfer({
-            ...watchArgs,
-            timeoutMs: opts.timeoutMs,
-            signal: abortController.signal,
-            kvStore: ctx.kvStore,
-            txId,
-          }),
+        () => getLiveResult(abortController.signal),
         {
           makeAbortController: ctx.makeAbortController,
           signal: abortController.signal,
           log: (msg, ...args) => log(`${logPrefix} ${msg}`, ...args),
         },
-        e => log(`${logPrefix} Live watcher failed:`, e),
+        err => log(`${logPrefix} Live watcher failed:`, err),
       );
       void liveResultP.then(result => {
-        if (result.settled) {
-          log(`${logPrefix} Live mode completed`);
-          abortController.abort();
-        }
+        if (result.settled) finish(`${logPrefix} Live mode completed`);
       });
 
-      await null;
       // Wait for at least one block to ensure overlap between lookback and live mode
+      await null;
       const currentBlock = await rpc.getBlockNumber();
       await waitForBlock(rpc, currentBlock + 1);
 
-      // Scan historical blocks
       transferResult = await lookBackCctp({
         ...watchArgs,
         publishTimeMs: opts.publishTimeMs,
@@ -251,12 +246,8 @@ const cctpMonitor: PendingTxMonitor<CctpTx> = {
       });
 
       if (transferResult.settled) {
-        // Found in lookback, cancel live mode
-        const reason = `${logPrefix} Lookback found transaction`;
-        log(reason);
-        abortController.abort(reason);
+        finish(`${logPrefix} Lookback found transaction`);
       } else {
-        // Not found in lookback, rely on live mode
         log(
           `${logPrefix} Lookback completed without finding transaction, waiting for live mode`,
         );
@@ -317,32 +308,31 @@ const gmpMonitor: PendingTxMonitor<GmpTx> = {
     };
 
     let transferResult: GmpWatcherResult | undefined;
-
-    if (opts.mode === 'live') {
-      transferResult = await watchGmp({
+    const getLiveResult = (signal?: AbortSignal) =>
+      watchGmp({
         ...watchArgs,
         timeoutMs: opts.timeoutMs,
-        signal: opts.signal,
+        signal,
         kvStore: ctx.kvStore,
         makeAbortController: ctx.makeAbortController,
       });
+
+    if (opts.mode === 'live') {
+      transferResult = await getLiveResult(opts.signal);
     } else {
       // Lookback mode with concurrent live watching
-      // Start live mode now in case the txId has not yet appeared
       const abortController = ctx.makeAbortController(
         undefined,
         opts.signal ? [opts.signal] : undefined,
       );
+      const finish = (reason: string) => {
+        log(reason);
+        abortController.abort(reason);
+      };
 
+      // Start live mode now in case the txId has not yet appeared
       const liveResultP = liveWatchWithRetry(
-        () =>
-          watchGmp({
-            ...watchArgs,
-            timeoutMs: opts.timeoutMs,
-            signal: abortController.signal,
-            kvStore: ctx.kvStore,
-            makeAbortController: ctx.makeAbortController,
-          }),
+        () => getLiveResult(abortController.signal),
         {
           makeAbortController: ctx.makeAbortController,
           signal: abortController.signal,
@@ -350,25 +340,16 @@ const gmpMonitor: PendingTxMonitor<GmpTx> = {
         },
         err => log(`${logPrefix} Live watcher failed:`, err),
       );
-
-      // Attach handler to abort lookback if live mode completes first with
-      // a definitive result. This handler does NOT resolve the transaction -
-      // resolution happens once at the end to prevent duplicate resolutions.
       void liveResultP.then(result => {
-        if (result.settled) {
-          const reason = `${logPrefix} Live mode completed`;
-          log(reason);
-          abortController.abort(reason);
-        }
+        if (result.settled) finish(`${logPrefix} Live mode completed`);
       });
 
-      await null;
       // Wait for at least one block to ensure overlap between lookback and live mode
+      await null;
       const currentBlock = await rpc.getBlockNumber();
       await waitForBlock(rpc, currentBlock + 1);
 
-      // Scan historical blocks
-      const lookBackResult = await lookBackGmp({
+      transferResult = await lookBackGmp({
         ...watchArgs,
         publishTimeMs: opts.publishTimeMs,
         chainId: caipId,
@@ -378,15 +359,9 @@ const gmpMonitor: PendingTxMonitor<GmpTx> = {
         makeAbortController: ctx.makeAbortController,
       });
 
-      // Determine which result to use based on what completed successfully
-      if (lookBackResult.settled) {
-        // Found in lookback, cancel live mode
-        transferResult = lookBackResult;
-        const reason = `${logPrefix} Lookback found transaction`;
-        log(reason);
-        abortController.abort(reason);
+      if (transferResult.settled) {
+        finish(`${logPrefix} Lookback found transaction`);
       } else {
-        // Not found in lookback, rely on live mode
         log(
           `${logPrefix} Lookback completed without finding transaction, waiting for live mode`,
         );
@@ -466,28 +441,30 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx> = {
     };
 
     let walletResult: WatcherResult | undefined;
-
-    if (opts.mode === 'live') {
-      walletResult = await watchSmartWalletTx({
+    const getLiveResult = (signal?: AbortSignal) =>
+      watchSmartWalletTx({
         ...watchArgs,
         timeoutMs: opts.timeoutMs,
-        signal: opts.signal,
+        signal,
         txId,
       });
+
+    if (opts.mode === 'live') {
+      walletResult = await getLiveResult(opts.signal);
     } else {
+      // Lookback mode with concurrent live watching
       const abortController = ctx.makeAbortController(
         undefined,
         opts.signal ? [opts.signal] : undefined,
       );
+      const finish = (reason: string) => {
+        log(reason);
+        abortController.abort(reason);
+      };
 
+      // Start live mode now in case the txId has not yet appeared
       const liveResultP = liveWatchWithRetry(
-        () =>
-          watchSmartWalletTx({
-            ...watchArgs,
-            timeoutMs: opts.timeoutMs,
-            signal: abortController.signal,
-            txId,
-          }),
+        () => getLiveResult(abortController.signal),
         {
           makeAbortController: ctx.makeAbortController,
           signal: abortController.signal,
@@ -496,14 +473,11 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx> = {
         err => log(`${logPrefix} Live watcher failed:`, err),
       );
       void liveResultP.then(result => {
-        if (result.settled) {
-          log(`${logPrefix} Live mode completed`);
-          abortController.abort();
-        }
+        if (result.settled) finish(`${logPrefix} Live mode completed`);
       });
 
+      // Wait for at least one block to ensure overlap between lookback and live mode
       await null;
-
       const currentBlock = await rpc.getBlockNumber();
       await waitForBlock(rpc, currentBlock + 1);
 
@@ -519,8 +493,7 @@ const makeAccountMonitor: PendingTxMonitor<MakeAccountTx> = {
       });
 
       if (walletResult.settled) {
-        log(`${logPrefix} Lookback found wallet creation`);
-        abortController.abort();
+        finish(`${logPrefix} Lookback found wallet creation`);
       } else {
         log(
           `${logPrefix} Lookback completed without finding wallet creation, waiting for live mode`,
@@ -586,27 +559,29 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx> = {
     };
 
     let transferResult: WatcherResult | undefined;
-
-    if (opts.mode === 'live') {
-      transferResult = await watchOperationResult({
+    const getLiveResult = (signal?: AbortSignal) =>
+      watchOperationResult({
         ...watchArgs,
         timeoutMs: opts.timeoutMs,
-        signal: opts.signal,
+        signal,
       });
+
+    if (opts.mode === 'live') {
+      transferResult = await getLiveResult(opts.signal);
     } else {
       // Lookback mode with concurrent live watching
       const abortController = ctx.makeAbortController(
         undefined,
         opts.signal ? [opts.signal] : undefined,
       );
+      const finish = (reason: string) => {
+        log(reason);
+        abortController.abort(reason);
+      };
 
+      // Start live mode now in case the txId has not yet appeared
       const liveResultP = liveWatchWithRetry(
-        () =>
-          watchOperationResult({
-            ...watchArgs,
-            timeoutMs: opts.timeoutMs,
-            signal: abortController.signal,
-          }),
+        () => getLiveResult(abortController.signal),
         {
           makeAbortController: ctx.makeAbortController,
           signal: abortController.signal,
@@ -614,22 +589,16 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx> = {
         },
         err => log(`${logPrefix} Live watcher failed:`, err),
       );
-
       void liveResultP.then(result => {
-        if (result.settled) {
-          const reason = `${logPrefix} Live mode completed`;
-          log(reason);
-          abortController.abort(reason);
-        }
+        if (result.settled) finish(`${logPrefix} Live mode completed`);
       });
 
-      await null;
       // Wait for at least one block to ensure overlap between lookback and live mode
+      await null;
       const currentBlock = await rpc.getBlockNumber();
       await waitForBlock(rpc, currentBlock + 1);
 
-      // Scan historical blocks
-      const lookBackResult = await lookBackOperationResult({
+      transferResult = await lookBackOperationResult({
         ...watchArgs,
         publishTimeMs: opts.publishTimeMs,
         signal: abortController.signal,
@@ -637,11 +606,8 @@ const routedGmpMonitor: PendingTxMonitor<RoutedGmpTx> = {
         makeAbortController: ctx.makeAbortController,
       });
 
-      if (lookBackResult.settled) {
-        transferResult = lookBackResult;
-        const reason = `${logPrefix} Lookback found transaction`;
-        log(reason);
-        abortController.abort(reason);
+      if (transferResult.settled) {
+        finish(`${logPrefix} Lookback found transaction`);
       } else {
         log(
           `${logPrefix} Lookback completed without finding transaction, waiting for live mode`,

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -10,6 +10,7 @@ import {
   YieldProtocol,
 } from '@agoric/portfolio-api/src/constants.js';
 import type { SupportedChain } from '@agoric/portfolio-api/src/constants.js';
+import { makePromiseKit } from '@endo/promise-kit';
 import type { EvmContext } from './pending-tx-manager.ts';
 import { lookupValueForKey } from './utils.ts';
 
@@ -456,30 +457,43 @@ export const prepareAbortController = ({
    * Make a new manually-abortable AbortSignal with optional timeout and/or
    * optional signals whose own aborts should propagate (as with
    * `AbortSignal.any`).
+   * As a convenience, the returned value includes an `abortedP` promise that
+   * promptly fulfills to undefined after the returned signal is aborted.
    */
   const makeAbortController = (
     timeoutMillisec?: number,
     racingSignals?: Iterable<AbortSignal | undefined>,
-  ): AbortController => {
+  ): AbortController & { abortedP: Promise<void> } => {
     let controller: AbortController | null = new AbortController();
     const abort: AbortController['abort'] = reason => {
-      try {
-        return controller?.abort(reason);
-      } finally {
-        controller = null;
-      }
+      const controllerRef = controller;
+      controller = null;
+      return controllerRef?.abort(reason);
     };
     if (timeoutMillisec !== undefined) {
       setTimeout(() => abort(makeTimeoutReason()), timeoutMillisec);
     }
     const racingArray: AbortSignal[] | undefined =
-      racingSignals && [...racingSignals].filter(x => !!x);
-    if (!racingArray?.length) {
-      return { abort, signal: controller.signal };
-    }
-    const signal = AbortSignal.any([controller.signal, ...racingArray]);
-    signal.addEventListener('abort', _event => abort());
-    return { abort, signal };
+      racingSignals && [...racingSignals].filter((x): x is AbortSignal => !!x);
+
+    let signal: AbortSignal | null = racingArray?.length
+      ? AbortSignal.any([controller.signal, ...racingArray])
+      : controller.signal;
+    const { promise: abortedP, resolve } = makePromiseKit<void>();
+    const finish = async () => {
+      resolve();
+      signal?.removeEventListener('abort', onSignalAbort);
+      // Forget `signal`, but not before returning it to the caller.
+      signal = await null;
+    };
+    const onSignalAbort = _event => {
+      abort(signal?.reason);
+      void finish();
+    };
+    signal.addEventListener('abort', onSignalAbort);
+    if (signal?.aborted) void finish();
+
+    return { abort, signal: signal as AbortSignal, abortedP };
   };
   return makeAbortController;
 };

--- a/services/ymax-planner/src/support.ts
+++ b/services/ymax-planner/src/support.ts
@@ -459,7 +459,7 @@ export const prepareAbortController = ({
    */
   const makeAbortController = (
     timeoutMillisec?: number,
-    racingSignals?: Iterable<AbortSignal>,
+    racingSignals?: Iterable<AbortSignal | undefined>,
   ): AbortController => {
     let controller: AbortController | null = new AbortController();
     const abort: AbortController['abort'] = reason => {
@@ -472,10 +472,12 @@ export const prepareAbortController = ({
     if (timeoutMillisec !== undefined) {
       setTimeout(() => abort(makeTimeoutReason()), timeoutMillisec);
     }
-    if (!racingSignals) {
+    const racingArray: AbortSignal[] | undefined =
+      racingSignals && [...racingSignals].filter(x => !!x);
+    if (!racingArray?.length) {
       return { abort, signal: controller.signal };
     }
-    const signal = AbortSignal.any([controller.signal, ...racingSignals]);
+    const signal = AbortSignal.any([controller.signal, ...racingArray]);
     signal.addEventListener('abort', _event => abort());
     return { abort, signal };
   };

--- a/services/ymax-planner/src/watchers/gmp-watcher.ts
+++ b/services/ymax-planner/src/watchers/gmp-watcher.ts
@@ -323,11 +323,7 @@ export const lookBackGmp = async ({
 
     // Options shared by both scans. The abort signal propagates external
     // cancellation.
-    // see `prepareAbortController` in services/ymax-planner/src/main.ts
-    const { signal: sharedSignal } = makeAbortController(
-      undefined,
-      signal ? [signal] : [],
-    );
+    const { signal: sharedSignal } = makeAbortController(undefined, [signal]);
     const sharedOpts = {
       provider,
       toBlock,

--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -440,10 +440,7 @@ export const lookBackOperationResult = async ({
 
     // Options shared by both scans. The abort signal propagates external
     // cancellation.
-    const { signal: sharedSignal } = makeAbortController(
-      undefined,
-      signal ? [signal] : [],
-    );
+    const { signal: sharedSignal } = makeAbortController(undefined, [signal]);
 
     // Phase 1: Scan for OperationResult events (cheap: uses eth_getLogs)
     const matchingEvent = await scanEvmLogsInChunks({

--- a/services/ymax-planner/src/watchers/wallet-watcher.ts
+++ b/services/ymax-planner/src/watchers/wallet-watcher.ts
@@ -412,10 +412,7 @@ export const lookBackSmartWalletTx = async ({
 
     // Options shared by all scans. The abort signal propagates external
     // cancellation.
-    const { signal: sharedSignal } = makeAbortController(
-      undefined,
-      signal ? [signal] : [],
-    );
+    const { signal: sharedSignal } = makeAbortController(undefined, [signal]);
     const sharedOpts = {
       provider,
       toBlock,

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -2,7 +2,6 @@ import type { TransactionReceipt, Filter, Log } from 'ethers';
 import { Interface, AbiCoder, getAddress, keccak256 } from 'ethers';
 import type { CaipChainId } from '@agoric/orchestration';
 import { depositFactoryCreateAndDepositInputs } from '@aglocal/portfolio-contract/src/utils/evm-orch-factory.ts';
-import { makePromiseKit } from '@endo/promise-kit';
 import { decodeAbiParameters } from 'viem';
 import type { EvmRpc } from '../evm-scanner.ts';
 import { waitForConfirmations } from '../evm-scanner.ts';
@@ -10,7 +9,6 @@ import {
   getBlockTimeMs,
   getConfirmationsRequired,
   getRevertConfirmationsRequired,
-  type MakeAbortController,
 } from '../support.ts';
 
 export type RetryOptions = {
@@ -31,21 +29,6 @@ export const FAILED_TX_SCOPE = 'failedTx';
 // Re-exported from its canonical leaf module (avoids an import cycle with the
 // RPC layer, which also throws it).
 export { WatcherTransportError } from '../errors.ts';
-
-/**
- * Sleep for `ms` milliseconds or until `signal` aborts (whichever comes first).
- */
-export const abortableSleep = async (
-  makeAbortController: MakeAbortController,
-  ms: number,
-  signal?: AbortSignal,
-): Promise<void> => {
-  if (signal?.aborted) return;
-  const { promise, resolve } = makePromiseKit<void>();
-  const { signal: timeout } = makeAbortController(ms, [signal]);
-  timeout.addEventListener('abort', () => resolve());
-  return promise;
-};
 
 //#region Axelar execute calldata extraction
 // AxelarExecutable entrypoint (standard)

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -42,7 +42,7 @@ export const abortableSleep = async (
 ): Promise<void> => {
   if (signal?.aborted) return;
   const { promise, resolve } = makePromiseKit<void>();
-  const { signal: timeout } = makeAbortController(ms, signal ? [signal] : []);
+  const { signal: timeout } = makeAbortController(ms, [signal]);
   timeout.addEventListener('abort', () => resolve());
   return promise;
 };


### PR DESCRIPTION
## Description
* Improve consistency across the various pending-tx-manager monitors
* Filter out undefined signals inside `makeAbortController` rather than at
every call site.
* Extend the `makeAbortController` return value to include a promise corresponding with abort.

### Security Considerations
None known.

### Scaling Considerations
n/a

### Documentation Considerations
n/a

### Testing Considerations
Covered by existing tests.

### Upgrade Considerations
Safe for immediate deployment.