### PR TITLE
chore(portfolio-contract): put swap behind experimental feature flag

### DIFF
--- a/packages/portfolio-api/src/constants.js
+++ b/packages/portfolio-api/src/constants.js
@@ -200,6 +200,7 @@ export const FlowFeaturesShape = M.splitRecord(
   {},
   {
     useProgressTracker: M.boolean(),
+    experimentalSwap: M.boolean(),
   },
 );
 

--- a/packages/portfolio-api/src/types.ts
+++ b/packages/portfolio-api/src/types.ts
@@ -32,6 +32,8 @@ import type {
 export type FlowFeatures = {
   /** Control `ProgressTracker` support. */
   useProgressTracker?: boolean;
+  /** Enable experimental swap feature. */
+  experimentalSwap?: boolean;
 };
 
 /**

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -1140,6 +1140,7 @@ const stepFlow = async (
 
       case 'swap': {
         const { chain } = way;
+        features?.experimentalSwap || Fail`swap not supported: ${q(move)}`;
         todo.push({
           how: 'swap',
           amount,

--- a/packages/portfolio-contract/test/portfolio.flows.test.ts
+++ b/packages/portfolio-contract/test/portfolio.flows.test.ts
@@ -2440,6 +2440,14 @@ test('swap reward token to USDC via 1inch', async t => {
       ],
     },
     kit,
+    undefined,
+    {
+      ...DEFAULT_FLOW_CONFIG,
+      features: {
+        ...DEFAULT_FLOW_CONFIG?.features,
+        experimentalSwap: true,
+      },
+    },
   );
   await Promise.all([swapP, txResolver.settleUntil(swapP)]);
 

--- a/packages/portfolio-contract/test/portfolio.flows.test.ts
+++ b/packages/portfolio-contract/test/portfolio.flows.test.ts
@@ -2518,6 +2518,60 @@ test('swap reward token to USDC via 1inch', async t => {
   await documentStorageSchema(t, storage, docOpts);
 });
 
+test('swap fails when experimentalSwap feature is disabled', async t => {
+  const amount = AmountMath.make(USDC, 1_000_000n);
+  const feeCall = AmountMath.make(BLD, 100n);
+  const { orch, ctx, offer } = mocks({}, { Deposit: amount });
+  const { log } = offer;
+
+  const kit = await ctx.makePortfolioKit();
+
+  const swapParams = {
+    provider: '1inch',
+    tokenIn: '0x0000000000000000000000000000000000000abc',
+    amountIn: 5_000_000n,
+    flags: 0n,
+    executor: '0x2222222222222222222222222222222222222222',
+    srcReceiver: '0x3333333333333333333333333333333333333333',
+    data: '0xdeadbeef',
+  } as const;
+
+  const seat = makeMockSeat({ Deposit: amount }, undefined, log);
+  // DEFAULT_FLOW_CONFIG has no `experimentalSwap` feature flag set, so the
+  // swap step must be rejected before any GMP calls are made.
+  await rebalance(
+    orch,
+    ctx,
+    seat,
+    {
+      flow: [
+        {
+          src: '@Avalanche',
+          dest: '@Avalanche',
+          amount,
+          fee: feeCall,
+          swap: swapParams,
+        },
+      ],
+    },
+    kit,
+    undefined,
+    DEFAULT_FLOW_CONFIG,
+  );
+
+  t.falsy(
+    log.some((e: any) => e._method === 'transfer'),
+    'no GMP transfer should be attempted',
+  );
+
+  const failCall = log.find((e: any) => e._method === 'fail');
+  t.truthy(
+    failCall,
+    'seat.fail() should be called when experimentalSwap is disabled',
+  );
+  t.regex(`${failCall?.reason}`, /swap not supported/);
+});
+
 // EVM wallet integration flow
 test('openPortfolio from EVM with Permit2 completes a deposit flow', async t => {
   // Use a mixed-case spender to ensure case-insensitive address checks.


### PR DESCRIPTION
closes: https://linear.app/agoric/issue/AGO-729
refs: #12706

## Description
Add an `experimentalSwap` flow config feature flag, and require it be set to use the swap flow step

### Security Considerations
Restricts usage of a non production ready code path

### Scaling Considerations
None

### Documentation Considerations
None

### Testing Considerations
Updated existing flow test

### Upgrade Considerations
In the future removing this feature flag could result in a different replay behavior, but we admit this possibility.
