### PR TITLE
fix(ymax-planner): Expose configurable `scaleToNat` strictness

### DIFF
--- a/services/ymax-planner/src/engine.ts
+++ b/services/ymax-planner/src/engine.ts
@@ -1095,6 +1095,7 @@ export const startEngine = async (
 
   const updatePortfolioBalances = async () => {
     await null;
+    const errContext: Record<string, unknown> = Object.create(null);
     try {
       const autoPortfolios = partialMap(
         [...portfolioRecordForKey],
@@ -1103,10 +1104,12 @@ export const startEngine = async (
           return (auto?.claimRewards || auto?.rebalance) && portfolioKey;
         },
       );
+      errContext.autoPortfolios = autoPortfolios;
       const summaries = await getPortfolioSummaries?.(autoPortfolios);
       if (!summaries) return;
       for (const { portfolioId, latestSnapshot } of summaries) {
         if (!latestSnapshot) continue;
+        errContext[portfolioId] = latestSnapshot;
         const { tokenBalances } = latestSnapshot;
 
         // This data might be more stale than that of our own balance queries,
@@ -1127,9 +1130,14 @@ export const startEngine = async (
             tokenBalances,
           });
         }
+        delete errContext[portfolioId];
       }
     } catch (err) {
-      console.error('🚨 [updatePortfolioBalances]', err);
+      console.error(
+        '🚨 [updatePortfolioBalances]',
+        err,
+        ...(Object.keys(errContext).length >= 1 ? [errContext] : []),
+      );
     }
   };
 

--- a/services/ymax-planner/src/ses-utils.ts
+++ b/services/ymax-planner/src/ses-utils.ts
@@ -3,7 +3,7 @@
  */
 
 import { Fail, q } from '@endo/errors';
-import { Nat } from '@endo/nat';
+import { isNat, Nat } from '@endo/nat';
 
 const { freeze } = Object;
 
@@ -52,6 +52,11 @@ export const scaleToNat = (
   fixedPlaces: number,
   strictness: number = Infinity,
 ): bigint => {
+  (isNat(fixedPlaces) && fixedPlaces <= 30) ||
+    Fail`internal: scaleToNat fixedPlaces must be a natural number no greater than 30: ${fixedPlaces}`;
+  strictness === Infinity ||
+    (isNat(strictness) && strictness <= 30) ||
+    Fail`internal: scaleToNat strictness must be a natural number no greater than 30: ${strictness}`;
   if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
     throw Fail`scaleToNat requires a non-negative finite number, not ${value}`;
   }

--- a/services/ymax-planner/src/ses-utils.ts
+++ b/services/ymax-planner/src/ses-utils.ts
@@ -3,6 +3,7 @@
  */
 
 import { Fail, q } from '@endo/errors';
+import { Nat } from '@endo/nat';
 
 const { freeze } = Object;
 
@@ -40,3 +41,55 @@ export const generateDiff = <T>(
 ): ReturnType<typeof generateDiffInternal<T>> =>
   harden(generateDiffInternal(...args));
 harden(generateDiff);
