### PR TITLE
fix(portfolio-api): keep unrecognized EIP-712 fields instead of dropping them

### DIFF
--- a/packages/portfolio-api/src/evm-wallet/message-handler-helpers.ts
+++ b/packages/portfolio-api/src/evm-wallet/message-handler-helpers.ts
@@ -47,6 +47,15 @@ export type YmaxOperationDetails<
   [P in T]: {
     operation: P;
     domain: YmaxFullDomain;
+    /**
+     * A *lower bound* on the runtime shape, not an exact description: since
+     * `extractOperationDetailsFromStandaloneData` /
+     * `extractOperationDetailsFromPermit2WitnessData` keep (rather than
+     * drop) genuinely-signed fields this version doesn't recognize, `data`
+     * can carry extra properties beyond `YmaxOperationType<P>` at runtime.
+     * Consumers that must reject such fields (e.g. permission records)
+     * need to validate that themselves against a closed shape.
+     */
     data: YmaxOperationType<P>;
   };
 }[T];
@@ -115,15 +124,19 @@ export const makeEVMHandlerUtils = (viemUtils: {
    * By the time this is called, `data.message` has already been through the
    * "reject anything unsigned" normalize pass (see
    * `extractOperationDetailsFromDataWithAddress`), so any field here was
-   * actually part of what was signed. This function normalizes *and
-   * validates* it a second time against the types this (possibly older)
-   * version of the code expects for the operation: any field the signer's
-   * client signed but this version doesn't know about is dropped (not
-   * rejected -- it was signed, just not supported yet), and any `optional`
-   * field is resolved based on whether it's actually present in the
-   * message. The returned `data` is exactly the normalized/expected shape,
-   * never a superset of it, and is guaranteed to satisfy the expected types
-   * (required fields present, values of the right shape/range).
+   * actually part of what was signed. This function normalizes it a second
+   * time against the types this (possibly older) version of the code
+   * expects for the operation, resolving any `optional` field based on
+   * whether it's actually present in the message, but *keeps* rather than
+   * drops fields the signer's client signed that this version doesn't know
+   * about yet: dropping them would let a permissions-bearing field silently
+   * disappear (e.g. a not-yet-understood attenuation on a `Grant`), turning
+   * an attenuated grant into an unconstrained one. The returned `data` can
+   * therefore be a superset of the expected shape; it is guaranteed to
+   * satisfy the expected types (required fields present, values of the
+   * right shape/range), but consumers that must reject unrecognized fields
+   * (e.g. permission records) need to validate that themselves against a
+   * closed shape.
    *
    * Assumes the domain has the expected shape of a Ymax domain.
    *
@@ -159,7 +172,7 @@ export const makeEVMHandlerUtils = (viemUtils: {
         types: getYmaxOperationTypes(operation),
         primaryType: operation,
       },
-      { onExtraField: 'drop' },
+      { onExtraField: 'keep' },
     );
     return {
       operation,
@@ -176,15 +189,18 @@ export const makeEVMHandlerUtils = (viemUtils: {
    * through the "reject anything unsigned" normalize pass (see
    * `extractOperationDetailsFromDataWithAddress`), so any field in the
    * witness data here was actually part of what was signed. This function
-   * normalizes *and validates* it a second time against the types this
-   * (possibly older) version of the code expects for the operation: any
-   * field the signer's client signed but this version doesn't know about is
-   * dropped (not rejected -- it was signed, just not supported yet), and
-   * any `optional` field is resolved based on whether it's actually present
-   * in the witness data. The returned `data` is exactly the
-   * normalized/expected shape, never a superset of it, and is guaranteed to
-   * satisfy the expected types (required fields present, values of the
-   * right shape/range).
+   * normalizes it a second time against the types this (possibly older)
+   * version of the code expects for the operation, resolving any `optional`
+   * field based on whether it's actually present in the witness data, but
+   * *keeps* rather than drops fields the signer's client signed that this
+   * version doesn't know about yet: dropping them would let a
+   * permissions-bearing field silently disappear (e.g. a not-yet-understood
+   * attenuation on a `Grant`), turning an attenuated grant into an
+   * unconstrained one. The returned `data` can therefore be a superset of
+   * the expected shape; it is guaranteed to satisfy the expected types
+   * (required fields present, values of the right shape/range), but
+   * consumers that must reject unrecognized fields (e.g. permission
+   * records) need to validate that themselves against a closed shape.
    *
    * Assumes the message has already been validated against the types from the data.
    * Assumes the domain has the expected shape of a permit2 domain.
@@ -216,7 +232,7 @@ export const makeEVMHandlerUtils = (viemUtils: {
         types: getYmaxOperationTypes(operation),
         primaryType: operation,
       },
-      { onExtraField: 'drop' },
+      { onExtraField: 'keep' },
     );
     const spender = permitData.message.spender;
     return {
@@ -341,10 +357,15 @@ export const makeEVMHandlerUtils = (viemUtils: {
    * the same way, separately (its values live outside `message`).
    * A *different*, later normalize pass (in
    * `extractOperationDetailsFromStandaloneData` /
-   * `extractOperationDetailsFromPermit2WitnessData`) drops -- rather than
+   * `extractOperationDetailsFromPermit2WitnessData`) keeps -- rather than
    * rejects -- fields that were genuinely signed but aren't supported by
-   * this version's generated operation types; those are legitimate,
-   * merely unsupported (yet), not a security concern.
+   * this version's generated operation types: they were legitimately
+   * signed, merely not (yet) understood by this version. They are not
+   * dropped, because a permissions-bearing field this version doesn't
+   * understand yet must not silently vanish and be treated as absent (that
+   * would turn an attenuated grant into an unconstrained one); instead,
+   * downstream permission consumers validate against a closed shape and
+   * reject any field they don't recognize.
    *
    * @param data The operation data with an `address` field of the signing owner.
    * @param contractAddresses Optionally, a set of valid contract addresses to validate against

--- a/packages/portfolio-api/test/message-handler-helpers.test.ts
+++ b/packages/portfolio-api/test/message-handler-helpers.test.ts
@@ -128,7 +128,7 @@ test('extractOperationDetailsFromDataWithAddress accepts a legitimate optional f
   });
 });
 
-test('extractOperationDetailsFromDataWithAddress drops (does not reject) a field that was genuinely signed but is unsupported by this version (standalone Grant)', t => {
+test('extractOperationDetailsFromDataWithAddress keeps (does not reject or drop) a field that was genuinely signed but is unsupported by this version (standalone Grant)', t => {
   const message = getYmaxStandaloneOperationData(
     {
       accountHolder: 'agoric1exampleaccountholder',
@@ -145,8 +145,10 @@ test('extractOperationDetailsFromDataWithAddress drops (does not reject) a field
   // Simulate a newer client that signs an extra `memo` field on `Grant`,
   // declaring it in `types` too -- so it's genuinely part of what gets
   // hashed/signed. This (older) code doesn't know about `memo` yet, but
-  // since it was actually signed (not smuggled in unsigned), it should be
-  // silently dropped rather than rejected.
+  // since it was actually signed (not smuggled in unsigned), it must be
+  // kept rather than silently dropped -- an unknown field could be
+  // permissions-bearing (e.g. a not-yet-understood attenuation), and
+  // dropping it would turn an attenuated grant into an unconstrained one.
   const augmented = {
     ...message,
     types: {
@@ -166,8 +168,60 @@ test('extractOperationDetailsFromDataWithAddress drops (does not reject) a field
     accountHolder: 'agoric1exampleaccountholder',
     permissions: { allocation: true, rebalance: false },
     portfolio: 0n,
+    memo: 'hello',
   });
-  t.false('memo' in (details.data as any));
+});
+
+test('extractOperationDetailsFromDataWithAddress keeps a signed-but-unsupported field nested inside `permissions` (standalone Grant)', t => {
+  const message = getYmaxStandaloneOperationData(
+    {
+      accountHolder: 'agoric1exampleaccountholder',
+      permissions: { allocation: true, rebalance: false },
+      portfolio: 0n,
+      nonce: 1n,
+      deadline: 1700000000n,
+    },
+    'Grant',
+    CHAIN_ID,
+    CONTRACT_ADDRESS,
+  );
+
+  // Simulate a newer client whose `permissions` struct carries an extra,
+  // genuinely signed constraint field this (older) code doesn't understand
+  // yet -- e.g. a future per-instrument attenuation. This is exactly the
+  // compatibility hazard: silently dropping it here would make an
+  // attenuated grant look unconstrained to this version's `grant()`.
+  // Permission consumers, not this extraction step, are responsible for
+  // rejecting the unrecognized field.
+  const augmented = {
+    ...message,
+    types: {
+      ...message.types,
+      PortfolioPermissions: [
+        ...message.types.PortfolioPermissions,
+        { name: 'allocationMaxWeights', type: 'string' },
+      ],
+    },
+    message: {
+      ...message.message,
+      permissions: {
+        ...message.message.permissions,
+        allocationMaxWeights: 'unsupported-constraint',
+      },
+    },
+  };
+
+  const details = extractOperationDetailsFromDataWithAddress(
+    { ...augmented, signature: MOCK_SIGNATURE, address: MOCK_ADDRESS } as any,
+    {},
+  );
+
+  t.is(details.operation, 'Grant');
+  t.deepEqual((details.data as any).permissions, {
+    allocation: true,
+    rebalance: false,
+    allocationMaxWeights: 'unsupported-constraint',
+  });
 });
 
 test('extractOperationDetailsFromDataWithAddress rejects an extra field nested inside a permit2 witness (OpenPortfolio with grantee)', t => {
@@ -214,7 +268,7 @@ test('extractOperationDetailsFromDataWithAddress rejects an extra field nested i
   );
 });
 
-test('extractOperationDetailsFromDataWithAddress computes the permit2 witness hash/type string from the actual signed data, not the (dropped) generated-types data', t => {
+test('extractOperationDetailsFromDataWithAddress computes the permit2 witness hash/type string from the actual signed data, consistent with the kept generated-types data', t => {
   const witness = getYmaxWitness('OpenPortfolio', {
     allocations: [{ instrument: 'Aave_Arbitrum', portion: 10000n }],
   });
@@ -266,12 +320,13 @@ test('extractOperationDetailsFromDataWithAddress computes the permit2 witness ha
     {},
   );
 
-  // The authorization-facing `data` is still shaped by (and dropped against)
-  // this version's generated types -- `memo` has no business influencing
-  // what the contract acts on.
+  // The authorization-facing `data` keeps `memo` even though it isn't part
+  // of this version's generated types for `OpenPortfolio` -- it was
+  // genuinely signed, so it must not silently disappear.
   t.is(details.operation, 'OpenPortfolio');
   t.deepEqual(details.data, {
     allocations: [{ instrument: 'Aave_Arbitrum', portion: 10000n }],
+    memo: 'hello',
   });
 
   // But the permit2 witness hash and type string -- what actually gets

--- a/packages/portfolio-contract/src/portfolio.contract.ts
+++ b/packages/portfolio-contract/src/portfolio.contract.ts
@@ -35,14 +35,16 @@ import {
   type OrchestrationTools,
 } from '@agoric/orchestration';
 import { sameEvmAddress } from '@agoric/orchestration/src/utils/address.js';
-import type {
-  ChainTokenMetadata,
-  FlowConfig,
-  PortfolioAgentGrantee,
-  PortfolioAgentKey,
-  PortfolioPermissionsExt,
-  PortfolioPublicInvitationMaker,
-  TargetAllocation,
+import {
+  PortfolioAutoFeaturesShape,
+  PortfolioPermissionsShape,
+  type ChainTokenMetadata,
+  type FlowConfig,
+  type PortfolioAgentGrantee,
+  type PortfolioAgentKey,
+  type PortfolioPermissionsExt,
+  type PortfolioPublicInvitationMaker,
+  type TargetAllocation,
 } from '@agoric/portfolio-api';
 import {
   AxelarChain,
@@ -848,6 +850,24 @@ export const contract = async (
         'grantee' in data && data.grantee !== undefined
           ? data.grantee
           : undefined;
+      const features =
+        'features' in data && data.features !== undefined
+          ? data.features
+          : undefined;
+
+      // Validate the nested permission/feature records before any preflight
+      // or portfolio allocation below. `grant()`/`setAutoFeatures()` already
+      // enforce these shapes, but only after `makeNextPortfolioKit()` has
+      // allocated a persistent kit -- validating here first keeps a
+      // combined open+grant/setAutoFeatures message carrying an
+      // unrecognized permission/feature key (kept, not dropped, per
+      // AGO-1131) from leaving an orphaned shell.
+      if (features !== undefined) {
+        mustMatch(features, PortfolioAutoFeaturesShape);
+      }
+      if (grantee) {
+        mustMatch(grantee.permissions, PortfolioPermissionsShape);
+      }
 
       await null;
       if (grantee) {
@@ -864,9 +884,9 @@ export const contract = async (
         `eip155:${permitDetails.chainId}:${permitDetails.permit2Payload.owner.toLowerCase()}` as AccountId;
       const kit = makeNextPortfolioKit({ sourceAccountId });
 
-      if ('features' in data && data.features !== undefined) {
+      if (features !== undefined) {
         // setAutoFeatures is promptly resolved
-        await vowTools.asPromise(kit.evmHandler.setAutoFeatures(data.features));
+        await vowTools.asPromise(kit.evmHandler.setAutoFeatures(features));
       }
       if (grantee) {
         // `grant()` already enforces the shared auth and permission checks.

--- a/packages/portfolio-contract/test/delegation.test.ts
+++ b/packages/portfolio-contract/test/delegation.test.ts
@@ -19,12 +19,18 @@ import type { Bech32Address } from '@agoric/orchestration';
 import { ROOT_STORAGE_PATH } from '@agoric/orchestration/tools/contract-tests.js';
 import type { NameAdmin } from '@agoric/vats';
 import type { Invitation, Proposal, ZoeService } from '@agoric/zoe';
+import {
+  getYmaxStandaloneOperationData,
+  getYmaxWitness,
+} from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.js';
+import { getPermitWitnessTransferFromData } from '@agoric/orchestration/src/utils/permit2.js';
 import { E, Far } from '@endo/far';
 import type { ExecutionContext } from 'ava';
 import type { PortfolioDelegationClient } from '../src/delegation.exo.ts';
 import { deploy, makeEvmTraderKit } from './contract-setup.ts';
-import { evmTrader0PrivateKey } from './mocks.ts';
+import { contractsMock, evmTrader0PrivateKey } from './mocks.ts';
 import type { PortfolioStatus } from './contract-test-support.ts';
+import { chainInfoWithCCTP } from './supports.ts';
 
 const PETE_AGENT = 'agoric1petesAgent' as const;
 type Deployed = Awaited<ReturnType<typeof deploy>>;
@@ -359,6 +365,85 @@ test('Grant rejects allocation permission set to false', async t => {
   t.regex(grantStatus.error || '', /grant requires allocation permission/);
 });
 
+test('SetAutoFeatures keeps a UI-added tosAcceptance field signed at the top level of the message, and consumers ignore it', async t => {
+  const deployed = await deploy(t);
+  const { peteKit, portfolioId } = await openPetePortfolio(deployed);
+  const { evmWalletHandler, evmAccount, readPublished } = peteKit;
+  const { when } = deployed.common.utils.vowTools;
+
+  const address = evmAccount.address;
+  const priorStatus: any = await readPublished(`evmWallets.${address}`);
+  const nonce = priorStatus.nonce + 1n;
+  const { absValue: now } = await E(
+    deployed.timerService,
+  ).getCurrentTimestamp();
+  const deadline = now + 3600n;
+
+  const chainId = BigInt(chainInfoWithCCTP.Arbitrum.reference);
+  const verifyingContract = contractsMock.Arbitrum
+    .depositFactory as `0x${string}`;
+
+  const message = getYmaxStandaloneOperationData(
+    {
+      features: { rebalance: true },
+      portfolio: BigInt(portfolioId),
+      nonce,
+      deadline,
+    },
+    'SetAutoFeatures',
+    chainId,
+    verifyingContract,
+  );
+
+  // Mirrors ymax-web's `addTermsAcceptanceToSetAutoFeaturesTypedData`
+  // (ui/src/evm/setAutoFeaturesTermsPatch.ts), a documented AGO-681
+  // workaround that has the user sign a `tosAcceptance` struct alongside
+  // (not nested inside) `features`/`portfolio` on the SetAutoFeatures
+  // message, until portfolio-api supports the field natively. The contract
+  // doesn't know about it, so per AGO-1131 it is kept (not dropped) through
+  // EIP-712 extraction rather than silently vanishing -- but since nothing
+  // downstream validates the *whole* operation payload against a closed
+  // shape (only the nested `features`/`permissions` records are closed),
+  // it is simply ignored rather than rejected.
+  const augmented = {
+    ...message,
+    types: {
+      ...message.types,
+      SetAutoFeatures: [
+        ...message.types.SetAutoFeatures,
+        { name: 'tosAcceptance', type: 'TermsAcceptance' },
+      ],
+      TermsAcceptance: [
+        { name: 'agreementName', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'documentId', type: 'bytes32' },
+        { name: 'acceptedAt', type: 'uint256' },
+      ],
+    },
+    message: {
+      ...message.message,
+      tosAcceptance: {
+        agreementName: 'Automation Terms of Service',
+        version: '1.0',
+        documentId: `0x${'ab'.repeat(32)}`,
+        acceptedAt: 1700000000000n,
+      },
+    },
+  };
+
+  const signature = await evmAccount.signTypedData(augmented as any);
+
+  await when(
+    E(evmWalletHandler).handleMessage({
+      ...augmented,
+      signature,
+    } as any),
+  );
+
+  const status = await peteKit.evmTrader.getPortfolioStatus();
+  t.like(status, { enabledAutoFeatures: { rebalance: true } });
+});
+
 test('Grant delivery failure is surfaced in wallet vstorage without publishing an unusable agent', async t => {
   const deployed = await deploy(t);
   const peteKit = await makeEvmTraderKit(deployed, {
@@ -545,6 +630,105 @@ test('open+grant with an unregistered grantee aborts before portfolio creation',
   );
 
   await t.throwsAsync(peteKit.readPublished('portfolios.portfolio0'), {
+    message: /no data at path/,
+  });
+});
+
+test('open+grant with an unrecognized permission key aborts before portfolio creation', async t => {
+  const deployed = await deploy(t);
+  const peteKit = await makeEvmTraderKit(deployed, {
+    privateKey: evmTrader0PrivateKey,
+  });
+  const { evmWalletHandler, evmAccount, readPublished } = peteKit;
+  const walletAddress = evmAccount.address;
+
+  const witness = getYmaxWitness('OpenPortfolio', {
+    allocations: [
+      { instrument: 'Aave_Arbitrum', portion: 60n },
+      { instrument: 'Compound_Arbitrum', portion: 40n },
+    ],
+    grantee: {
+      address: PETE_AGENT,
+      permissions: { allocation: true },
+    },
+  });
+
+  // Simulate a newer client that signs a not-yet-supported narrowing
+  // constraint on `grantee.permissions` (e.g. from #12848) that this
+  // (older) contract doesn't recognize yet. Per AGO-1131 it is kept
+  // (not dropped) through extraction, so `grant()`'s closed-shape check
+  // rejects it -- and, since that check is now validated before
+  // `makeNextPortfolioKit()` runs, the combined open+grant aborts without
+  // orphaning a portfolio shell, exactly like the unregistered-grantee
+  // case above.
+  const { grantee: witnessGrantee, ...restWitness } = witness.witness as any;
+  const augmentedWitness = {
+    witnessField: witness.witnessField,
+    witnessTypes: {
+      ...witness.witnessTypes,
+      PortfolioPermissions: [
+        ...(witness.witnessTypes as any).PortfolioPermissions,
+        { name: 'allocationMaxWeights', type: 'bool' },
+      ],
+    },
+    witness: {
+      ...restWitness,
+      grantee: {
+        ...witnessGrantee,
+        permissions: {
+          ...witnessGrantee.permissions,
+          allocationMaxWeights: true,
+        },
+      },
+    },
+  };
+
+  const { absValue: now } = await E(
+    deployed.timerService,
+  ).getCurrentTimestamp();
+  const permitMessage = getPermitWitnessTransferFromData(
+    {
+      permitted: {
+        token: contractsMock.Arbitrum.usdc as `0x${string}`,
+        amount: 10_000_000n,
+      },
+      spender: contractsMock.Arbitrum.depositFactory as `0x${string}`,
+      nonce: 1n,
+      deadline: now + 3600n,
+    },
+    contractsMock.Arbitrum.permit2 as `0x${string}`,
+    BigInt(chainInfoWithCCTP.Arbitrum.reference),
+    augmentedWitness as any,
+  );
+
+  const signature = await evmAccount.signTypedData(permitMessage as any);
+  const { when } = deployed.common.utils.vowTools;
+
+  // The failure happens asynchronously (inside `openPortfolioFromEVM`,
+  // watched rather than awaited by the dispatcher), so `handleMessage`
+  // itself resolves; the failure is recorded on the wallet status instead,
+  // same as the unregistered-grantee case above.
+  await when(
+    E(evmWalletHandler).handleMessage({
+      ...permitMessage,
+      signature,
+    } as any),
+  );
+  await eventLoopIteration();
+
+  const walletStatus = (await readPublished(`evmWallets.${walletAddress}`)) as {
+    status: string;
+    error?: string;
+  };
+  t.is(walletStatus.status, 'error');
+  t.regex(walletStatus.error || '', /allocationMaxWeights/);
+
+  await t.throwsAsync(
+    readPublished(`evmWallets.${walletAddress}.portfolio`),
+    { message: /no data at path/ },
+    'no portfolio path is published for the wallet after the aborted open+grant',
+  );
+  await t.throwsAsync(readPublished('portfolios.portfolio0'), {
     message: /no data at path/,
   });
 });

--- a/packages/portfolio-contract/test/portfolio.exo.test.ts
+++ b/packages/portfolio-contract/test/portfolio.exo.test.ts
@@ -1066,6 +1066,25 @@ test('evmHandler grant passes only the delegation client to delivery', async t =
   t.deepEqual(permissions, { allocation: true });
 });
 
+test('evmHandler grant rejects an unrecognized permission key', async t => {
+  const ownerAddress = '0x1313131313131313131313131313131313131313' as const;
+  const { makePortfolioKit, vowTools } = makeTestSetup();
+  const { evmHandler } = makePortfolioKit({
+    portfolioId: 15,
+    sourceAccountId: `eip155:42161:${ownerAddress}`,
+  });
+
+  await t.throwsAsync(
+    vowTools.when(
+      evmHandler.grant('agoric1delegate', {
+        allocation: true,
+        allocationMaxWeights: true,
+      } as any),
+    ),
+    { message: /allocationMaxWeights/ },
+  );
+});
+
 test('evmHandler grant allocates sequential agent ids', async t => {
   const ownerAddress = '0x3434343434343434343434343434343434343434' as const;
   const { makePortfolioKit, getCallLog, vowTools } = makeTestSetup();
@@ -1462,6 +1481,25 @@ test('evmHandler setAutoFeatures returns the resulting auto-features settings', 
     policyVersion: 2,
     enabledAutoFeatures: { rebalance: false },
   });
+});
+
+test('evmHandler setAutoFeatures rejects an unrecognized feature key', async t => {
+  const ownerAddress = '0x6868686868686868686868686868686868686868' as const;
+  const { makePortfolioKit, vowTools } = makeTestSetup();
+  const { evmHandler } = makePortfolioKit({
+    portfolioId: 25,
+    sourceAccountId: `eip155:42161:${ownerAddress}`,
+  });
+
+  await t.throwsAsync(
+    vowTools.when(
+      evmHandler.setAutoFeatures({
+        rebalance: true,
+        autoCompound: true,
+      } as any),
+    ),
+    { message: /autoCompound/ },
+  );
 });
 
 test('awaitingSteps is published in flowsRunning and reflects resolution state', async t => {


### PR DESCRIPTION
closes: https://linear.app/agoric/issue/AGO-1131
refs: https://linear.app/agoric/issue/AGO-1112
refs: https://github.com/Agoric/agoric-sdk/pull/12847

## Description
The EIP-712 extraction path in `portfolio-api`'s `message-handler-helpers.ts` normalized a verified-signed message against the *locally known* operation types with `onExtraField: 'drop'`, silently discarding any field the signer's client actually signed but this code version doesn't recognize yet. This is unsafe for permissions: an older contract receiving a `Grant`/`SetAutoFeatures` carrying an attenuating field it doesn't understand would drop it and treat the grant as unconstrained, rather than erroring.

This PR switches those two extraction call sites from `'drop'` to `'keep'` (the underlying `eip712-normalize.ts` engine already supported `'keep'` mode; it just wasn't used here). Authoring-side call sites in `eip712-messages.ts`, which build the client's own message from trusted local data rather than adversarial input, are left on `'drop'`.

`PortfolioPermissionsShape`/`PortfolioAutoFeaturesShape` (used by `grant()`/`setAutoFeatures()` in `portfolio.exo.ts`) were already closed shapes that reject unrecognized keys — they just never got the chance to see them, since extraction dropped unknown fields first. No new validation code was needed there; the fix is entirely at the extraction layer.

### Security Considerations
This closes a compatibility hazard: a not-yet-understood permission field (e.g. a future narrowing/attenuation field, see #12848) is now kept through extraction and rejected by the existing closed-shape checks in `grant()`/`setAutoFeatures()`, instead of silently disappearing and producing an unconstrained grant. Only the nested `permissions`/`features` records are validated against a closed shape; a genuinely-signed field elsewhere in the message (e.g. ymax-web's `tosAcceptance` struct, added client-side as a documented AGO-681 workaround) is kept but simply ignored by consumers that don't read it, since nothing validates the *whole* operation payload as closed.

### Scaling Considerations
None. Same single-pass normalization; extra fields are size-bounded by the existing EIP-712 message-size handling.

### Documentation Considerations
None.

### Testing Considerations
- `packages/portfolio-api/test/message-handler-helpers.test.ts`: updated the two tests that previously asserted a signed-but-unsupported field was dropped to assert it is now kept, including a case where the extra field is nested inside `permissions`.
- `packages/portfolio-contract/test/portfolio.exo.test.ts`: added direct coverage that `evmHandler.grant`/`evmHandler.setAutoFeatures` reject an unrecognized key in `permissions`/`features` — previously unreachable via a real signed message since extraction dropped the field first.
- `packages/portfolio-contract/test/delegation.test.ts`: added an end-to-end test against the real deployed contract confirming a genuinely-signed field at the top level of a `SetAutoFeatures` message (modeled on ymax-web's real `tosAcceptance` shape) is kept but harmlessly ignored, not rejected.

### Upgrade Considerations
No coordination required. Any client already signing extra, not-yet-understood fields (forward-compatible by design) is unaffected unless that field lives inside `permissions`/`features`, in which case it now correctly fails fast instead of being silently ignored.
