### PR TITLE
test(a3p): exercise Presley's delegated mandate journey

### DIFF
--- a/a3p-integration/proposals/p:instrument-oracle/README.md
+++ b/a3p-integration/proposals/p:instrument-oracle/README.md
@@ -1,4 +1,7 @@
 # Instrument oracle upgrade
 
 Upgrade the existing `ymax1` instance to the locally-built portfolio contract,
-then exercise the instrument-oracle invitation and saved wallet entry.
+then exercise the instrument-oracle invitation and Presley's owner-signed
+delegation journey through saved wallet entries and published audit state.
+The test verifies each EIP-712 signature off-chain before submitting the
+verified signer, matching the EVM Message Service boundary.

--- a/a3p-integration/proposals/p:instrument-oracle/package.json
+++ b/a3p-integration/proposals/p:instrument-oracle/package.json
@@ -9,6 +9,7 @@
     "@agoric/client-utils",
     "@agoric/cosmic-proto",
     "@agoric/deploy-script-support",
+    "@agoric/orchestration",
     "@agoric/portfolio-api"
   ],
   "type": "module",
@@ -19,15 +20,18 @@
     "@agoric/client-utils": "portal:./local-packages/client-utils",
     "@agoric/cosmic-proto": "dev",
     "@agoric/deploy-script-support": "dev",
+    "@agoric/orchestration": "dev",
     "@agoric/portfolio-api": "dev",
     "@agoric/synthetic-chain": "^0.7.1",
     "@endo/init": "^1.1.12",
-    "ava": "^6.4.1"
+    "ava": "^6.4.1",
+    "viem": "^2.31.0"
   },
   "resolutions": {
     "@agoric/client-utils": "portal:./local-packages/client-utils",
     "@agoric/cosmic-proto": "portal:./local-packages/cosmic-proto",
     "@agoric/deploy-script-support": "portal:./local-packages/deploy-script-support",
+    "@agoric/orchestration": "portal:./local-packages/orchestration",
     "@agoric/portfolio-api": "portal:./local-packages/portfolio-api",
     "@aglocal/portfolio-contract": "portal:./local-packages/portfolio-contract",
     "@aglocal/portfolio-deploy": "portal:./local-packages/portfolio-deploy"

--- a/a3p-integration/proposals/p:instrument-oracle/test/instrument-oracle.test.js
+++ b/a3p-integration/proposals/p:instrument-oracle/test/instrument-oracle.test.js
@@ -2,6 +2,13 @@
 import '@endo/init/debug.js';
 
 import { LOCAL_CONFIG, makeVstorageKit } from '@agoric/client-utils';
+import { getPermitWitnessTransferFromData } from '@agoric/orchestration/src/utils/permit2.ts';
+import { recoverTypedDataAddress } from '@agoric/orchestration/src/vendor/viem/viem-typedData.js';
+import {
+  getYmaxStandaloneOperationData,
+  getYmaxWitness,
+} from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.js';
+import { portfolioPermissionsToEIP712 } from '@agoric/portfolio-api/src/portfolio-permissions.js';
 import {
   makeWalletStoreFromSigner,
   makeYmaxControlKitForSynthetic,
@@ -14,10 +21,14 @@ import anyTest from 'ava';
 import { execFileSync } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { isDeepStrictEqual } from 'node:util';
+import { privateKeyToAccount } from 'viem/accounts';
 import { makeSyntheticWalletKit } from '../synthetic-wallet-kit.js';
 
 /**
+ * @import {EVMWalletMessageHandler} from '@aglocal/portfolio-contract/src/evm-wallet-handler.exo.ts';
  * @import {InstrumentOracle} from '@aglocal/portfolio-contract/src/instrument-oracle.exo.ts';
+ * @import {PortfolioDelegationClient} from '@aglocal/portfolio-contract/src/delegation.exo.ts';
+ * @import {ExternalPortfolioPermissions, StatusFor} from '@agoric/portfolio-api';
  * @import {WalletStoreEntryProxy} from '@agoric/client-utils/src/wallet-store.ts';
  * @import {TestFn} from 'ava';
  */
@@ -43,6 +54,13 @@ const makeStore = address => {
   });
 };
 