+
+/**
+ * Scale a floating-point number up to a natural number without rounding (beyond
+ * a configurable count of subsequent decimal places that must be entirely zeros
+ * or entirely nines).
+ */
+export const scaleToNat = (
+  value: unknown,
+  fixedPlaces: number,
+  strictness: number = Infinity,
+): bigint => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw Fail`scaleToNat requires a non-negative finite number, not ${value}`;
+  }
+  const [, N, F = '', E] =
+    value.toExponential().match(/^(\d)(?:\.(\d+))?e([+-]\d+)$/) ||
+    Fail`internal: scaleToNat requires parsable toExponential() output from ${value}`;
+  const exp = Number(E);
+  let [n, f] = [N, F];
+  try {
+    let fracDigitCount = f.length - exp;
+    if (fracDigitCount > fixedPlaces) {
+      // We have unexpected fractional digits, but they might still fit within
+      // our strictness (e.g., 17.578324000000002 with fixedPlaces=6 passes when
+      // strictness<=8).
+      const tail = f.slice(exp + fixedPlaces, exp + fixedPlaces + strictness);
+      if (tail.match(/^0+$/)) {
+        // round down via truncation
+        f = f.slice(0, exp + fixedPlaces);
+        fracDigitCount = fixedPlaces;
+      } else if (tail.length === strictness && tail.match(/^9+$/)) {
+        // round up, possibly with carry
+        f = f.slice(0, exp + fixedPlaces);
+        fracDigitCount = fixedPlaces;
+        if (f.match(/^9+$/)) {
+          n = String(Number(n) + 1);
+          f = f.replaceAll('9', '0');
+        } else {
+          f = String(Number(f) + 1);
+        }
+      } else {
+        throw Fail``;
+      }
+    }
+    const big = BigInt(`${n}${f}${'0'.repeat(fixedPlaces - fracDigitCount)}`);
+    return Nat(Number(big));
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (_err) {
+    throw Fail`scaleToNat found precision loss at scale ${q(fixedPlaces)}: ${value}`;
+  }
+};
+harden(scaleToNat);

--- a/services/ymax-planner/src/ses-utils.ts
+++ b/services/ymax-planner/src/ses-utils.ts
@@ -55,41 +55,37 @@ export const scaleToNat = (
   if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
     throw Fail`scaleToNat requires a non-negative finite number, not ${value}`;
   }
-  const [, N, F = '', E] =
+  const exponential =
     value.toExponential().match(/^(\d)(?:\.(\d+))?e([+-]\d+)$/) ||
     Fail`internal: scaleToNat requires parsable toExponential() output from ${value}`;
