### PR TITLE
feat(portfolio-api): Improve the `chainOf` fallback path

### DIFF
--- a/packages/portfolio-api/src/places.ts
+++ b/packages/portfolio-api/src/places.ts
@@ -200,7 +200,7 @@ export const chainOf = (id: AssetPlaceRef): SupportedChain => {
     return PoolPlaces[id as PoolKey].chainName;
   }
 
-  // Fallback: syntactic pool id like `${Protocol}_${Chain}` => `${Chain}`.
+  // Fallback: syntactic pool id ending in `_${Chain}` => `${Chain}`.
   // This enables base graph edges for pools even if not listed in PoolPlaces.
   const m = /^(?:[A-Za-z0-9]+_)+([A-Za-z0-9]+)$/.exec(id);
   if (m) return m[1] as SupportedChain;

--- a/packages/portfolio-api/src/places.ts
+++ b/packages/portfolio-api/src/places.ts
@@ -202,8 +202,8 @@ export const chainOf = (id: AssetPlaceRef): SupportedChain => {
 
   // Fallback: syntactic pool id like `${Protocol}_${Chain}` => `${Chain}`.
   // This enables base graph edges for pools even if not listed in PoolPlaces.
-  const m = /^([A-Za-z0-9]+)_([A-Za-z0-9-]+)$/.exec(id);
-  if (m) return m[2] as SupportedChain;
+  const m = /^(?:[A-Za-z0-9]+_)+([A-Za-z0-9]+)$/.exec(id);
+  if (m) return m[1] as SupportedChain;
 
   throw Fail`Cannot determine chain for ${id}`;
 };


### PR DESCRIPTION
...for InstrumentId strings with more than two underscore-separated components

### Upgrade Considerations
Safe for immediate deployment.