### PR TITLE
fix(ci): validate and use env-var for release tag to prevent shell injection

### DIFF
--- a/.github/workflows/after-merge.yml
+++ b/.github/workflows/after-merge.yml
@@ -118,7 +118,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: record approval
-        run: echo "Approved publishing dist-tag '${{ inputs.tag }}' from branch '${{ inputs.branch }}'"
+        env:
+          NPM_DIST_TAG: ${{ inputs.tag }}
+          RELEASE_BRANCH: ${{ inputs.branch }}
+        run: |
+          printf "Approved publishing dist-tag '%s' from branch '%s'\n" \
+            "${NPM_DIST_TAG}" "${RELEASE_BRANCH}"
 
   release-publish:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'release' }}
@@ -131,13 +136,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: validate inputs
+        env:
+          NPM_DIST_TAG: ${{ inputs.tag }}
         run: |
           set -o errexit -o xtrace
 
-          case "${{ inputs.tag }}" in
+          case "${NPM_DIST_TAG}" in
             '' | latest)
-              echo "tag must name a release tag (e.g. agoric-upgrade-23); got '${{ inputs.tag }}'"
-              echo "Refusing to publish to '${{ inputs.tag }}'."
+              printf "tag must name a release tag (e.g. agoric-upgrade-23); got '%s'\n" \
+                "${NPM_DIST_TAG}"
+              printf "Refusing to publish to '%s'.\n" "${NPM_DIST_TAG}"
+              exit 1
+              ;;
+            *[!A-Za-z0-9._-]* | .* | -*)
+              printf "tag must contain only letters, numbers, dots, underscores, and hyphens, and must not start with dot or hyphen; got '%s'\n" \
+                "${NPM_DIST_TAG}"
               exit 1
               ;;
           esac
@@ -159,6 +172,8 @@ jobs:
         run: npm whoami
 
       - name: publish release versions to NPM
+        env:
+          NPM_DIST_TAG: ${{ inputs.tag }}
         run: |
           set -o errexit -o xtrace
 
@@ -168,7 +183,7 @@ jobs:
 
           AGORIC_POSTPACK_PRESERVE_PACKAGE_JSON="1" \
             yarn lerna publish from-package \
-            --concurrency "1" --dist-tag "${{ inputs.tag }}" --loglevel "verbose" \
+            --concurrency "1" --dist-tag "${NPM_DIST_TAG}" --loglevel "verbose" \
             --no-push --no-verify-access --yes
 
           git stash pop || true


### PR DESCRIPTION
### Motivation
- Prevent command-injection from untrusted `workflow_dispatch` inputs by avoiding direct GitHub-expression interpolation inside `run:` shells in the release workflow.
- Ensure the manual release path cannot execute injected commands after npm credentials or OIDC tokens are available while preserving the existing manual-release flow.

### Description
- Pass `inputs.tag` and `inputs.branch` through environment variables (`NPM_DIST_TAG`, `RELEASE_BRANCH`) in the `release-approval` step and print them with `printf` instead of embedding expressions directly in `run:` lines in `.github/workflows/after-merge.yml`.
- Validate the tag in the `release-publish` job using a `case` that rejects empty, `latest`, tags containing unsafe characters, tags starting with `.` or `-`, and path separators, using the environment variable `NPM_DIST_TAG` for checks.
- Use the validated `NPM_DIST_TAG` environment variable in the privileged `yarn lerna publish` invocation instead of `${{ inputs.tag }}` to avoid expression expansion in shell context.
- Replace `echo` with `printf` for clearer and safer formatted output in script steps.

### Testing
- Ran `git diff --check` to ensure no trivial whitespace/format issues and committed the change successfully (commit message: `fix(ci): quote release publish tag input`).
- Parsed the workflow with `ruby -e 'require "yaml"; YAML.load_file(...)'` to validate YAML syntax and ran a `bash -n` style check for `run:` blocks, both succeeding.
- Executed a custom detection script that searches for `${{ inputs.* }}` inside `run:` blocks and confirmed none remain, which succeeded.
- Performed a manual shell validation loop exercising safe and malicious `NPM_DIST_TAG` examples (e.g. `agoric-upgrade-23`, `agoric-upgrade-23$(cat ~/.npmrc)`, `latest`, `''`, `.bad`, `-bad`, `bad/tag`) and observed the expected accept/reject exit statuses; all checks behaved as intended.
- Note: `actionlint` was not installed in the runner, so it was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5f3831b1b88323a6305a396edf9efa)