-  const exp = Number(E);
-  let [n, f] = [N, F];
-  try {
-    let fracDigitCount = f.length - exp;
-    if (fracDigitCount > fixedPlaces) {
-      // We have unexpected fractional digits, but they might still fit within
-      // our strictness (e.g., 17.578324000000002 with fixedPlaces=6 passes when
-      // strictness<=8).
-      const tail = f.slice(exp + fixedPlaces, exp + fixedPlaces + strictness);
-      if (tail.match(/^0+$/)) {
-        // round down via truncation
-        f = f.slice(0, exp + fixedPlaces);
-        fracDigitCount = fixedPlaces;
-      } else if (tail.length === strictness && tail.match(/^9+$/)) {
-        // round up, possibly with carry
-        f = f.slice(0, exp + fixedPlaces);
-        fracDigitCount = fixedPlaces;
-        if (f.match(/^9+$/)) {
-          n = String(Number(n) + 1);
-          f = f.replaceAll('9', '0');
-        } else {
-          f = String(Number(f) + 1);
-        }
-      } else {
-        throw Fail``;
-      }
-    }
-    const big = BigInt(`${n}${f}${'0'.repeat(fixedPlaces - fracDigitCount)}`);
-    return Nat(Number(big));
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (_err) {
-    throw Fail`scaleToNat found precision loss at scale ${q(fixedPlaces)}: ${value}`;
+  const [, n, f = '', e] = exponential;
+  const exp = Number(e);
+
+  // exp defines the relevant partitioning of `${n}${f}`.
+  let prefixLen = 1 + exp + fixedPlaces;
+
+  // Fast path for short input.
+  const fillLen = prefixLen - f.length - 1;
+  if (fillLen >= 0) {
+    return Nat(Number(BigInt(`${n}${f}${'0'.repeat(fillLen)}`)));
   }
+
+  // Collect post-prefix digits according to the strictness threshold, requiring
+  // them to either be zeros (and truncated) or nines (and rounding the prefix
+  // up). For example, 17.578324000000002 with fixedPlaces=6 passes when
+  // strictness<=8.
+  const allDigits = `${prefixLen < 0 ? '0'.repeat(-prefixLen) : ''}${n}${f}`;
+  if (prefixLen < 0) prefixLen = 0;
+  const suffix = allDigits.slice(prefixLen, prefixLen + strictness);
+  if (
+    suffix.match(/^0*$/) ||
+    (suffix.match(/^9+$/) && [suffix.length, Infinity].includes(strictness))
+  ) {
+    const prefixBigint = BigInt(allDigits.slice(0, prefixLen));
+    const roundUp = allDigits.charAt(prefixLen).match(/[5-9]/);
+    return Nat(Number(roundUp ? prefixBigint + 1n : prefixBigint));
+  }
+
+  throw Fail`scaleToNat found precision loss at scale ${q(fixedPlaces)}: ${value}`;
 };
 harden(scaleToNat);

--- a/services/ymax-planner/src/yds-portfolio-balances.ts
+++ b/services/ymax-planner/src/yds-portfolio-balances.ts
@@ -6,7 +6,7 @@ import type { EvmAddress } from '@agoric/fast-usdc';
 import type { Bech32Address, CaipChainId } from '@agoric/orchestration';
 import { SupportedChain } from '@agoric/portfolio-api/src/constants.js';
 import { PoolPlaces } from '@agoric/portfolio-api/src/places.js';
-import { Fail, bare, q } from '@endo/errors';
+import { Fail, q } from '@endo/errors';
 import type { PortfolioKey } from '@agoric/portfolio-api';
 import { Nat } from '@endo/nat';
 import type { UsdcNumber } from './support.ts';
@@ -86,17 +86,13 @@ const assertRecord = (
 /**
  * Scale a floating-point number up to a natural number without rounding.
  */
-const scaleToNat = (
-  value: unknown,
-  fixedPlaces: number,
-  label: string,
-): bigint => {
+const scaleToNat = (value: unknown, fixedPlaces: number): bigint => {
   if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
-    throw Fail`${bare(label)} ${value} must be a non-negative finite number`;
+    throw Fail`scaleToNat requires a non-negative finite number, not ${value}`;
   }
   const [, n, f = '', e] =
     value.toExponential().match(/^(\d)(?:\.(\d+))?e([+-]\d+)$/) ||
-    Fail`${bare(label)} must be representable in exponential notation`;
+    Fail`internal: scaleToNat requires parsable toExponential() output from ${value}`;
   try {
     const fracDigitCount = f.length - Number(e);
     fracDigitCount <= fixedPlaces || Fail``;
@@ -104,7 +100,7 @@ const scaleToNat = (
     return Nat(Number(big));
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (_err) {
-    throw Fail`${bare(label)} ${value} loses precision at scale ${q(fixedPlaces)}`;
+    throw Fail`scaleToNat found precision loss at scale ${q(fixedPlaces)}: ${value}`;
   }
 };
 
@@ -120,11 +116,7 @@ export const normalizeYdsPortfolioBalances = (
   for (const [instrumentId, value] of Object.entries(positions)) {
     Object.hasOwn(PoolPlaces, instrumentId) ||
       Fail`Invalid YDS instrument id ${q(instrumentId)}`;
-    const balance = scaleToNat(
-      value,
-      USDC_DECIMALS,
-      `YDS balance ${instrumentId}`,
-    );
+    const balance = scaleToNat(value, USDC_DECIMALS);
     if (balance <= 0n) continue;
     balances[instrumentId] = AmountMath.make(brand, balance);
   }
@@ -132,7 +124,7 @@ export const normalizeYdsPortfolioBalances = (
     Object.hasOwn(SupportedChain, chainName) ||
       Fail`Invalid YDS account chain ${q(chainName)}`;
     const place = `@${chainName}` as AssetPlaceRef;
-    const balance = scaleToNat(value, USDC_DECIMALS, `YDS balance ${place}`);
+    const balance = scaleToNat(value, USDC_DECIMALS);
     if (balance <= 0n) continue;
     balances[place] = AmountMath.make(brand, balance);
   }

--- a/services/ymax-planner/src/yds-portfolio-balances.ts
+++ b/services/ymax-planner/src/yds-portfolio-balances.ts
@@ -84,18 +84,48 @@ const assertRecord = (
 };
 
 /**
- * Scale a floating-point number up to a natural number without rounding.
+ * Scale a floating-point number up to a natural number without rounding (beyond
+ * a configurable count of subsequent decimal places that must be entirely zeros
+ * or entirely nines).
  */
-const scaleToNat = (value: unknown, fixedPlaces: number): bigint => {
+const scaleToNat = (
+  value: unknown,
+  fixedPlaces: number,
+  strictness: number = Infinity,
+): bigint => {
   if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
     throw Fail`scaleToNat requires a non-negative finite number, not ${value}`;
   }
-  const [, n, f = '', e] =
+  const [, N, F = '', E] =
     value.toExponential().match(/^(\d)(?:\.(\d+))?e([+-]\d+)$/) ||
     Fail`internal: scaleToNat requires parsable toExponential() output from ${value}`;
+  const exp = Number(E);
+  let [n, f] = [N, F];
   try {
-    const fracDigitCount = f.length - Number(e);
-    fracDigitCount <= fixedPlaces || Fail``;
+    let fracDigitCount = f.length - exp;
+    if (fracDigitCount > fixedPlaces) {
+      // We have unexpected fractional digits, but they might still fit within
+      // our strictness (e.g., 17.578324000000002 with fixedPlaces=6 passes when
+      // strictness<=8).
+      const tail = f.slice(exp + fixedPlaces, exp + fixedPlaces + strictness);
+      if (tail.match(/^0+$/)) {
+        // round down via truncation
+        f = f.slice(0, exp + fixedPlaces);
+        fracDigitCount = fixedPlaces;
+      } else if (tail.length === strictness && tail.match(/^9+$/)) {
+        // round up, possibly with carry
+        f = f.slice(0, exp + fixedPlaces);
+        fracDigitCount = fixedPlaces;
+        if (f.match(/^9+$/)) {
+          n = String(Number(n) + 1);
+          f = f.replaceAll('9', '0');
+        } else {
+          f = String(Number(f) + 1);
+        }
+      } else {
+        throw Fail``;
+      }
+    }
     const big = BigInt(`${n}${f}${'0'.repeat(fixedPlaces - fracDigitCount)}`);
     return Nat(Number(big));
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -116,7 +146,7 @@ export const normalizeYdsPortfolioBalances = (
   for (const [instrumentId, value] of Object.entries(positions)) {
     Object.hasOwn(PoolPlaces, instrumentId) ||
       Fail`Invalid YDS instrument id ${q(instrumentId)}`;
-    const balance = scaleToNat(value, USDC_DECIMALS);
+    const balance = scaleToNat(value, USDC_DECIMALS, 3);
     if (balance <= 0n) continue;
     balances[instrumentId] = AmountMath.make(brand, balance);
   }
@@ -124,7 +154,7 @@ export const normalizeYdsPortfolioBalances = (
     Object.hasOwn(SupportedChain, chainName) ||
       Fail`Invalid YDS account chain ${q(chainName)}`;
     const place = `@${chainName}` as AssetPlaceRef;
-    const balance = scaleToNat(value, USDC_DECIMALS);
+    const balance = scaleToNat(value, USDC_DECIMALS, 3);
     if (balance <= 0n) continue;
     balances[place] = AmountMath.make(brand, balance);
   }

--- a/services/ymax-planner/src/yds-portfolio-balances.ts
+++ b/services/ymax-planner/src/yds-portfolio-balances.ts
@@ -8,7 +8,7 @@ import { SupportedChain } from '@agoric/portfolio-api/src/constants.js';
 import { PoolPlaces } from '@agoric/portfolio-api/src/places.js';
 import { Fail, q } from '@endo/errors';
 import type { PortfolioKey } from '@agoric/portfolio-api';
-import { Nat } from '@endo/nat';
+import { scaleToNat } from './ses-utils.ts';
 import type { UsdcNumber } from './support.ts';
 
 export const YDS_PORTFOLIO_BALANCE_CACHE_TTL_MS = 60 * 60 * 1000;
@@ -81,57 +81,6 @@ const assertRecord = (
     throw Fail`YDS ${label} must be a record`;
   }
   return value as Record<string, unknown>;
-};
-
-/**
- * Scale a floating-point number up to a natural number without rounding (beyond
- * a configurable count of subsequent decimal places that must be entirely zeros
- * or entirely nines).
- */
-const scaleToNat = (
-  value: unknown,
-  fixedPlaces: number,
-  strictness: number = Infinity,
-): bigint => {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
-    throw Fail`scaleToNat requires a non-negative finite number, not ${value}`;
-  }
-  const [, N, F = '', E] =
-    value.toExponential().match(/^(\d)(?:\.(\d+))?e([+-]\d+)$/) ||
-    Fail`internal: scaleToNat requires parsable toExponential() output from ${value}`;
-  const exp = Number(E);
-  let [n, f] = [N, F];
-  try {
-    let fracDigitCount = f.length - exp;
-    if (fracDigitCount > fixedPlaces) {
-      // We have unexpected fractional digits, but they might still fit within
-      // our strictness (e.g., 17.578324000000002 with fixedPlaces=6 passes when
-      // strictness<=8).
-      const tail = f.slice(exp + fixedPlaces, exp + fixedPlaces + strictness);
-      if (tail.match(/^0+$/)) {
-        // round down via truncation
-        f = f.slice(0, exp + fixedPlaces);
-        fracDigitCount = fixedPlaces;
-      } else if (tail.length === strictness && tail.match(/^9+$/)) {
-        // round up, possibly with carry
-        f = f.slice(0, exp + fixedPlaces);
-        fracDigitCount = fixedPlaces;
-        if (f.match(/^9+$/)) {
-          n = String(Number(n) + 1);
-          f = f.replaceAll('9', '0');
-        } else {
-          f = String(Number(f) + 1);
-        }
-      } else {
-        throw Fail``;
-      }
-    }
-    const big = BigInt(`${n}${f}${'0'.repeat(fixedPlaces - fracDigitCount)}`);
-    return Nat(Number(big));
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (_err) {
-    throw Fail`scaleToNat found precision loss at scale ${q(fixedPlaces)}: ${value}`;
-  }
 };
 
 export const normalizeYdsPortfolioBalances = (

--- a/services/ymax-planner/test/ses-utils.test.ts
+++ b/services/ymax-planner/test/ses-utils.test.ts
@@ -1,0 +1,30 @@
+/* eslint-disable no-loss-of-precision */
+import test from 'ava';
+
+import { scaleToNat } from '../src/ses-utils.ts';
+
+test('scaleToNat input validation', t => {
+  const rejected = { message: /non-negative finite number/ };
+  t.throws(() => scaleToNat('0', 6), rejected, 'string');
+  t.throws(() => scaleToNat(0n, 6), rejected, 'bigint');
+  t.throws(() => scaleToNat(NaN, 6), rejected, 'NaN');
+  t.throws(() => scaleToNat(Infinity, 6), rejected, 'Infinity');
+  t.throws(() => scaleToNat(-1, 6), rejected, 'negative');
+});
+
+test('scaleToNat fixed place count', t => {
+  t.is(scaleToNat(1.23, 2), 123n);
+  t.is(scaleToNat(1.23, 3), 1230n);
+});
+
+test('scaleToNat strictness', t => {
+  const lossy = { message: /precision loss/ };
+  t.throws(
+    () => scaleToNat(17.578324000000002, 6),
+    lossy,
+    'strictness defaults to maximum',
+  );
+  t.throws(() => scaleToNat(17.578324000000002, 6, 9), lossy);
+  t.is(scaleToNat(17.578324000000002, 6, 8), 17_578_324n);
+  t.is(scaleToNat(17.578320000000002, 5, 9), 1_757_832n);
+});

--- a/services/ymax-planner/test/ses-utils.test.ts
+++ b/services/ymax-planner/test/ses-utils.test.ts
@@ -15,10 +15,20 @@ test('scaleToNat input validation', t => {
 test('scaleToNat fixed place count', t => {
   t.is(scaleToNat(1.23, 2), 123n);
   t.is(scaleToNat(1.23, 3), 1230n);
+  t.is(scaleToNat(0.01, 2), 1n);
+  t.is(scaleToNat(0.01, 3), 10n);
+  t.is(scaleToNat(0, 2), 0n);
+  t.is(scaleToNat(0, 3), 0n);
+
+  t.is(scaleToNat(0.09, 1, 0), 1n);
+  t.is(scaleToNat(0.09, 1, 1), 1n);
+  t.is(scaleToNat(1.09, 1, 0), 11n);
+  t.is(scaleToNat(1.09, 1, 1), 11n);
 });
 
 test('scaleToNat strictness', t => {
   const lossy = { message: /precision loss/ };
+
   t.throws(
     () => scaleToNat(17.578324000000002, 6),
     lossy,
@@ -27,4 +37,17 @@ test('scaleToNat strictness', t => {
   t.throws(() => scaleToNat(17.578324000000002, 6, 9), lossy);
   t.is(scaleToNat(17.578324000000002, 6, 8), 17_578_324n);
   t.is(scaleToNat(17.578320000000002, 5, 9), 1_757_832n);
+
+  t.is(scaleToNat(1.00991, 2, 2), 101n);
+  t.is(scaleToNat(1.0099, 2, 2), 101n);
+  t.throws(() => scaleToNat(1.0098, 2, 2), lossy);
+  t.throws(() => scaleToNat(1.009, 2, 2), lossy);
+
+  // Exhaustively check 0.00_01_##.
+  for (let i = 0; i < 100; i += 1) {
+    const x = Number(`0.0001${String(i).padStart(2, '0')}`);
+    t.throws(() => scaleToNat(x, 2, 2), lossy, `x=${x}`);
+    t.is(scaleToNat(x, 2, 1), 0n, `x=${x}`);
+    t.is(scaleToNat(x, 2, 0), 0n, `x=${x}`);
+  }
 });

--- a/services/ymax-planner/test/ses-utils.test.ts
+++ b/services/ymax-planner/test/ses-utils.test.ts
@@ -3,7 +3,17 @@ import test from 'ava';
 
 import { scaleToNat } from '../src/ses-utils.ts';
 
-test('scaleToNat input validation', t => {
+test('scaleToNat configuration validation', t => {
+  t.throws(() => scaleToNat(0, -10), { message: /fixedPlaces/ });
+  t.throws(() => scaleToNat(0, 2.5), { message: /fixedPlaces/ });
+  t.throws(() => scaleToNat(0, 31), { message: /fixedPlaces/ });
+
+  t.throws(() => scaleToNat(0, 1, -10), { message: /strictness/ });
+  t.throws(() => scaleToNat(0, 1, 2.5), { message: /strictness/ });
+  t.throws(() => scaleToNat(0, 1, 31), { message: /strictness/ });
+});
+
+test('scaleToNat value validation', t => {
   const rejected = { message: /non-negative finite number/ };
   t.throws(() => scaleToNat('0', 6), rejected, 'string');
   t.throws(() => scaleToNat(0n, 6), rejected, 'bigint');


### PR DESCRIPTION
 ...so it can handle values derived from IEEE 754 binary64 floating-point arithmetic.

## Description
Fixes the "_YDS balance Aave_Avalanche 17.578324000000002 loses precision at scale 6_" errors observed from the ymax1 planner.

### Security Considerations
None known.

### Scaling Considerations
n/a

### Documentation Considerations
Covered by JSDoc.

### Testing Considerations
Covered by unit tests.

### Upgrade Considerations
Safe for immediate deployment.