### PR TITLE
chore: add rockawayx usdc yield vault

### DIFF
--- a/packages/portfolio-api/src/instruments.js
+++ b/packages/portfolio-api/src/instruments.js
@@ -68,6 +68,8 @@ export const InstrumentId = /** @type {const} */ ({
   ERC4626_morphoEthenaSteakhouseUsdc_Base:
     'ERC4626_morphoEthenaSteakhouseUsdc_Base',
   ERC4626_morphoKpkUsdcPrime_Ethereum: 'ERC4626_morphoKpkUsdcPrime_Ethereum',
+  ERC4626_morphoRockawayxUsdcYield_Ethereum:
+    'ERC4626_morphoRockawayxUsdcYield_Ethereum',
   USDN: 'USDN',
   USDNVault: 'USDNVault',
 });

--- a/packages/portfolio-api/src/places.ts
+++ b/packages/portfolio-api/src/places.ts
@@ -152,6 +152,10 @@ export const ERC4626PoolPlaces = {
     protocol: 'ERC4626',
     chainName: 'Ethereum',
   },
+  ERC4626_morphoRockawayxUsdcYield_Ethereum: {
+    protocol: 'ERC4626',
+    chainName: 'Ethereum',
+  },
 } as const satisfies Partial<Record<InstrumentId, PoolPlaceInfo>>;
 deepFreeze(ERC4626PoolPlaces);
 

--- a/packages/portfolio-contract/test/network/prod-network.test.ts
+++ b/packages/portfolio-contract/test/network/prod-network.test.ts
@@ -87,6 +87,7 @@ const POOLS: ReadonlyArray<PoolKey> = [
   'ERC4626_morphoGauntletUsdcPrime_Ethereum',
   'ERC4626_morphoEthenaSteakhouseUsdc_Base',
   'ERC4626_morphoKpkUsdcPrime_Ethereum',
+  'ERC4626_morphoRockawayxUsdcYield_Ethereum',
 ];
 
 // Helpers

--- a/packages/portfolio-deploy/src/axelar-configs.js
+++ b/packages/portfolio-deploy/src/axelar-configs.js
@@ -385,6 +385,12 @@ const erc4626VaultAddresses = harden({
     },
     testnet: {},
   },
+  morphoRockawayxUsdcYield: {
+    mainnet: {
+      Ethereum: '0xE0181090c22579B6A217f1522cbf8c9f1F0C1965', // https://app.morpho.org/ethereum/vault/0xE0181090c22579B6A217f1522cbf8c9f1F0C1965/rockawayx-usdc-yield
+    },
+    testnet: {},
+  },
 });
 
 /** @type {AddressesMap} */
@@ -646,6 +652,8 @@ const mainnetContracts = {
     walletHelper: walletHelperAddresses.mainnet.Ethereum,
     ERC4626_morphoKpkUsdcPrime_Ethereum:
       erc4626VaultAddresses.morphoKpkUsdcPrime.mainnet.Ethereum,
+    ERC4626_morphoRockawayxUsdcYield_Ethereum:
+      erc4626VaultAddresses.morphoRockawayxUsdcYield.mainnet.Ethereum,
     oneInchRouter,
   },
   Optimism: {

--- a/packages/portfolio-deploy/test/privateArgs-ymax0.json
+++ b/packages/portfolio-deploy/test/privateArgs-ymax0.json
@@ -1404,6 +1404,7 @@
       "ERC4626_morphoSteakhouseHighYieldInstant_Ethereum": "0xbeeff2C5bF38f90e3482a8b19F12E5a6D2FCa757",
       "ERC4626_morphoGauntletUsdcPrime_Ethereum": "0x8c106EEDAd96553e64287A5A6839c3Cc78afA3D0",
       "ERC4626_morphoKpkUsdcPrime_Ethereum": "0x4Ef53d2cAa51C447fdFEEedee8F07FD1962C9ee6",
+      "ERC4626_morphoRockawayxUsdcYield_Ethereum": "0xE0181090c22579B6A217f1522cbf8c9f1F0C1965",
       "aavePool": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
       "aaveRewardsController": "0x8164Cc65827dcFe994AB23944CBC90e0aa80bFcb",
       "aaveUSDC": "0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c",

--- a/packages/portfolio-deploy/test/privateArgs-ymax1.json
+++ b/packages/portfolio-deploy/test/privateArgs-ymax1.json
@@ -1404,6 +1404,7 @@
       "ERC4626_morphoSteakhouseHighYieldInstant_Ethereum": "0xbeeff2C5bF38f90e3482a8b19F12E5a6D2FCa757",
       "ERC4626_morphoGauntletUsdcPrime_Ethereum": "0x8c106EEDAd96553e64287A5A6839c3Cc78afA3D0",
       "ERC4626_morphoKpkUsdcPrime_Ethereum": "0x4Ef53d2cAa51C447fdFEEedee8F07FD1962C9ee6",
+      "ERC4626_morphoRockawayxUsdcYield_Ethereum": "0xE0181090c22579B6A217f1522cbf8c9f1F0C1965",
       "aavePool": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
       "aaveRewardsController": "0x8164Cc65827dcFe994AB23944CBC90e0aa80bFcb",
       "aaveUSDC": "0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c",


### PR DESCRIPTION
closes: https://linear.app/agoric/issue/AGO-927/agoric-sdk-register-rockawayx-usdc-yield-vault-erc4626-morpho-v2
## Description
Adds the address for the RockawayX Usdc Yield vault to the ymax contract

### Testing Considerations
Can only be tested once deployed to ymax0 mainnet

### Upgrade Considerations
Both ymax0 mainnet and later ymax1 mainnet contract must be redeployed for this address to be registered on them