### PR TITLE
test(a3p): start ymax1 from release fixture

### DIFF
--- a/a3p-integration/proposals/g:ymax1/README.md
+++ b/a3p-integration/proposals/g:ymax1/README.md
@@ -12,3 +12,8 @@ then installs and starts ymax1 ([`install-and-start.js`](./install-and-start.js)
 so the contract is live with a stable vatID by the end of this layer, for
 other proposals (e.g. `o:ymax1-multisig-control`, `n:upgrade-next`) to
 reference.
+
+The initial instance uses the `ymax-v0.3.2605-beta1` contract bundle and ymax1
+private arguments, both checksum-pinned by `eval.sh`. Synthetic-chain asset
+metadata is added because the release's upgrade overrides rely on an existing
+instance to retain it.

--- a/a3p-integration/proposals/g:ymax1/consts.js
+++ b/a3p-integration/proposals/g:ymax1/consts.js
@@ -2,241 +2,57 @@
 export const ymax0ControlAddr = 'agoric15u29seyj3c9rdwg7gwkc97uttrk6j9fl4jkuyh';
 export const ymax1ControlAddr = 'agoric1c0eq3m8sze9cj8lxr7h66fu3jgqtevqxv8svcm';
 
-// Must be the bundle used in the `use-invitation.js` of a3p 106
-export const bundleId =
+// Must be the bundle used in the `use-invitation.js` of a3p 106.
+export const ymax0BundleId =
   'b1-078729b9683de5f81afe8b14bd163f0165b8dd803f587413df8dff76b557d56e5d0d67f8f654bc920b5bb3a734d7d7644791692efbbc08c08984e37c6e0e6c88';
 
-const evmContractAddressesStub = {
-  aavePool: '0x',
-  compound: '0x',
-  factory: '0x',
-  usdc: '0x',
-};
+// The ymax-v0.3.2605-beta1 release bundle installed by eval.sh.
+export const ymax1BundleId =
+  'b1-03d5ff17d1f29f8d1993525d0a9e82e6cd74b117a64cff64d3ca7e246bc69428d8e7d6947b69ee6bf37c024d16920490e684f83f263d6fed0c6ba875d57bf621';
 
-export const ymaxDataArgs = {
-  assetInfo: [
-    [
-      'ubld',
-      {
-        baseDenom: 'ubld',
-        baseName: 'agoric',
-        brandKey: 'BLD',
-        chainName: 'agoric',
-      },
-    ],
-    [
-      'ibc/AD211FEDD6DF0EDA18873D4E2A49972759BD761D96C3BBD9D6731FDC3F948F93',
-      {
-        baseDenom: 'ubld',
-        baseName: 'agoric',
-        chainName: 'axelar',
-      },
-    ],
-    [
-      'ibc/3C01172339ABAE4EAF1EB56FE9A69B7C818601FF9252E7DD633C14B165113C6B',
-      {
-        baseDenom: 'ubld',
-        baseName: 'agoric',
-        chainName: 'noble',
-      },
-    ],
-    [
-      'uusdc',
-      {
-        baseDenom: 'uusdc',
-        baseName: 'noble',
-        chainName: 'noble',
-      },
-    ],
-    [
-      'ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9',
-      {
-        baseDenom: 'uusdc',
-        baseName: 'noble',
-        brandKey: 'USDC',
-        chainName: 'agoric',
-      },
-    ],
-    [
-      'uaxl',
-      {
-        baseDenom: 'uaxl',
-        baseName: 'axelar',
-        chainName: 'axelar',
-      },
-    ],
-    [
-      'ibc/C01154C2547F4CB10A985EA78E7CD4BA891C1504360703A37E1D7043F06B5E1F',
-      {
-        baseDenom: 'uaxl',
-        baseName: 'axelar',
-        brandKey: 'AXL',
-        chainName: 'agoric',
-      },
-    ],
+// Release upgrade overrides rely on the existing instance's asset metadata.
+// A fresh synthetic instance needs the subset used to register BLD and USDC.
+export const syntheticAssetInfo = [
+  [
+    'ubld',
+    {
+      baseDenom: 'ubld',
+      baseName: 'agoric',
+      brandKey: 'BLD',
+      chainName: 'agoric',
+    },
   ],
-  axelarIds: {
-    Arbitrum: 'arbitrum',
-    Avalanche: 'Avalanche',
-    Base: 'base',
-    Ethereum: 'Ethereum',
-    Optimism: 'optimism',
-    Polygon: 'Polygon',
-  },
-  chainInfo: {
-    Arbitrum: {
-      cctpDestinationDomain: 3,
-      namespace: 'eip155',
-      reference: '421614',
+  [
+    'ibc/AD211FEDD6DF0EDA18873D4E2A49972759BD761D96C3BBD9D6731FDC3F948F93',
+    {
+      baseDenom: 'ubld',
+      baseName: 'agoric',
+      chainName: 'axelar',
     },
-    Avalanche: {
-      cctpDestinationDomain: 1,
-      namespace: 'eip155',
-      reference: '43113',
+  ],
+  [
+    'ibc/3C01172339ABAE4EAF1EB56FE9A69B7C818601FF9252E7DD633C14B165113C6B',
+    {
+      baseDenom: 'ubld',
+      baseName: 'agoric',
+      chainName: 'noble',
     },
-    Binance: {
-      namespace: 'eip155',
-      reference: '97',
+  ],
+  [
+    'uusdc',
+    {
+      baseDenom: 'uusdc',
+      baseName: 'noble',
+      chainName: 'noble',
     },
-    Ethereum: {
-      cctpDestinationDomain: 0,
-      namespace: 'eip155',
-      reference: '11155111',
+  ],
+  [
+    'ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9',
+    {
+      baseDenom: 'uusdc',
+      baseName: 'noble',
+      brandKey: 'USDC',
+      chainName: 'agoric',
     },
-    Fantom: {
-      namespace: 'eip155',
-      reference: '4002',
-    },
-    Optimism: {
-      cctpDestinationDomain: 2,
-      namespace: 'eip155',
-      reference: '11155420',
-    },
-    Polygon: {
-      cctpDestinationDomain: 7,
-      namespace: 'eip155',
-      reference: '80002',
-    },
-    agoric: {
-      bech32Prefix: 'agoric',
-      chainId: 'agoric-3',
-      connections: {
-        'axelar-dojo-1': {
-          client_id: '07-tendermint-11',
-          counterparty: {
-            client_id: '07-tendermint-69',
-            connection_id: 'connection-51',
-          },
-          id: 'connection-14',
-          state: 3,
-          transferChannel: {
-            channelId: 'channel-9',
-            counterPartyChannelId: 'channel-41',
-            counterPartyPortId: 'transfer',
-            ordering: 0,
-            portId: 'transfer',
-            state: 3,
-            version: 'ics20-1',
-          },
-        },
-        'noble-1': {
-          client_id: '07-tendermint-77',
-          counterparty: {
-            client_id: '07-tendermint-32',
-            connection_id: 'connection-38',
-          },
-          id: 'connection-72',
-          state: 3,
-          transferChannel: {
-            channelId: 'channel-62',
-            counterPartyChannelId: 'channel-21',
-            counterPartyPortId: 'transfer',
-            ordering: 0,
-            portId: 'transfer',
-            state: 3,
-            version: 'ics20-1',
-          },
-        },
-      },
-      icqEnabled: false,
-      namespace: 'cosmos',
-      reference: 'agoric-3',
-      stakingTokens: [
-        {
-          denom: 'ubld',
-        },
-      ],
-    },
-    axelar: {
-      bech32Prefix: 'axelar',
-      chainId: 'axelar-dojo-1',
-      connections: {
-        'agoric-3': {
-          client_id: '07-tendermint-69',
-          counterparty: {
-            client_id: '07-tendermint-11',
-            connection_id: 'connection-14',
-          },
-          id: 'connection-51',
-          state: 3,
-          transferChannel: {
-            channelId: 'channel-41',
-            counterPartyChannelId: 'channel-9',
-            counterPartyPortId: 'transfer',
-            ordering: 0,
-            portId: 'transfer',
-            state: 3,
-            version: 'ics20-1',
-          },
-        },
-      },
-      icqEnabled: false,
-      namespace: 'cosmos',
-      reference: 'axelar-dojo-1',
-      stakingTokens: [
-        {
-          denom: 'uaxl',
-        },
-      ],
-    },
-    noble: {
-      bech32Prefix: 'noble',
-      chainId: 'noble-1',
-      connections: {
-        'agoric-3': {
-          client_id: '07-tendermint-32',
-          counterparty: {
-            client_id: '07-tendermint-77',
-            connection_id: 'connection-72',
-          },
-          id: 'connection-38',
-          state: 3,
-          transferChannel: {
-            channelId: 'channel-21',
-            counterPartyChannelId: 'channel-62',
-            counterPartyPortId: 'transfer',
-            ordering: 0,
-            portId: 'transfer',
-            state: 3,
-            version: 'ics20-1',
-          },
-        },
-      },
-      icqEnabled: false,
-      namespace: 'cosmos',
-      reference: 'noble-1',
-    },
-  },
-  contracts: {
-    Arbitrum: evmContractAddressesStub,
-    Avalanche: evmContractAddressesStub,
-    Base: evmContractAddressesStub,
-    Ethereum: evmContractAddressesStub,
-    Optimism: evmContractAddressesStub,
-    Polygon: evmContractAddressesStub,
-  },
-  gmpAddresses: {
-    AXELAR_GAS: 'axelar1gas',
-    AXELAR_GMP: 'axelar1gmp',
-  },
-};
+  ],
+];

--- a/a3p-integration/proposals/g:ymax1/eval.sh
+++ b/a3p-integration/proposals/g:ymax1/eval.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+source /usr/src/upgrade-test-scripts/env_setup.sh
+
+cp /usr/src/upgrade-test-scripts/eval_submission.js .
+yarn node ./eval_submission.js
+
+bundle_file=./bundle-ymax1-base.json
+private_args_file=./privateArgsOverrides-ymax1-base.json
+
+curl --fail --location --silent --show-error \
+  --output "$bundle_file" \
+  https://github.com/Agoric/agoric-sdk/releases/download/ymax-v0.3.2605-beta1/bundle-ymax0.json
+curl --fail --location --silent --show-error \
+  --output "$private_args_file" \
+  https://github.com/Agoric/agoric-sdk/releases/download/ymax-v0.3.2605-beta1/ymax1-main-privateArgsOverrides-ea14a159d1c6.json
+
+sha256sum --check <<EOF
+6eb97a6237622ffdc1b4bebb28c0b104ae8adba6b961b5189bd551b5002d5da6  $bundle_file
+ea14a159d1c6cc23b8827146a054016ac72f1d7fce578b05ccf443dc10046f9f  $private_args_file
+EOF
+
+test "$(jq -r .endoZipBase64Sha512 "$bundle_file")" = \
+  03d5ff17d1f29f8d1993525d0a9e82e6cd74b117a64cff64d3ca7e246bc69428d8e7d6947b69ee6bf37c024d16920490e684f83f263d6fed0c6ba875d57bf621
+
+# shellcheck disable=SC2086
+agd tx swingset install-bundle @"$bundle_file" \
+  $SIGN_BROADCAST_OPTS --from validator

--- a/a3p-integration/proposals/g:ymax1/install-and-start.js
+++ b/a3p-integration/proposals/g:ymax1/install-and-start.js
@@ -8,8 +8,13 @@ import '@endo/init/legacy.js'; // XXX axios
 
 import { LOCAL_CONFIG, makeVstorageKit } from '@agoric/client-utils';
 import { makeYmaxControlKitForSynthetic } from '@aglocal/portfolio-deploy/src/ymax-control.js';
+import { readFile } from 'node:fs/promises';
 import { makeSyntheticWalletKit } from './synthetic-wallet-kit.js';
-import { bundleId, ymax1ControlAddr, ymaxDataArgs } from './consts.js';
+import {
+  syntheticAssetInfo,
+  ymax1BundleId,
+  ymax1ControlAddr,
+} from './consts.js';
 
 const { fromEntries } = Object;
 
@@ -31,11 +36,17 @@ const { BLD, USDC, PoC26 } = fromEntries(
   await vsc.readPublished('agoricNames.issuer'),
 );
 const issuers = harden({ USDC, Access: PoC26, BLD, Fee: BLD });
+const privateArgsOverrides = harden({
+  ...JSON.parse(
+    await readFile('./privateArgsOverrides-ymax1-base.json', 'utf8'),
+  ),
+  assetInfo: syntheticAssetInfo,
+});
 
 await ymaxControl.installAndStart({
-  bundleId,
+  bundleId: ymax1BundleId,
   issuers,
-  privateArgsOverrides: ymaxDataArgs,
+  privateArgsOverrides,
 });
 
 console.error('ymax1 installed and started');

--- a/a3p-integration/proposals/g:ymax1/test/ymax0.test.js
+++ b/a3p-integration/proposals/g:ymax1/test/ymax0.test.js
@@ -8,7 +8,10 @@ import {
 } from '@agoric/synthetic-chain';
 import anyTest from 'ava';
 import { makeYmaxControlKitForSynthetic } from '@aglocal/portfolio-deploy/src/ymax-control.js';
-import { bundleId, ymax0ControlAddr as ymaxControlAddr } from '../consts.js';
+import {
+  ymax0BundleId,
+  ymax0ControlAddr as ymaxControlAddr,
+} from '../consts.js';
 import { redeemInvitation, submitYmaxControl } from '../ymax-util.js';
 import { makeSyntheticWalletKit } from '../synthetic-wallet-kit.js';
 
@@ -77,7 +80,7 @@ test.before(async t => (t.context = await makeTestContext(t)));
 test.serial('null upgrade existing instance with args override', async t => {
   // Get contract control from wallet store and call upgrade directly
   const yc = ymaxControl;
-  await yc.upgrade({ bundleId, privateArgsOverrides });
+  await yc.upgrade({ bundleId: ymax0BundleId, privateArgsOverrides });
 
   const { [contractName]: instance } = fromEntries(
     await vsc.readPublished(`agoricNames.instance`),

--- a/a3p-integration/proposals/g:ymax1/test/ymax1.test.js
+++ b/a3p-integration/proposals/g:ymax1/test/ymax1.test.js
@@ -12,7 +12,10 @@ import anyTest from 'ava';
 import { makeSyntheticWalletKit } from '../synthetic-wallet-kit.js';
 import { makeActionId, sendWalletAction } from '../wallet-util.js';
 import { redeemInvitation, submitYmaxControl } from '../ymax-util.js';
-import { bundleId, ymax1ControlAddr as ymaxControlAddr } from '../consts.js';
+import {
+  ymax1BundleId,
+  ymax1ControlAddr as ymaxControlAddr,
+} from '../consts.js';
 
 /**
  * @import {BridgeAction} from '@agoric/smart-wallet/src/smartWallet.js';
@@ -106,7 +109,7 @@ test.serial('invoke ymaxControl to getCreatorFacet', async t => {
   t.truthy(result, 'Creator facet saved to wallet store');
 });
 
-test.serial('ymax told zoe that Access token is required', async t => {
+test.serial('ymax accepts an open offer without an Access token', async t => {
   const { [contractName]: instance } = fromEntries(
     await vsc.readPublished(`agoricNames.instance`),
   );
@@ -123,20 +126,19 @@ test.serial('ymax told zoe that Access token is required', async t => {
         instance,
         publicInvitationMaker: 'makeOpenPortfolioInvitation',
       },
+      offerArgs: {},
       proposal: {},
     },
   };
 
   await sendWalletAction(vsc, ymaxControlAddr, redeemAction);
 
-  await t.throwsAsync(wup.offerResult(id), {
-    message: /missing properties \["Access"\]/,
-  });
+  t.is(await wup.offerResult(id), 'UNPUBLISHED');
 });
 
 test.serial('null upgrade existing instance with args override', async t => {
   const yc = ymaxControl;
-  await yc.upgrade({ bundleId, privateArgsOverrides });
+  await yc.upgrade({ bundleId: ymax1BundleId, privateArgsOverrides });
 
   const { [contractName]: instance } = fromEntries(
     await vsc.readPublished(`agoricNames.instance`),
@@ -176,7 +178,7 @@ test.serial('get new contract control and upgrade', async t => {
   t.deepEqual(result, { name: 'ymaxControl', passStyle: 'remotable' });
 
   const yc = ymaxControl;
-  await yc.upgrade({ bundleId });
+  await yc.upgrade({ bundleId: ymax1BundleId });
 
   const { [contractName]: instance } = fromEntries(
     await vsc.readPublished(`agoricNames.instance`),

--- a/a3p-integration/proposals/o:ymax1-multisig-control/test/ymax-multisig.test.js
+++ b/a3p-integration/proposals/o:ymax1-multisig-control/test/ymax-multisig.test.js
@@ -34,10 +34,11 @@ import { config as opsConfig } from '../scripts/make-test-multisig.js';
  * @import {ContractControl} from '@agoric/deploy-script-support/src/control/contract-control.contract.js';
  */
 
-// a3p proposal 106 (`ymax-alpha4`), adopted in agoric-sdk commit
-// ac0680c98384 (`chore(a3p): use ymax-alpha4`).
+// The ymax-v0.3.2605-beta1 release bundle installed by g:ymax1. Using the
+// fixture's bundle keeps its retained private args compatible with this
+// authority smoke test.
 export const bundleId =
-  'b1-078729b9683de5f81afe8b14bd163f0165b8dd803f587413df8dff76b557d56e5d0d67f8f654bc920b5bb3a734d7d7644791692efbbc08c08984e37c6e0e6c88';
+  'b1-03d5ff17d1f29f8d1993525d0a9e82e6cd74b117a64cff64d3ca7e246bc69428d8e7d6947b69ee6bf37c024d16920490e684f83f263d6fed0c6ba875d57bf621';
 
 const ymax1Control = {
   keyName: 'ymax1-ms',


### PR DESCRIPTION
## Description

While doing an a3p test to upgrade to a TVL oracle (#12830), a `ymax0` upgrade failed:

```
durable Kind stateShape mismatch (no old shape)
vat v90 failed to upgrade from incarnation 0
```

Diagnosis: v90 was running a bundle whose exos don't have state shapes (alpha4 bundle `b1-078729…`). That same bundle was used to start `ymax1` in `g:ymax1`; this doesn't match mainnet. On mainnet, we started with state shapes.

The fix: Start `ymax1` from `ymax-v0.3.2605-beta1`, a release from the mainnet upgrade history.
_Note: this PR makes no fix/change regarding ymax0._

## Security Considerations

Downloaded release artifacts are pinned by SHA-256, and the contract bundle ID is checked before installation.

## Documentation Considerations

The proposal README records the release and why synthetic asset metadata is overlaid.

## Testing Considerations

The end-to-end upgrade path is exercised by a3p integration CI; downstream feature proposals can test `ymax1` upgrades from this common released baseline.

## Upgrade Considerations

This changes only the synthetic a3p fixture. It does not alter a production deployment proposal.
