### PR TITLE
chore(ci): update default for release tag

### DIFF
--- a/.github/workflows/deploy-ymax-release.yml
+++ b/.github/workflows/deploy-ymax-release.yml
@@ -19,7 +19,7 @@ on:
         description: Release tag to create or use
         required: true
         type: string
-        default: v0.3.YYMM-betaN
+        default: ymax-v0.3.YYMM-betaN
       branch:
         description: Branch to build for ymax0-devnet
         required: false


### PR DESCRIPTION
## Description
Drive-by fix as our convention is tagging the release with `ymax-v0.3.YYMM-betaN` and I tried to release without `ymax-` in the tag and [failed](https://github.com/Agoric/agoric-sdk/actions/runs/32047135854) several times before realizing the issue

### Security Considerations
N/A

### Scaling Considerations
N/A

### Documentation Considerations
This PR updates documentation, sort of

### Testing Considerations
N/A

### Upgrade Considerations
Hopefully makes deployment slightly less error prone
