### PR TITLE
fix(portfolio-deploy): polish wallet-admin

### DIFF
--- a/packages/portfolio-deploy/scripts/wallet-admin.ts
+++ b/packages/portfolio-deploy/scripts/wallet-admin.ts
@@ -50,7 +50,9 @@ export const main = async (
     now = Date.now,
     cwd = process.cwd,
     // KLUDGE! avoid flaky load-balanced setup
-    rpcAddrMainGood = 'https://rpc.agoric-main-eu1.ccvalidators.com:443',
+    rpcAddrMainGood = env.AGORIC_NET === 'main'
+      ? 'https://rpc.agoric-main-eu1.ccvalidators.com:443'
+      : undefined,
   } = {},
 ) => {
   const fresh = () => new Date(now()).toISOString();
@@ -58,13 +60,9 @@ export const main = async (
     new Promise(resolve => setTimeout(resolve, ms)).then(_ => {});
 
   const networkConfig0 = await fetchEnvNetworkConfig({ env, fetch });
-  const networkConfig =
-    !env.AGORIC_NET || env.AGORIC_NET === 'local' || env.AGORIC_NET === 'devnet'
-      ? networkConfig0
-      : {
-          ...networkConfig0,
-          rpcAddrs: [rpcAddrMainGood],
-        };
+  const networkConfig = rpcAddrMainGood
+    ? { ...networkConfig0, rpcAddrs: [rpcAddrMainGood] }
+    : networkConfig0;
   const walletKit = await makeSmartWalletKit({ fetch, delay }, networkConfig);
 
   const storeOpts = {

--- a/packages/portfolio-deploy/scripts/wallet-admin.ts
+++ b/packages/portfolio-deploy/scripts/wallet-admin.ts
@@ -19,6 +19,11 @@ import { E } from '@endo/far';
 import fsp from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  chooseRpcAddrMainGood,
+  withWalletAdminRpcKludge,
+} from '../src/wallet-admin-rpc.ts';
 import type { RunTools } from '../src/wallet-admin-types.ts';
 
 const Usage = `tool.ts MODULE ...args`;
@@ -50,9 +55,7 @@ export const main = async (
     now = Date.now,
     cwd = process.cwd,
     // KLUDGE! avoid flaky load-balanced setup
-    rpcAddrMainGood = env.AGORIC_NET === 'main'
-      ? 'https://rpc.agoric-main-eu1.ccvalidators.com:443'
-      : undefined,
+    rpcAddrMainGood = chooseRpcAddrMainGood(env),
   } = {},
 ) => {
   const fresh = () => new Date(now()).toISOString();
@@ -60,9 +63,10 @@ export const main = async (
     new Promise(resolve => setTimeout(resolve, ms)).then(_ => {});
 
   const networkConfig0 = await fetchEnvNetworkConfig({ env, fetch });
-  const networkConfig = rpcAddrMainGood
-    ? { ...networkConfig0, rpcAddrs: [rpcAddrMainGood] }
-    : networkConfig0;
+  const networkConfig = withWalletAdminRpcKludge(
+    networkConfig0,
+    rpcAddrMainGood,
+  );
   const walletKit = await makeSmartWalletKit({ fetch, delay }, networkConfig);
 
   const storeOpts = {
@@ -146,8 +150,9 @@ export const main = async (
   await fn(tools);
 };
 
-// TODO: use endo-exec so we can unit test the above
-main().catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/portfolio-deploy/scripts/ymax-deploy-target.ts
+++ b/packages/portfolio-deploy/scripts/ymax-deploy-target.ts
@@ -1572,7 +1572,7 @@ type SignedTxRecord = {
   signedTxAssetName: string;
   txBytes: Uint8Array;
   bodyBytes: Uint8Array;
-  authInfoBytes: Uint8Array;
+  authInfo: unknown;
 };
 
 const findSignedTx = async (
@@ -1596,8 +1596,28 @@ const findSignedTx = async (
     signedTxAssetName: name,
     txBytes: parseSignedTxBytes(text),
     bodyBytes: encodeTxBodyBytes(specimen.body),
-    authInfoBytes: encodeAuthInfoBytes(specimen.auth_info),
+    authInfo: specimen.auth_info,
   };
+};
+
+const normalizeSignedAuthInfo = (
+  signedAuthInfo: any,
+  unsignedAuthInfo: any,
+) => {
+  const comparableAuthInfo = JSON.parse(JSON.stringify(signedAuthInfo));
+  for (const [index, signerInfo] of (
+    comparableAuthInfo.signer_infos || []
+  ).entries()) {
+    const unsignedSignerInfo = unsignedAuthInfo.signer_infos?.[index];
+    if (
+      unsignedSignerInfo &&
+      !('public_key' in unsignedSignerInfo) &&
+      'public_key' in signerInfo
+    ) {
+      delete signerInfo.public_key;
+    }
+  }
+  return comparableAuthInfo;
 };
 
 const requireMatchingDetachedSignedTx = async (
@@ -1629,10 +1649,11 @@ const requireMatchingDetachedSignedTx = async (
       `${signedTx.signedTxAssetName} body does not match ${unsignedTxAssetName}`,
     );
   }
+  const signedAuthInfoBytes = encodeAuthInfoBytes(
+    normalizeSignedAuthInfo(signedTx.authInfo, unsignedTx.auth_info),
+  );
   if (
-    !Buffer.from(signedTx.authInfoBytes).equals(
-      Buffer.from(unsignedAuthInfoBytes),
-    )
+    !Buffer.from(signedAuthInfoBytes).equals(Buffer.from(unsignedAuthInfoBytes))
   ) {
     throw Error(
       `${signedTx.signedTxAssetName} auth_info does not match ${unsignedTxAssetName}`,
@@ -2031,12 +2052,12 @@ export const makeGraph = (
             install as InstallRecord,
             { cause, privateArgs, ...tools },
           );
-          await asset!.writeText(`${JSON.stringify(pending, null, 2)}\n`);
           await requireMatchingDetachedSignedTx(
             'ymax0-devnet',
             signedTx as SignedTxRecord,
             tools,
           );
+          await asset!.writeText(`${JSON.stringify(pending, null, 2)}\n`);
           await submitAuthzOperatorUpgrade(
             'ymax0-devnet',
             (signedTx as SignedTxRecord).txBytes,
@@ -2116,12 +2137,12 @@ export const makeGraph = (
             install as InstallRecord,
             { cause, privateArgs, ...tools },
           );
-          await asset!.writeText(`${JSON.stringify(pending, null, 2)}\n`);
           await requireMatchingDetachedSignedTx(
             'ymax0-main',
             signedTx as SignedTxRecord,
             tools,
           );
+          await asset!.writeText(`${JSON.stringify(pending, null, 2)}\n`);
           await submitAuthzOperatorUpgrade(
             'ymax0-main',
             (signedTx as SignedTxRecord).txBytes,
@@ -2199,12 +2220,12 @@ export const makeGraph = (
             install as InstallRecord,
             { cause, privateArgs, ...tools },
           );
-          await asset!.writeText(`${JSON.stringify(pending, null, 2)}\n`);
           await requireMatchingDetachedSignedTx(
             'ymax1-main',
             signedTx as SignedTxRecord,
             tools,
           );
+          await asset!.writeText(`${JSON.stringify(pending, null, 2)}\n`);
           await submitAuthzOperatorUpgrade(
             'ymax1-main',
             (signedTx as SignedTxRecord).txBytes,

--- a/packages/portfolio-deploy/scripts/ymax-deploy-target.ts
+++ b/packages/portfolio-deploy/scripts/ymax-deploy-target.ts
@@ -1224,6 +1224,9 @@ const formatAgdSignCommand = ({
   signedTxAssetName: string;
 }) => {
   const download = `gh release download ${shQuote(releaseTag)} --pattern ${shQuote(unsignedTxAssetName)} --clobber`;
+  const upload = (assetName: string) =>
+    `gh release upload ${shQuote(releaseTag)} ${shQuote(assetName)} --clobber`;
+  const chainCommands = (commands: string[]) => commands.join(' &&\n  ');
   const authInfo = AuthInfo.decode(
     Buffer.from(request.authInfoBytesBase64, 'base64'),
   );
@@ -1237,7 +1240,7 @@ const formatAgdSignCommand = ({
       encodeJsonPublicKey(granteePubkey),
     );
     const signatureAssetName = `${detachedSignatureAssetPrefix(target)}<your-name>.json`;
-    return [
+    return chainCommands([
       download,
       `agd keys add ${shQuote(multisigName)} --pubkey=${shQuote(multisigPubkeyJson)}`,
       [
@@ -1258,11 +1261,11 @@ const formatAgdSignCommand = ({
         '--output-document',
         shQuote(signatureAssetName),
       ].join(' '),
-      `gh release upload ${shQuote(releaseTag)} ${shQuote(signatureAssetName)} --clobber`,
-    ].join('\n');
+      upload(signatureAssetName),
+    ]);
   }
   const signerAddress = request.grantee || request.controlAddress;
-  return [
+  return chainCommands([
     download,
     [
       'agd tx sign',
@@ -1281,8 +1284,8 @@ const formatAgdSignCommand = ({
       '--output-document',
       shQuote(signedTxAssetName),
     ].join(' '),
-    `gh release upload ${shQuote(releaseTag)} ${shQuote(signedTxAssetName)} --clobber`,
-  ].join('\n');
+    upload(signedTxAssetName),
+  ]);
 };
 
 /**

--- a/packages/portfolio-deploy/scripts/ymax-deploy-target.ts
+++ b/packages/portfolio-deploy/scripts/ymax-deploy-target.ts
@@ -33,6 +33,7 @@ import assert from 'node:assert/strict';
 import {
   encodeAuthInfoBytes,
   encodeJsonPublicKey,
+  encodeTxBodyBytes,
   makeAgdUnsignedTx,
   parseSignedTxBytes,
 } from '../src/ymax-authz-msgs.ts';
@@ -1567,18 +1568,76 @@ const findUnsignedTx = async (
   return { unsignedTxAssetName: name };
 };
 
+type SignedTxRecord = {
+  signedTxAssetName: string;
+  txBytes: Uint8Array;
+  bodyBytes: Uint8Array;
+  authInfoBytes: Uint8Array;
+};
+
 const findSignedTx = async (
   name: string,
   asset: AssetRd,
   release: ReleaseInfo,
-) => {
+): Promise<SignedTxRecord> => {
   if (!hasAsset(release, name)) {
     throw Error(`missing required release asset ${name}`);
   }
+  const text = await asset.readText();
+  const specimen = JSON.parse(text) as any;
+  if (
+    !specimen?.body ||
+    !specimen?.auth_info ||
+    !Array.isArray(specimen?.signatures)
+  ) {
+    throw Error('not signed tx JSON');
+  }
   return {
     signedTxAssetName: name,
-    txBytes: parseSignedTxBytes(await asset.readText()),
+    txBytes: parseSignedTxBytes(text),
+    bodyBytes: encodeTxBodyBytes(specimen.body),
+    authInfoBytes: encodeAuthInfoBytes(specimen.auth_info),
   };
+};
+
+const requireMatchingDetachedSignedTx = async (
+  upgradeTarget: Target,
+  signedTx: SignedTxRecord,
+  {
+    release,
+    grantee,
+  }: {
+    release: ReleaseRW;
+    grantee: string | undefined;
+  },
+) => {
+  const unsignedTxAssetName = detachedUnsignedTxAssetName(
+    upgradeTarget,
+    grantee,
+  );
+  const unsignedTx = (await release.join(unsignedTxAssetName).readJSON()) as {
+    body?: unknown;
+    auth_info?: unknown;
+  };
+  if (!unsignedTx.body || !unsignedTx.auth_info) {
+    throw Error(`${unsignedTxAssetName} is not unsigned tx JSON`);
+  }
+  const unsignedBodyBytes = encodeTxBodyBytes(unsignedTx.body);
+  const unsignedAuthInfoBytes = encodeAuthInfoBytes(unsignedTx.auth_info);
+  if (!Buffer.from(signedTx.bodyBytes).equals(Buffer.from(unsignedBodyBytes))) {
+    throw Error(
+      `${signedTx.signedTxAssetName} body does not match ${unsignedTxAssetName}`,
+    );
+  }
+  if (
+    !Buffer.from(signedTx.authInfoBytes).equals(
+      Buffer.from(unsignedAuthInfoBytes),
+    )
+  ) {
+    throw Error(
+      `${signedTx.signedTxAssetName} auth_info does not match ${unsignedTxAssetName}`,
+    );
+  }
 };
 
 const confirmUpgradeContract = async (
@@ -1973,9 +2032,14 @@ export const makeGraph = (
             { cause, privateArgs, ...tools },
           );
           await asset!.writeText(`${JSON.stringify(pending, null, 2)}\n`);
+          await requireMatchingDetachedSignedTx(
+            'ymax0-devnet',
+            signedTx as SignedTxRecord,
+            tools,
+          );
           await submitAuthzOperatorUpgrade(
             'ymax0-devnet',
-            (signedTx as { txBytes: Uint8Array }).txBytes,
+            (signedTx as SignedTxRecord).txBytes,
             { connectRpc: connectTargetRpc },
           );
           return pending;
@@ -2053,9 +2117,14 @@ export const makeGraph = (
             { cause, privateArgs, ...tools },
           );
           await asset!.writeText(`${JSON.stringify(pending, null, 2)}\n`);
+          await requireMatchingDetachedSignedTx(
+            'ymax0-main',
+            signedTx as SignedTxRecord,
+            tools,
+          );
           await submitAuthzOperatorUpgrade(
             'ymax0-main',
-            (signedTx as { txBytes: Uint8Array }).txBytes,
+            (signedTx as SignedTxRecord).txBytes,
             { connectRpc: connectTargetRpc },
           );
           return pending;
@@ -2131,9 +2200,14 @@ export const makeGraph = (
             { cause, privateArgs, ...tools },
           );
           await asset!.writeText(`${JSON.stringify(pending, null, 2)}\n`);
+          await requireMatchingDetachedSignedTx(
+            'ymax1-main',
+            signedTx as SignedTxRecord,
+            tools,
+          );
           await submitAuthzOperatorUpgrade(
             'ymax1-main',
-            (signedTx as { txBytes: Uint8Array }).txBytes,
+            (signedTx as SignedTxRecord).txBytes,
             { connectRpc: connectTargetRpc },
           );
           return pending;

--- a/packages/portfolio-deploy/src/wallet-admin-rpc.ts
+++ b/packages/portfolio-deploy/src/wallet-admin-rpc.ts
@@ -1,0 +1,16 @@
+export const MAINNET_RPC_ADDR_KLUDGE =
+  'https://rpc.agoric-main-eu1.ccvalidators.com:443';
+
+export const chooseRpcAddrMainGood = (
+  env: Record<string, string | undefined>,
+) => (env.AGORIC_NET === 'main' ? MAINNET_RPC_ADDR_KLUDGE : undefined);
+
+export const withWalletAdminRpcKludge = <
+  T extends { rpcAddrs: readonly string[] },
+>(
+  networkConfig0: T,
+  rpcAddrMainGood: string | undefined,
+): T =>
+  rpcAddrMainGood
+    ? { ...networkConfig0, rpcAddrs: [rpcAddrMainGood] }
+    : networkConfig0;

--- a/packages/portfolio-deploy/test/wallet-admin.test.ts
+++ b/packages/portfolio-deploy/test/wallet-admin.test.ts
@@ -1,0 +1,31 @@
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import {
+  chooseRpcAddrMainGood,
+  MAINNET_RPC_ADDR_KLUDGE,
+  withWalletAdminRpcKludge,
+} from '../src/wallet-admin-rpc.ts';
+
+test('wallet-admin only applies the RPC kludge on mainnet by default', t => {
+  t.is(chooseRpcAddrMainGood({ AGORIC_NET: 'main' }), MAINNET_RPC_ADDR_KLUDGE);
+  t.is(chooseRpcAddrMainGood({ AGORIC_NET: 'devnet' }), undefined);
+  t.is(chooseRpcAddrMainGood({ AGORIC_NET: 'local' }), undefined);
+  t.is(chooseRpcAddrMainGood({}), undefined);
+});
+
+test('wallet-admin preserves fetched RPCs unless a kludge RPC is supplied', t => {
+  const networkConfig = {
+    chainName: 'agoricdev-25',
+    rpcAddrs: ['https://devnet.rpc.agoric.net:443'],
+    apiAddrs: ['https://devnet.api.agoric.net:443'],
+  };
+
+  t.is(withWalletAdminRpcKludge(networkConfig, undefined), networkConfig);
+  t.deepEqual(
+    withWalletAdminRpcKludge(networkConfig, MAINNET_RPC_ADDR_KLUDGE),
+    {
+      ...networkConfig,
+      rpcAddrs: [MAINNET_RPC_ADDR_KLUDGE],
+    },
+  );
+});

--- a/packages/portfolio-deploy/test/ymax-deploy-target.test.ts
+++ b/packages/portfolio-deploy/test/ymax-deploy-target.test.ts
@@ -1602,9 +1602,9 @@ test('authz operator-sign path generates and broadcasts for ymax0-main', async t
     record: 'ymax0-main-authz-unsigned-tx.json',
     detail: {
       agdSignCommand: [
-        "gh release download 'v0.3.2604-beta1' --pattern 'ymax0-main-authz-unsigned-tx.json' --clobber",
-        "agd tx sign 'ymax0-main-authz-unsigned-tx.json' --offline --sign-mode direct --from 'agoric1operator0000000000000000000000000000000' --account-number 12 --sequence 34 --chain-id 'agoric-3' --overwrite --output-document 'ymax0-main-authz-signed-tx.json'",
-        "gh release upload 'v0.3.2604-beta1' 'ymax0-main-authz-signed-tx.json' --clobber",
+        "gh release download 'v0.3.2604-beta1' --pattern 'ymax0-main-authz-unsigned-tx.json' --clobber &&",
+        "  agd tx sign 'ymax0-main-authz-unsigned-tx.json' --offline --sign-mode direct --from 'agoric1operator0000000000000000000000000000000' --account-number 12 --sequence 34 --chain-id 'agoric-3' --overwrite --output-document 'ymax0-main-authz-signed-tx.json' &&",
+        "  gh release upload 'v0.3.2604-beta1' 'ymax0-main-authz-signed-tx.json' --clobber",
       ].join('\n'),
       unsignedTxAssetName: 'ymax0-main-authz-unsigned-tx.json',
       pending: {
@@ -1942,10 +1942,10 @@ test('authz operator-sign path embeds a multisig grantee pubkey resolved from ch
   t.is(
     JSON.parse(ctx.stdoutChunks[0]!).detail.agdSignCommand,
     [
-      "gh release download 'v0.3.2604-beta1' --pattern 'ymax0-main-authz-unsigned-tx.json' --clobber",
-      'agd keys add \'ymax-grantee-00000000\' --pubkey=\'{"@type":"/cosmos.crypto.multisig.LegacyAminoPubKey","threshold":2,"public_keys":[{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A43NKCA60Po/kXiKIsA2CKVERUMsRnRsmEB1T4pnHgS3"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Azb3Hn7YJIsE0NAnSN1HNnRQ/CQ8rQiJpxA1Bo8LS3bl"}]}\'',
-      "agd tx sign 'ymax0-main-authz-unsigned-tx.json' --offline --sign-mode amino-json --multisig=ymax-grantee-00000000 --from <your-key-name> --account-number 12 --sequence 34 --chain-id 'agoric-3' --overwrite --output-document 'ymax0-main-authz-signature-<your-name>.json'",
-      "gh release upload 'v0.3.2604-beta1' 'ymax0-main-authz-signature-<your-name>.json' --clobber",
+      "gh release download 'v0.3.2604-beta1' --pattern 'ymax0-main-authz-unsigned-tx.json' --clobber &&",
+      '  agd keys add \'ymax-grantee-00000000\' --pubkey=\'{"@type":"/cosmos.crypto.multisig.LegacyAminoPubKey","threshold":2,"public_keys":[{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A43NKCA60Po/kXiKIsA2CKVERUMsRnRsmEB1T4pnHgS3"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Azb3Hn7YJIsE0NAnSN1HNnRQ/CQ8rQiJpxA1Bo8LS3bl"}]}\'',
+      "  agd tx sign 'ymax0-main-authz-unsigned-tx.json' --offline --sign-mode amino-json --multisig=ymax-grantee-00000000 --from <your-key-name> --account-number 12 --sequence 34 --chain-id 'agoric-3' --overwrite --output-document 'ymax0-main-authz-signature-<your-name>.json' &&",
+      "  gh release upload 'v0.3.2604-beta1' 'ymax0-main-authz-signature-<your-name>.json' --clobber",
     ].join('\n'),
   );
 });
@@ -2267,9 +2267,9 @@ test('detached direct-sign path generates and broadcasts for ymax0-main without 
     record: 'ymax0-main-unsigned-tx.json',
     detail: {
       agdSignCommand: [
-        "gh release download 'v0.3.2604-beta1' --pattern 'ymax0-main-unsigned-tx.json' --clobber",
-        "agd tx sign 'ymax0-main-unsigned-tx.json' --offline --sign-mode direct --from 'agoric1e80twfutmrm3wrk3fysjcnef4j82mq8dn6nmcq' --account-number 12 --sequence 34 --chain-id 'agoric-3' --overwrite --output-document 'ymax0-main-signed-tx.json'",
-        "gh release upload 'v0.3.2604-beta1' 'ymax0-main-signed-tx.json' --clobber",
+        "gh release download 'v0.3.2604-beta1' --pattern 'ymax0-main-unsigned-tx.json' --clobber &&",
+        "  agd tx sign 'ymax0-main-unsigned-tx.json' --offline --sign-mode direct --from 'agoric1e80twfutmrm3wrk3fysjcnef4j82mq8dn6nmcq' --account-number 12 --sequence 34 --chain-id 'agoric-3' --overwrite --output-document 'ymax0-main-signed-tx.json' &&",
+        "  gh release upload 'v0.3.2604-beta1' 'ymax0-main-signed-tx.json' --clobber",
       ].join('\n'),
       unsignedTxAssetName: 'ymax0-main-unsigned-tx.json',
       pending: {

--- a/packages/portfolio-deploy/test/ymax-deploy-target.test.ts
+++ b/packages/portfolio-deploy/test/ymax-deploy-target.test.ts
@@ -1943,7 +1943,7 @@ test('authz operator-sign path embeds a multisig grantee pubkey resolved from ch
     JSON.parse(ctx.stdoutChunks[0]!).detail.agdSignCommand,
     [
       "gh release download 'v0.3.2604-beta1' --pattern 'ymax0-main-authz-unsigned-tx.json' --clobber &&",
-      '  agd keys add \'ymax-grantee-00000000\' --pubkey=\'{"@type":"/cosmos.crypto.multisig.LegacyAminoPubKey","threshold":2,"public_keys":[{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A43NKCA60Po/kXiKIsA2CKVERUMsRnRsmEB1T4pnHgS3"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Azb3Hn7YJIsE0NAnSN1HNnRQ/CQ8rQiJpxA1Bo8LS3bl"}]}\'',
+      '  agd keys add \'ymax-grantee-00000000\' --pubkey=\'{"@type":"/cosmos.crypto.multisig.LegacyAminoPubKey","threshold":2,"public_keys":[{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A43NKCA60Po/kXiKIsA2CKVERUMsRnRsmEB1T4pnHgS3"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Azb3Hn7YJIsE0NAnSN1HNnRQ/CQ8rQiJpxA1Bo8LS3bl"}]}\' &&',
       "  agd tx sign 'ymax0-main-authz-unsigned-tx.json' --offline --sign-mode amino-json --multisig=ymax-grantee-00000000 --from <your-key-name> --account-number 12 --sequence 34 --chain-id 'agoric-3' --overwrite --output-document 'ymax0-main-authz-signature-<your-name>.json' &&",
       "  gh release upload 'v0.3.2604-beta1' 'ymax0-main-authz-signature-<your-name>.json' --clobber",
     ].join('\n'),
@@ -2335,6 +2335,183 @@ test('detached direct-sign path generates and broadcasts for ymax0-main without 
         event.command.includes('/wallet-admin.ts'),
     ),
   );
+});
+
+const makeDetachedDirectSignAssets = async () => {
+  const ctx = makeScenario();
+  const releaseTag = happyPathReleaseTag;
+  const broadcastCalls: Uint8Array[] = [];
+
+  seedRelease(ctx.releases, releaseTag, {
+    'bundle-ymax0.json': jsonText(examples.bundle),
+    'ymax0-devnet-install.json': jsonText(examples.install.devnet0),
+    'ymax0-devnet-upgrade.json': jsonText(examples.upgrade.devnet0),
+    'ymax0-main-install.json': jsonText(examples.install.main0),
+  });
+
+  const connectRpc = (async (_rpcAddr: string) => ({
+    getAccount: async () => ({
+      accountNumber: 12,
+      sequence: 34,
+      pubkey: null,
+    }),
+    broadcastTx: async (txBytes: Uint8Array) => {
+      broadcastCalls.push(txBytes);
+      return {
+        transactionHash: 'DIRECTSUBMIT123',
+        height: 91,
+      };
+    },
+  })) as unknown as typeof import('@cosmjs/stargate').StargateClient.connect;
+  const makeWalletKit = async () =>
+    ({
+      marshaller: {
+        toCapData: (specimen: unknown) => ({
+          body: `#${JSON.stringify(specimen)}`,
+          slots: [],
+        }),
+      },
+      agoricNames: {
+        instance: {
+          postalService: 'board0371',
+        },
+      },
+    }) as unknown as Awaited<
+      ReturnType<typeof import('@agoric/client-utils').makeSmartWalletKit>
+    >;
+
+  await runPhase(
+    {
+      agoricSdk: ctx.agoricSdk,
+      execFile: ctx.execFile,
+      fetchFn: ctx.fetchFn,
+      connectRpc,
+      makeWalletKit,
+      stdout: ctx.stdout,
+    },
+    'phase-upgrade-generate',
+    { target: 'ymax0-main', tag: releaseTag },
+    {
+      ...ctx.env,
+      MNEMONIC: undefined,
+      GRANTEE: undefined,
+      PRIVATE_ARGS_OVERRIDES: '{"oracle":"value"}',
+    },
+  );
+
+  const assets = ctx.releases.get(releaseTag)?.assets;
+  const unsignedTx = JSON.parse(
+    assets?.get('ymax0-main-unsigned-tx.json') || 'null',
+  );
+  const signedTx = {
+    ...unsignedTx,
+    auth_info: {
+      ...unsignedTx.auth_info,
+      signer_infos: [
+        {
+          ...unsignedTx.auth_info.signer_infos[0],
+          public_key: {
+            '@type': '/cosmos.crypto.secp256k1.PubKey',
+            key: Buffer.from([2, 3, 4]).toString('base64'),
+          },
+        },
+      ],
+    },
+    signatures: [Buffer.from([7, 8, 9]).toString('base64')],
+  };
+  clearTrace(ctx);
+
+  return {
+    ...ctx,
+    assets,
+    broadcastCalls,
+    connectRpc,
+    makeWalletKit,
+    releaseTag,
+    signedTx,
+    unsignedTx,
+  };
+};
+
+test('detached direct-sign submit rejects signed tx with mismatched body', async t => {
+  const ctx = await makeDetachedDirectSignAssets();
+  const signedTx = {
+    ...ctx.signedTx,
+    body: {
+      ...ctx.signedTx.body,
+      memo: 'changed after signing instructions were generated',
+    },
+  };
+  ctx.assets?.set('ymax0-main-signed-tx.json', jsonText(signedTx));
+
+  await t.throwsAsync(
+    runPhase(
+      {
+        agoricSdk: ctx.agoricSdk,
+        execFile: ctx.execFile,
+        fetchFn: ctx.fetchFn,
+        connectRpc: ctx.connectRpc,
+        makeWalletKit: ctx.makeWalletKit,
+        stdout: ctx.stdout,
+      },
+      'phase-upgrade-submit',
+      { target: 'ymax0-main', tag: ctx.releaseTag },
+      {
+        ...ctx.env,
+        MNEMONIC: undefined,
+        GRANTEE: undefined,
+        PRIVATE_ARGS_OVERRIDES: '{"oracle":"value"}',
+      },
+    ),
+    {
+      message:
+        'ymax0-main-signed-tx.json body does not match ymax0-main-unsigned-tx.json',
+    },
+  );
+  t.deepEqual(ctx.broadcastCalls, []);
+  t.falsy(ctx.assets?.get('ymax0-main-upgrade-pending.json'));
+});
+
+test('detached direct-sign submit rejects signed tx with mismatched auth info', async t => {
+  const ctx = await makeDetachedDirectSignAssets();
+  const signedTx = {
+    ...ctx.signedTx,
+    auth_info: {
+      ...ctx.signedTx.auth_info,
+      fee: {
+        ...ctx.signedTx.auth_info.fee,
+        gas_limit: '9000000',
+      },
+    },
+  };
+  ctx.assets?.set('ymax0-main-signed-tx.json', jsonText(signedTx));
+
+  await t.throwsAsync(
+    runPhase(
+      {
+        agoricSdk: ctx.agoricSdk,
+        execFile: ctx.execFile,
+        fetchFn: ctx.fetchFn,
+        connectRpc: ctx.connectRpc,
+        makeWalletKit: ctx.makeWalletKit,
+        stdout: ctx.stdout,
+      },
+      'phase-upgrade-submit',
+      { target: 'ymax0-main', tag: ctx.releaseTag },
+      {
+        ...ctx.env,
+        MNEMONIC: undefined,
+        GRANTEE: undefined,
+        PRIVATE_ARGS_OVERRIDES: '{"oracle":"value"}',
+      },
+    ),
+    {
+      message:
+        'ymax0-main-signed-tx.json auth_info does not match ymax0-main-unsigned-tx.json',
+    },
+  );
+  t.deepEqual(ctx.broadcastCalls, []);
+  t.falsy(ctx.assets?.get('ymax0-main-upgrade-pending.json'));
 });
 
 test('operator must remove upgrade artifact to change privateArgsOverrides', async t => {


### PR DESCRIPTION
### Description
- Make copy-paste signing workflows fail fast so a failed download, key import, or signing step stops subsequent upload steps and prevents accidental publication of unintended artifacts (using `&&` plus newline/indentation).
- Remove `rpcAddress[0]` kludge
- Verify a detached-signed tx before broadcasting.


