### PR TITLE
chore: Document "claimRewards" and "swap" fields in publishable types

### DIFF
--- a/packages/portfolio-api/src/types.ts
+++ b/packages/portfolio-api/src/types.ts
@@ -297,19 +297,23 @@ export type MovementDesc = {
   fee?: NatAmount;
   /** for example: { usdnOut: 98n } */
   detail?: Record<string, bigint>;
+  /** Present only for reward-token claims. */
   claimRewards?: ClaimRewardsParams;
+  /** Present only for reward-token -> stable-token swaps. */
   swap?: SwapDesc;
 };
 
 export type TxPhase = 'makeSrcAccount' | 'makeDestAccount' | 'apply';
 
-export type FlowStep = {
-  /** Human readable description of how the step accomplishes the transfer from `src` to `dest` */
-  // Distinct from `Way.how` in the contract
+export type FlowStep = Pick<
+  MovementDesc,
+  'amount' | 'src' | 'dest' | 'claimRewards' | 'swap'
+> & {
+  /**
+   * Human-readable description of how the step accomplishes the transfer from
+   * `src` to `dest` (distinct from `Way.how` in the contract).
+   */
   how: string;
-  amount: NatAmount;
-  src: AssetPlaceRef;
-  dest: AssetPlaceRef;
   /**
    * A single FlowStep can have an arbitrary number of associated pendingTxs
    * entries. They are tracked by grouping them into "phases", each phase
@@ -324,13 +328,7 @@ export type FlowStep = {
    * and for each property, to have an array of zero or more TxIds.
    */
   phases?: Partial<Record<TxPhase, TxId[]>>;
-  /**
-   * The swap request this step performs, carried through from the plan
-   * `MovementDesc` so it is visible in published flow steps. Present only on
-   * reward-token -> stable-token swap steps.
-   */
-  swap?: SwapDesc;
-  // XXX remaining plan parts (fee, detail, claim) could be surfaced the same way
+  // XXX remaining plan parts (fee, detail, etc.) could be surfaced the same way
 };
 
 /**

--- a/packages/portfolio-api/test/types.test-d.ts
+++ b/packages/portfolio-api/test/types.test-d.ts
@@ -192,7 +192,33 @@ const flowStep: FlowStep = {
   dest: '+agoric',
 };
 
-const flowSteps: FlowStep[] = [flowStep, { ...flowStep, dest: '@Base' }];
+const flowSteps: FlowStep[] = [
+  flowStep,
+  { ...flowStep, dest: '@Base', phases: { apply: ['tx42'] } },
+  {
+    how: 'Compound',
+    amount: natAmount,
+    src: 'Compound_Arbitrum',
+    dest: '@Arbitrum',
+    claimRewards: { tokens: ['0xCAFED00D'], minAmounts: [1000n] },
+  },
+  {
+    how: 'Compound',
+    amount: natAmount,
+    src: '@Arbitrum',
+    dest: '@Arbitrum',
+    swap: {
+      provider: '1inch',
+      tokenIn: '0xCAFED00D',
+      tokenOut: '0xDEADBEEF',
+      amountIn: 1000n,
+      flags: 0n,
+      executor: '0xca11ab1e',
+      srcReceiver: '0xBOB5C0FFEEFACADE',
+      data: '0xB0A710AD',
+    },
+  },
+];
 
 expectType<FlowKey>('flow1');
 expectNotAssignable<FlowKey>('flow');

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -160,12 +160,7 @@ type AccountsByChain = {
   noble?: AccountInfoFor['noble'];
 } & EVMAccounts;
 
-type AssetMovement = {
-  how: string;
-  amount: Amount<'nat'>;
-  src: AssetPlaceRef;
-  dest: AssetPlaceRef;
-  swap?: FlowStep['swap'];
+type AssetMovement = FlowStep & {
   apply: (
     accounts: AccountsByChain,
     tracer: TraceLogger,
@@ -1046,7 +1041,7 @@ const stepFlow = async (
 
     const { amount } = move;
     const phases =
-      features?.useProgressTracker && ({} as Record<TxPhase, TxId>);
+      features?.useProgressTracker && ({} as Record<TxPhase, TxId[]>);
     const { how, poolKey } = way;
     // XXX type-fest: const { claimRewards } = way as AllUnionFields<Way>;
     type ClaimRewardsWay = Extract<Way, { claimRewards: any }>;

--- a/packages/portfolio-contract/src/portfolio.flows.ts
+++ b/packages/portfolio-contract/src/portfolio.flows.ts
@@ -7,7 +7,7 @@
 
 import type { GuestInterface } from '@agoric/async-flow';
 import { VaultType } from '@agoric/cosmic-proto/noble/dollar/vaults/v1/vaults.js';
-import { type Amount, type Brand, type NatAmount } from '@agoric/ertp';
+import { type Brand, type NatAmount } from '@agoric/ertp';
 import {
   deeplyFulfilledObject,
   fromTypedEntries,

--- a/packages/portfolio-contract/src/schedule-order.ts
+++ b/packages/portfolio-contract/src/schedule-order.ts
@@ -79,7 +79,7 @@ const cycleCheck = (
  * call runTask(ix, ...) for each 0 <= ix < job.taskQty,
  * only when dependent tasks are finished.
  *
- * @throws before any calls to runTask() in case of cycles
+ * @throws {Error} before any calls to runTask() in case of cycles
  */
 export const runJob = async (
   job: Job,

--- a/packages/portfolio-contract/src/type-guards.ts
+++ b/packages/portfolio-contract/src/type-guards.ts
@@ -410,6 +410,8 @@ export const FlowStepsShape: TypedPattern<StatusFor['flowSteps']> = M.arrayOf(
     },
     {
       phases: M.recordOf(M.string(), M.arrayOf(M.string())),
+      // `claimRewards` and `swap` are intentionally non-strict.
+      claimRewards: M.record(),
       swap: M.record(),
     },
   ),

--- a/packages/portfolio-contract/tools/graph-diagnose.ts
+++ b/packages/portfolio-contract/tools/graph-diagnose.ts
@@ -47,7 +47,9 @@ const bfs = <T>(start: T, adj: Map<T, T[]>): Set<T> => {
  * Heuristics only: checks supply balance and reachability of sinks from sources.
  *
  * Example output (when graph.debug is true):
- * `No feasible solution: nodes=7 edges=12 | supply: sum=0 pos=1500 neg=1500 (pos should equal neg; sum should be 0) | sources=2 sinks=2 | sources with no path to any sink (1): Aave_Arbitrum(800) | hubs: @agoric, @noble, @Arbitrum | inter-hub edges: @agoric->@noble, @noble->@Arbitrum`
+ * ```
+ * No feasible solution: nodes=7 edges=12 | supply: sum=0 pos=1500 neg=1500 (pos should equal neg; sum should be 0) | sources=2 sinks=2 | sources with no path to any sink (1): Aave_Arbitrum(800) | hubs: @agoric, @noble, @Arbitrum | inter-hub edges: @agoric->@noble, @noble->@Arbitrum
+ * ```
  *
  * How to enable:
  *   - Set `debug: true` on the NetworkSpec used to build the graph.

--- a/packages/portfolio-contract/tools/plan-transfers.ts
+++ b/packages/portfolio-contract/tools/plan-transfers.ts
@@ -71,7 +71,7 @@ export function planDepositTransfers(
 
 /**
  * Build deposit (give) and movement steps to achieve goal amounts per protocol.
- * Aggregates deposit at @noble then fan-outs to chain-specific pools.
+ * Aggregates deposit at `@noble` then fan-outs to chain-specific pools.
  */
 export const makePortfolioSteps = async <
   G extends Partial<Record<YieldProtocol, NatAmount>>,


### PR DESCRIPTION
These fields are already present, but were inappropriately excluded from type definitions.

Ref AGO-1115