### PR TITLE
fix(portfolio-contract): skip zero-weight vault mandate checks

### DIFF
--- a/packages/portfolio-contract/src/mandate.ts
+++ b/packages/portfolio-contract/src/mandate.ts
@@ -59,7 +59,7 @@ export const assertMandateForPlanObservations = (
   );
 
   for (const [instrument, portion = 0n] of Object.entries(targetAllocation)) {
-    if (isInterChainAccountRef(instrument)) continue;
+    if (isInterChainAccountRef(instrument) || portion === 0n) continue;
 
     const status = observations.instrumentTvls[instrument];
     status || Fail`mandate.instrumentData.missing:${instrument}`;

--- a/packages/portfolio-contract/test/mandate.test.ts
+++ b/packages/portfolio-contract/test/mandate.test.ts
@@ -127,6 +127,21 @@ test('cash is exempt from observation-dependent limits', t => {
   );
 });
 
+test('zero-weight vaults are exempt from observation-dependent limits', t => {
+  t.notThrows(() =>
+    assertMandateForPlanObservations(
+      harden({
+        allocation: { minVaultTvlUsd: 30_000_000n, maxVaultShareBps: 0n },
+      }),
+      harden({ '@Base': 100n, Aave_Base: 0n, Compound_Base: 0n }),
+      harden({
+        balances: { '@Base': 1_000_000n },
+        instrumentTvls: { Aave_Base: { tvlUsd: 20_000_000n } },
+      }),
+    ),
+  );
+});
+
 test('global minimum TVL rejects a later applicable instrument', t => {
   t.throws(
     () =>


### PR DESCRIPTION
Refs AGO-1176

## Description

Skip zero-weight instruments before consulting TVL observations.

### Security / Scaling / Documentation / Testing / Upgrade Considerations

N/A
