### PR TITLE
test(a3p): cover Presley global-mandate journey

### DIFF
--- a/a3p-integration/proposals/p:lazy-noble-provisioning/README.md
+++ b/a3p-integration/proposals/p:lazy-noble-provisioning/README.md
@@ -5,3 +5,10 @@ then open a portfolio through the EVM wallet handler. The test verifies that
 the ETH-wallet open completes without creating a Noble ICA or beginning Noble
 Forwarding Account registration. A later Noble-dependent plan must begin that
 provisioning on demand.
+
+`presley-plan-observations.test.js` shares this upgrade to exercise Presley's
+owner-signed delegation journey through saved wallet entries and published audit
+state. The real planner capability resolves one delegated flow with acceptable
+observations for two instruments and rejects another after Presley tightens the
+single global mandate. Owner flows and automatic rebalancing do not use the
+observation path.

--- a/a3p-integration/proposals/p:lazy-noble-provisioning/synthetic-wallet-kit.js
+++ b/a3p-integration/proposals/p:lazy-noble-provisioning/synthetic-wallet-kit.js
@@ -1,24 +1,49 @@
 // @ts-check
-import { agoric, mkTemp } from '@agoric/synthetic-chain';
+import { mkTemp } from '@agoric/synthetic-chain';
 import { writeFile } from 'node:fs/promises';
 
 /**
  * @import {UpdateRecord} from '@agoric/smart-wallet/src/smartWallet.js';
+ * @import {agoric as syntheticChainAgoric} from '@agoric/synthetic-chain';
  * @import {VstorageKit} from '@agoric/client-utils';
  * @import {WalletStoreSigner} from '@agoric/client-utils/src/wallet-store.ts';
  */
 
 /**
+ * `agoric wallet send` reports only success or failure, so the rest of the
+ * DeliverTxResponse is synthesized. reflectWalletStore reads only `code` and
+ * `rawLog`.
+ *
+ * XXX narrow `WalletStoreSigner['sendBridgeAction']` to return
+ * `Pick<DeliverTxResponse, 'code' | 'rawLog'>` so that this can go away. That
+ * type is documented as the minimal interface `reflectWalletStore` needs, but
+ * demanding a full tx response obliges every synthetic implementation to invent
+ * these seven fields.
+ */
+const txDetail = harden({
+  height: -1,
+  txIndex: 0,
+  transactionHash: '',
+  events: [],
+  msgResponses: [],
+  gasUsed: 0n,
+  gasWanted: 0n,
+});
+
+/**
  * @param {object} options
+ * @param {typeof syntheticChainAgoric} options.agoric
  * @param {string} options.address
- * @param {VstorageKit} options.vstorageKit
+ * @param {Pick<VstorageKit, 'marshaller'> & {
+ *   readPublished: (path: `wallet.${string}`) => Promise<UpdateRecord>,
+ * }} options.vstorageKit
  * @returns {WalletStoreSigner}
  */
