### PR TITLE
chore: add checks for source address to operation watcher

### DIFF
--- a/services/ymax-planner/src/watchers/operation-watcher.ts
+++ b/services/ymax-planner/src/watchers/operation-watcher.ts
@@ -22,6 +22,7 @@ import type { WatcherResult } from '../pending-tx-manager.ts';
 import {
   extractPayloadHash,
   extractPaddedTxId,
+  extractExecuteSourceAddress,
   fetchReceiptWithRetry,
   handleTxRevert,
   handleOperationFailure,
@@ -71,8 +72,13 @@ export const padTxId = (txId: string, sourceAddress: string): string => {
 
 /**
  * Check whether a transaction's calldata matches the expected padded txId
- * or payloadHash. Resilient to contract bugs that may not correctly pad the
- * txId — returns true if either identifier matches, and warns if they disagree.
+ * or payloadHash, and that it was sent by the expected source address.
+ * Resilient to contract bugs that may not correctly pad the txId — returns true
+ * if either identifier matches, and warns if they disagree.
+ *
+ * The router is shared by all portfolios, so identifier agreement alone does not
+ * prove the transaction belongs to this pending tx: the GMP `sourceAddress` must
+ * also name the LCA that sent the message (cf. watchGmp).
  */
 const matchesTxPayload = (
   txData: string,
@@ -81,7 +87,16 @@ const matchesTxPayload = (
   log: (...args: unknown[]) => void,
   txHash: string,
   txId: string,
+  expectedSourceAddress: string,
 ): boolean => {
+  const gmpSourceAddress = extractExecuteSourceAddress(txData);
+  if (gmpSourceAddress !== expectedSourceAddress) {
+    log(
+      `⚠️  IGNORED: txHash=${txHash} sourceAddress mismatch: expected ${expectedSourceAddress}, got ${gmpSourceAddress}`,
+    );
+    return false;
+  }
+
   const extractedTxId = extractPaddedTxId(txData);
   const txIdMatches = extractedTxId === paddedTxId;
 
@@ -120,6 +135,7 @@ const parseOperationResultLog = (
   abiCoder: AbiCoder = new AbiCoder(),
 ): {
   idHash: string;
+  sourceAddressHash: string;
   txId: string;
   allegedRemoteAccount: string;
   instructionSelector: string;
@@ -131,6 +147,7 @@ const parseOperationResultLog = (
   }
 
   const idHash = log.topics[1];
+  const sourceAddressHash = log.topics[2];
   const allegedRemoteAccount = log.topics[3];
   const [txIdPadded, instructionSelector, success, reason] = abiCoder.decode(
     ['string', 'bytes4', 'bool', 'bytes'],
@@ -139,6 +156,7 @@ const parseOperationResultLog = (
 
   return {
     idHash,
+    sourceAddressHash,
     txId: txIdPadded.replace(/\0+$/, ''),
     allegedRemoteAccount,
     instructionSelector,
@@ -175,6 +193,8 @@ export const watchOperationResult = ({
     // The txId must be padded to match sourceAddress length
     const paddedTxId = padTxId(txId, sourceAddress);
     const expectedIdHash = id(paddedTxId);
+    // For indexed strings, Solidity stores keccak256(string) in the topic.
+    const expectedSourceAddressHash = id(sourceAddress);
 
     log(
       `Watching for OperationResult on router ${routerAddress} with id: ${txId}`,
@@ -277,7 +297,15 @@ export const watchOperationResult = ({
         }
 
         if (
-          !matchesTxPayload(txData, paddedTxId, payloadHash, log, txHash, txId)
+          !matchesTxPayload(
+            txData,
+            paddedTxId,
+            payloadHash,
+            log,
+            txHash,
+            txId,
+            sourceAddress,
+          )
         ) {
           return;
         }
@@ -294,11 +322,14 @@ export const watchOperationResult = ({
           return;
         }
 
-        // Check for OperationResult event in receipt
+        // Check for OperationResult event in receipt. The txId hash alone does
+        // not identify our transaction on a router shared by all portfolios, so
+        // the event must also come from the expected source address.
         const matchingLog = receipt.logs.find(
           l =>
             l.topics?.[0] === OPERATION_RESULT_SIGNATURE &&
-            l.topics?.[1] === expectedIdHash,
+            l.topics?.[1] === expectedIdHash &&
+            l.topics?.[2] === expectedSourceAddressHash,
         );
         if (matchingLog) {
           const { success } = parseOperationResultLog(matchingLog);
@@ -311,7 +342,11 @@ export const watchOperationResult = ({
           // Event-level failure: wait for confirmations before declaring failure
           const logFilter: Filter = {
             address: routerAddress,
-            topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
+            topics: [
+              OPERATION_RESULT_SIGNATURE,
+              expectedIdHash,
+              expectedSourceAddressHash,
+            ],
           };
           const watcherResult = await handleOperationFailure({
             eventLog: matchingLog,
@@ -425,14 +460,22 @@ export const lookBackOperationResult = async ({
     // The txId must be padded to match sourceAddress length (see padTxId).
     const paddedTxId = padTxId(txId, sourceAddress);
     const expectedIdHash = id(paddedTxId);
+    const expectedSourceAddressHash = id(sourceAddress);
 
     log(
-      `Searching blocks ${savedFromBlock} → ${toBlock} for OperationResult with id ${txId} (hash: ${expectedIdHash})`,
+      `Searching blocks ${savedFromBlock} → ${toBlock} for OperationResult with id ${txId} (hash: ${expectedIdHash}, sourceAddressHash: ${expectedSourceAddressHash})`,
     );
 
+    // The sourceAddressIndex topic authenticates the event against the LCA that
+    // sent this transaction's message; the shared router emits events for all
+    // sources, and any of them can carry a colliding id hash.
     const baseFilter: Filter = {
       address: routerAddress,
-      topics: [OPERATION_RESULT_SIGNATURE, expectedIdHash],
+      topics: [
+        OPERATION_RESULT_SIGNATURE,
+        expectedIdHash,
+        expectedSourceAddressHash,
+      ],
     };
 
     const updateFailedTxLowerBound = (_from: number, to: number) =>
@@ -456,8 +499,13 @@ export const lookBackOperationResult = async ({
       predicate: ev => {
         try {
           const parsed = parseOperationResultLog(ev);
-          log(`Check: idHash=${parsed.idHash} success=${parsed.success}`);
-          return parsed.idHash === expectedIdHash;
+          log(
+            `Check: idHash=${parsed.idHash} txId=${parsed.txId} sourceAddressHash=${parsed.sourceAddressHash} success=${parsed.success}`,
+          );
+          return (
+            parsed.idHash === expectedIdHash &&
+            parsed.sourceAddressHash === expectedSourceAddressHash
+          );
         } catch (e) {
           log(`Parse error:`, e);
           return false;
@@ -503,7 +551,15 @@ export const lookBackOperationResult = async ({
       signal: sharedSignal,
       toAddress: routerAddress,
       verifyFailedTx: tx =>
-        matchesTxPayload(tx.data, paddedTxId, payloadHash, log, tx.hash, txId),
+        matchesTxPayload(
+          tx.data,
+          paddedTxId,
+          payloadHash,
+          log,
+          tx.hash,
+          txId,
+          sourceAddress,
+        ),
       onRejectedChunk: updateFailedTxLowerBound,
     });
 

--- a/services/ymax-planner/src/watchers/watcher-utils.ts
+++ b/services/ymax-planner/src/watchers/watcher-utils.ts
@@ -156,6 +156,26 @@ export const extractPayloadHash = (data: string): string | null => {
 };
 
 /**
+ * Parses the `execute(bytes32, string, string, bytes)` calldata and returns the
+ * Axelar GMP `sourceAddress` (arg index 2) — the account on the source chain
+ * that sent the message.
+ *
+ * @param data - Transaction input data (the full `execute()` calldata)
+ * @returns The source address, or null if parsing fails
+ */
+export const extractExecuteSourceAddress = (data: string): string | null => {
+  try {
+    const parsed = axelarExecuteIface.parseTransaction({ data });
+    if (!parsed) return null;
+
+    const [_commandId, _sourceChain, sourceAddress] = parsed.args;
+    return typeof sourceAddress === 'string' ? sourceAddress : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
  * Parses the `execute(bytes32, string, string, bytes)` calldata, extracts the
  * inner `payload`, strips its 4-byte function selector, and abi-decodes the
  * first argument as a string — which is the padded txId.

--- a/services/ymax-planner/test/operation-watcher.test.ts
+++ b/services/ymax-planner/test/operation-watcher.test.ts
@@ -23,6 +23,8 @@ const OPERATION_RESULT_SIGNATURE = id(
 );
 
 const MOCK_SOURCE_ADDRESS = 'agoric1testaddr0123456789abcdefghijklmno';
+/** Same length as MOCK_SOURCE_ADDRESS, so it pads txIds identically. */
+const ATTACKER_SOURCE_ADDRESS = 'agoric1attacker0123456789abcdefghijklmn';
 
 /**
  * Build a mock router payload that embeds the padded txId as the first
@@ -81,18 +83,19 @@ const createMockOperationResultLog = (
   reason: string = '',
   blockNumber: number = 1000,
   transactionHash: string = '0x123abc',
+  sourceAddress: string = MOCK_SOURCE_ADDRESS,
 ): Pick<
   Log,
   'address' | 'topics' | 'data' | 'blockNumber' | 'transactionHash'
 > => {
   const abiCoder = new AbiCoder();
   const expectedIdHash = id(paddedId);
-  const sourceAddressHash = id(MOCK_SOURCE_ADDRESS);
+  const sourceAddressHash = id(sourceAddress);
   const mockAccountAddress = zeroPadValue('0x01', 32);
   const reasonBytes = reason ? Buffer.from(reason, 'utf8') : new Uint8Array(0);
   const data = abiCoder.encode(
     ['string', 'bytes4', 'bool', 'bytes'],
-    [MOCK_SOURCE_ADDRESS, '0x00000000', success, reasonBytes],
+    [paddedId, '0x00000000', success, reasonBytes],
   );
 
   return {
@@ -425,7 +428,10 @@ test('lookBackOperationResult phase 2 detects reverted tx via padded txId', asyn
   // Build a router payload containing the padded txId
   const paddedId = padTxId(txId, MOCK_SOURCE_ADDRESS);
   const payload = buildRouterPayload(paddedId);
-  const { calldata, payloadHash } = encodeExecuteCalldata(payload);
+  const { calldata, payloadHash } = encodeExecuteCalldata(
+    payload,
+    MOCK_SOURCE_ADDRESS,
+  );
 
   // No OperationResult events (phase 1 finds nothing)
   const provider = createMockProvider(latestBlock, []);
@@ -508,7 +514,10 @@ test('watchOperationResult detects revert via Alchemy subscription (live mode)',
   // Build a router payload containing the padded txId
   const paddedId = padTxId(txId, MOCK_SOURCE_ADDRESS);
   const payload = buildRouterPayload(paddedId);
-  const { calldata, payloadHash } = encodeExecuteCalldata(payload);
+  const { calldata, payloadHash } = encodeExecuteCalldata(
+    payload,
+    MOCK_SOURCE_ADDRESS,
+  );
 
   // Receipt for the reverted tx (no OperationResult events)
   (provider as any).getTransactionReceipt = async (hash: string) => {
@@ -608,6 +617,329 @@ test('lookBackOperationResult returns not-found when both phases find nothing', 
   });
 
   t.false(result.settled, 'Should not be settled when nothing found');
+  t.true(
+    logMessages.some(msg => msg.includes('ROUTED_GMP_TX_NOT_FOUND')),
+    'Should log not-found code',
+  );
+});
+
+// --- Source authentication tests ---
+//
+// The router is shared by all portfolios, so an OperationResult whose padded id
+// hash collides with a pending txId must not settle that tx unless it also came
+// from the LCA that sent the message.
+
+test('watchOperationResult ignores OperationResult event from another source (live mode)', async t => {
+  const routerAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const txId = 'tx8' as `tx${number}`;
+  const paddedId = padTxId(txId, MOCK_SOURCE_ADDRESS);
+  const chainId = 'eip155:1';
+  const provider = createMockProvider(1000);
+  const kvStore = makeKVStoreFromMap(new Map());
+  const txHash = '0xspoofedlivetx';
+  const blockNumber = 18500000;
+
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  // Event carries the victim's id hash but the attacker's source address.
+  const spoofedLog = createMockOperationResultLog(
+    routerAddress,
+    paddedId,
+    true, // success
+    '',
+    blockNumber,
+    txHash,
+    ATTACKER_SOURCE_ADDRESS,
+  );
+
+  const payload = buildRouterPayload(paddedId);
+  const { calldata, payloadHash } = encodeExecuteCalldata(
+    payload,
+    MOCK_SOURCE_ADDRESS,
+  );
+
+  (provider as any).getTransactionReceipt = async (hash: string) => {
+    if (hash === txHash) {
+      return {
+        status: 1,
+        blockNumber,
+        blockHash: '0xblockhash',
+        transactionHash: txHash,
+        logs: [spoofedLog],
+      };
+    }
+    return null;
+  };
+
+  const abortController = new AbortController();
+
+  setTimeout(() => {
+    const wsMessage = JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'eth_subscription',
+      params: {
+        result: {
+          removed: false,
+          transaction: {
+            hash: txHash,
+            input: calldata,
+            to: routerAddress,
+            from: '0x0000000000000000000000000000000000000001',
+            value: '0x0',
+            blockNumber: `0x${blockNumber.toString(16)}`,
+          },
+        },
+        subscription: 'mock-sub-id',
+      },
+    });
+
+    (provider as any).websocket.emit('message', wsMessage);
+  }, 50);
+
+  // The watcher keeps waiting when it rejects an event, so stop it explicitly.
+  setTimeout(() => abortController.abort('test done'), 500);
+
+  const result = await watchOperationResult({
+    routerAddress: routerAddress as `0x${string}`,
+    provider,
+    chainId,
+    kvStore,
+    txId,
+    sourceAddress: MOCK_SOURCE_ADDRESS,
+    payloadHash,
+    timeoutMs: 3000,
+    signal: abortController.signal,
+    log: logger,
+  });
+
+  t.false(result.settled, 'Should not settle on an event from another source');
+  t.false(
+    logMessages.some(msg => msg.includes('✅ SUCCESS')),
+    'Should not log success',
+  );
+});
+
+test('watchOperationResult ignores router tx from another source (live mode)', async t => {
+  const routerAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const txId = 'tx9' as `tx${number}`;
+  const paddedId = padTxId(txId, MOCK_SOURCE_ADDRESS);
+  const chainId = 'eip155:1';
+  const provider = createMockProvider(1000);
+  const kvStore = makeKVStoreFromMap(new Map());
+  const txHash = '0xspoofedcalldatatx';
+  const blockNumber = 18500000;
+
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  // Replay of the victim's payload (so payloadHash matches) from the attacker's
+  // source address, reverting so it would otherwise settle as a failure.
+  const payload = buildRouterPayload(paddedId);
+  const { calldata, payloadHash } = encodeExecuteCalldata(
+    payload,
+    ATTACKER_SOURCE_ADDRESS,
+  );
+
+  (provider as any).getTransactionReceipt = async (hash: string) => {
+    if (hash === txHash) {
+      return {
+        status: 0,
+        blockNumber,
+        blockHash: '0xblockhash',
+        transactionHash: txHash,
+        logs: [],
+      };
+    }
+    return null;
+  };
+  (provider as any).getBlockNumber = async () => blockNumber + 5000;
+
+  const abortController = new AbortController();
+
+  setTimeout(() => {
+    const wsMessage = JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'eth_subscription',
+      params: {
+        result: {
+          removed: false,
+          transaction: {
+            hash: txHash,
+            input: calldata,
+            to: routerAddress,
+            from: '0x0000000000000000000000000000000000000001',
+            value: '0x0',
+            blockNumber: `0x${blockNumber.toString(16)}`,
+          },
+        },
+        subscription: 'mock-sub-id',
+      },
+    });
+
+    (provider as any).websocket.emit('message', wsMessage);
+  }, 50);
+
+  setTimeout(() => abortController.abort('test done'), 500);
+
+  const result = await watchOperationResult({
+    routerAddress: routerAddress as `0x${string}`,
+    provider,
+    chainId,
+    kvStore,
+    txId,
+    sourceAddress: MOCK_SOURCE_ADDRESS,
+    payloadHash,
+    timeoutMs: 3000,
+    signal: abortController.signal,
+    log: logger,
+  });
+
+  t.false(result.settled, 'Should not settle on a tx from another source');
+  t.true(
+    logMessages.some(msg => msg.includes('sourceAddress mismatch')),
+    'Should log the source mismatch',
+  );
+  t.false(
+    logMessages.some(msg => msg.includes('REVERTED')),
+    'Should not report a revert',
+  );
+});
+
+test('lookBackOperationResult ignores OperationResult event from another source', async t => {
+  const routerAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const txId = 'tx10' as `tx${number}`;
+  const paddedId = padTxId(txId, MOCK_SOURCE_ADDRESS);
+  const chainId = 'eip155:1';
+  const kvStore = makeKVStoreFromMap(new Map());
+  const latestBlock = 1000;
+
+  // Event carries the victim's id hash but the attacker's source address. The
+  // mock provider ignores topic filters, so this also covers an RPC that
+  // returns more logs than the filter asked for.
+  const spoofedLog = createMockOperationResultLog(
+    routerAddress,
+    paddedId,
+    true, // success
+    '',
+    latestBlock,
+    '0xspoofedlookbacktx',
+    ATTACKER_SOURCE_ADDRESS,
+  );
+
+  const provider = createMockProvider(latestBlock, [spoofedLog]);
+  // No failed txs either (phase 2 finds nothing)
+  (provider as any).send = async (method: string) => {
+    if (method === 'trace_filter') return [];
+    return 'mock-subscription-id';
+  };
+
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  const result = await lookBackOperationResult({
+    routerAddress: routerAddress as `0x${string}`,
+    provider,
+    chainId,
+    kvStore,
+    txId,
+    sourceAddress: MOCK_SOURCE_ADDRESS,
+    payloadHash: MOCK_PAYLOAD_HASH,
+    makeAbortController,
+    publishTimeMs: Date.now() - 60000,
+    log: logger,
+  });
+
+  t.false(result.settled, 'Should not settle on an event from another source');
+  t.true(
+    logMessages.some(msg =>
+      msg.includes(`sourceAddressHash=${id(ATTACKER_SOURCE_ADDRESS)}`),
+    ),
+    'Should log the rejected event source hash',
+  );
+  t.true(
+    logMessages.some(msg => msg.includes('ROUTED_GMP_TX_NOT_FOUND')),
+    'Should log not-found code',
+  );
+});
+
+test('lookBackOperationResult phase 2 ignores reverted tx from another source', async t => {
+  const routerAddress = '0x8Cb4b25E77844fC0632aCa14f1f9B23bdd654EbF';
+  const txId = 'tx11' as `tx${number}`;
+  const chainId = 'eip155:1';
+  const kvStore = makeKVStoreFromMap(new Map());
+  const latestBlock = 1000;
+  const revertTxHash = '0xspoofedrevertedtx';
+
+  // Replay of the victim's payload from the attacker's source address.
+  const paddedId = padTxId(txId, MOCK_SOURCE_ADDRESS);
+  const payload = buildRouterPayload(paddedId);
+  const { calldata, payloadHash } = encodeExecuteCalldata(
+    payload,
+    ATTACKER_SOURCE_ADDRESS,
+  );
+
+  const provider = createMockProvider(latestBlock, []);
+
+  (provider as any).send = async (method: string, _params: any[]) => {
+    if (method === 'trace_filter') {
+      return [
+        {
+          type: 'call',
+          action: {
+            from: '0x0000000000000000000000000000000000000001',
+            to: routerAddress.toLowerCase(),
+            input: calldata,
+            value: '0x0',
+            gas: '0x186a0',
+            callType: 'call',
+          },
+          blockNumber: latestBlock,
+          transactionHash: revertTxHash,
+          error: 'Reverted',
+          subtraces: 0,
+          traceAddress: [],
+        },
+      ];
+    }
+    return 'mock-subscription-id';
+  };
+
+  (provider as any).getTransactionReceipt = async (hash: string) => {
+    if (hash === revertTxHash) {
+      return {
+        status: 0,
+        blockNumber: latestBlock,
+        blockHash: '0xblockhash',
+        transactionHash: revertTxHash,
+        logs: [],
+      };
+    }
+    return null;
+  };
+  (provider as any).getBlockNumber = async () => latestBlock + 5000;
+
+  const logMessages: string[] = [];
+  const logger = (...args: any[]) => logMessages.push(args.join(' '));
+
+  const result = await lookBackOperationResult({
+    routerAddress: routerAddress as `0x${string}`,
+    provider,
+    chainId,
+    kvStore,
+    txId,
+    sourceAddress: MOCK_SOURCE_ADDRESS,
+    payloadHash,
+    makeAbortController,
+    publishTimeMs: Date.now() - 60000,
+    log: logger,
+  });
+
+  t.false(result.settled, 'Should not settle on a tx from another source');
+  t.true(
+    logMessages.some(msg => msg.includes('sourceAddress mismatch')),
+    'Should log the source mismatch',
+  );
   t.true(
     logMessages.some(msg => msg.includes('ROUTED_GMP_TX_NOT_FOUND')),
     'Should log not-found code',


### PR DESCRIPTION
closes: https://linear.app/agoric/issue/AGO-890/resolver-doesnt-check-source-of-operationresult-event

## Description
This PR adds checks to the operation watcher to check for the source address of the `OperationResult` event fired by the shared router contract.

### Testing Considerations
Unit tests have been added to verify the functionality of the new code

### Upgrade Considerations
This will require redeployment of the ymax-planner for ymax1 to use the modified code
