### PR TITLE
feat(ymax-planner): attach observations to delegated plans

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -60,6 +60,7 @@ import { makeWorkPool } from '@agoric/internal/src/work-pool.js';
 import type {
   FlowKey,
   FundsFlowPlan,
+  PlanObservations,
   PortfolioKey,
   SupportedChain,
 } from '@agoric/portfolio-api';
@@ -77,7 +78,10 @@ import {
 import type { CosmosRPCClient, SubscriptionResponse } from './cosmos-rpc.ts';
 import type { ChainGasState } from './gas-estimation.ts';
 import type { Sdk as SpectrumBlockchainSdk } from './graphql/api-spectrum-blockchain/__generated/sdk.ts';
-import type { InstrumentBlocks } from './instrument-status.ts';
+import type {
+  InstrumentBlocks,
+  InstrumentSnapshot,
+} from './instrument-status.ts';
 import type {
   EvmChain,
   EvmContext,
@@ -223,7 +227,7 @@ export type Powers = {
   network: NetworkSpec;
   getExchangeRates?: () => Promise<RewardTokenRate[] | undefined>;
   getGasCosts?: () => Promise<ChainGasState[] | undefined>;
-  getInstrumentBlocks?: () => Promise<InstrumentBlocks | undefined>;
+  getInstrumentSnapshot?: () => Promise<InstrumentSnapshot | undefined>;
   getPortfolioSummaries?: (
     portfolioKeys: PortfolioKey[],
   ) => Promise<YdsPortfolioSummary[] | undefined>;
@@ -282,6 +286,7 @@ export type ProcessPortfolioPowers = Pick<
   exchangeRates?: RewardTokenRate[];
   gasCosts?: ChainGasState[];
   instrumentBlocks?: InstrumentBlocks;
+  instrumentTvls: PlanObservations['instrumentTvls'];
   vstoragePathPrefixes: {
     portfoliosPathPrefix: string;
   };
@@ -362,6 +367,7 @@ export const processPortfolioEvents = async (
     exchangeRates,
     gasCosts,
     instrumentBlocks,
+    instrumentTvls,
     signingSmartWalletKit,
     walletStore,
     makeNonce,
@@ -451,7 +457,15 @@ export const processPortfolioEvents = async (
     const portfolioId = portfolioIdFromKey(portfolioKey);
     const flowId = flowIdFromKey(flowKey);
     const scope = [portfolioId, flowId] as const;
-    const { policyVersion, rebalanceCount, targetAllocation } = portfolioStatus;
+    const { policyVersion, rebalanceCount } = portfolioStatus;
+    const pendingTargetAllocation =
+      flowDetail.type === 'rebalance' &&
+      flowDetail.initiatingOperation?.type === 'setTargetAllocation' &&
+      flowDetail.initiatingOperation.status === 'pending'
+        ? flowDetail.initiatingOperation.targetAllocation
+        : undefined;
+    const targetAllocation =
+      pendingTargetAllocation ?? portfolioStatus.targetAllocation;
     const versions = [policyVersion, rebalanceCount] as const;
 
     const currentBalances = await getFreshBalances(
@@ -544,7 +558,21 @@ export const processPortfolioEvents = async (
       (logContext as any).plan = plan;
 
       const planOrSteps = plan.order ? plan : plan.flow;
-      return settle('resolvePlan', [...scope, planOrSteps, ...versions], {
+      const observations: PlanObservations | undefined = flowDetail.agent
+        ? {
+            balances: Object.fromEntries(
+              Object.entries(currentBalances).map(([place, amount]) => [
+                place,
+                amount.value,
+              ]),
+            ),
+            instrumentTvls,
+          }
+        : undefined;
+      const args: Parameters<PortfolioPlanner['resolvePlan']> = observations
+        ? [...scope, planOrSteps, ...versions, observations]
+        : [...scope, planOrSteps, ...versions];
+      return settle('resolvePlan', args, {
         plan,
       });
     } catch (err) {
@@ -1035,7 +1063,7 @@ export const startEngine = async (
     makeNonce,
     getExchangeRates,
     getGasCosts,
-    getInstrumentBlocks,
+    getInstrumentSnapshot,
     getPortfolioSummaries,
     now,
   } = powers;
@@ -1048,12 +1076,12 @@ export const startEngine = async (
   const ydsFetchers = {
     exchangeRates: getExchangeRates,
     gasCosts: getGasCosts,
-    instrumentBlocks: getInstrumentBlocks,
+    instrumentSnapshot: getInstrumentSnapshot,
   } as const;
   const ydsState = {
     exchangeRates: undefined as RewardTokenRate[] | undefined,
     gasCosts: undefined as ChainGasState[] | undefined,
-    instrumentBlocks: undefined as InstrumentBlocks | undefined,
+    instrumentSnapshot: undefined as InstrumentSnapshot | undefined,
   };
   const refreshYdsState = async () =>
     Promise.all(
@@ -1072,6 +1100,17 @@ export const startEngine = async (
         },
       ),
     );
+
+  /** Instrument observations are reported per plan; blocks steer planning. */
+  const ydsPowers = () => {
+    const { exchangeRates, gasCosts, instrumentSnapshot } = ydsState;
+    return {
+      exchangeRates,
+      gasCosts,
+      instrumentBlocks: instrumentSnapshot?.blocks,
+      instrumentTvls: instrumentSnapshot?.tvls ?? {},
+    };
+  };
 
   const [vbankAssetCapData] = await Promise.all([
     readStreamCellValue(query.vstorage, 'published.agoricNames.vbankAsset', {
@@ -1201,7 +1240,7 @@ export const startEngine = async (
     feeBrand: feeAsset.brand as Brand<'nat'>,
     vstoragePathPrefixes,
     evmProviders: evmCtx.evmProviders,
-    ...ydsState,
+    ...ydsPowers(),
   });
   await makeWorkPool(portfolioKeys, undefined, async portfolioKey => {
     const { streamCellJson, event } = makeVstorageEvent(
@@ -1379,7 +1418,7 @@ export const startEngine = async (
       Promise.all([refreshYdsState(), updatePortfolioBalances()]).then(() =>
         processPortfolioEvents(portfolioEvents, respHeight, portfoliosMemory, {
           ...processPortfolioPowers,
-          ...ydsState,
+          ...ydsPowers(),
         }),
       ),
       processPendingTxEvents(pendingTxEvents, handlePendingTx, txPowers),

--- a/services/ymax-planner/src/instrument-status.ts
+++ b/services/ymax-planner/src/instrument-status.ts
@@ -1,5 +1,6 @@
 import type { AssetPlaceRef } from '@aglocal/portfolio-contract/src/type-guards-steps.js';
 import type { CaipChainId } from '@agoric/orchestration';
+import type { PlanObservations } from '@agoric/portfolio-api';
 import type { ComputeTargetBalancesOptions } from '@agoric/portfolio-api/src/target-balances.js';
 
 /** cf. https://github.com/Agoric/ymax-web/blob/main/yds/src/api-schemas.ts: Instrument */
@@ -15,6 +16,22 @@ export type YdsInstrument = {
 export type InstrumentBlocks = Required<
   ComputeTargetBalancesOptions<any, any>
 >['instrumentBlocks'];
+
+export type InstrumentSnapshot = {
+  blocks?: InstrumentBlocks;
+  tvls: PlanObservations['instrumentTvls'];
+};
+
+export const extractInstrumentTvls = (
+  instruments: YdsInstrument[],
+): PlanObservations['instrumentTvls'] =>
+  Object.fromEntries(
+    instruments.flatMap(({ id, tvl }) =>
+      tvl !== undefined && Number.isFinite(tvl) && tvl >= 0
+        ? [[id, { tvlUsd: BigInt(Math.round(tvl)) }]]
+        : [],
+    ),
+  );
 
 export const calculateInstrumentBlocks = (
   instruments: YdsInstrument[],

--- a/services/ymax-planner/src/main.ts
+++ b/services/ymax-planner/src/main.ts
@@ -44,8 +44,15 @@ import { makeGraphqlMultiClient } from './graphql-client.ts';
 import { getSdk as getSpectrumBlockchainSdk } from './graphql/api-spectrum-blockchain/__generated/sdk.ts';
 import { startEngine } from './engine.ts';
 import type { ChainGasState } from './gas-estimation.ts';
-import { calculateInstrumentBlocks } from './instrument-status.ts';
-import type { InstrumentBlocks, YdsInstrument } from './instrument-status.ts';
+import {
+  calculateInstrumentBlocks,
+  extractInstrumentTvls,
+} from './instrument-status.ts';
+import type {
+  InstrumentBlocks,
+  InstrumentSnapshot,
+  YdsInstrument,
+} from './instrument-status.ts';
 import { GAS_UNITS_PER_CLAIM, GAS_UNITS_PER_SWAP } from './rewards.ts';
 import {
   createEVMContext,
@@ -425,8 +432,8 @@ export const main = async (
     const sets = { noDepositInstruments, noWithdrawInstruments };
     return JSON.stringify(objectMap(sets, s => [...s].sort()));
   };
-  const getInstrumentBlocks = ydsClient
-    ? async (): Promise<InstrumentBlocks | undefined> => {
+  const getInstrumentSnapshot = ydsClient
+    ? async (): Promise<InstrumentSnapshot | undefined> => {
         const resp = await withHealthLogging(
           'instruments',
           ydsClient.get('instruments?includeAll=true').json(),
@@ -435,6 +442,7 @@ export const main = async (
         if (!resp) return undefined;
         const instruments = (resp as any).data as YdsInstrument[];
         const instrumentBlocks = calculateInstrumentBlocks(instruments);
+        const tvls = extractInstrumentTvls(instruments);
 
         const newBlocksString = stringifyInstrumentBlocks(instrumentBlocks);
         if (newBlocksString !== lastInstrumentBlocksString) {
@@ -442,8 +450,8 @@ export const main = async (
         }
         lastInstrumentBlocksString = newBlocksString;
 
-        // TODO(AGO-550): return instrumentBlocks;
-        return undefined;
+        // TODO(AGO-550): return instrumentBlocks as `blocks`.
+        return { tvls };
       }
     : undefined;
 
@@ -568,7 +576,7 @@ export const main = async (
     network: PROD_NETWORK,
     getExchangeRates,
     getGasCosts,
-    getInstrumentBlocks,
+    getInstrumentSnapshot,
     getPortfolioSummaries,
     signingSmartWalletKit,
     makeNonce,

--- a/services/ymax-planner/test/cctp-watcher.test.ts
+++ b/services/ymax-planner/test/cctp-watcher.test.ts
@@ -86,8 +86,6 @@ test('handlePendingTx processes CCTP transaction successfully', async t => {
 
 test('handlePendingTx keeps tx pending on amount mismatch until timeout and then logs it', async t => {
   const opts = createMockPendingTxOpts();
-  opts.setTimeout = ((callback, _ms, ...args) =>
-    setTimeout(callback, 100, ...args)) as typeof setTimeout;
   const txId = 'tx2';
   opts.fetch = mockFetch({ txId });
   const chain = 'eip155:1'; // Ethereum
@@ -155,13 +153,13 @@ test('handlePendingTx keeps tx pending on amount mismatch until timeout and then
     };
 
     (provider as any).emit(filter, mockLog);
-  }, 200);
+  }, 1000);
 
   await t.notThrowsAsync(async () => {
     await handlePendingTx(cctpTx, {
       ...opts,
       log: logger,
-      timeoutMs: 3000,
+      timeoutMs: 300,
     });
   });
 
@@ -170,7 +168,7 @@ test('handlePendingTx keeps tx pending on amount mismatch until timeout and then
     `[${txId}] Watching for ERC-20 transfers to: ${receiver} with amount: ${expectedAmount}`,
     `[${txId}] Transfer detected: token=${usdcAddress} from=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 to=${receiver} amount=${notExpectedAmt} tx=0x123abc`,
     `[${txId}] Amount mismatch. Expected: ${expectedAmount}, Received: ${notExpectedAmt}`,
-    `[${txId}] [CCTP_TX_NOT_FOUND] ✗ No matching transfer found within 0.05 minutes`,
+    `[${txId}] [CCTP_TX_NOT_FOUND] ✗ No matching transfer found within 0.005 minutes`,
     `[${txId}] Transfer detected: token=${usdcAddress} from=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 to=${receiver} amount=${amount} tx=0x123abc`,
     `[${txId}] ✓ Amount matches! Expected: ${amount}, Received: ${amount}`,
     `[${txId}] CCTP tx resolved`,

--- a/services/ymax-planner/test/engine.test.ts
+++ b/services/ymax-planner/test/engine.test.ts
@@ -448,6 +448,7 @@ const fakePortfolioKit = async ({
     isDryRun: true,
     depositBrand,
     feeBrand,
+    instrumentTvls: {},
     vstoragePathPrefixes: { portfoliosPathPrefix },
     chainNameToChainIdMap: CaipChainIds.testnet,
     evmProviders: mockEvmCtx.evmProviders,
@@ -1149,6 +1150,12 @@ const testSettlement = test.macro(
         portfolioStatus.rebalanceCount,
       ],
     };
+    if (flow.agent && 'expectedPlan' in config) {
+      expectedInvocation.args.push({
+        balances: {},
+        instrumentTvls: powers.instrumentTvls,
+      });
+    }
 
     const vstorageEventDetail = makeVstorageEventDetail(
       blockHeight,
@@ -1190,6 +1197,31 @@ const testSettlement = test.macro(
 
 test('no-step flows resolve with an empty plan', testSettlement, {
   flow: { type: 'rebalance' },
+  expectedPlan: [],
+});
+
+test('delegated plans include current observations', testSettlement, {
+  mutatePortfolioKit: kit => {
+    kit.powers.instrumentTvls = {
+      USDN: { tvlUsd: 10_000_000n },
+    };
+  },
+  flow: { type: 'rebalance', agent: 'agent1', createdAtPolicyVersion: 1 },
+  expectedPlan: [],
+});
+
+test('delegated plans use the flow proposed target', testSettlement, {
+  portfolioStatusOverrides: { targetAllocation: { USDN: 0n } },
+  flow: {
+    type: 'rebalance',
+    agent: 'agent1',
+    createdAtPolicyVersion: 1,
+    initiatingOperation: {
+      type: 'setTargetAllocation',
+      targetAllocation: { USDN: 1n },
+      status: 'pending',
+    },
+  },
   expectedPlan: [],
 });
 

--- a/services/ymax-planner/test/gmp-watcher.test.ts
+++ b/services/ymax-planner/test/gmp-watcher.test.ts
@@ -117,13 +117,13 @@ test('handlePendingTx logs a time out on a GMP transaction with no matching even
     };
 
     (provider as any).emit(filter, mockLog);
-  }, 700);
+  }, 1000);
 
   await t.notThrowsAsync(async () => {
     await handlePendingTx(gmpTx, {
       ...opts,
       log: logger,
-      timeoutMs: 600,
+      timeoutMs: 300,
     });
   });
 
@@ -131,7 +131,7 @@ test('handlePendingTx logs a time out on a GMP transaction with no matching even
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching transaction status for contract ${contractAddress}`,
     `[${txId}] Subscribed with subId=mock-subscription-id for contract ${contractAddress}`,
-    `[${txId}] [GMP_TX_NOT_FOUND] ✗ No transaction status found within 0.01 minutes`,
+    `[${txId}] [GMP_TX_NOT_FOUND] ✗ No transaction status found within 0.005 minutes`,
     `[${txId}] ✅ SUCCESS: txHash=0x123abc block=18500000`,
     `[${txId}] GMP tx resolved`,
   ]);

--- a/services/ymax-planner/test/instrument-status.test.ts
+++ b/services/ymax-planner/test/instrument-status.test.ts
@@ -2,6 +2,7 @@ import test from 'ava';
 
 import {
   calculateInstrumentBlocks,
+  extractInstrumentTvls,
   type YdsInstrument,
 } from '../src/instrument-status.ts';
 
@@ -19,6 +20,26 @@ const instrument = (
 });
 
 const missingDataInstrument: YdsInstrument = { id: '@Ethereum', caipChainId };
+
+test('extractInstrumentTvls reports valid TVL observations', t => {
+  const instruments: YdsInstrument[] = [
+    {
+      ...missingDataInstrument,
+      id: 'aave' as YdsInstrument['id'],
+      tvl: 12_345.6,
+    },
+    { ...missingDataInstrument, id: 'missing' as YdsInstrument['id'] },
+    {
+      ...missingDataInstrument,
+      id: 'invalid' as YdsInstrument['id'],
+      tvl: -1,
+    },
+  ];
+
+  t.deepEqual(extractInstrumentTvls(instruments), {
+    aave: { tvlUsd: 12_346n },
+  });
+});
 
 test('calculateInstrumentBlocks ignores instruments without supply/liquidity data', t => {
   const { noDepositInstruments, noWithdrawInstruments } =

--- a/services/ymax-planner/test/wallet-watcher.test.ts
+++ b/services/ymax-planner/test/wallet-watcher.test.ts
@@ -154,13 +154,13 @@ test('handlePendingTx logs timeout on MAKE_ACCOUNT transaction with no matching 
     };
 
     (provider as any).emit(filter, mockLog);
-  }, 3010);
+  }, 1000);
 
   await t.notThrowsAsync(async () => {
     await handlePendingTx(makeAccountTx, {
       ...opts,
       log: logger,
-      timeoutMs: 3000,
+      timeoutMs: 300,
     });
   });
 
@@ -168,7 +168,7 @@ test('handlePendingTx logs timeout on MAKE_ACCOUNT transaction with no matching 
     `[${txId}] handling ${type} tx`,
     `[${txId}] Watching for wallet creation: subscribing to ${factoryAddress}, expecting event from ${factoryAddress}, expectedAddr ${expectedWalletAddr}`,
     `[${txId}] Subscribed with subId=mock-subscription-id to ${factoryAddress}`,
-    `[${txId}] [WALLET_TX_NOT_FOUND] ✗ No wallet creation found for expectedAddr ${expectedWalletAddr} within 0.05 minutes`,
+    `[${txId}] [WALLET_TX_NOT_FOUND] ✗ No wallet creation found for expectedAddr ${expectedWalletAddr} within 0.005 minutes`,
     `[${txId}] ✅ SUCCESS: expectedAddr=${expectedWalletAddr} txHash=0x123abc block=18500000`,
     `[${txId}] MAKE_ACCOUNT tx resolved`,
   ]);


### PR DESCRIPTION
## Description

Delegated allocation enforcement needs current portfolio balances and vault TVLs. This PR makes the ymax planner and resolver attach that evidence when resolving an agent-attributed plan.

The planner already fetches YDS instruments. It now retains each valid TVL, rounded to whole USD, and sends a balance snapshot plus the per-instrument TVL map as the final `resolvePlan` argument. Owner-attributed flows do not carry observations and remain outside mandate enforcement.

While a delegated target is awaiting mandate acceptance, the planner builds the rebalance from the proposal published on that flow rather than from the last committed portfolio policy. This lets the contract defer policy commitment until validation succeeds without planning the wrong allocation.

`extractInstrumentTvls` omits absent, non-finite, or negative values. Omission is denial rather than a bypass: the contract fails a delegated flow closed when a global TVL or vault-share limit requires an observation for an applicable instrument. The mandate itself remains one global set of scalars; only the evidence is instrument-specific.

`getInstrumentBlocks` becomes `getInstrumentSnapshot`, returning `{ blocks?, tvls }`. Block calculation remains disabled pending AGO-550.

Answers [AGO-1067](https://linear.app/agoric/issue/AGO-1067). PR 3 of 4, stacked on #12848 and followed by #12850.

### Security Considerations

The planner supplies both the plan and the observations used for TVL-dependent checks. These checks detect inconsistent inputs but are not an independent control against planner compromise.

### Scaling Considerations

Each delegated `resolvePlan` message carries a balance map and TVL map bounded by the portfolio's places and the supported instrument set.

### Testing Considerations

Coverage distinguishes agent-attributed from owner flows, exercises TVL rounding plus omission of invalid values, and verifies that a pending flow proposal overrides the last committed policy for planning.

### Upgrade Considerations

Deploy #12848 first: an older contract rejects the widened delegated `resolvePlan` call. Owner flows are unaffected in either deploy order.