-export const makeSyntheticWalletKit = ({ address, vstorageKit }) => {
+export const makeSyntheticWalletKit = ({ agoric, address, vstorageKit }) => {
   /** @type {WalletStoreSigner['sendBridgeAction']} */
   const sendBridgeAction = async action => {
     const capData = vstorageKit.marshaller.toCapData(harden(action));
-    const offerFile = await mkTemp('lazy-noble-action-XXX');
+    const offerFile = await mkTemp('synthetic-wallet-action-XXX');
     await writeFile(offerFile, JSON.stringify(capData), 'utf-8');
 
     try {
@@ -30,9 +55,10 @@ export const makeSyntheticWalletKit = ({ address, vstorageKit }) => {
         '--offer',
         offerFile,
       );
-      return { code: 0 };
+      return { ...txDetail, code: 0 };
     } catch (error) {
       return {
+        ...txDetail,
         code: 1,
         rawLog: error instanceof Error ? error.message : String(error),
       };

--- a/a3p-integration/proposals/p:lazy-noble-provisioning/test/lazy-noble-provisioning.test.js
+++ b/a3p-integration/proposals/p:lazy-noble-provisioning/test/lazy-noble-provisioning.test.js
@@ -14,6 +14,7 @@ import {
   makeYmaxControlKitForSynthetic,
 } from '@aglocal/portfolio-deploy/src/ymax-control.js';
 import {
+  agoric as agoricAmbient,
   getDetailsMatchingVats,
   getVatInfoFromID,
 } from '@agoric/synthetic-chain';
@@ -52,7 +53,11 @@ const makeNonce = () =>
   `lazy-noble-provisioning-a3p-${Date.now()}-${(walletNonce += 1)}`;
 
 const makeStore = address => {
-  const signer = makeSyntheticWalletKit({ address, vstorageKit: vsc });
+  const signer = makeSyntheticWalletKit({
+    agoric: agoricAmbient,
+    address,
+    vstorageKit: vsc,
+  });
   return makeWalletStoreFromSigner(signer, {
     setTimeout,
     makeNonce,
@@ -108,6 +113,7 @@ const makeContext = async () => {
     { setTimeout },
     {
       signer: makeSyntheticWalletKit({
+        agoric: agoricAmbient,
         address: ymax1ControlAddress,
         vstorageKit: vsc,
       }),

--- a/a3p-integration/proposals/p:lazy-noble-provisioning/test/presley-plan-observations.test.js
+++ b/a3p-integration/proposals/p:lazy-noble-provisioning/test/presley-plan-observations.test.js
@@ -1,0 +1,597 @@
+// @ts-check
+
+// NOTE: While it would be useful to be able to unredact rejections from the
+// portfolio-contract, that runs in a separate vat from these tests.
+import '@endo/init/debug.js';
+
+import {
+  makeWalletStoreFromSigner,
+  makeYmaxControlKitForSynthetic,
+} from '@aglocal/portfolio-deploy/src/ymax-control.js';
+import {
+  LOCAL_CONFIG,
+  makeVstorageKit,
+  retryUntilCondition,
+} from '@agoric/client-utils';
+import { getPermitWitnessTransferFromData } from '@agoric/orchestration/src/utils/permit2.ts';
+import { recoverTypedDataAddress } from '@agoric/orchestration/src/vendor/viem/viem-typedData.js';
+import {
+  getYmaxStandaloneOperationData,
+  getYmaxWitness,
+} from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.js';
+import { portfolioPermissionsToEIP712 } from '@agoric/portfolio-api/src/portfolio-permissions.js';
+import {
+  agd as agdAmbient,
+  agoric as agoricAmbient,
+  getDetailsMatchingVats,
+  getVatInfoFromID,
+} from '@agoric/synthetic-chain';
+import anyTest from 'ava';
+import { readFile } from 'node:fs/promises';
+import { get } from 'node:http';
+import { privateKeyToAccount } from 'viem/accounts';
+import { makeSyntheticWalletKit } from '../synthetic-wallet-kit.js';
+
+/**
+ * @import {EVMWalletMessageHandler} from '@aglocal/portfolio-contract/src/evm-wallet-handler.exo.ts';
+ * @import {PortfolioDelegationClient} from '@aglocal/portfolio-contract/src/delegation.exo.ts';
+ * @import {EVMContractAddresses, PortfolioPrivateArgs} from '@aglocal/portfolio-contract/src/portfolio.contract.js';
+ * @import {PortfolioPlanner} from '@aglocal/portfolio-contract/src/planner.exo.ts';
+ * @import {ExternalPortfolioPermissions, PlanObservations, PortfolioKey, PortfolioPublishedPathTypes, StatusFor} from '@agoric/portfolio-api';
+ * @import {WalletStoreEntryProxy} from '@agoric/client-utils/src/wallet-store.ts';
+ * @import {VstorageKit} from '@agoric/client-utils';
+ * @import {PrivateKeyAccount} from 'viem';
+ * @import {TestFn} from 'ava';
+ */
+
+/** @typedef {ReturnType<typeof makeWalletStoreFromSigner>} WalletStore */
+
+const ymax1ControlAddress = 'agoric1c0eq3m8sze9cj8lxr7h66fu3jgqtevqxv8svcm';
+const bundleIdPath =
+  '/usr/src/agoric-sdk/packages/portfolio-deploy/dist/ymax0.bundleId';
+const privateArgsPath =
+  '/usr/src/agoric-sdk/packages/portfolio-deploy/test/privateArgs-ymax1.json';
+
+/**
+ * Work around Node's global fetch/Undici conflicting with SES lockdown. During
+ * shutdown, after the assertions pass, Undici emits unhandled rejections with
+ * `TypeError: Cannot assign to read only property 'message' of object
+ * 'ClientDestroyedError'`, causing AVA to exit with status 1.
+ *
+ * @type {typeof fetch}
+ */
+const rpcFetch = /** @type {typeof fetch} */ (
+  resource =>
+    new Promise((resolve, reject) => {
+      const request = get(String(resource), response => {
+        const chunks = [];
+        response.on('data', chunk => chunks.push(chunk));
+        response.on('end', () => {
+          const body = Buffer.concat(chunks).toString('utf8');
+          resolve(
+            /** @type {Response} */ ({
+              json: async () => JSON.parse(body),
+            }),
+          );
+        });
+      });
+      request.on('error', reject);
+    })
+);
+
+const getKeyAddress = (agd, keyName) =>
+  agd.keys('show', '-a', keyName, '--keyring-backend=test').then(s => s.trim());
+
+/**
+ * @template T
+ * @param {Promise<[string, T][]>} p
+ * @returns {Promise<Record<string, T>>}
+ */
+const fromEntriesP = p => p.then(Object.fromEntries);
+
+/**
+ * @param {PortfolioKey} portfolioKey
+ * @param {VstorageKit<PortfolioPublishedPathTypes>} vsc
+ * @param {(...args: unknown[]) => void} log the current test's t.log
+ */
+const makePortfolioReader = (portfolioKey, vsc, log) => {
+  const id = Number(portfolioKey.replace('portfolio', ''));
+  const path = /** @type {const} */ (`ymax1.portfolios.${portfolioKey}`);
+  const agentsPath = /** @type {const} */ (`${path}.agents`);
+  const waitFor = (publishedPath, predicate, description) =>
+    retryUntilCondition(
+      () => vsc.readPublished(publishedPath),
+      predicate,
+      description,
+      { setTimeout, retryIntervalMs: 3_000, maxRetries: 10, log },
+    );
+
+  return harden({
+    id,
+    path,
+    agentsPath,
+    readStatus: () => vsc.readPublished(path),
+    readAgents: () => vsc.readPublished(agentsPath),
+    waitForStatus: (predicate, description) =>
+      waitFor(path, predicate, description),
+    waitForAgents: (predicate, description) =>
+      waitFor(agentsPath, predicate, description),
+    waitForFlow: (flowKey, predicate, description) =>
+      waitFor(`${path}.flows.${flowKey}`, predicate, description),
+  });
+};
+
+/**
+ * @param {{
+ *   account: PrivateKeyAccount,
+ *   handler: WalletStoreEntryProxy<EVMWalletMessageHandler>,
+ *   base: EVMContractAddresses,
+ *   chainId: bigint,
+ *   vsc: VstorageKit<PortfolioPublishedPathTypes>,
+ *   now: () => number,
+ *   log: (...args: unknown[]) => void,
+ * }} opts
+ */
+const makeEvmOwner = ({ account, handler, base, chainId, vsc, now, log }) => {
+  let ownerNonce = 0n;
+  /** @type {number} set by openPortfolio, which every other method follows */
+  let openedId;
+  const walletPath = /** @type {const} */ (
+    `ymax1.evmWallets.${account.address}`
+  );
+  const submitMessage = async (makeMessage, description) => {
+    ownerNonce += 1n;
+    const messageNonce = ownerNonce;
+    const deadline = BigInt(Math.floor(now() / 1_000) + 3_600);
+    const message = makeMessage(messageNonce, deadline);
+    const signed = harden({
+      ...message,
+      signature: await account.signTypedData(message),
+    });
+    const verifiedSigner = await recoverTypedDataAddress(signed);
+    assert(verifiedSigner === account.address);
+    await handler.handleMessage(harden({ ...signed, verifiedSigner }));
+    const status = await retryUntilCondition(
+      () => vsc.readPublished(walletPath),
+      value =>
+        value?.nonce === messageNonce &&
+        value?.deadline === deadline &&
+        value?.status === 'ok',
+      description,
+      { setTimeout, retryIntervalMs: 3_000, maxRetries: 10, log },
+    );
+    // re-establish, for tsc, what the predicate above already required
+    assert.equal(status.status, 'ok');
+    return status;
+  };
+
+  return harden({
+    async openPortfolio({ allocations, depositAmount, grantee }) {
+      const status = await submitMessage((messageNonce, messageDeadline) => {
+        const witness = getYmaxWitness('OpenPortfolio', {
+          allocations,
+          grantee: {
+            address: grantee.address,
+            permissions: portfolioPermissionsToEIP712(grantee.permissions),
+          },
+        });
+        return getPermitWitnessTransferFromData(
+          {
+            permitted: { token: base.usdc, amount: depositAmount },
+            spender: base.depositFactory,
+            nonce: messageNonce,
+            deadline: messageDeadline,
+          },
+          base.permit2,
+          chainId,
+          witness,
+        );
+      }, 'signed open+grant did not succeed');
+      assert.typeof(status.result, 'string');
+      const reader = makePortfolioReader(
+        /** @type {PortfolioKey} */ (status.result),
+        vsc,
+        log,
+      );
+      openedId = reader.id;
+      return reader;
+    },
+    async changePermissions(agentId, permissions) {
+      await submitMessage(
+        (messageNonce, messageDeadline) =>
+          getYmaxStandaloneOperationData(
+            {
+              agentId: BigInt(agentId),
+              permissions: portfolioPermissionsToEIP712(permissions),
+              portfolio: BigInt(openedId),
+              nonce: messageNonce,
+              deadline: messageDeadline,
+            },
+            'ChangePermissions',
+            chainId,
+            base.depositFactory,
+          ),
+        'signed permission change did not succeed',
+      );
+    },
+    async revoke(agentId) {
+      await submitMessage(
+        (messageNonce, messageDeadline) =>
+          getYmaxStandaloneOperationData(
+            {
+              agentId: BigInt(agentId),
+              portfolio: BigInt(openedId),
+              nonce: messageNonce,
+              deadline: messageDeadline,
+            },
+            'Revoke',
+            chainId,
+            base.depositFactory,
+          ),
+        'signed revocation did not succeed',
+      );
+    },
+  });
+};
+
+const makeDelegate = async ({ id, instance, store }) => {
+  await store.saveOfferResult(
+    { instance, description: 'portfolioMandate' },
+    'portfolioMandate',
+  );
+  /** @type {WalletStoreEntryProxy<PortfolioDelegationClient>} */
+  const delegation = store.get('portfolioMandate');
+
+  return harden({
+    id,
+    key: /** @type {const} */ (`agent${id}`),
+    setTargetAllocation(targetAllocation, portfolioStatus, agentMemo) {
+      return delegation.setTargetAllocation(
+        harden({
+          targetAllocation,
+          syncState: {
+            policyVersion: portfolioStatus.policyVersion,
+            rebalanceCount: portfolioStatus.rebalanceCount,
+          },
+          ...(agentMemo && { agentMemo }),
+        }),
+      );
+    },
+  });
+};
+
+const makePlanner = store => {
+  /** @type {WalletStoreEntryProxy<PortfolioPlanner>} */
+  const planner = store.get('planner');
+
+  const resolve = (reader, flowKey, status, observations) => {
+    const flowId = Number(flowKey.replace('flow', ''));
+    return observations
+      ? planner.resolvePlan(
+          reader.id,
+          flowId,
+          [],
+          status.policyVersion,
+          status.rebalanceCount,
+          observations,
+        )
+      : planner.resolvePlan(
+          reader.id,
+          flowId,
+          [],
+          status.policyVersion,
+          status.rebalanceCount,
+        );
+  };
+
+  return harden({
+    async rejectOpeningDeposit(reader) {
+      const status = await reader.waitForStatus(
+        value => Object.keys(value?.flowsRunning || {}).length === 1,
+        'opening flow was not published',
+      );
+      const flowKey = Object.keys(status.flowsRunning || {})[0];
+      assert(flowKey);
+      const reason = 'A3P fixture cannot execute the opening deposit';
+      await planner.rejectPlan(
+        reader.id,
+        Number(flowKey.replace('flow', '')),
+        reason,
+        status.policyVersion,
+        status.rebalanceCount,
+      );
+      await reader.waitForFlow(
+        flowKey,
+        value => value?.state === 'fail' && value.error === reason,
+        'opening deposit flow was not rejected',
+      );
+    },
+    async resolveDelegatedPlan(reader, agentKey, observations) {
+      const awaiting = value =>
+        Object.entries(value?.flowsRunning || {}).find(
+          ([, flow]) => flow.awaitingSteps === true && flow.agent === agentKey,
+        );
+      const status = await reader.waitForStatus(
+        value => !!awaiting(value),
+        'delegated flow awaiting a plan was not published',
+      );
+      const entry = awaiting(status);
+      assert(entry);
+      const [flowKey] = entry;
+      await resolve(reader, flowKey, status, observations);
+      return flowKey;
+    },
+  });
+};
+
+const makeContext = async () => {
+  const now = Date.now;
+  let nonce = 0;
+  const makeNonce = () => `plan-observations-a3p-${now()}-${(nonce += 1)}`;
+
+  /** @type {VstorageKit<PortfolioPublishedPathTypes>} */
+  const vsc = makeVstorageKit({ fetch: rpcFetch }, LOCAL_CONFIG);
+
+  /** @param {string} address */
+  const makeStore = address => {
+    const signer = makeSyntheticWalletKit({
+      agoric: agoricAmbient,
+      address,
+      vstorageKit: vsc,
+    });
+    return makeWalletStoreFromSigner(signer, {
+      setTimeout,
+      makeNonce,
+      log: () => {},
+    });
+  };
+
+  const bundleId = (await readFile(bundleIdPath, 'utf8')).trim();
+  assert(bundleId.startsWith('b1-'));
+  /** @type {PortfolioPrivateArgs} */
+  const { chainInfo, contracts } = JSON.parse(
+    await readFile(privateArgsPath, 'utf8'),
+  );
+  const control = makeYmaxControlKitForSynthetic(
+    { setTimeout },
+    {
+      signer: makeSyntheticWalletKit({
+        agoric: agoricAmbient,
+        address: ymax1ControlAddress,
+        vstorageKit: vsc,
+      }),
+      makeNonce,
+      log: () => {},
+    },
+  );
+  const { ymax1: instance } = await fromEntriesP(
+    vsc.readPublished('agoricNames.instance'),
+  );
+  const vats = (await getDetailsMatchingVats('ymax1')).filter(
+    vat => !vat.terminated,
+  );
+  assert(vats.length > 0);
+  return {
+    agd: agdAmbient,
+    bundleId,
+    chainInfo: harden(chainInfo),
+    contracts: harden(contracts),
+    control,
+    instance,
+    makeStore,
+    now,
+    vatDetails: vats.at(-1),
+    vsc,
+  };
+};
+
+const test = /** @type {TestFn<Awaited<ReturnType<typeof makeContext>>>} */ (
+  anyTest
+);
+
+test.before(async t => {
+  t.context = await makeContext();
+});
+
+test.serial('upgrade ymax1 and provision handler and planner', async t => {
+  const { agd, bundleId, contracts, control, makeStore, vatDetails, vsc } =
+    t.context;
+  assert(vatDetails);
+  const { postalService: postalServiceInstance } = await fromEntriesP(
+    vsc.readPublished('agoricNames.instance'),
+  );
+  await control.ymaxControl.upgrade({
+    bundleId,
+    privateArgsOverrides: harden({ contracts, postalServiceInstance }),
+  });
+
+  const vatInfo = await getVatInfoFromID(vatDetails.vatID);
+  t.is(
+    /** @type {{incarnation: number}} */ (vatInfo.currentSpan()).incarnation,
+    vatDetails.incarnation + 1,
+  );
+
+  const { result: creatorFacet } =
+    await control.ymaxControl.getCreatorFacet.once({
+      saveAs: 'creatorFacet',
+      overwrite: true,
+    })();
+  assert(creatorFacet);
+  const { ymax1, postalService } = await fromEntriesP(
+    vsc.readPublished('agoricNames.instance'),
+  );
+  const addr = {
+    handler: await getKeyAddress(agd, 'evmHandler'),
+    planner: await getKeyAddress(agd, 'planner'),
+  };
+  await creatorFacet.deliverEVMWalletHandlerInvitation(
+    addr.handler,
+    postalService,
+  );
+  await creatorFacet.deliverPlannerInvitation(addr.planner, postalService);
+
+  await makeStore(addr.handler).saveOfferResult(
+    { instance: ymax1, description: 'evmWalletHandler' },
+    'evmWalletHandler',
+  );
+  await makeStore(addr.planner).saveOfferResult(
+    { instance: ymax1, description: 'planner' },
+    'planner',
+  );
+});
+
+test.serial('Presley completes the delegated mandate journey', async t => {
+  const { agd, chainInfo, contracts, makeStore, now, vsc } = t.context;
+  const agentAddress = await getKeyAddress(agd, 'presleyAgent');
+  const handlerStore = makeStore(await getKeyAddress(agd, 'evmHandler'));
+  /** @type {WalletStoreEntryProxy<EVMWalletMessageHandler>} */
+  const handler = handlerStore.get('evmWalletHandler', { sendOnly: true });
+  const { ymax1 } = await fromEntriesP(
+    vsc.readPublished('agoricNames.instance'),
+  );
+  const base = contracts.Base;
+  const chainId = BigInt(chainInfo.Base.reference);
+
+  // Distinct from the key in lazy-noble-provisioning.test.js: the handler
+  // rejects a replayed (wallet, nonce) until its deadline passes, and that
+  // test's nonces are an hour from expiring when this one runs.
+  const presleyAccount = privateKeyToAccount(
+    '0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+  );
+  const presley = makeEvmOwner({
+    account: presleyAccount,
+    handler,
+    base,
+    chainId,
+    vsc,
+    now,
+    log: t.log,
+  });
+  const planner = makePlanner(makeStore(await getKeyAddress(agd, 'planner')));
+  const allocations = harden([
+    { instrument: 'Aave_Base', portion: 40n },
+    { instrument: 'Compound_Base', portion: 40n },
+    { instrument: '@Base', portion: 20n },
+  ]);
+  /** @type {ExternalPortfolioPermissions} */
+  const initialPermissions = harden({
+    allocation: {
+      maxWeightBps: 9_000n,
+      minVaultTvlUsd: 10_000_000n,
+      maxVaultShareBps: 100n,
+    },
+  });
+  const reader = await presley.openPortfolio({
+    allocations,
+    depositAmount: 1_000_000_000_000n,
+    grantee: {
+      address: agentAddress,
+      permissions: initialPermissions,
+    },
+  });
+  const agentId = 1;
+  const agentStatus = await reader.waitForAgents(
+    value => value?.[`agent${agentId}`]?.state === 'active',
+    'delegation was not published',
+  );
+  t.deepEqual(agentStatus[`agent${agentId}`].permissions, initialPermissions);
+
+  const presleyAgent = await makeDelegate({
+    id: agentId,
+    instance: ymax1,
+    store: makeStore(agentAddress),
+  });
+
+  // This A3P proposal cannot complete the IBC round trip needed by the deposit.
+  await planner.rejectOpeningDeposit(reader);
+
+  /** @type {StatusFor['portfolio']} */
+  const beforeAccepted = await reader.readStatus();
+  await presleyAgent.setTargetAllocation(
+    { Aave_Base: 40n, Compound_Base: 40n, '@Base': 20n },
+    beforeAccepted,
+    'presley-a3p-accepted',
+  );
+  /** @type {PlanObservations} */
+  const observations = harden({
+    // One global 1% limit accepts both positions: $400k is 0.4% of Aave's
+    // $100m TVL and 0.8% of Compound's $50m TVL.
+    balances: { '@Base': 1_000_000_000_000n },
+    instrumentTvls: {
+      Aave_Base: { tvlUsd: 100_000_000n },
+      Compound_Base: { tvlUsd: 50_000_000n },
+    },
+  });
+  const acceptedFlow = await planner.resolveDelegatedPlan(
+    reader,
+    presleyAgent.key,
+    observations,
+  );
+  await reader.waitForFlow(
+    acceptedFlow,
+    value => value?.state === 'done' && value?.agent === presleyAgent.key,
+    'delegated plan with valid observations did not complete',
+  );
+
+  /** @type {ExternalPortfolioPermissions} */
+  const tighterPermissions = harden({
+    allocation: {
+      maxWeightBps: 9_000n,
+      minVaultTvlUsd: 10_000_000n,
+      maxVaultShareBps: 50n,
+    },
+  });
+  const beforeChange = await reader.readStatus();
+  await presley.changePermissions(presleyAgent.id, tighterPermissions);
+  const afterChange = await reader.waitForStatus(
+    value => value?.policyVersion > beforeChange.policyVersion,
+    'permission replacement was not published',
+  );
+  t.deepEqual(
+    (await reader.readAgents())[presleyAgent.key].permissions,
+    tighterPermissions,
+  );
+
+  await t.throwsAsync(
+    presleyAgent.setTargetAllocation(
+      { Aave_Base: 40n, Compound_Base: 40n, '@Base': 20n },
+      beforeAccepted,
+    ),
+    { message: /expected policyVersion/ },
+  );
+
+  await presleyAgent.setTargetAllocation(
+    { Aave_Base: 40n, Compound_Base: 40n, '@Base': 20n },
+    afterChange,
+    'presley-a3p-rejected',
+  );
+  const rejectedFlow = await planner.resolveDelegatedPlan(
+    reader,
+    presleyAgent.key,
+    observations,
+  );
+  const failedFlow = await reader.waitForFlow(
+    rejectedFlow,
+    value => value?.state === 'fail',
+    'delegated plan exceeding maximum vault share did not fail',
+  );
+  t.regex(
+    failedFlow.error,
+    /mandate\.maxVaultShare:(?:\(a string\)|Compound_Base)/,
+  );
+
+  await presley.revoke(presleyAgent.id);
+  await reader.waitForAgents(
+    value => value?.[presleyAgent.key]?.state === 'revoked',
+    'revocation was not published',
+  );
+  /** @type {StatusFor['portfolio']} */
+  const afterRevoke = await reader.readStatus();
+  await t.throwsAsync(
+    presleyAgent.setTargetAllocation(
+      { Aave_Base: 30n, Compound_Base: 30n, '@Base': 40n },
+      afterRevoke,
+    ),
+    { message: /delegation client is not active/ },
+  );
+});

--- a/a3p-integration/proposals/p:lazy-noble-provisioning/tsconfig.json
+++ b/a3p-integration/proposals/p:lazy-noble-provisioning/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "checkJs": true,
+    "allowImportingTsExtensions": true,
+    "strict": false,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    // XXX synthetic-chain has some errors
+    "skipLibCheck": true
+  },
+  "exclude": [
+    "local-packages/"
+  ]
+}

--- a/a3p-integration/proposals/p:lazy-noble-provisioning/use.sh
+++ b/a3p-integration/proposals/p:lazy-noble-provisioning/use.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 source /usr/src/upgrade-test-scripts/env_setup.sh
 
-for key_name in evmHandler planner; do
+for key_name in presleyAgent evmHandler planner; do
   if ! agd keys show "$key_name" --keyring-backend=test >/dev/null 2>&1; then
     agd keys add "$key_name" --keyring-backend=test >/dev/null 2>&1
   fi


### PR DESCRIPTION
## Description

This PR adds a synthetic-chain journey for the complete owner-signed delegation and observation-enforcement path after upgrading the existing `ymax1` instance.

Presley opens a portfolio with Aave, Compound, and Base cash positions while granting an agent one global allocation mandate. The agent redeems its invitation and submits a target with 40% in each vault and 20% cash. The real planner resolves the owner-attributed opening flow without observations, then resolves the delegated flow with a $1 million balance snapshot, $100 million Aave TVL, and $50 million Compound TVL.

The same 1% maximum-vault-share limit accepts both positions: each $400,000 position is respectively 0.4% and 0.8% of its vault. Presley then replaces the mandate with one global 0.5% limit. A stale request fails its policy-version check, while a current request reaches planning and fails on Compound. Presley finally revokes the delegation and the redeemed capability can no longer start a flow.

The journey shares the lazy-Noble upgrade proposal rather than adding another synthetic-chain run. It also provisions the agent, handler, and planner wallets and shares the synthetic signer helper used by the proposal's tests.

Answers [AGO-1067](https://linear.app/agoric/issue/AGO-1067). PR 4 of 4, stacked on #12849.

### Security Considerations

The journey verifies owner signature handling, invitation delivery and redemption, stale-policy rejection, observation-dependent failure, attribution, and revocation. It does not treat planner-supplied observations as independent attestations.

### Testing Considerations

The scenario belongs in A3P because it requires a full chain image and contract upgrade. Accepted and rejected delegated plans use the same target and observations; only the owner's global mandate replacement changes the result.

### Upgrade Considerations

N/A