+const getKeyAddress = keyName =>
+  execFileSync(
+    'agd',
+    ['keys', 'show', '-a', keyName, '--keyring-backend=test'],
+    { encoding: 'utf8' },
+  ).trim();
+
 const eventuallyRead = async (path, expected) => {
   let lastError;
   for (let attempt = 0; attempt < 30; attempt += 1) {
@@ -60,10 +78,40 @@ const eventuallyRead = async (path, expected) => {
   throw lastError;
 };
 
+const eventuallyReadWhere = async (path, predicate, description) => {
+  let lastValue;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      lastValue = await vsc.readPublished(path);
+      if (predicate(lastValue)) return lastValue;
+    } catch {
+      // The path may not have been published yet.
+    }
+    await new Promise(resolve => setTimeout(resolve, 1_000));
+  }
+  throw Error(`${description}; last value: ${String(lastValue)}`);
+};
+
+const presleyAccount = privateKeyToAccount(
+  '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+);
+
+const signMessage = async message => {
+  const signed = harden({
+    ...message,
+    signature: await presleyAccount.signTypedData(message),
+  });
+  const verifiedSigner = await recoverTypedDataAddress(signed);
+  assert(verifiedSigner === presleyAccount.address);
+  return harden({ ...signed, verifiedSigner });
+};
+
 const makeContext = async () => {
   const bundleId = (await readFile(bundleIdPath, 'utf8')).trim();
   assert(bundleId.startsWith('b1-'));
-  const { contracts } = JSON.parse(await readFile(privateArgsPath, 'utf8'));
+  const { chainInfo, contracts } = JSON.parse(
+    await readFile(privateArgsPath, 'utf8'),
+  );
 
   const controlSigner = makeSyntheticWalletKit({
     address: ymax1ControlAddress,
@@ -83,6 +131,7 @@ const makeContext = async () => {
 
   return {
     bundleId,
+    chainInfo: harden(chainInfo),
     contracts: harden(contracts),
     control,
     instance,
@@ -98,7 +147,7 @@ test.before(async t => {
   t.context = await makeContext();
 });
 
-test.serial('upgrade ymax1 and exercise the instrument oracle', async t => {
+test.serial('upgrade ymax1 and provision policy capabilities', async t => {
   const { bundleId, contracts, control, instance, vatDetails } = t.context;
   assert(vatDetails);
 
@@ -131,17 +180,18 @@ test.serial('upgrade ymax1 and exercise the instrument oracle', async t => {
     })();
   assert(creatorFacet);
 
-  const oracleAddress = execFileSync(
-    'agd',
-    ['keys', 'show', '-a', 'instrumentOracle', '--keyring-backend=test'],
-    { encoding: 'utf8' },
-  ).trim();
+  const oracleAddress = getKeyAddress('instrumentOracle');
+  const handlerAddress = getKeyAddress('evmHandler');
   const { ymax1, postalService } = await fromPublishedEntries(
     'agoricNames.instance',
   );
 
   await creatorFacet.deliverInstrumentOracleInvitation(
     oracleAddress,
+    postalService,
+  );
+  await creatorFacet.deliverEVMWalletHandlerInvitation(
+    handlerAddress,
     postalService,
   );
 
@@ -152,6 +202,12 @@ test.serial('upgrade ymax1 and exercise the instrument oracle', async t => {
   );
   /** @type {WalletStoreEntryProxy<InstrumentOracle>} */
   const oracle = oracleStore.get('instrumentOracle');
+
+  const handlerStore = makeStore(handlerAddress);
+  await handlerStore.saveOfferResult(
+    { instance: ymax1, description: 'evmWalletHandler' },
+    'evmWalletHandler',
+  );
 
   await oracle.submitTvlUpdate('Aave_Base', 12_345_679n, 1_786_123_456);
   await oracle.submitTvlUpdate('Aave_Base', 12_600_000n, 1_786_123_516);
@@ -164,6 +220,225 @@ test.serial('upgrade ymax1 and exercise the instrument oracle', async t => {
     await eventuallyRead('ymax1.instruments.Aave_Base', expected),
     expected,
   );
+});
+
+test.serial('Presley delegates, changes mandate, and revokes', async t => {
+  const { chainInfo, contracts } = t.context;
+  const agentAddress = getKeyAddress('presleyAgent');
+  const handlerAddress = getKeyAddress('evmHandler');
+  const handlerStore = makeStore(handlerAddress);
+  /** @type {WalletStoreEntryProxy<EVMWalletMessageHandler>} */
+  const handler = handlerStore.get('evmWalletHandler', { sendOnly: true });
+  const { ymax1 } = await fromPublishedEntries('agoricNames.instance');
+  const base = contracts.Base;
+  const chainId = BigInt(chainInfo.Base.reference);
+  const allocations = harden([
+    { instrument: 'Aave_Base', portion: 80n },
+    { instrument: '@Base', portion: 20n },
+  ]);
+  /** @type {ExternalPortfolioPermissions} */
+  const initialPermissions = harden({
+    allocation: {
+      instruments: {
+        Aave_Base: {
+          maxWeightBps: 9_000,
+          minVaultTvlUsd: 10_000_000n,
+        },
+      },
+    },
+  });
+  const deadline = BigInt(Math.floor(Date.now() / 1_000) + 3_600);
+  const witness = getYmaxWitness('OpenPortfolio', {
+    allocations,
+    grantee: {
+      address: agentAddress,
+      permissions: portfolioPermissionsToEIP712(initialPermissions),
+    },
+  });
+  const openMessage = getPermitWitnessTransferFromData(
+    {
+      permitted: { token: base.usdc, amount: 1_000_000n },
+      spender: base.depositFactory,
+      nonce: 1n,
+      deadline,
+    },
+    base.permit2,
+    chainId,
+    witness,
+  );
+  await handler.handleMessage(await signMessage(openMessage));
+
+  const walletPath = `ymax1.evmWallets.${presleyAccount.address}`;
+  const openStatus = await eventuallyReadWhere(
+    walletPath,
+    value => value?.status === 'ok' && typeof value.result === 'string',
+    'signed open+grant did not succeed',
+  );
+  const portfolioKey = openStatus.result;
+  t.regex(portfolioKey, /^portfolio\d+$/);
+  const portfolioPath = `ymax1.portfolios.${portfolioKey}`;
+  const agentsPath = `${portfolioPath}.agents`;
+
+  t.deepEqual(
+    await eventuallyReadWhere(
+      agentsPath,
+      value => value?.agent1?.state === 'active',
+      'delegation was not published',
+    ),
+    {
+      agent1: {
+        grantee: agentAddress,
+        permissions: initialPermissions,
+        state: 'active',
+        updatedAtPolicyVersion: 1,
+      },
+    },
+  );
+
+  const agentStore = makeStore(agentAddress);
+  await agentStore.saveOfferResult(
+    { instance: ymax1, description: 'portfolioMandate' },
+    'portfolioMandate',
+  );
+  /** @type {WalletStoreEntryProxy<PortfolioDelegationClient>} */
+  const delegation = agentStore.get('portfolioMandate');
+  /** @type {StatusFor['portfolio']} */
+  const beforeAccepted = await vsc.readPublished(portfolioPath);
+  const acceptedSyncState = harden({
+    policyVersion: beforeAccepted.policyVersion,
+    rebalanceCount: beforeAccepted.rebalanceCount,
+  });
+  await delegation.setTargetAllocation(
+    harden({
+      targetAllocation: {
+        Aave_Base: 80n,
+        '@Base': 20n,
+      },
+      syncState: acceptedSyncState,
+      agentMemo: 'presley-a3p',
+    }),
+  );
+
+  const afterAccepted = await eventuallyReadWhere(
+    portfolioPath,
+    value => value?.flowCount > beforeAccepted.flowCount,
+    'delegated allocation did not start a flow',
+  );
+  t.true(
+    Object.values(afterAccepted.flowsRunning || {}).some(
+      flow =>
+        flow.agent === 'agent1' &&
+        flow.policyVersion === acceptedSyncState.policyVersion,
+    ),
+  );
+
+  /** @type {ExternalPortfolioPermissions} */
+  const tighterPermissions = harden({
+    allocation: {
+      instruments: {
+        Aave_Base: {
+          maxWeightBps: 7_000,
+          minVaultTvlUsd: 10_000_000n,
+        },
+      },
+    },
+  });
+  const changeMessage = getYmaxStandaloneOperationData(
+    {
+      agentId: 1n,
+      permissions: portfolioPermissionsToEIP712(tighterPermissions),
+      portfolio: BigInt(portfolioKey.replace('portfolio', '')),
+      nonce: 2n,
+      deadline,
+    },
+    'ChangePermissions',
+    chainId,
+    base.depositFactory,
+  );
+  await handler.handleMessage(await signMessage(changeMessage));
+  const afterChange = await eventuallyReadWhere(
+    portfolioPath,
+    value => value?.policyVersion > acceptedSyncState.policyVersion,
+    'permission replacement was not published',
+  );
+  const changedAgents = /** @type {StatusFor['portfolioAgents']} */ (
+    await vsc.readPublished(agentsPath)
+  );
+  t.deepEqual(changedAgents.agent1.permissions, tighterPermissions);
+
+  await t.throwsAsync(
+    delegation.setTargetAllocation(
+      harden({
+        targetAllocation: { Aave_Base: 80n, '@Base': 20n },
+        syncState: acceptedSyncState,
+      }),
+    ),
+    { message: /expected policyVersion/ },
+  );
+
+  const currentSyncState = harden({
+    policyVersion: afterChange.policyVersion,
+    rebalanceCount: afterChange.rebalanceCount,
+  });
+  await t.throwsAsync(
+    delegation.setTargetAllocation(
+      harden({
+        targetAllocation: { Aave_Base: 80n, '@Base': 20n },
+        syncState: currentSyncState,
+      }),
+    ),
+    { message: /mandate\.maxWeight/ },
+  );
+  const afterRejections = /** @type {StatusFor['portfolio']} */ (
+    await vsc.readPublished(portfolioPath)
+  );
+  t.is(afterRejections.flowCount, afterChange.flowCount);
+
+  const revokeMessage = getYmaxStandaloneOperationData(
+    {
+      agentId: 1n,
+      portfolio: BigInt(portfolioKey.replace('portfolio', '')),
+      nonce: 3n,
+      deadline,
+    },
+    'Revoke',
+    chainId,
+    base.depositFactory,
+  );
+  await handler.handleMessage(await signMessage(revokeMessage));
+  await eventuallyReadWhere(
+    agentsPath,
+    value => value?.agent1?.state === 'revoked',
+    'revocation was not published',
+  );
+  const afterRevoke = /** @type {StatusFor['portfolio']} */ (
+    await vsc.readPublished(portfolioPath)
+  );
+  await t.throwsAsync(
+    delegation.setTargetAllocation(
+      harden({
+        targetAllocation: { Aave_Base: 60n, '@Base': 40n },
+        syncState: {
+          policyVersion: afterRevoke.policyVersion,
+          rebalanceCount: afterRevoke.rebalanceCount,
+        },
+      }),
+    ),
+    { message: /delegation client is not active/ },
+  );
+});
+
+test.serial('instrument-oracle revocation remains effective', async t => {
+  const { control } = t.context;
+  const { result: creatorFacet } =
+    await control.ymaxControl.getCreatorFacet.once({
+      saveAs: 'creatorFacet',
+      overwrite: true,
+    })();
+  assert(creatorFacet);
+  const oracleStore = makeStore(getKeyAddress('instrumentOracle'));
+  /** @type {WalletStoreEntryProxy<InstrumentOracle>} */
+  const oracle = oracleStore.get('instrumentOracle');
 
   await creatorFacet.revokeInstrumentOracle();
   await t.throwsAsync(

--- a/a3p-integration/proposals/p:instrument-oracle/test/instrument-oracle.test.js
+++ b/a3p-integration/proposals/p:instrument-oracle/test/instrument-oracle.test.js
@@ -243,6 +243,7 @@ test.serial('Presley delegates, changes mandate, and revokes', async t => {
         Aave_Base: {
           maxWeightBps: 9_000,
           minVaultTvlUsd: 10_000_000n,
+          maxVaultShareBps: 100,
         },
       },
     },
@@ -339,6 +340,7 @@ test.serial('Presley delegates, changes mandate, and revokes', async t => {
         Aave_Base: {
           maxWeightBps: 7_000,
           minVaultTvlUsd: 10_000_000n,
+          maxVaultShareBps: 50,
         },
       },
     },

--- a/a3p-integration/proposals/p:instrument-oracle/use.sh
+++ b/a3p-integration/proposals/p:instrument-oracle/use.sh
@@ -3,8 +3,10 @@ set -euo pipefail
 
 source /usr/src/upgrade-test-scripts/env_setup.sh
 
-if ! agd keys show instrumentOracle --keyring-backend=test >/dev/null 2>&1; then
-  agd keys add instrumentOracle --keyring-backend=test >/dev/null 2>&1
-fi
-oracle_addr="$(agd keys show -a instrumentOracle --keyring-backend=test)"
-provisionSmartWallet "$oracle_addr" "200000000ubld"
+for key_name in instrumentOracle presleyAgent evmHandler; do
+  if ! agd keys show "$key_name" --keyring-backend=test >/dev/null 2>&1; then
+    agd keys add "$key_name" --keyring-backend=test >/dev/null 2>&1
+  fi
+  key_addr="$(agd keys show -a "$key_name" --keyring-backend=test)"
+  provisionSmartWallet "$key_addr" "200000000ubld"
+done

--- a/a3p-integration/proposals/p:instrument-oracle/yarn.lock
+++ b/a3p-integration/proposals/p:instrument-oracle/yarn.lock
@@ -79,14 +79,14 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@agoric/async-flow@npm:0.1.1-dev-90d550b.0.90d550b":
-  version: 0.1.1-dev-90d550b.0.90d550b
-  resolution: "@agoric/async-flow@npm:0.1.1-dev-90d550b.0.90d550b"
+"@agoric/async-flow@npm:dev":
+  version: 0.1.1-dev-277e6df.0.277e6df
+  resolution: "@agoric/async-flow@npm:0.1.1-dev-277e6df.0.277e6df"
   dependencies:
-    "@agoric/base-zone": "npm:0.1.1-dev-90d550b.0.90d550b"
-    "@agoric/internal": "npm:0.3.3-dev-90d550b.0.90d550b"
-    "@agoric/store": "npm:0.9.3-dev-90d550b.0.90d550b"
-    "@agoric/vow": "npm:0.1.1-dev-90d550b.0.90d550b"
+    "@agoric/base-zone": "npm:0.1.1-dev-277e6df.0.277e6df"
+    "@agoric/internal": "npm:0.3.3-dev-277e6df.0.277e6df"
+    "@agoric/store": "npm:0.9.3-dev-277e6df.0.277e6df"
+    "@agoric/vow": "npm:0.1.1-dev-277e6df.0.277e6df"
     "@endo/common": "npm:^1.4.0"
     "@endo/errors": "npm:^1.3.1"
     "@endo/eventual-send": "npm:^1.5.0"
@@ -94,7 +94,22 @@ __metadata:
     "@endo/pass-style": "npm:^1.8.1"
     "@endo/patterns": "npm:^1.9.1"
     "@endo/promise-kit": "npm:^1.2.1"
-  checksum: 10c0/bb821f7022f510f70ce2bdf8737f52a2e48b1ff6fa432d35e4cf16a17b2dea5bcdaca9f726263a118d8cc3b968629d63d8b991ae9b50682a297e8c4c2cc6958a
+  checksum: 10c0/8e705fb05436713aed9fe45920f41f58e1baa8d1719e0ec1268c34aa4bd5082382458cc0325777c243c7df5f21cab1a5ad6efdac376af3339a8c561bb9e58d42
+  languageName: node
+  linkType: hard
+
+"@agoric/base-zone@npm:0.1.1-dev-277e6df.0.277e6df":
+  version: 0.1.1-dev-277e6df.0.277e6df
+  resolution: "@agoric/base-zone@npm:0.1.1-dev-277e6df.0.277e6df"
+  dependencies:
+    "@agoric/store": "npm:0.9.3-dev-277e6df.0.277e6df"
+    "@endo/common": "npm:^1.4.0"
+    "@endo/errors": "npm:^1.3.1"
+    "@endo/exo": "npm:^1.7.0"
+    "@endo/far": "npm:^1.1.14"
+    "@endo/pass-style": "npm:^1.8.1"
+    "@endo/patterns": "npm:^1.9.1"
+  checksum: 10c0/1346cf06a80d85ae762c9e7e70b0c5005c5954953bdb870b973d6f2a8496fae2d303e0fcd69f8d3a25891d32030aad0d234472265772cd3f95c8f2221eebd4d1
   languageName: node
   linkType: hard
 
@@ -255,6 +270,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@agoric/internal@npm:0.3.3-dev-277e6df.0.277e6df":
+  version: 0.3.3-dev-277e6df.0.277e6df
+  resolution: "@agoric/internal@npm:0.3.3-dev-277e6df.0.277e6df"
+  dependencies:
+    "@agoric/base-zone": "npm:0.1.1-dev-277e6df.0.277e6df"
+    "@endo/cache-map": "npm:^1.1.0"
+    "@endo/common": "npm:^1.4.0"
+    "@endo/compartment-mapper": "npm:^2.3.0"
+    "@endo/errors": "npm:^1.3.1"
+    "@endo/eventual-send": "npm:^1.5.0"
+    "@endo/far": "npm:^1.1.14"
+    "@endo/init": "npm:^1.1.13"
+    "@endo/marshal": "npm:^1.10.0"
+    "@endo/nat": "npm:^5.2.0"
+    "@endo/pass-style": "npm:^1.8.1"
+    "@endo/patterns": "npm:^1.9.1"
+    "@endo/promise-kit": "npm:^1.2.1"
+    "@endo/stream": "npm:^1.3.1"
+    import-meta-resolve: "npm:^4.1.0"
+    jessie.js: "npm:^0.3.4"
+  checksum: 10c0/db4b928c4721c14aacb3162823995675b0b3f3a57899fd8f55fc3465f3b8c036f4798a832a290451b310d064f00991255bf24c2802061c833c4ac9027b0e4adb
+  languageName: node
+  linkType: hard
+
 "@agoric/internal@npm:0.3.3-dev-90d550b.0.90d550b, @agoric/internal@npm:dev":
   version: 0.3.3-dev-90d550b.0.90d550b
   resolution: "@agoric/internal@npm:0.3.3-dev-90d550b.0.90d550b"
@@ -307,6 +346,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@agoric/network@npm:dev":
+  version: 0.1.1-dev-277e6df.0.277e6df
+  resolution: "@agoric/network@npm:0.1.1-dev-277e6df.0.277e6df"
+  dependencies:
+    "@agoric/internal": "npm:0.3.3-dev-277e6df.0.277e6df"
+    "@agoric/store": "npm:0.9.3-dev-277e6df.0.277e6df"
+    "@agoric/vat-data": "npm:0.5.3-dev-277e6df.0.277e6df"
+    "@endo/base64": "npm:^1.1.1"
+    "@endo/errors": "npm:^1.3.1"
+    "@endo/far": "npm:^1.1.14"
+    "@endo/pass-style": "npm:^1.8.1"
+    "@endo/patterns": "npm:^1.9.1"
+    "@endo/promise-kit": "npm:^1.2.1"
+  checksum: 10c0/30cc6ff74fa64c6f8d37b041e6eab6129326e933bfaa360f7aaf31dfd89aded42f941829430e5ab5f6051caf6563081b08bedb56904deb84fa26a912eb00f696
+  languageName: node
+  linkType: hard
+
 "@agoric/notifier@npm:0.6.3-dev-90d550b.0.90d550b, @agoric/notifier@npm:dev":
   version: 0.6.3-dev-90d550b.0.90d550b
   resolution: "@agoric/notifier@npm:0.6.3-dev-90d550b.0.90d550b"
@@ -322,22 +378,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@agoric/orchestration@npm:dev":
-  version: 0.1.1-dev-90d550b.0.90d550b
-  resolution: "@agoric/orchestration@npm:0.1.1-dev-90d550b.0.90d550b"
+"@agoric/orchestration@portal:./local-packages/orchestration::locator=p%3Ainstrument-oracle%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@agoric/orchestration@portal:./local-packages/orchestration::locator=p%3Ainstrument-oracle%40workspace%3A."
   dependencies:
-    "@agoric/async-flow": "npm:0.1.1-dev-90d550b.0.90d550b"
-    "@agoric/cosmic-proto": "npm:0.4.1-dev-90d550b.0.90d550b"
-    "@agoric/ertp": "npm:0.16.3-dev-90d550b.0.90d550b"
-    "@agoric/internal": "npm:0.3.3-dev-90d550b.0.90d550b"
-    "@agoric/network": "npm:0.1.1-dev-90d550b.0.90d550b"
-    "@agoric/notifier": "npm:0.6.3-dev-90d550b.0.90d550b"
-    "@agoric/store": "npm:0.9.3-dev-90d550b.0.90d550b"
-    "@agoric/time": "npm:0.3.3-dev-90d550b.0.90d550b"
-    "@agoric/vat-data": "npm:0.5.3-dev-90d550b.0.90d550b"
-    "@agoric/vow": "npm:0.1.1-dev-90d550b.0.90d550b"
-    "@agoric/zoe": "npm:0.26.3-dev-90d550b.0.90d550b"
-    "@agoric/zone": "npm:0.2.3-dev-90d550b.0.90d550b"
+    "@agoric/async-flow": "npm:dev"
+    "@agoric/cosmic-proto": "npm:dev"
+    "@agoric/ertp": "npm:dev"
+    "@agoric/internal": "npm:dev"
+    "@agoric/network": "npm:dev"
+    "@agoric/notifier": "npm:dev"
+    "@agoric/store": "npm:dev"
+    "@agoric/time": "npm:dev"
+    "@agoric/vat-data": "npm:dev"
+    "@agoric/vow": "npm:dev"
+    "@agoric/zoe": "npm:dev"
+    "@agoric/zone": "npm:dev"
     "@cosmjs/encoding": "npm:^0.36.0"
     "@endo/base64": "npm:^1.1.1"
     "@endo/common": "npm:^1.4.0"
@@ -351,13 +407,12 @@ __metadata:
     bech32: "npm:^2.0.0"
     bs58: "npm:^6.0.0"
   peerDependencies:
-    "@agoric/vats": 0.15.1
+    "@agoric/vats": "*"
   peerDependenciesMeta:
     "@agoric/vats":
       optional: true
-  checksum: 10c0/6f768a4304ff96858905840634841a8f9e55ffba12c13b5b6660a3291aac812cfa04613a599b9709ca697c64ea1067fd2cf94500232041ecbcede423f593465a
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@agoric/pola-io@npm:dev":
   version: 0.1.1-dev-90d550b.0.90d550b
@@ -406,6 +461,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@agoric/store@npm:0.9.3-dev-277e6df.0.277e6df":
+  version: 0.9.3-dev-277e6df.0.277e6df
+  resolution: "@agoric/store@npm:0.9.3-dev-277e6df.0.277e6df"
+  dependencies:
+    "@endo/errors": "npm:^1.3.1"
+    "@endo/exo": "npm:^1.7.0"
+    "@endo/marshal": "npm:^1.10.0"
+    "@endo/pass-style": "npm:^1.8.1"
+    "@endo/patterns": "npm:^1.9.1"
+  checksum: 10c0/bc4cb01093ecd904c8481753dc0808d4959aa1f4e074330171cafb90efa668688f8f3ca8013944a1ece0691a64674386a2691dc8dfd33695b50b9efebc063878
+  languageName: node
+  linkType: hard
+
 "@agoric/store@npm:0.9.3-dev-90d550b.0.90d550b, @agoric/store@npm:dev":
   version: 0.9.3-dev-90d550b.0.90d550b
   resolution: "@agoric/store@npm:0.9.3-dev-90d550b.0.90d550b"
@@ -431,6 +499,27 @@ __metadata:
     "@endo/nat": "npm:^5.2.0"
     better-sqlite3: "npm:^12.10.0"
   checksum: 10c0/4b63e3fae8902adb522c4f5fdc875292485b06dfe80ed2b97ed7efdfb43dcd1be3d09a0cd56b873a56ca7a779701826264b127db5a95d2a61b03bc262eb76754
+  languageName: node
+  linkType: hard
+
+"@agoric/swingset-liveslots@npm:0.10.3-dev-277e6df.0.277e6df":
+  version: 0.10.3-dev-277e6df.0.277e6df
+  resolution: "@agoric/swingset-liveslots@npm:0.10.3-dev-277e6df.0.277e6df"
+  dependencies:
+    "@agoric/internal": "npm:0.3.3-dev-277e6df.0.277e6df"
+    "@agoric/store": "npm:0.9.3-dev-277e6df.0.277e6df"
+    "@endo/env-options": "npm:^1.1.11"
+    "@endo/errors": "npm:^1.3.1"
+    "@endo/eventual-send": "npm:^1.5.0"
+    "@endo/exo": "npm:^1.7.0"
+    "@endo/far": "npm:^1.1.14"
+    "@endo/init": "npm:^1.1.13"
+    "@endo/marshal": "npm:^1.10.0"
+    "@endo/nat": "npm:^5.2.0"
+    "@endo/pass-style": "npm:^1.8.1"
+    "@endo/patterns": "npm:^1.9.1"
+    "@endo/promise-kit": "npm:^1.2.1"
+  checksum: 10c0/0808422ebefcfb733a083d7e860f8ba2b28168d49019087ae279215289173fc23cfe9c8afc5d24e7a882af22668a2a9e3bfac44ed7e65b877e1eb5f4b7cc7c30
   languageName: node
   linkType: hard
 
@@ -543,6 +632,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@agoric/vat-data@npm:0.5.3-dev-277e6df.0.277e6df":
+  version: 0.5.3-dev-277e6df.0.277e6df
+  resolution: "@agoric/vat-data@npm:0.5.3-dev-277e6df.0.277e6df"
+  dependencies:
+    "@agoric/base-zone": "npm:0.1.1-dev-277e6df.0.277e6df"
+    "@agoric/store": "npm:0.9.3-dev-277e6df.0.277e6df"
+    "@agoric/swingset-liveslots": "npm:0.10.3-dev-277e6df.0.277e6df"
+    "@endo/errors": "npm:^1.3.1"
+    "@endo/exo": "npm:^1.7.0"
+    "@endo/patterns": "npm:^1.9.1"
+  checksum: 10c0/814fabf57c2cfa687926944c1f5eec9f8e886f1a880c0c3dbbf0f70a4095fd3f8435899c683b7f961d1ee37974ebfdfdac3433efb838613eed46d7de0fae47b3
+  languageName: node
+  linkType: hard
+
 "@agoric/vat-data@npm:0.5.3-dev-90d550b.0.90d550b, @agoric/vat-data@npm:dev":
   version: 0.5.3-dev-90d550b.0.90d550b
   resolution: "@agoric/vat-data@npm:0.5.3-dev-90d550b.0.90d550b"
@@ -585,6 +688,22 @@ __metadata:
     import-meta-resolve: "npm:^4.1.0"
     jessie.js: "npm:^0.3.4"
   checksum: 10c0/2859c5d9abdd4ba60aaf68ce91dc642138bf45a89fbf7908eb2c38ae572e78d33220c5ee441d025bd9fcb708f818e0079182f57bee4f6130cc73318e7f5192ca
+  languageName: node
+  linkType: hard
+
+"@agoric/vow@npm:0.1.1-dev-277e6df.0.277e6df":
+  version: 0.1.1-dev-277e6df.0.277e6df
+  resolution: "@agoric/vow@npm:0.1.1-dev-277e6df.0.277e6df"
+  dependencies:
+    "@agoric/base-zone": "npm:0.1.1-dev-277e6df.0.277e6df"
+    "@agoric/internal": "npm:0.3.3-dev-277e6df.0.277e6df"
+    "@endo/env-options": "npm:^1.1.11"
+    "@endo/errors": "npm:^1.3.1"
+    "@endo/eventual-send": "npm:^1.5.0"
+    "@endo/pass-style": "npm:^1.8.1"
+    "@endo/patterns": "npm:^1.9.1"
+    "@endo/promise-kit": "npm:^1.2.1"
+  checksum: 10c0/935380cae4f29a85b0e24b72c8f6d0c115e8560a0a5d9571a24cbe4c3939840eb895dcfd13e25bab71acc8883cab8448e43f2323cf507b81e8a99277a53522c3
   languageName: node
   linkType: hard
 
@@ -3455,11 +3574,13 @@ __metadata:
     "@agoric/client-utils": "portal:./local-packages/client-utils"
     "@agoric/cosmic-proto": "npm:dev"
     "@agoric/deploy-script-support": "npm:dev"
+    "@agoric/orchestration": "npm:dev"
     "@agoric/portfolio-api": "npm:dev"
     "@agoric/synthetic-chain": "npm:^0.7.1"
     "@endo/init": "npm:^1.1.12"
     ava: "npm:^6.4.1"
     ts-blank-space: "npm:^0.7.0"
+    viem: "npm:^2.31.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

This PR adds upgrade-level integration coverage for the complete owner-signed delegation lifecycle introduced by the preceding mandate PRs. It extends the existing instrument-oracle A3P proposal so a test starts from a released ymax1 deployment, upgrades it, provisions the required operators, and then follows a delegated agent from initial grant through enforcement and revocation.

The scenario:

- upgrades ymax1 and provisions the instrument oracle, EVM handler, and delegated agent;
- publishes Aave Base TVL;
- signs and verifies an EIP-712 Permit2 `OpenPortfolio` carrying the initial delegation;
- redeems the mandate invitation and performs an allowed delegated allocation;
- carries a maximum-vault-share limit through the initial and replacement mandates;
- replaces the owner's permissions with a tighter per-instrument `Aave_Base` mandate;
- proves stale-policy and over-weight requests are rejected before a flow starts;
- signs and processes revocation, then proves the revoked capability can no longer act; and
- follows the mandate, policy version, acting agent, flow attribution, and revocation through vstorage audit state.

The test's signature verifier models the EVM Message Service trust boundary by recovering the signer before submitting `verifiedSigner`; it does not bypass signer authentication merely to exercise the contract.

This PR depends on #12838, which fixes XSnap normalization of the mandate's typed-data arrays; #12838 depends on the contract enforcement in #12836, which in turn depends on the schema in #12835.

## Security Considerations

The scenario checks the authority transitions that matter at the integration boundary: owner-authenticated grant and replacement, per-agent capability redemption, policy-version rejection, limit enforcement before flow creation, signer recovery, and revocation.

Mandate enforcement relies on the instrument oracle to provide sufficiently timely TVL updates and a suitable `asOf` time. The contract has no independent freshness bound, so stale high TVL could incorrectly satisfy a minimum-TVL or maximum-vault-share constraint. This test-only PR does not alter that trust boundary.

## Testing Considerations

This is the stack's end-to-end upgrade test. It complements the preceding unit tests by exercising released-state upgrade, invitation provisioning, oracle publication, EIP-712 signing and signer recovery, per-instrument mandates including maximum vault share, contract enforcement, vstorage attribution, and revocation in one lifecycle.

The scenario uses a modeled EVM Message Service verifier rather than an external deployed EMS. External EMS/YDS interoperability remains outside this repository's A3P coverage. It does not test stale-TVL rejection because the contract deliberately relies on oracle update timeliness rather than enforcing an on-chain age bound.

## Upgrade Considerations

The test verifies that the mandate features can be exercised after upgrading a released ymax1 state. It is test-only and introduces no additional production migration or rollout step.
