### PR TITLE
feat(portfolio-contract): Open with grant

### DIFF
--- a/packages/portfolio-api/src/evm-wallet/eip712-messages.ts
+++ b/packages/portfolio-api/src/evm-wallet/eip712-messages.ts
@@ -75,6 +75,24 @@ const OperationTypes = {
     { name: 'allocations', type: 'Allocation[]' },
     { name: 'features', type: 'PortfolioAutoFeatures' },
   ],
+  /**
+   * Open a portfolio and, in the same signed message, grant portfolio
+   * permissions to an automation agent's Agoric address. This collapses the
+   * former two-step "create portfolio" + "Grant" flow into a single user
+   * signature: the contract creates the portfolio with the given allocations
+   * and then delivers the delegation to `grantee.address`, exactly as a
+   * standalone {@link Grant} would.
+   *
+   * Like {@link OpenPortfolio}, this is a permit2-wrapped (funds-bearing)
+   * operation; the accompanying Permit2 supplies the initial deposit.
+   *
+   * - allocations: initial target allocation across instruments
+   * - grantee: delegation recipient and encoded portfolio permissions
+   */
+  OpenPortfolioWithGrant: [
+    { name: 'allocations', type: 'Allocation[]' },
+    { name: 'grantee', type: 'DelegationGrantee' },
+  ],
   Rebalance: [PortfolioIdParam],
   SetTargetAllocation: [
     { name: 'allocations', type: 'Allocation[]' },
@@ -122,6 +140,10 @@ const OperationSubTypes = {
   Asset: TokenPermissionsComponents,
   /** @see {@link PortfolioPermissions} */
   PortfolioPermissions: [{ name: 'allocation', type: 'bool' }],
+  DelegationGrantee: [
+    { name: 'address', type: 'string' },
+    { name: 'permissions', type: 'PortfolioPermissions' },
+  ],
   /** @see {@link PortfolioAutoFeatures} */
   PortfolioAutoFeatures: [{ name: 'rebalance', type: 'bool' }],
 } as const satisfies TypedData;

--- a/packages/portfolio-api/test/eip712-messages.test.ts
+++ b/packages/portfolio-api/test/eip712-messages.test.ts
@@ -210,6 +210,31 @@ test('getYmaxWitness for OpenPortfolio', t => {
   t.deepEqual(witness.witness, { allocations });
 });
 
+test('getYmaxWitness for OpenPortfolioWithGrant nests grantee fields', t => {
+  const allocations: TargetAllocation[] = [
+    { instrument: 'Aave_Arbitrum', portion: 10000n },
+  ];
+  const grantee = {
+    address: 'agoric1exampleagentaddress',
+    permissions: { allocation: true },
+  };
+
+  const witness = getYmaxWitness('OpenPortfolioWithGrant', {
+    allocations,
+    grantee,
+  });
+
+  t.deepEqual(witness.witnessTypes.YmaxV1OpenPortfolioWithGrant, [
+    { name: 'allocations', type: 'Allocation[]' },
+    { name: 'grantee', type: 'DelegationGrantee' },
+  ]);
+  t.deepEqual(witness.witnessTypes.DelegationGrantee, [
+    { name: 'address', type: 'string' },
+    { name: 'permissions', type: 'PortfolioPermissions' },
+  ]);
+  t.deepEqual(witness.witness, { allocations, grantee });
+});
+
 test('getYmaxWitness for Deposit', t => {
   const witness = getYmaxWitness('Deposit', { portfolio: 5n });
 

--- a/packages/portfolio-contract/src/evm-wallet-handler.exo.ts
+++ b/packages/portfolio-contract/src/evm-wallet-handler.exo.ts
@@ -60,7 +60,8 @@ interface PortfolioContractPublicFacet {
   openPortfolioFromEVM(
     data:
       | YmaxOperationDetails<'OpenPortfolio'>['data']
-      | YmaxOperationDetails<'OpenPortfolioWithAutoFeatures'>['data'],
+      | YmaxOperationDetails<'OpenPortfolioWithAutoFeatures'>['data']
+      | YmaxOperationDetails<'OpenPortfolioWithGrant'>['data'],
     permitDetails: PermitDetails,
   ): Promise<{
     evmHandler: PortfolioEVMFacet;
@@ -313,7 +314,8 @@ export const prepareEVMPortfolioOperationManager = (
       try {
         const portfolioId =
           operationDetails.operation !== 'OpenPortfolio' &&
-          operationDetails.operation !== 'OpenPortfolioWithAutoFeatures'
+          operationDetails.operation !== 'OpenPortfolioWithAutoFeatures' &&
+          operationDetails.operation !== 'OpenPortfolioWithGrant'
             ? operationDetails.data.portfolio
             : undefined;
         const portfolio =
@@ -328,7 +330,8 @@ export const prepareEVMPortfolioOperationManager = (
 
         switch (operationDetails.operation) {
           case 'OpenPortfolio':
-          case 'OpenPortfolioWithAutoFeatures': {
+          case 'OpenPortfolioWithAutoFeatures':
+          case 'OpenPortfolioWithGrant': {
             const { permitDetails, data } = operationDetails;
             if (!permitDetails) {
               throw Fail`Missing permit details for OpenPortfolio operation`;

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -227,6 +227,7 @@ export type AxelarConfig = {
 };
 
 interface PostalService {
+  getDepositFacet(addr: string): Promise<unknown>;
   deliverPayment(addr: string, pmt: Payment): Promise<void>;
 }
 type PostalServiceInstance = Instance<() => { publicFacet: PostalService }>;
@@ -790,6 +791,17 @@ export const contract = async (
     /**
      * Open a portfolio for EVM users with a signed Permit2 deposit.
      *
+     * If `data` includes `grantee`, this also performs the combined
+     * open+grant flow: delegate control to that Agoric address in the same
+     * signed message, reusing the same authorization and validation as a
+     * standalone `grant()`.
+     *
+     * Ordering guarantee: a rejected combined grant preflight aborts before
+     * the portfolio kit is allocated or the funding flow starts, so no
+     * portfolio shell is published and no deposit is pulled. Funding is still
+     * fire-and-forget, so a later funding failure can leave a delegated-but-
+     * unfunded portfolio.
+     *
      * @returns storagePath (vstorage) and evmHandler facet
      *
      * @see {@link openPortfolio} for the flow implementation
@@ -797,7 +809,8 @@ export const contract = async (
     async openPortfolioFromEVM(
       data:
         | YmaxOperationDetails<'OpenPortfolio'>['data']
-        | YmaxOperationDetails<'OpenPortfolioWithAutoFeatures'>['data'],
+        | YmaxOperationDetails<'OpenPortfolioWithAutoFeatures'>['data']
+        | YmaxOperationDetails<'OpenPortfolioWithGrant'>['data'],
       permitDetails: PermitDetails,
     ): Promise<{
       storagePath: string;
@@ -824,16 +837,44 @@ export const contract = async (
       sameEvmAddress(permitDetails.token, contracts[fromChain].usdc) ||
         Fail`permit2 token address ${permitDetails.token} does not match usdc contract address ${contracts[fromChain].usdc} for chain ${fromChain}`;
       const amount = AmountMath.make(brands.USDC, permitDetails.amount);
+      const grantee =
+        'grantee' in data && data.grantee !== undefined
+          ? data.grantee
+          : undefined;
+
+      await null;
+      if (grantee) {
+        // Preflight the smart wallet depositFacet before allocating a
+        // portfolio ID. `grant()` will still deliver the invitation below, but
+        // this keeps an unregistered grantee from leaving an orphaned shell.
+        const ps =
+          postalServiceP || Fail`postal service not configured in private args`;
+        await E(ps).getDepositFacet(grantee.address);
+      }
 
       // Store the authenticated source EVM account in CAIP-10 format
       const sourceAccountId =
         `eip155:${permitDetails.chainId}:${permitDetails.permit2Payload.owner.toLowerCase()}` as AccountId;
       const kit = makeNextPortfolioKit({ sourceAccountId });
 
-      await null;
       if ('features' in data && data.features !== undefined) {
         // setAutoFeatures is promptly resolved
         await vowTools.asPromise(kit.evmHandler.setAutoFeatures(data.features));
+      }
+      if (grantee) {
+        // `grant()` already enforces the shared auth and permission checks.
+        // `asPromise()` is safe because grant delivery is prompt: it hands the
+        // invitation to an already-provisioned smart wallet via
+        // `deliverDelegation` / `NamesByAddress`, so success resolves promptly
+        // and an unregistered grantee rejects promptly too.
+        await vowTools.asPromise(
+          // cast from EIP-712 string to agoric1 Bech32 address, as in the
+          // standalone Grant handler; the string is looked up in NamesByAddress.
+          kit.evmHandler.grant(
+            grantee.address as Bech32Address,
+            grantee.permissions,
+          ),
+        );
       }
 
       const seat = zcf.makeEmptySeatKit().zcfSeat;

--- a/packages/portfolio-contract/test/contract-setup.ts
+++ b/packages/portfolio-contract/test/contract-setup.ts
@@ -155,11 +155,11 @@ const forkDeployBase = async (
     timerService,
   );
   const postalService = Far('DummyPostalServicePublicFacet', {
+    async getDepositFacet(addr: string) {
+      return E(common.bootstrap.namesByAddress).lookup(addr, 'depositFacet');
+    },
     async deliverPayment(addr: string, payment: Invitation) {
-      const depositFacet = await E(common.bootstrap.namesByAddress).lookup(
-        addr,
-        'depositFacet',
-      );
+      const depositFacet = await this.getDepositFacet(addr);
       await E(depositFacet).receive(payment);
     },
   });

--- a/packages/portfolio-contract/test/delegation.test.ts
+++ b/packages/portfolio-contract/test/delegation.test.ts
@@ -398,3 +398,136 @@ test('Grant delivery failure is surfaced in wallet vstorage without publishing a
     'grant delivery failure vstorage',
   );
 });
+
+test('Pete may open a portfolio and grant control in a single signed message', async t => {
+  const deployed = await deploy(t);
+  const { zoe } = deployed;
+
+  // The agent's deposit facet is registered so the grant can be delivered.
+  const receiver = await registerDepositFacet(
+    deployed.common.bootstrap.namesByAddressAdmin,
+    PETE_AGENT,
+  );
+  const peteKit = await makeEvmTraderKit(deployed, {
+    privateKey: evmTrader0PrivateKey,
+  });
+  const peteArbitrum = peteKit.evmTrader.forChain('Arbitrum');
+
+  // One user signature: create the portfolio AND grant allocation control to
+  // the agent, replacing the former two-step OpenPortfolio + Grant flow.
+  const { portfolioId } = await peteArbitrum.openPortfolioWithGrant(
+    [
+      { instrument: 'Aave_Arbitrum', portion: 60n },
+      { instrument: 'Compound_Arbitrum', portion: 40n },
+    ],
+    10_000_000n,
+    PETE_AGENT,
+    harden({ allocation: true }),
+  );
+  await eventLoopIteration();
+
+  // The combined operation delivered the delegation as part of the same call.
+  // (openPortfolioWithGrant only resolves once the contract's
+  // openPortfolioFromEVM has awaited the grant, so success here implies the
+  // grant succeeded; a rejected grant would have failed the whole message.)
+  const { delegationClient } = await redeemAndCheckDelegation({
+    t,
+    zoe,
+    grantStatus: { status: 'ok' },
+    receiver,
+    expectedDetails: {
+      portfolioId,
+      agentId: 'agent1',
+      permissions: { allocation: true },
+    },
+  });
+
+  // The published agents record reflects the delegation.
+  const portfolioPath = stripRootStoragePath(
+    peteKit.evmTrader.getPortfolioPath(),
+  ) as `ymax${'0' | '1'}.portfolios.portfolio${number}`;
+  const agents = await peteKit.readPublished(`${portfolioPath}.agents`);
+  t.deepEqual(agents, {
+    agent1: {
+      grantee: PETE_AGENT,
+      permissions: { allocation: true },
+      state: 'active',
+    },
+  });
+
+  // The grant is live end-to-end: the grantee rebalances through the redeemed
+  // delegation facet, proving the single-message open+grant produced a usable
+  // delegation.
+  const before = await peteKit.evmTrader.getPortfolioStatus();
+  const rebalanceFlowId = await E(delegationClient).setTargetAllocation({
+    targetAllocation: {
+      Aave_Arbitrum: 50n,
+      Compound_Arbitrum: 50n,
+    },
+    syncState: getSyncState(before),
+    agentMemo: '67890',
+  });
+  t.regex(String(rebalanceFlowId), /^flow\d+$/);
+
+  await eventLoopIteration();
+  const after = await peteKit.evmTrader.getPortfolioStatus();
+  t.deepEqual(after.targetAllocation, {
+    Aave_Arbitrum: 50n,
+    Compound_Arbitrum: 50n,
+  });
+});
+
+test('open+grant with an unregistered grantee aborts before portfolio creation', async t => {
+  const deployed = await deploy(t);
+
+  // Deliberately do NOT register a depositFacet for PETE_AGENT. A standalone
+  // Grant surfaces this NamesByAddress miss non-fatally (see the "Grant
+  // delivery failure is surfaced ..." test above); in the combined flow the
+  // smart-wallet depositFacet is preflighted before a portfolio kit is
+  // allocated, so the same caller-triggerable failure aborts the whole
+  // open+grant operation without orphaning a portfolio shell.
+  const peteKit = await makeEvmTraderKit(deployed, {
+    privateKey: evmTrader0PrivateKey,
+  });
+  const peteArbitrum = peteKit.evmTrader.forChain('Arbitrum');
+  const walletAddress = peteKit.evmAccount.address;
+
+  await t.throwsAsync(
+    peteArbitrum.openPortfolioWithGrant(
+      [
+        { instrument: 'Aave_Arbitrum', portion: 60n },
+        { instrument: 'Compound_Arbitrum', portion: 40n },
+      ],
+      10_000_000n,
+      PETE_AGENT,
+      harden({ allocation: true }),
+    ),
+    { message: /"nameKey" not found: "agoric1petesAgent"/ },
+    'combined open+grant rejects when the grantee is not registered',
+  );
+  await eventLoopIteration();
+
+  // The failed message is recorded on the wallet as an error, not silently
+  // swallowed.
+  const walletStatus = (await peteKit.readPublished(
+    `evmWallets.${walletAddress}`,
+  )) as { status: string; error?: string };
+  t.is(walletStatus.status, 'error');
+  t.regex(walletStatus.error || '', /"nameKey" not found: "agoric1petesAgent"/);
+
+  // The funding flow never started and the portfolio kit was never allocated:
+  // the wallet's portfolio path is published only by
+  // OpenOutcomeWatcher.onFulfilled (when openPortfolioFromEVM resolves), so
+  // its absence pins the ordering invariant. This is an indirect proxy for "no
+  // deposit pulled": the deposit is drawn inside the funding flow, which is
+  // never reached here.
+  await t.throwsAsync(
+    peteKit.readPublished(`evmWallets.${walletAddress}.portfolio`),
+    { message: /no data at path/ },
+    'no portfolio path is published for the wallet after the aborted open+grant',
+  );
+
+  await t.throwsAsync(peteKit.readPublished('portfolios.portfolio0'), {
+    message: /no data at path/,
+  });
+});

--- a/packages/portfolio-contract/test/evm-wallet-handler.exo.test.ts
+++ b/packages/portfolio-contract/test/evm-wallet-handler.exo.test.ts
@@ -495,6 +495,104 @@ test('handleOperation - openPortfolio with auto-features', async t => {
   t.snapshot(getStatuses(), 'Published Statuses');
 });
 
+test('handleOperation - openPortfolio with grant', async t => {
+  const { zone } = t.context;
+  const {
+    vowTools,
+    getCalls,
+    mockWallet,
+    mockStorageNode,
+    getStatuses,
+    handleOperation,
+  } = makeHandleOperationTestSetup(zone, 'vow1', {
+    namePrefix: 'test1c_',
+  });
+
+  // Create an OpenPortfolioWithGrant operation: create the portfolio AND
+  // delegate control to an automation agent in a single signed message.
+  const granteeAddress = 'agoric1exampleagentaddress';
+  const openPortfolioOperationDetails: YmaxOperationDetails<'OpenPortfolioWithGrant'> &
+    Required<Pick<FullMessageDetails, 'permitDetails'>> = {
+    operation: 'OpenPortfolioWithGrant',
+    domain: {
+      name: 'Ymax',
+      version: '1',
+      chainId: 42161n,
+      verifyingContract: '0xVerifyingContractAddress' as const,
+    },
+    data: {
+      allocations: [{ instrument: 'inst1', portion: 100n }],
+      grantee: {
+        address: granteeAddress,
+        permissions: { allocation: true },
+      },
+    },
+    permitDetails: {
+      chainId: 42161n,
+      token: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as const,
+      amount: 1_000_000n,
+      spender: '0xSpenderAddress' as const,
+      permit2Payload: {
+        owner: '0xOwnerAddress' as const,
+        witness: '0xWitnessData' as const,
+        witnessTypeString: 'WitnessTypeString' as const,
+        permit: {
+          permitted: {
+            token: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as const,
+            amount: 1_000_000n,
+          },
+          nonce: 123n,
+          deadline: 1700000000n,
+        },
+        signature: '0xSignatureData' as const,
+      },
+    },
+  };
+
+  // Call handleOperation
+  const resultVow = handleOperation({
+    wallet: mockWallet,
+    storageNode: mockStorageNode,
+    address: openPortfolioOperationDetails.permitDetails.permit2Payload.owner,
+    operationDetails: harden(openPortfolioOperationDetails),
+    nonce: 123n,
+    deadline: 1700000000n,
+  });
+
+  // Wait for the vow to settle
+  await vowTools.when(resultVow);
+
+  // The combined operation is recognized as an "open" operation (no
+  // pre-existing portfolioId is looked up) and routes to openPortfolioFromEVM,
+  // which forwards the full data — including the grant fields — so the contract
+  // can create the portfolio and deliver the delegation in the same call. The
+  // grant delivery itself lives in openPortfolioFromEVM (exercised by the
+  // contract-level tests); here we verify the handler dispatch and payload.
+  const calls = getCalls();
+  t.is(
+    calls.openPortfolioFromEVM.length,
+    1,
+    'OpenPortfolioWithGrant routes to openPortfolioFromEVM',
+  );
+  const [forwardedData] = calls.openPortfolioFromEVM[0];
+  t.deepEqual(
+    forwardedData,
+    openPortfolioOperationDetails.data,
+    'forwards allocations and grantee parameters',
+  );
+  t.deepEqual(
+    [...mockWallet.portfolios.keys()],
+    [1n],
+    'creates exactly one portfolio',
+  );
+  const statuses = getStatuses();
+  t.truthy(statuses.length, 'publishes a message status');
+  t.false(
+    statuses.some(s => 'error' in s && s.error !== undefined),
+    'no error status published',
+  );
+});
+
 test('handleOperation - openPortfolio requires permitDetails', async t => {
   const { zone } = t.context;
   const {

--- a/packages/portfolio-contract/tools/portfolio-actors.ts
+++ b/packages/portfolio-contract/tools/portfolio-actors.ts
@@ -49,7 +49,10 @@ import {
   getYmaxStandaloneOperationData,
   getYmaxWitness,
 } from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.js';
-import type { TargetAllocation } from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.js';
+import type {
+  PortfolioPermissionsEIP712,
+  TargetAllocation,
+} from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.js';
 import type { TimerService } from '@agoric/time';
 import { mustMatch, type ERemote } from '@agoric/internal';
 import { E } from '@endo/far';
@@ -436,6 +439,63 @@ export const makeEvmTrader = ({
             witness,
           );
 
+          const expectedNonce = nonce;
+          await submitMessage(permitMessage);
+          const result = (await getMessageResult(
+            expectedNonce,
+            deadline,
+          )) as string;
+          const parsedId = Number(result.replace(/^portfolio/, ''));
+          Number.isInteger(parsedId) ||
+            assert.fail('invalid portfolio id result');
+          const storagePath = await updatePortfolioPath(parsedId);
+          return harden({ storagePath, portfolioId: parsedId });
+        },
+        /**
+         * Open a portfolio AND grant control to an automation agent in a
+         * single signed (permit2-wrapped) message — the combined form of
+         * {@link openPortfolio} + {@link grant}, matching the contract's
+         * `OpenPortfolioWithGrant` operation. Like `grant`, the requested
+         * permission bag is validated against the current wire shape before
+         * signing.
+         */
+        async openPortfolioWithGrant(
+          allocations: TargetAllocation[],
+          depositAmount: bigint,
+          granteeAddress: Bech32Address,
+          permissions: PortfolioPermissions,
+        ) {
+          assert(contractRepresentative, 'missing contract representative');
+          mustMatch(
+            harden({ ...permissions }),
+            PortfolioPermissionsEIP712Shape,
+          );
+          const witness = getYmaxWitness('OpenPortfolioWithGrant', {
+            allocations,
+            grantee: {
+              address: granteeAddress,
+              // validated against PortfolioPermissionsEIP712Shape just above
+              permissions: permissions as PortfolioPermissionsEIP712,
+            },
+          }) as unknown as ReturnType<
+            // getPermitWitnessTransferFromData is not a fan of witness union types
+            typeof getYmaxWitness<'OpenPortfolio'>
+          >;
+          const deadline = await getDeadline();
+          const permitMessage = getPermitWitnessTransferFromData(
+            {
+              permitted: {
+                token: usdcToken,
+                amount: depositAmount,
+              },
+              spender: contractRepresentative,
+              nonce: (nonce += 1n),
+              deadline,
+            },
+            permit2Address,
+            chainId,
+            witness,
+          );
           const expectedNonce = nonce;
           await submitMessage(permitMessage);
           const result = (await getMessageResult(


### PR DESCRIPTION
closes: AGO-615
refs: kriskowal/garden#42

## Description

This PR adds `OpenPortfolioWithGrant`, a permit2-wrapped EVM operation that opens a portfolio and grants allocation control in one signed message.

- this adds a new wire operation to the EIP-712 surface, with grant fields nested under `grantee` for human legibility
- the combined flow preflights the grantee smart-wallet deposit facet before allocating a portfolio, then opens the portfolio and delivers the delegation before starting funding
- this is fail-closed for delegation delivery before funding starts, but not fully atomic overall: a later funding failure can still leave a delegated-but-unfunded portfolio

This does not include EMS/UI work to construct or submit the new message outside the existing test tooling.

### Security Considerations

- In the combined flow, a grantee lookup failure rejects before the portfolio kit is allocated and before funding starts, so no orphaned shell portfolio is published and no deposit is pulled for an unknown grantee.
- Funding is still fire-and-forget after the grant succeeds, so a later funding failure can leave a delegated-but-unfunded portfolio.

### Scaling Considerations

N/A.

### Documentation Considerations

N/A.

### Testing Considerations

`multichain-testing/scripts/ymax-tool.ts` is not updated to support this.

### Upgrade Considerations

Suggested rollout:

- publish the `portfolio-api` package with the new EIP-712 message type
- deploy the updated `portfolio-contract` when ready; it does not need to be deployed at the same moment as the `portfolio-api` publication
- upgrade EMS after it consumes the newer `portfolio-api`; at runtime EMS can still present a backwards-compatible `OpenPortfolio` operation to YDS until the new flow is enabled
- update YDS typing after it consumes the newer `portfolio-api`; it should explicitly `Exclude` `OpenPortfolioWithGrant` from operation types that it expects to handle directly
- upgrade UI after the EMS relay path supports the message, and gate the new `OpenPortfolioWithGrant` flow behind a UI flag before enabling it end-to-end

No contract state migration is required.
