### PR TITLE
fix(orchestration): preserve typed-data arrays in XSnap

### DIFF
--- a/packages/orchestration/src/utils/viem-utils/eip712-normalize.ts
+++ b/packages/orchestration/src/utils/viem-utils/eip712-normalize.ts
@@ -310,10 +310,13 @@ const visit = (
       ? actualLength
       : Math.min(actualLength, requiredLength ?? actualLength);
     result = keep ? value : new Array(length);
-    type = Array.from({ length }, () => ({
-      state: 'required' as const,
-      type: base,
-    })) as unknown as TypeFields;
+    // Do not use an Array as the field record. Under XSnap, Object.keys on a
+    // two-element array can return duplicate "0" keys, which would visit the
+    // first element twice and leave the second result as a hole.
+    type = Object.create(null) as TypeFields;
+    for (let index = 0; index < length; index += 1) {
+      type[index] = { state: 'required', type: base };
+    }
   } else {
     // Guaranteed defined (the `!isArray && !baseType` case already
     // returned above); this is just for TS's narrowing.
@@ -336,12 +339,14 @@ const visit = (
     }
   }
 
-  // `fieldName in obj`, not `hasOwnProperty`: matches how viem itself reads
-  // field values (plain property access resolves the prototype chain).
-  // `type` is null-prototype or a fresh array-literal record, so there's no
-  // inherited-property risk to guard against here.
-  // eslint-disable-next-line guard-for-in
-  for (const fieldName in type) {
+  // Snapshot the keys and use an indexed loop before recursing. `fieldName in
+  // obj`, rather than `hasOwnProperty`, matches how viem reads field values
+  // (plain property access resolves the prototype chain). `type` is a
+  // null-prototype record, so Object.keys includes exactly the fields to
+  // visit.
+  const fieldNames = Object.keys(type);
+  for (let fieldIndex = 0; fieldIndex < fieldNames.length; fieldIndex += 1) {
+    const fieldName = fieldNames[fieldIndex];
     const field = type[fieldName];
     const present = fieldName in value;
 

--- a/packages/xsnap/test/xs-js.test.js
+++ b/packages/xsnap/test/xs-js.test.js
@@ -13,6 +13,35 @@ import { options } from './message-tools.js';
 
 const io = { spawn: proc.spawn, os: os.type(), fs, tmpName }; // WARNING: ambient
 
+// Fixed upstream on 2024-09-17 by eac811dcd ("XS: Array.from fix"):
+// https://github.com/Moddable-OpenSource/moddable/commit/eac811dcd989bc6ecd56f4eb125e4a9ffd1a8860
+// Remove `.failing` when the embedded XS engine includes that fix.
+test.failing('Array.from result enumerates every element', async t => {
+  const opts = options(io);
+  const vat = await xsnap(opts);
+  await vat.evaluate(`
+    const array = Array.from({ length: 2 }, (_, index) => index);
+    const iteratedKeys = [];
+    for (const key in array) {
+      iteratedKeys.push(key);
+    }
+    const report = {
+      keys: Object.keys(array),
+      iteratedKeys,
+      propertyNames: Object.getOwnPropertyNames(array),
+    };
+    issueCommand(
+      new TextEncoder().encode(JSON.stringify(report)).buffer,
+    );
+  `);
+  await vat.close();
+  t.deepEqual(JSON.parse(opts.messages[0]), {
+    keys: ['0', '1'],
+    iteratedKeys: ['0', '1'],
+    propertyNames: ['0', '1', 'length'],
+  });
+});
+
 test('reject odd regex range', async t => {
   const opts = options(io);
   const vat = await xsnap(opts);


### PR DESCRIPTION
## Description

EIP-712 normalization inside XSnap can silently omit elements from typed-data arrays. The XS engine embedded by XSnap mis-enumerates a two-element array created by `Array.from`: `Object.keys` and `Object.getOwnPropertyNames` report a duplicate `"0"`, while `for...in` visits only `"0"`. The existing normalization path therefore skipped the second element and left a hole, causing Permit2 hashing to fail for signed delegation messages containing per-instrument arrays.

This PR preserves every element by avoiding an Array as the normalization field record and by snapshotting keys before recursive normalization. It also records the underlying XS enumeration defect as an expected-failure engine test so that a future engine correction is visible.

This fix depends on #12836 because that branch supplies the signed mandate message that exposed the application failure. #12839 exercises the corrected path through an upgrade-level delegation journey.

## Security Considerations

Normalization is part of the signed-message boundary. Dropping or changing an array element can make the data being authorized differ from the data being hashed or enforced. This change preserves the complete typed-data array before Permit2 hashing and downstream validation.

## Testing Considerations

Direct normalization coverage exercises typed-data arrays and recursive normalization. A separate XSnap regression test records the engine defect as an intentional expected failure. The A3P scenario in #12839 covers the application impact end to end by signing and processing a mandate with multiple typed-data array elements.

The expected-failure test is not evidence that this fix is incomplete: it describes the underlying XS enumeration behavior, while the production normalization path now avoids relying on that behavior.

## Upgrade Considerations

The change affects message normalization code used after contract upgrade and does not require durable-state migration. Deployments accepting the new per-instrument signed messages need this fix before exercising array-valued mandates in XSnap.
