### PR TITLE
fix(flaky): handlePendingTx logs timeout on MAKE_ACCOUNT transaction with no matching event

### DIFF
--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -136,13 +136,17 @@ test('handlePendingTx logs timeout on MAKE_ACCOUNT transaction with no matching 
     sourceAddress,
   };
 
-  setTimeout(() => {
+  // A short timeout keeps the test fast. The exact value is only used to build
+  // the expected "within N minutes" message below, so it stays in sync.
+  const timeoutMs = 300;
+
+  const emitWalletCreated = () => {
     const mockLog = createSmartWalletCreatedLog(
       expectedWalletAddr,
       walletOwner,
       'agoric-3',
     );
-    // Add metadata for mock WebSocket simulation (though this arrives after timeout)
+    // Add metadata for mock WebSocket simulation (arrives after the timeout).
     (mockLog as any).expectedWalletAddress = expectedWalletAddr;
 
     const filter = {
@@ -154,21 +158,36 @@ test('handlePendingTx logs timeout on MAKE_ACCOUNT transaction with no matching 
     };
 
     (provider as any).emit(filter, mockLog);
-  }, 3010);
+  };
+
+  // This test exercises the path where the timeout warning fires first and the
+  // matching event arrives afterwards (still resolving the watcher). Racing a
+  // fixed emit delay against the timeout was flaky: with only a ~10ms margin,
+  // CI timer jitter routinely let the event's SUCCESS resolve `done` before the
+  // timeout callback ran, dropping the WALLET_TX_NOT_FOUND log. Instead, emit
+  // the event only *after* observing the timeout warning, so the ordering is
+  // deterministic regardless of scheduling jitter.
+  const emitAfterTimeoutP = (async () => {
+    while (!logMessages.some(m => m.includes('[WALLET_TX_NOT_FOUND]'))) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    emitWalletCreated();
+  })();
 
   await t.notThrowsAsync(async () => {
     await handlePendingTx(makeAccountTx, {
       ...opts,
       log: logger,
-      timeoutMs: 3000,
+      timeoutMs,
     });
   });
+  await emitAfterTimeoutP;
 
   t.deepEqual(logMessages, [
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching for wallet creation: subscribing to ${factoryAddress}, expecting event from ${factoryAddress}, expectedAddr ${expectedWalletAddr}`,
     `[${txId}] Subscribed with subId=mock-subscription-id to ${factoryAddress}`,
-    `[${txId}] [WALLET_TX_NOT_FOUND] ✗ No wallet creation found for expectedAddr ${expectedWalletAddr} within 0.05 minutes`,
+    `[${txId}] [WALLET_TX_NOT_FOUND] ✗ No wallet creation found for expectedAddr ${expectedWalletAddr} within ${timeoutMs / 60000} minutes`,
     `[${txId}] ✅ SUCCESS: expectedAddr=${expectedWalletAddr} txHash=0x123abc block=18500000`,
     `[${txId}] MAKE_ACCOUNT tx resolved`,
   ]);


### PR DESCRIPTION
## Description

Fixes a flaky test in `services/ymax-planner`:

- **Test:** `wallet-watcher › handlePendingTx logs timeout on MAKE_ACCOUNT transaction with no matching event`
- **File:** `services/ymax-planner/test/wallet-watcher.test.ts`

### Root cause — timing race with a ~10 ms margin

The test schedules the mock wallet-creation event to be emitted **3010 ms** into the run, while the watcher's timeout is configured for **3000 ms** — a nominal ordering margin of only ~10 ms.

In `watchSmartWalletTx` (`src/watchers/wallet-watcher.ts`) the timeout callback is *log-only* and never resolves the watcher:

```js
// Intentional: does not resolve/reject; only logs on timeout
const timeoutId = setTimeout(() => {
  if (done) return;
  log(`[${PendingTxCode.WALLET_TX_NOT_FOUND}] ✗ No wallet creation found ...`);
}, timeoutMs);
```

The watcher settles (`done = true`) only when the matching event arrives and logs `✅ SUCCESS`. So the expected log sequence — `WALLET_TX_NOT_FOUND` **then** `SUCCESS` — depends on the 3000 ms timeout firing before the 3010 ms event handler sets `done`.

Under CI timer jitter (and because the internal 3000 ms timer is registered a few ms *after* the test's 3010 ms timer, following several `await` hops), the 3000 ms timeout regularly fired *after* the event had already resolved `done`. The `if (done) return` guard then skipped the `WALLET_TX_NOT_FOUND` log, and `t.deepEqual(logMessages, [...])` failed with the timeout line missing and only `SUCCESS` present.

### Evidence it is flaky (not a regression)

Observed the identical `AssertionError` on **three unrelated master commits** in the last two weeks — `acbc12e3`, `236258498`, and `563ce87d` (a `Bump policyVersion` change) — across both the `node-old` and `node-new` lanes. The test file (last changed 2026-06-29) and `wallet-watcher.ts` (2026-07-06) were **unchanged** across every passing and failing commit, so the test both passed and failed on identical code. A sibling SwingSet flake even failed on a docs-only commit in the same window.

### Fix

Make the ordering deterministic instead of racing a fixed delay against the timeout: emit the wallet-creation event only **after** observing the `WALLET_TX_NOT_FOUND` warning in the captured logs. A short `timeoutMs` (300 ms) keeps the test fast, and the expected `within N minutes` string is derived from the same `timeoutMs` so it stays in sync.

### Verification

- `yarn test test/wallet-watcher.test.ts` run **20×** consecutively → **20/20 pass** (was intermittently failing).
- Full `@aglocal/ymax-planner` suite: **179 passed**, 2 pre-existing known failures, 1 skipped — no regression.
- Test wall-clock dropped from ~3.0 s to ~0.3 s.

### Security Considerations

None. Test-only change; no production code or authority boundaries are affected.

### Scaling Considerations

None — the test now runs ~10× faster and uses no additional resources.

### Documentation Considerations

None.

### Testing Considerations

This is itself a test-reliability fix. The `WALLET_TX_NOT_FOUND` alerting code prefix (matched by ops tooling) is preserved; only the test's timing strategy changed. The pattern — deriving the event emission from an observed log rather than a wall-clock delay — is a good template for the other timeout tests in this file should they show similar jitter.

### Upgrade Considerations

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_013YsvQitpzBcYjx5P25U5qs)_